### PR TITLE
Publish a signed CycloneDX SBOM with each release

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,65 @@
+# Generates a CycloneDX SBOM, signs it keylessly with Sigstore/cosign, and
+# attaches it to each published release. The cyclonedx-maven-plugin is already
+# configured in pom.xml (makeAggregateBom at the package phase); this workflow
+# runs it, signs the output, and publishes it.
+name: SBOM
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # attach the SBOM to the release
+      id-token: write      # keyless signing via Sigstore OIDC
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: maven
+
+      - name: Generate the CycloneDX SBOM
+        run: mvn -B -ntp org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the SBOM (keyless)
+        run: |
+          for f in target/bom.json target/bom.xml; do
+            cosign sign-blob --yes "$f" \
+              --output-signature "$f.sig" \
+              --output-certificate "$f.pem"
+          done
+
+      - name: Upload the SBOM as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            target/bom.json
+            target/bom.xml
+            target/bom.json.sig
+            target/bom.json.pem
+            target/bom.xml.sig
+            target/bom.xml.pem
+
+      - name: Attach the signed SBOM to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            target/bom.json target/bom.json.sig target/bom.json.pem \
+            target/bom.xml target/bom.xml.sig target/bom.xml.pem \
+            --clobber


### PR DESCRIPTION
## What

Adds `.github/workflows/sbom.yml` — on each published release (and on manual `workflow_dispatch`), it:

1. Generates the CycloneDX SBOM via the `cyclonedx-maven-plugin` **already configured in `pom.xml`** (`makeAggregateBom`)
2. Signs `bom.json` and `bom.xml` **keylessly** with Sigstore/cosign (no key to manage — uses the workflow's OIDC identity)
3. Attaches the SBOMs, signatures (`.sig`), and certificates (`.pem`) to the GitHub Release
4. Also uploads them as a build artifact, so the whole thing can be exercised via `workflow_dispatch` **without cutting a release**

## Why

The plugin was already in the build, but nothing published its output and CI runs Ant, so the SBOM was never actually produced anywhere. A CMS whose releases ship attested SBOMs speaks EO 14028 / SSDF directly — it's the cheapest concrete supply-chain differentiator available here, since the generation was already wired.

## Verified

- **SBOM generation, locally**: `mvn org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom` produced a valid **CycloneDX 1.4** SBOM — 167 components, dependency graph, serial number.
- **Workflow**: YAML validated; least-privilege `permissions` (top-level `contents: read`, job elevates to `contents: write` for the release upload and `id-token: write` for keyless signing).
- **Signing + release upload** are standard `sigstore/cosign-installer` + `gh release upload` steps — validated by construction rather than run locally (keyless signing needs the Actions OIDC context). The `workflow_dispatch` path exists precisely so this can be proven end-to-end before relying on it at release time.

## How to test before merging

Run the workflow manually (Actions → SBOM → Run workflow). It produces a downloadable `sbom` artifact with the signed files. Verify a signature with:

```
cosign verify-blob target/bom.json \
  --signature bom.json.sig --certificate bom.json.pem \
  --certificate-identity-regexp 'https://github.com/SimisRnD/simis-cms/.github/workflows/sbom.yml@.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

## Note

This attaches SBOMs to *releases*. `simis-cms` doesn't yet have an image-publishing/release pipeline (that's a separate modernization step), but this works against the standard GitHub Release flow the repo already uses for its version tags.