### PR TITLE
Move to Java 21

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         # setup-java v2+ requires an explicit distribution (v1 did not)
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
     - name: Compile the source
       run: ant -noinput -buildfile build.xml clean compile
     - name: Run unit tests

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 <project name="SimIS CMS" default="build" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
 
   <property name="project" value="simis-cms" />
-  <property name="jdk" value="17" />
+  <property name="jdk" value="21" />
   <property name="fs" value="${file.separator}"/>
   <property name="lf" value="${line.separator}"/>
   <property name="javadoc.dir" value="docs" />

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>


### PR DESCRIPTION
## What

Bumps the Java level from 17 to 21 in the three places that pin it:

- `build.xml` — `<property name="jdk" value="21" />` (source/target/release for the Ant build)
- `pom.xml` — `<java.version>21</java.version>`
- `.github/workflows/ant.yml` — `java-version: 21`

## Why

This is the first slice of **tranche T1** in the modernization plan — the runtime foundation everything else builds on. cms-platform requires Java 21 as of early 2026; matching it here unblocks the later capability ports and closes the version gap.

## Verified

Built and tested locally on **Temurin 21**:

- `ant clean compile` — BUILD SUCCESSFUL
- `ant checkstyle` — BUILD SUCCESSFUL
- `ant -lib lib/tests ci-test` — BUILD SUCCESSFUL, 0 failures

Only pre-existing deprecation warnings remain (`URL(String)`, `WriterOutputStream`) — no errors. Lombok 1.18.46 supports 21, so annotation processing is unaffected (this is *not* the JDK-26 Lombok issue).

## Scope

Runtime/level bump only. The **owned container build** — a `Dockerfile` plus CI image publishing to `ghcr.io/simisrnd` with Trivy scanning — is the next T1 slice and its own PR. That's the piece that lets simis-cms build and publish its own release images for the first time since 2024.