### PR TITLE
Send HSTS header when the deployment requires SSL

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -153,6 +153,12 @@ public class PageServlet extends HttpServlet {
     response.setHeader("X-Frame-Options", "SAMEORIGIN");
     response.setHeader("X-Content-Type-Options", "nosniff");
     response.setHeader("X-XSS-Protection", "1; mode=block");
+    // Advertise HTTPS-only via HSTS, but only when the deployment is configured for SSL. Sending this from a
+    // site that cannot serve HTTPS would make browsers refuse it for the max-age, so it is gated on system.ssl
+    // rather than the per-request scheme, which also stays correct behind a TLS-terminating proxy.
+    if ("true".equals(LoadSitePropertyCommand.loadByName("system.ssl"))) {
+      response.setHeader("Strict-Transport-Security", "max-age=31536000");
+    }
 
     try {
       // Determine the resource


### PR DESCRIPTION
## What

Adds `Strict-Transport-Security` to the response headers `PageServlet` already sets, gated on the site's `system.ssl` property:

```java
if ("true".equals(LoadSitePropertyCommand.loadByName("system.ssl"))) {
  response.setHeader("Strict-Transport-Security", "max-age=31536000");
}
```

This is the first slice of the "hardened security-header baseline" from the platform brief — the header set gains HSTS alongside the existing `X-Frame-Options`, `X-Content-Type-Options`, and `X-XSS-Protection`.

## Why gated on `system.ssl`

HSTS tells a browser to refuse plain HTTP for the `max-age`. Sending it from a deployment that can't actually serve HTTPS would lock users out. Gating on `system.ssl` — the app's own "this site requires SSL" flag, the same one `WebRequestFilter` uses — means it's only advertised when the operator has declared HTTPS. Gating on that property rather than the per-request scheme also stays correct behind a TLS-terminating proxy, where `request.isSecure()` can read false.

`max-age=31536000` (1 year), no `includeSubDomains`/`preload` — those are larger commitments best left to the admin-selectable presets the brief envisions as the follow-on.

## Verified in a running instance

Booted the app against a database and observed the actual response headers:

| Condition | `Strict-Transport-Security` |
|---|---|
| `system.ssl=false` | absent ✓ |
| `system.ssl=true` (Host: localhost) | `max-age=31536000` ✓ |
| `system.ssl=true`, other host | request 301s to HTTPS first ✓ |

`X-Frame-Options` was present in every case, confirming the code path executes. Build, checkstyle, and the test suite pass on JDK 17.

## Not included — CSP, deliberately

The brief bundles CSP into this baseline, but `ContentWidget` already emits **per-page** `Content-Security-Policy` headers for video embeds, and a CMS front end with inline scripts and vendored JS will trip a strict global policy. A safe CSP baseline needs `Content-Security-Policy-Report-Only` first and reconciliation with `ContentWidget` — a separate PR, not a drop-in here.