### PR TITLE
Refresh Java dependencies (v1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,73 +22,74 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
-    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-checkstyle.version>10.12.5</maven-checkstyle.version>
-    <maven-cyclonedx-plugin.version>2.7.10</maven-cyclonedx-plugin.version>
-    <maven-jacoco-plugin.version>0.8.11</maven-jacoco-plugin.version>
+    <maven-cyclonedx-plugin.version>2.9.2</maven-cyclonedx-plugin.version>
+    <maven-jacoco-plugin.version>0.8.15</maven-jacoco-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-    <tomcat.version>9.0.76</tomcat.version>
-    <junit.version>5.9.2</junit.version>
-    <mockito.version>5.7.0</mockito.version>
-    <argon2.version>2.11</argon2.version>
-    <args4j.version>2.33</args4j.version>
-    <bucket4j.version>8.3.0</bucket4j.version>
-    <caffeine.version>3.1.8</caffeine.version>
-    <apache-http.version>5.2.2</apache-http.version>
-    <classgraph.version>4.8.151</classgraph.version>
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
-    <commons-codec.version>1.16.0</commons-codec.version>
-    <commons-collections4.version>4.4</commons-collections4.version>
+    <tomcat.version>9.0.119</tomcat.version>
+    <junit.version>5.14.4</junit.version>
+    <mockito.version>5.23.0</mockito.version>
+    <argon2.version>2.12</argon2.version>
+    <args4j.version>2.37</args4j.version>
+    <bucket4j.version>8.10.1</bucket4j.version>
+    <caffeine.version>3.2.4</caffeine.version>
+    <apache-http.version>5.4.3</apache-http.version>
+    <classgraph.version>4.8.184</classgraph.version>
+    <commons-beanutils.version>1.11.0</commons-beanutils.version>
+    <commons-codec.version>1.22.0</commons-codec.version>
+    <commons-collections4.version>4.5.0</commons-collections4.version>
     <commons-collections3.version>3.2.2</commons-collections3.version>
-    <commons-compress.version>1.25.0</commons-compress.version>
-    <commons-email.version>1.5</commons-email.version>
-    <commons-io.version>2.12.0</commons-io.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
+    <commons-email.version>1.6.0</commons-email.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <!-- Held at 3.2.1: 3.3+ throws on undefined properties (WorkflowTaskTest); refresh separately -->
     <commons-jexl3.version>3.2.1</commons-jexl3.version>
-    <commons-lang3.version>3.13.0</commons-lang3.version>
-    <commons-text.version>1.10.0</commons-text.version>
-    <commons-validator.version>1.7</commons-validator.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
+    <commons-text.version>1.15.0</commons-text.version>
+    <commons-validator.version>1.10.1</commons-validator.version>
     <easy-flows-playbook.version>0.6-SNAPSHOT</easy-flows-playbook.version>
-    <flexmark.version>0.64.0</flexmark.version>
-    <flyway.version>10.4.1</flyway.version>
+    <flexmark.version>0.64.8</flexmark.version>
+    <flyway.version>12.11.0</flyway.version>
     <geoip2.version>4.0.1</geoip2.version>
     <geojson.version>1.14</geojson.version>
     <granule.version>1.0.18-SNAPSHOT</granule.version>
-    <gson.version>2.10.1</gson.version>
+    <gson.version>2.14.0</gson.version>
     <!-- <guava.version>32.1.1</guava.version> -->
-    <hikaricp.version>5.0.1</hikaricp.version>
+    <hikaricp.version>7.1.0</hikaricp.version>
     <im4java.version>1.4.0</im4java.version>
-    <jackson.version>2.15.2</jackson.version>
-    <jackson-coreutils.version>1.0</jackson-coreutils.version>
-    <jackson-databind.version>2.15.2</jackson-databind.version>
+    <jackson.version>2.22.1</jackson.version>
+    <jackson-coreutils.version>1.8</jackson-coreutils.version>
+    <jackson-databind.version>2.22.1</jackson-databind.version>
     <java-activation.version>1.2.0</java-activation.version>
     <java-mail.version>1.6.2</java-mail.version>
     <jmail.version>1.5.1</jmail.version>
-    <jna.version>5.8.0</jna.version>
+    <jna.version>5.19.1</jna.version>
     <jobrunr.version>6.3.0</jobrunr.version>
-    <johnzon.version>1.2.21</johnzon.version>
-    <jsoup.version>1.16.1</jsoup.version>
+    <johnzon.version>1.3.0</johnzon.version>
+    <jsoup.version>1.22.2</jsoup.version>
     <jstl.version>1.2.5</jstl.version>
     <!-- <kafka.version>3.5.1</kafka.version> -->
-    <libphonenumber.version>8.13.16</libphonenumber.version>
-    <lombok.version>1.18.30</lombok.version>
-    <netty.version>4.1.101</netty.version>
-    <postgresql.version>42.7.1</postgresql.version>
-    <pushy.version>0.15.2</pushy.version>
-    <rabbitmq.version>5.18.0</rabbitmq.version>
-    <resilience4j.version>2.1.0</resilience4j.version>
+    <libphonenumber.version>9.0.34</libphonenumber.version>
+    <lombok.version>1.18.46</lombok.version>
+    <netty.version>4.2.16.Final</netty.version>
+    <postgresql.version>42.7.13</postgresql.version>
+    <pushy.version>0.15.6</pushy.version>
+    <rabbitmq.version>5.34.0</rabbitmq.version>
+    <resilience4j.version>2.4.0</resilience4j.version>
     <restfb.version>2023.8.0</restfb.version>
     <rome-rss.version>2.1.0</rome-rss.version>
-    <slf4j.version>2.0.11</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <square.version>24.0.0.20220921</square.version>
     <okhttp.version>4.11.0</okhttp.version>
     <stripe.version>22.26.0</stripe.version>
-    <testcontainers.version>1.18.3</testcontainers.version>
-    <thymeleaf.version>3.1.2</thymeleaf.version>
-    <timeago.version>3.0.1</timeago.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
+    <thymeleaf.version>3.1.5</thymeleaf.version>
+    <timeago.version>3.0.2</timeago.version>
     <univocity.version>2.9.1</univocity.version>
   </properties>
   <dependencies>
@@ -225,27 +226,27 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
-      <version>${netty.version}.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.eatthepath</groupId>
@@ -280,7 +281,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>2.22</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -496,7 +497,7 @@
     <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
-      <version>1.0.1</version>
+      <version>1.4.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What this fixes
Backports the **tested Java dependency refresh** to the org repo (it previously lived only in a personal fork). Brings v1's backend libraries up to patched versions.

- Tier-one bumps (tomcat, junit, mockito, jackson, commons-*, gson, jsoup, lombok, postgresql, slf4j, thymeleaf, …)
- Majors: **Flyway 10→12**, **HikariCP 5→7**, **libphonenumber 8→9**
- **netty 4.1.101→4.2.16.Final**, **jackson 2.15.2→2.22.1**, rabbitmq, testcontainers, Maven plugins
- **commons-jexl3 held at 3.2.1** — 3.3+ throws on undefined properties (breaks `WorkflowTaskTest`); tracked for a separate follow-up

## Verification
`mvn clean package` → **BUILD SUCCESS, 198 tests pass**.

## Note
Flyway 10→12 is a DB-migration tool major — validate migrations against a staging database before deploy (the app runs Flyway on startup). Deps that need the jakarta migration (johnzon) and other majors (square, geoip2, timeago) are deliberately deferred.
