### PR TITLE
Add security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report privately using GitHub's **"Report a vulnerability"** button under this repository's **Security** tab (Security → Advisories → Report a vulnerability).
+You can also send us a message at https://simisinc.com/contact-us
+
+Please include: affected version/commit, a description and steps to reproduce.
+
+## What to expect
+
+- We aim to acknowledge reports within 5 business days.
+- We will keep you updated as we investigate and, where appropriate, coordinate a fix and disclosure timeline with you.
+- We ask that you give us a reasonable opportunity to remediate before any public disclosure.
+
+## Supported Versions
+
+Security fixes are applied to the 'main' branch. We do not maintain patched builds of older versions.
+
+## Scope
+
+This policy covers the code in this repository. It does **not** cover any
+third-party dependencies (report those to their upstream projects) or any
+hosted deployment infrastructure.


### PR DESCRIPTION
## What
Adds a `SECURITY.md` establishing a **private** channel for vulnerability reports (GitHub's "Report a vulnerability" button, plus a contact fallback), a modest response expectation (5 business days), a `main`-branch support statement, and a scope note that excludes third-party deps and hosted infrastructure.

## ⚠️ Admin action needed for this to actually work
The policy directs reporters to GitHub's private **"Report a vulnerability"** button, which only appears when **Private Vulnerability Reporting** is enabled: **Settings → Advanced Security → Private vulnerability reporting → Enable**. Please enable it (admin-only) when merging, or the primary reporting channel dead-ends.