### PR TITLE
Update actions/setup-java v1 -> v5

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v5
       with:
+        # setup-java v2+ requires an explicit distribution (v1 did not)
+        distribution: 'temurin'
         java-version: 17
     - name: Compile the source
       run: ant -noinput -buildfile build.xml clean compile


### PR DESCRIPTION
`actions/setup-java@v1` is long retired. #76 refreshed `checkout` (→v7) and `codeql-action` (→v4) but left this one behind.

**Why Dependabot's own bump never worked:** v2 and later require an explicit `distribution` input, which v1 did not have. A bare version bump therefore fails — the version and the input have to change together. Setting `temurin` matches the JDK 17 that v1 resolved to.

This exact change is already running green on the fork (`lizhsr/simis-cms`), so it's not speculative.

3 insertions, 1 deletion, one file.