### PR TITLE
Do not build the SSL redirect from the client-supplied Host header

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/HostnameCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/HostnameCommand.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class HostnameCommand {
 
   private static Log LOG = LogFactory.getLog(HostnameCommand.class);
-  static final String HOSTNAME_ALLOW_LIST = "hostname-allow-list.csv";
+  public static final String HOSTNAME_ALLOW_LIST = "hostname-allow-list.csv";
 
   private static Map<String, List<String>> listMap = new HashMap<>();
   private static Map<String, Long> lastModifiedMap = new HashMap<>();
@@ -75,6 +75,18 @@ public class HostnameCommand {
     }
     LOG.warn("Invalid hostname: " + hostname);
     return false;
+  }
+
+  /**
+   * Determines if an allow list is configured and names this hostname. Unlike passesCheck, an unconfigured allow list
+   * does not vouch for the hostname, so callers can tell "explicitly trusted" apart from "nothing was configured".
+   *
+   * @param hostname the hostname to look for
+   * @return true when a non-empty allow list contains the hostname
+   */
+  public static boolean isExplicitlyAllowed(String hostname) {
+    List<String> hostnameAllowList = listMap.get(HOSTNAME_ALLOW_LIST);
+    return hostnameAllowList != null && !hostnameAllowList.isEmpty() && hostnameAllowList.contains(hostname);
   }
 
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -173,6 +173,13 @@ public class WebRequestFilter implements Filter {
           && !InetAddressUtils.isIPv6Address(request.getServerName())) {
         String requestURL = httpServletRequest.getRequestURL().toString();
         requestURL = StringUtils.replace(requestURL, "http://", "https://");
+        // The request URL is built from the client-supplied Host header, so it is only echoed back when the
+        // hostname is named by an allow list. Otherwise prefer the configured site, because the allow list is
+        // empty unless an operator created hostname-allow-list.csv, and an empty list vouches for nothing.
+        String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
+        if (siteUrl != null && !HostnameCommand.isExplicitlyAllowed(request.getServerName())) {
+          requestURL = StringUtils.removeEnd(siteUrl, "/") + safeRedirectPath(requestURI);
+        }
         LOG.debug("Redirecting to: " + requestURL);
         do301(servletResponse, requestURL);
         return;
@@ -509,6 +516,31 @@ public class WebRequestFilter implements Filter {
     */
 
     chain.doFilter(request, servletResponse);
+  }
+
+  /**
+   * Restricts a request path so it can only ever be appended to the configured site URL as an absolute path on that
+   * site. This keeps the path from changing the host of the redirect (a protocol-relative "//host" or a backslash
+   * variant) or from splitting the response header (an embedded control character). Anything unexpected collapses to
+   * the site root.
+   *
+   * @param requestURI the request path from HttpServletRequest.getRequestURI()
+   * @return the same path when it is a plain absolute path, otherwise "/"
+   */
+  static String safeRedirectPath(String requestURI) {
+    // Must be an absolute path; reject protocol-relative ("//host") and backslash variants a browser reads as a host
+    if (requestURI == null || !requestURI.startsWith("/") || requestURI.startsWith("//")
+        || requestURI.startsWith("/\\")) {
+      return "/";
+    }
+    // Reject control characters, including the CR and LF that could split the response header
+    for (int i = 0; i < requestURI.length(); i++) {
+      char c = requestURI.charAt(i);
+      if (c < 0x20 || c == 0x7f) {
+        return "/";
+      }
+    }
+    return requestURI;
   }
 
   private void do301(ServletResponse servletResponse, String redirectLocation) throws IOException {

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static com.simisinc.platform.application.cms.HostnameCommand.HOSTNAME_ALLOW_LIST;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.BlockedIPListCommand;
+import com.simisinc.platform.application.cms.HostnameCommand;
+import com.simisinc.platform.application.cms.LoadBlockedIPListCommand;
+import com.simisinc.platform.application.cms.LoadRedirectsCommand;
+
+/**
+ * Verifies that the http to https redirect targets the configured site, and not the client-supplied Host header
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class WebRequestFilterTest {
+
+  private static final String SITE_URL = "https://www.example.com";
+
+  // HostnameCommand caches the allow list in static state shared by every test in the JVM, so it is reset both
+  // before and after each test to keep the non-empty list used below from leaking into other tests
+  @BeforeEach
+  @AfterEach
+  void resetHostnameAllowList() {
+    // The shipped configuration has no hostname-allow-list.csv, so the allow list is empty by default
+    HostnameCommand.setList(HOSTNAME_ALLOW_LIST, new ArrayList<>());
+  }
+
+  private HttpServletRequest httpRequestOverPlainHttp(String hostHeader) {
+    return httpRequestOverPlainHttp(hostHeader, "/about");
+  }
+
+  private HttpServletRequest httpRequestOverPlainHttp(String hostHeader, String requestURI) {
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getContextPath()).thenReturn("");
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getScheme()).thenReturn("http");
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getServletContext()).thenReturn(servletContext);
+    when(request.getRequestURI()).thenReturn(requestURI);
+    when(request.getRemoteAddr()).thenReturn("203.0.113.9");
+    // getServerName() and getRequestURL() are both derived from the Host header by the container
+    when(request.getServerName()).thenReturn(hostHeader);
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://" + hostHeader + requestURI));
+    return request;
+  }
+
+  private WebRequestFilter filterRequiringSSL(MockedStatic<LoadSitePropertyCommand> siteProperties) throws Exception {
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getAttribute(ContextConstants.STARTUP_SUCCESSFUL)).thenReturn("true");
+    FilterConfig filterConfig = mock(FilterConfig.class);
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+
+    siteProperties.when(() -> LoadSitePropertyCommand.loadByName("system.ssl")).thenReturn("true");
+
+    WebRequestFilter filter = new WebRequestFilter();
+    filter.init(filterConfig);
+    return filter;
+  }
+
+  @Test
+  void sslRedirectUsesTheConfiguredSiteUrlRatherThanTheHostHeader() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+      siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn(SITE_URL);
+
+      WebRequestFilter filter = filterRequiringSSL(siteProperties);
+      filter.doFilter(httpRequestOverPlainHttp("evil.example.net"), response, chain);
+
+      verify(response).setHeader("Location", SITE_URL + "/about");
+      verify(response, never()).setHeader("Location", "https://evil.example.net/about");
+    }
+  }
+
+  @Test
+  void sslRedirectFallsBackToTheRequestUrlWhenSiteUrlIsNotConfigured() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+      siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn("");
+
+      WebRequestFilter filter = filterRequiringSSL(siteProperties);
+      filter.doFilter(httpRequestOverPlainHttp("www.example.com"), response, chain);
+
+      verify(response).setHeader("Location", "https://www.example.com/about");
+    }
+  }
+
+  @Test
+  void sslRedirectUsesTheRequestUrlWhenTheHostIsOnTheAllowList() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    List<String> allowList = new ArrayList<>();
+    allowList.add("intranet.example.com");
+    HostnameCommand.setList(HOSTNAME_ALLOW_LIST, allowList);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+      siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn(SITE_URL);
+
+      WebRequestFilter filter = filterRequiringSSL(siteProperties);
+      filter.doFilter(httpRequestOverPlainHttp("intranet.example.com"), response, chain);
+
+      verify(response).setHeader("Location", "https://intranet.example.com/about");
+    }
+  }
+
+  @Test
+  void sslRedirectCollapsesAProtocolRelativePathToTheSiteRoot() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+      siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn(SITE_URL);
+
+      WebRequestFilter filter = filterRequiringSSL(siteProperties);
+      // A protocol-relative path would otherwise produce https://www.example.com//evil.example.net
+      filter.doFilter(httpRequestOverPlainHttp("evil.example.net", "//evil.example.net/path"), response, chain);
+
+      verify(response).setHeader("Location", SITE_URL + "/");
+    }
+  }
+
+  @Test
+  void safeRedirectPathAllowsAPlainAbsolutePath() {
+    Assertions.assertEquals("/about", WebRequestFilter.safeRedirectPath("/about"));
+    Assertions.assertEquals("/a/b/c.html", WebRequestFilter.safeRedirectPath("/a/b/c.html"));
+  }
+
+  @Test
+  void safeRedirectPathRejectsHostChangingAndSplittingPaths() {
+    // Protocol-relative and backslash variants a browser would read as a host
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath("//evil.example.net"));
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath("/\\evil.example.net"));
+    // Not an absolute path
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath("evil"));
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath(null));
+    // Embedded CR/LF that could split the response header
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath("/a\r\nSet-Cookie: x=y"));
+    Assertions.assertEquals("/", WebRequestFilter.safeRedirectPath("/a\nb"));
+  }
+}


### PR DESCRIPTION
## The bug

`WebRequestFilter`'s http→https redirect built its `Location` header from `getRequestURL()`, whose host is taken from the client's `Host` header:

```java
String requestURL = httpServletRequest.getRequestURL().toString();
requestURL = StringUtils.replace(requestURL, "http://", "https://");
do301(servletResponse, requestURL);
```

A plain-http request carrying a forged `Host` is answered with a `301` pointing at that host, so the site redirects its own visitors to an attacker's domain — a phishing vector on the path every casual `http://` visitor takes.

## Why the existing guard doesn't stop it

`HostnameCommand.passesCheck(request.getServerName())` runs earlier and looks like it should reject an unknown hostname. It fails open:

```java
if (hostnameAllowList == null || hostnameAllowList.isEmpty() || hostnameAllowList.contains(hostname)) {
  return true;   // empty list allows everything
}
```

The list is empty on a **default install**, not just a misconfigured one: `hostname-allow-list.csv` is not shipped, nothing creates it, and `FileSystemCommand.loadFileToList` returns an empty list for a missing file (one `WARN` at startup).

## The fix

Build the redirect from the configured `site.url`, and only echo the request's host back when an allow list **explicitly** names it. `safeRedirectPath` restricts the appended path to a plain absolute path, so it can't change the redirect host (a protocol-relative `//host`) or split the response header (an embedded control character):

```java
String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
if (siteUrl != null && !HostnameCommand.isExplicitlyAllowed(request.getServerName())) {
  requestURL = StringUtils.removeEnd(siteUrl, "/") + safeRedirectPath(requestURI);
}
```

`passesCheck` is deliberately unchanged. Its fail-open is pinned by `HostnameCommandTest.passesCheckWithEmptyConfiguration`; changing it would alter a shared primitive on the request path and could 404 live multi-host installs. `isExplicitlyAllowed` adds the "explicitly trusted vs nothing configured" distinction this caller needs without touching that contract.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Forged/unknown `Host`, `site.url` set | 301 → attacker's host | 301 → `site.url`, path preserved |
| Protocol-relative path (`//host`) | — | 301 → `site.url/` |
| Host on the allow list | 301 → that host | unchanged |
| `site.url` blank (fresh install) | 301 → reflected host | unchanged |

The blank-`site.url` case is left as-is rather than failing closed: with no canonical origin configured there's nothing better to redirect to, and refusing would take the site down.

## Provenance and verification

This is the same defect fixed in `SimisRnD/cms-platform#12` and hardened in `#14`, ported here (this repo uses `StringUtils` where cms-platform uses `Strings.CS`). On cms-platform the fix and the protocol-relative collapse were **reproduced end-to-end in a running container** — a forged `Host` returned `Location: https://evil.example.net/...` before and `Location: https://www.example.com/...` after.

CI gates run locally on **JDK 17** (matching this repo's workflow), full suite:

- `ant clean compile` — BUILD SUCCESSFUL
- `ant checkstyle` — BUILD SUCCESSFUL
- `ant -lib lib/tests ci-test` — BUILD SUCCESSFUL, 0 failures

Adds `WebRequestFilterTest`: forged host, unconfigured-`site.url` fallback, allow-listed host, protocol-relative collapse, and direct `safeRedirectPath` unit tests. The test resets `HostnameCommand`'s static allow-list cache `@BeforeEach`/`@AfterEach` so it doesn't leak into `HostnameCommandTest`.

## Note

This closes no CodeQL alert — CodeQL does not flag this particular redirect. It is a real fix regardless.