### PR TITLE
Fix SQL injection in ProductSkuRepository attribute filter (CWE-89)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/ecommerce/ProductSkuRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/ecommerce/ProductSkuRepository.java
@@ -83,7 +83,10 @@ public class ProductSkuRepository {
           sb.append("}");
         }
         if (sb.length() > 0) {
-          where.add("attributes @> '[" + sb.toString() + "]'");
+          // Bind the jsonb operand as a parameter (?::jsonb) rather than concatenating it into a
+          // single-quoted SQL literal: JsonCommand.toJson (escapeJson) does not escape single
+          // quotes, so a "'" in an attribute value could otherwise break out of the literal (SQLi).
+          where.add("attributes @> ?::jsonb", "[" + sb.toString() + "]");
         }
       }
     }


### PR DESCRIPTION
## The vulnerability (CWE-89, SQL injection)
Surfaced by investigating a CodeQL "Query built from user-controlled sources" alert (DB.java:705) and tracing it to the real sink:

1. `AddToCartWidget.java:223` — `context.getParameter("attribute" + index)` → **raw HTTP parameter** (blank-check only)
2. `ProductSkuRepository.java:86` — concatenated into a **single-quoted SQL literal**: `where.add("attributes @> '[" + sb + "]'")`
3. `JsonCommand.java:42` — `StringEscapeUtils.escapeJson` escapes `"` `\` `/` but **not `'`**

So a `'` in an `attributeN` value breaks out of the literal. **Unauthenticated, remotely reachable** via the storefront add-to-cart path.

## Severity: Medium (~CVSS 5–6)
Adversarial verification bounded the *demonstrable* impact to a reliable DB error (anonymous DoS of the purchase flow) — the escaped `"` prevent forming valid `jsonb`, so PostgreSQL rejects the statement at parse-time before any injected `OR`/`UNION`/`pg_sleep` executes. **Data exfiltration was not demonstrated**, but the escaper is the wrong control and this is one change from becoming exfil-capable — so it's fixed as a genuine injection defect. (Recommend an empirical `pg_sleep` test against a running instance to definitively rule exfil in/out.)

## The fix
```java
where.add("attributes @> ?::jsonb", "[" + sb.toString() + "]");
```
The jsonb operand now binds via `PreparedStatement` and can never alter SQL structure.

**Verified:** `mvn clean package` → BUILD SUCCESS, 198 tests pass. Sibling audit found this is the only `escapeJson`-into-single-quoted-SQL-literal in the codebase. (The related CodeQL `DB.java:70` alert is a confirmed false positive — all structural parts there are app constants.)
