### PR TITLE
Remove embedded Mapbox access token from a code comment

### DIFF
--- a/src/main/java/com/simisinc/platform/application/maps/MapBoxCommand.java
+++ b/src/main/java/com/simisinc/platform/application/maps/MapBoxCommand.java
@@ -80,7 +80,7 @@ public class MapBoxCommand {
     }
 
     // https://api.mapbox.com/geocoding/v5/mapbox.places/Wawa,23321.json
-    // ?limit=1&access_token=pk.eyJ1IjoibWF0dHNpbWlzIiwiYSI6ImNqZ2doZjh2bjB6NHUyd29pbm5yc3Y5cjQifQ.Qio8_yBfJeesjNHUDrLKtw
+    // ?limit=1&access_token=<access_token>
     String url = "https://api.mapbox.com/geocoding/v5/mapbox.places/" + query + ".json?limit=1&access_token=" + accessToken;
     try {
       // Use rate limiting


### PR DESCRIPTION
The Mapbox access token on line 83 sat inside an example URL in a comment. It was never used — line 84 reads the real token from the `maps.mapbox.accesstoken` site property via `LoadSitePropertyCommand`, which is where it belongs.

**This is not a credential disclosure.** The embedded value is a public (`pk.`) token, and Mapbox public tokens are designed to be readable in client-side source. GitHub secret scanning labels it "Mapbox Secret Access Token", but secret keys start with `sk.` — the pattern does not distinguish the two.

**This does not resolve the secret scanning alert, and is not meant to.** GitHub [does not close secret scanning alerts automatically](https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-secret-scanning-alerts/resolving-alerts) when a token is removed, and the value stays in git history regardless. The only true remediation for a leaked credential is revocation, and this token belongs to a third party — not ours to revoke.

So this is hygiene, not remediation: it keeps a live third-party token out of current source and stops it propagating into further copies. The comment does not need a working value to document the API shape.

One line, comment only. No runtime change.

Same change is open on `cms-platform` as #9, so the two stay consistent.