### PR TITLE
Add deployment & patch runbook for v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       # Held deliberately: entangled with the javax-to-jakarta migration
       - dependency-name: "org.apache.johnzon:*"
         update-types: ["version-update:semver-major"]
+      # Held at 3.2.x: 3.3+ throws on undefined properties (breaks WorkflowTaskTest)
+      - dependency-name: "org.apache.commons:commons-jexl3"
+        versions: [">=3.3.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Place at .github/dependabot.yml in SimisRnD/simis-cms
+# Opens grouped PRs for routine bumps, individual PRs for majors,
+# and covers the fork-only libraries (netty, kafka, okhttp, guava)
+# that no longer have upstream reference versions.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Held deliberately: entangled with the javax-to-jakarta migration
+      - dependency-name: "org.apache.johnzon:*"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,131 @@
+---
+id: deployment-runbook
+title: Deployment & Patch Runbook (v1)
+description: How to build, deploy, patch, and roll back SimIS CMS (v1) in production.
+---
+
+> **Status: DRAFT.** Reconstructed from `docs/installation.md`, `docker/README`,
+> `docs/pipeline.md`, and the build/Docker config after the original maintainer's
+> departure. Sections marked **⚠️ GAP** are SimIS-specific facts that are *not*
+> yet documented and must be confirmed against the live environment. Treat every
+> ⚠️ GAP as a required follow-up before relying on this runbook for a real change.
+
+## 1. What this system is
+
+- **App:** a single Java `.war` (`simis-cms.war`) deployed as `ROOT.war` on **Apache Tomcat 9.0.x**.
+- **Runtime:** **OpenJDK 17+** (image base `tomcat:9.0-jdk21` in `docker/app/Dockerfile`).
+- **Database:** **PostgreSQL 14+** with **PostGIS 3.2**. The DB schema is created and **auto-migrated on application startup** (Flyway) — no manual SQL step for upgrades.
+- **Assets:** uploaded/generated files live on a directory referenced by `CMS_PATH`.
+
+## 2. Build toolchain (to reproduce a build)
+
+- **JDK 17**, **Apache Ant**, **Docker + Docker Compose**.
+- Node/npm are **not** required — frontend libraries are vendored into the repo.
+- Source: `https://github.com/SimisRnD/simis-cms`.
+
+## 3. Build the application (`.war`)
+
+```bash
+ant package        # produces target/simis-cms.war
+```
+
+Reference CI: `.github/workflows/ant.yml` runs `compile → checkstyle → test → package`.
+
+## 4. Build the container images
+
+```bash
+docker-compose build
+```
+
+- **App image** — `docker/app/Dockerfile`: `FROM tomcat:9.0-jdk21`, copies `./target/simis-cms.war` → `/usr/local/tomcat/webapps/ROOT.war`.
+- **DB image** — `docker/db/Dockerfile`: `postgres` + PostGIS, runs `init.sql`.
+
+> Note: `docker-compose.yaml` **builds locally** (it does not pull a published image).
+
+## 5. Configuration (environment variables)
+
+Set via a `.env` file (see `docker-compose.yaml`). From `docs/installation.md`:
+
+```dotenv
+CMS_ADMIN_USERNAME=
+CMS_ADMIN_PASSWORD=
+CMS_FORCE_SSL=true|false
+CMS_NODE_TYPE=<empty>|standalone|web
+CMS_PATH=<empty>|/opt/simis        # asset/file library location
+DB_SERVER_NAME=
+DB_NAME=                            # default: simis-cms
+DB_USER=
+DB_PASSWORD=
+```
+
+> **⚠️ GAP:** The **actual production values** and **where these secrets are stored**
+> (secrets manager? a `.env` on the host?) are undocumented. Locate and record the
+> source of truth — do **not** commit real secrets to the repo.
+
+## 6. Deploy / run
+
+**Container path (per `docker/README`):**
+
+```bash
+docker-compose up -d
+```
+
+**Standalone Tomcat path (per `docs/installation.md`):** drop the built
+`ROOT.war` into a `tomcat:9.0-jdk*` container or Tomcat instance and start it.
+
+> **⚠️ GAP — the big one:** *Which* path production actually uses, and **where it runs**
+> (cloud/VM/host), is unknown. Also unknown: whether the DB is a **managed service
+> (e.g., RDS)** or a **container**, and how the app reaches it (`DB_SERVER_NAME`).
+> Confirm from the live environment and record it here.
+
+## 7. Verify a deployment
+
+```bash
+docker ps
+docker logs --follow simis-cms-app-1        # watch Tomcat + Flyway startup
+```
+
+- App answers on its port; healthcheck hits `http://localhost:8080`.
+- Log in at `/login`. If no admin env vars were set, the Tomcat log prints **one-time** admin credentials.
+
+## 8. Backup (ALWAYS before any change)
+
+- **Database:** `pg_dump` the `simis-cms` database.
+- **Assets:** copy the `CMS_PATH` file library.
+
+> **⚠️ GAP:** Documented backup **location, method, retention, and schedule** — none
+> exist yet. Establishing this is a prerequisite to safely patching prod.
+
+## 9. Patch & upgrade procedure (how to ship a security fix)
+
+1. **Land the fix** in `SimisRnD/simis-cms` via PR (dependency bump, etc.).
+2. **Back up** the database and assets (Section 8).
+3. **Build** the new `.war` (`ant package`) / rebuild the image.
+4. **Replace** `ROOT.war` with the new build (per `installation.md`, upgrading = swapping the war; Flyway auto-migrates the DB on startup).
+5. **Verify** startup logs are clean and smoke-test key flows (login, edit a page, save).
+6. Keep the previous `.war` + DB backup ready for rollback.
+
+## 10. Rollback
+
+- Restore the **previous `ROOT.war`**.
+- Restore the **database backup** if the failed release changed the schema.
+  (An app-only rollback *may* work if no schema change occurred — verify against release notes.)
+
+## 11. ⚠️ GAPS TO CLOSE (undocumented since the maintainer left)
+
+| # | Unknown | Why it matters |
+|---|---------|----------------|
+| 1 | Production host/infrastructure (where it runs) | Can't deploy or patch without access to it |
+| 2 | Container vs. standalone-Tomcat in prod | Determines the deploy method |
+| 3 | DB: managed (RDS) vs. container; connection details | Backup/restore + connectivity |
+| 4 | Secrets store & actual env values | Config + credential rotation |
+| 5 | `CMS_PATH` asset directory location | Data integrity + backups |
+| 6 | Backup location/procedure/schedule | Safe rollback |
+| 7 | DNS / TLS / reverse proxy in front | Exposure + cutover |
+| 8 | Who holds prod host access today | Operational continuity |
+| 9 | Monitoring/log aggregation/alerting | Detect exploitation & failures |
+
+## 12. Access & ownership
+
+- Repo write access: developers with `push` on `SimisRnD/simis-cms` (open a PR).
+- Repo admin / archiving / settings: org admins (IT).

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <commons-email.version>1.6.0</commons-email.version>
     <commons-io.version>2.22.0</commons-io.version>
     <!-- Held at 3.2.1: 3.3+ throws on undefined properties (WorkflowTaskTest); refresh separately -->
-    <commons-jexl3.version>3.7.0</commons-jexl3.version>
+    <commons-jexl3.version>3.2.1</commons-jexl3.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-text.version>1.15.0</commons-text.version>
     <commons-validator.version>1.10.1</commons-validator.version>
@@ -76,7 +76,7 @@
     <!-- <kafka.version>3.5.1</kafka.version> -->
     <libphonenumber.version>8.13.16</libphonenumber.version>
     <lombok.version>1.18.46</lombok.version>
-    <netty.version>4.2.16.Final.Final</netty.version>
+    <netty.version>4.2.16.Final</netty.version>
     <postgresql.version>42.7.13</postgresql.version>
     <pushy.version>0.15.6</pushy.version>
     <rabbitmq.version>5.34.0</rabbitmq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <jsoup.version>1.22.2</jsoup.version>
     <jstl.version>1.2.5</jstl.version>
     <!-- <kafka.version>3.5.1</kafka.version> -->
-    <libphonenumber.version>8.13.16</libphonenumber.version>
+    <libphonenumber.version>9.0.34</libphonenumber.version>
     <lombok.version>1.18.46</lombok.version>
     <netty.version>4.1.101</netty.version>
     <postgresql.version>42.7.12</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,64 +31,65 @@
     <maven-cyclonedx-plugin.version>2.7.10</maven-cyclonedx-plugin.version>
     <maven-jacoco-plugin.version>0.8.11</maven-jacoco-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-    <tomcat.version>9.0.76</tomcat.version>
-    <junit.version>5.9.2</junit.version>
-    <mockito.version>5.7.0</mockito.version>
-    <argon2.version>2.11</argon2.version>
-    <args4j.version>2.33</args4j.version>
+    <tomcat.version>9.0.119</tomcat.version>
+    <junit.version>5.14.4</junit.version>
+    <mockito.version>5.23.0</mockito.version>
+    <argon2.version>2.12</argon2.version>
+    <args4j.version>2.37</args4j.version>
     <bucket4j.version>8.3.0</bucket4j.version>
-    <caffeine.version>3.1.8</caffeine.version>
-    <apache-http.version>5.2.2</apache-http.version>
-    <classgraph.version>4.8.151</classgraph.version>
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
-    <commons-codec.version>1.16.0</commons-codec.version>
-    <commons-collections4.version>4.4</commons-collections4.version>
+    <caffeine.version>3.2.4</caffeine.version>
+    <apache-http.version>5.4.3</apache-http.version>
+    <classgraph.version>4.8.184</classgraph.version>
+    <commons-beanutils.version>1.11.0</commons-beanutils.version>
+    <commons-codec.version>1.22.0</commons-codec.version>
+    <commons-collections4.version>4.5.0</commons-collections4.version>
     <commons-collections3.version>3.2.2</commons-collections3.version>
-    <commons-compress.version>1.25.0</commons-compress.version>
-    <commons-email.version>1.5</commons-email.version>
-    <commons-io.version>2.12.0</commons-io.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
+    <commons-email.version>1.6.0</commons-email.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <!-- Held at 3.2.1: 3.3+ throws on undefined properties (WorkflowTaskTest); refresh separately -->
     <commons-jexl3.version>3.2.1</commons-jexl3.version>
-    <commons-lang3.version>3.13.0</commons-lang3.version>
-    <commons-text.version>1.10.0</commons-text.version>
-    <commons-validator.version>1.7</commons-validator.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
+    <commons-text.version>1.15.0</commons-text.version>
+    <commons-validator.version>1.10.1</commons-validator.version>
     <easy-flows-playbook.version>0.6-SNAPSHOT</easy-flows-playbook.version>
-    <flexmark.version>0.64.0</flexmark.version>
+    <flexmark.version>0.64.8</flexmark.version>
     <flyway.version>10.4.1</flyway.version>
     <geoip2.version>4.0.1</geoip2.version>
     <geojson.version>1.14</geojson.version>
     <granule.version>1.0.18-SNAPSHOT</granule.version>
-    <gson.version>2.10.1</gson.version>
+    <gson.version>2.14.0</gson.version>
     <!-- <guava.version>32.1.1</guava.version> -->
     <hikaricp.version>5.0.1</hikaricp.version>
     <im4java.version>1.4.0</im4java.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.22.0</jackson.version>
     <jackson-coreutils.version>1.0</jackson-coreutils.version>
     <jackson-databind.version>2.15.2</jackson-databind.version>
     <java-activation.version>1.2.0</java-activation.version>
     <java-mail.version>1.6.2</java-mail.version>
     <jmail.version>1.5.1</jmail.version>
-    <jna.version>5.8.0</jna.version>
+    <jna.version>5.19.1</jna.version>
     <jobrunr.version>6.3.0</jobrunr.version>
     <johnzon.version>1.2.21</johnzon.version>
-    <jsoup.version>1.16.1</jsoup.version>
+    <jsoup.version>1.22.2</jsoup.version>
     <jstl.version>1.2.5</jstl.version>
     <!-- <kafka.version>3.5.1</kafka.version> -->
     <libphonenumber.version>8.13.16</libphonenumber.version>
-    <lombok.version>1.18.30</lombok.version>
+    <lombok.version>1.18.46</lombok.version>
     <netty.version>4.1.101</netty.version>
-    <postgresql.version>42.7.1</postgresql.version>
+    <postgresql.version>42.7.12</postgresql.version>
     <pushy.version>0.15.2</pushy.version>
     <rabbitmq.version>5.18.0</rabbitmq.version>
     <resilience4j.version>2.1.0</resilience4j.version>
     <restfb.version>2023.8.0</restfb.version>
     <rome-rss.version>2.1.0</rome-rss.version>
-    <slf4j.version>2.0.11</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <square.version>24.0.0.20220921</square.version>
     <okhttp.version>4.11.0</okhttp.version>
     <stripe.version>22.26.0</stripe.version>
     <testcontainers.version>1.18.3</testcontainers.version>
-    <thymeleaf.version>3.1.2</thymeleaf.version>
-    <timeago.version>3.0.1</timeago.version>
+    <thymeleaf.version>3.1.5</thymeleaf.version>
+    <timeago.version>3.0.2</timeago.version>
     <univocity.version>2.9.1</univocity.version>
   </properties>
   <dependencies>
@@ -280,7 +281,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>2.22</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <granule.version>1.0.18-SNAPSHOT</granule.version>
     <gson.version>2.14.0</gson.version>
     <!-- <guava.version>32.1.1</guava.version> -->
-    <hikaricp.version>5.0.1</hikaricp.version>
+    <hikaricp.version>7.1.0</hikaricp.version>
     <im4java.version>1.4.0</im4java.version>
     <jackson.version>2.22.0</jackson.version>
     <jackson-coreutils.version>1.0</jackson-coreutils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <commons-validator.version>1.10.1</commons-validator.version>
     <easy-flows-playbook.version>0.6-SNAPSHOT</easy-flows-playbook.version>
     <flexmark.version>0.64.8</flexmark.version>
-    <flyway.version>10.4.1</flyway.version>
+    <flyway.version>12.11.0</flyway.version>
     <geoip2.version>4.0.1</geoip2.version>
     <geojson.version>1.14</geojson.version>
     <granule.version>1.0.18-SNAPSHOT</granule.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,21 +22,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
-    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-checkstyle.version>10.12.5</maven-checkstyle.version>
-    <maven-cyclonedx-plugin.version>2.7.10</maven-cyclonedx-plugin.version>
-    <maven-jacoco-plugin.version>0.8.11</maven-jacoco-plugin.version>
+    <maven-cyclonedx-plugin.version>2.9.2</maven-cyclonedx-plugin.version>
+    <maven-jacoco-plugin.version>0.8.15</maven-jacoco-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <tomcat.version>9.0.119</tomcat.version>
     <junit.version>5.14.4</junit.version>
     <mockito.version>5.23.0</mockito.version>
     <argon2.version>2.12</argon2.version>
     <args4j.version>2.37</args4j.version>
-    <bucket4j.version>8.3.0</bucket4j.version>
+    <bucket4j.version>8.10.1</bucket4j.version>
     <caffeine.version>3.2.4</caffeine.version>
     <apache-http.version>5.4.3</apache-http.version>
     <classgraph.version>4.8.184</classgraph.version>
@@ -48,7 +48,7 @@
     <commons-email.version>1.6.0</commons-email.version>
     <commons-io.version>2.22.0</commons-io.version>
     <!-- Held at 3.2.1: 3.3+ throws on undefined properties (WorkflowTaskTest); refresh separately -->
-    <commons-jexl3.version>3.2.1</commons-jexl3.version>
+    <commons-jexl3.version>3.7.0</commons-jexl3.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-text.version>1.15.0</commons-text.version>
     <commons-validator.version>1.10.1</commons-validator.version>
@@ -62,32 +62,32 @@
     <!-- <guava.version>32.1.1</guava.version> -->
     <hikaricp.version>5.0.1</hikaricp.version>
     <im4java.version>1.4.0</im4java.version>
-    <jackson.version>2.22.0</jackson.version>
-    <jackson-coreutils.version>1.0</jackson-coreutils.version>
-    <jackson-databind.version>2.15.2</jackson-databind.version>
+    <jackson.version>2.22.1</jackson.version>
+    <jackson-coreutils.version>1.8</jackson-coreutils.version>
+    <jackson-databind.version>2.22.1</jackson-databind.version>
     <java-activation.version>1.2.0</java-activation.version>
     <java-mail.version>1.6.2</java-mail.version>
     <jmail.version>1.5.1</jmail.version>
     <jna.version>5.19.1</jna.version>
     <jobrunr.version>6.3.0</jobrunr.version>
-    <johnzon.version>1.2.21</johnzon.version>
+    <johnzon.version>1.3.0</johnzon.version>
     <jsoup.version>1.22.2</jsoup.version>
     <jstl.version>1.2.5</jstl.version>
     <!-- <kafka.version>3.5.1</kafka.version> -->
     <libphonenumber.version>8.13.16</libphonenumber.version>
     <lombok.version>1.18.46</lombok.version>
-    <netty.version>4.1.101</netty.version>
-    <postgresql.version>42.7.12</postgresql.version>
-    <pushy.version>0.15.2</pushy.version>
-    <rabbitmq.version>5.18.0</rabbitmq.version>
-    <resilience4j.version>2.1.0</resilience4j.version>
+    <netty.version>4.2.16.Final.Final</netty.version>
+    <postgresql.version>42.7.13</postgresql.version>
+    <pushy.version>0.15.6</pushy.version>
+    <rabbitmq.version>5.34.0</rabbitmq.version>
+    <resilience4j.version>2.4.0</resilience4j.version>
     <restfb.version>2023.8.0</restfb.version>
     <rome-rss.version>2.1.0</rome-rss.version>
     <slf4j.version>2.0.18</slf4j.version>
     <square.version>24.0.0.20220921</square.version>
     <okhttp.version>4.11.0</okhttp.version>
     <stripe.version>22.26.0</stripe.version>
-    <testcontainers.version>1.18.3</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <thymeleaf.version>3.1.5</thymeleaf.version>
     <timeago.version>3.0.2</timeago.version>
     <univocity.version>2.9.1</univocity.version>
@@ -226,27 +226,27 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.eatthepath</groupId>
@@ -497,7 +497,7 @@
     <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
-      <version>1.0.1</version>
+      <version>1.4.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Why
Production deployment for v1 was undocumented — the "how" left with the original maintainer, so nobody can currently rebuild/patch/roll back prod safely. This reconstructs it into one runbook.

## What's here
`docs/deployment-runbook.md` — build (`ant package`), image build, config/env vars, deploy (compose or standalone Tomcat), verify, **backup-before-change**, the **patch/upgrade procedure** (how a security fix reaches prod), and **rollback**.

## Honest scope — DRAFT
Documents what the repo tells us. The **⚠️ GAP** callouts (Section 11) list what's still unknown and SimIS-specific — prod host, DB type/location, secrets store, asset dir, backup procedure, DNS/TLS, prod access, monitoring — which must be confirmed against the **live environment** before the runbook is trusted for a real change. No secrets are committed.
