### PR TITLE
MFA: enrollment schema and commands

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * Enrolls a user in TOTP multi-factor authentication and manages its lifecycle. Uses TotpCommand for the
+ * cryptography and stores the secret on the user record. Prompting for a code at login is handled separately.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaCommand {
+
+  private static Log LOG = LogFactory.getLog(UserMfaCommand.class);
+
+  private UserMfaCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * Begins enrollment: generates a fresh secret, stores it as pending (not yet enabled), and returns the otpauth://
+   * URI to present as a QR code. MFA is not active until confirmEnrollment succeeds with a valid code.
+   *
+   * @param user the user enrolling
+   * @return the otpauth:// enrollment URI
+   */
+  public static String startEnrollment(User user) {
+    String secret = TotpCommand.generateSecret();
+    UserRepository.saveMfaSecret(user, secret);
+    String issuer = StringUtils.defaultIfBlank(LoadSitePropertyCommand.loadByName("site.name"), "SimIS CMS");
+    String account = StringUtils.isNotBlank(user.getEmail()) ? user.getEmail() : user.getUsername();
+    return TotpCommand.generateUri(issuer, account, secret);
+  }
+
+  /**
+   * Confirms enrollment by verifying a code against the pending secret. On success the user's MFA becomes enabled.
+   *
+   * @param user the user enrolling
+   * @param code the code from the user's authenticator app
+   * @return true when the code verified and MFA was enabled
+   */
+  public static boolean confirmEnrollment(User user, String code) {
+    if (user == null || StringUtils.isBlank(user.getMfaSecret())) {
+      return false;
+    }
+    if (!TotpCommand.verifyCode(user.getMfaSecret(), code)) {
+      LOG.debug("MFA enrollment code did not verify for user: " + user.getId());
+      return false;
+    }
+    UserRepository.enableMfa(user);
+    return true;
+  }
+
+  /**
+   * Turns MFA off for a user and clears the stored secret.
+   *
+   * @param user the user
+   */
+  public static void disable(User user) {
+    UserRepository.disableMfa(user);
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/User.java
+++ b/src/main/java/com/simisinc/platform/domain/model/User.java
@@ -52,6 +52,8 @@ public class User extends Entity {
   private double longitude = 0.0;
 
   private boolean enabled = false;
+  private String mfaSecret = null;
+  private boolean mfaEnabled = false;
   private String accountToken = null;
   private Timestamp validated = null;
   private long createdBy = -1;
@@ -237,6 +239,22 @@ public class User extends Entity {
 
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public String getMfaSecret() {
+    return mfaSecret;
+  }
+
+  public void setMfaSecret(String mfaSecret) {
+    this.mfaSecret = mfaSecret;
+  }
+
+  public boolean getMfaEnabled() {
+    return mfaEnabled;
+  }
+
+  public void setMfaEnabled(boolean mfaEnabled) {
+    this.mfaEnabled = mfaEnabled;
   }
 
   public String getAccountToken() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -417,6 +417,52 @@ public class UserRepository {
     return null;
   }
 
+  public static User saveMfaSecret(User record, String secret) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("mfa_secret", secret)
+        .add("mfa_enabled", false)
+        .add("modified", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("user_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      record.setMfaSecret(secret);
+      record.setMfaEnabled(false);
+      return record;
+    }
+    LOG.error("saveMfaSecret failed!");
+    return null;
+  }
+
+  public static User enableMfa(User record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("mfa_enabled", true)
+        .add("modified", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("user_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      record.setMfaEnabled(true);
+      return record;
+    }
+    LOG.error("enableMfa failed!");
+    return null;
+  }
+
+  public static User disableMfa(User record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("mfa_secret", (String) null)
+        .add("mfa_enabled", false)
+        .add("modified", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("user_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      record.setMfaSecret(null);
+      record.setMfaEnabled(false);
+      return record;
+    }
+    LOG.error("disableMfa failed!");
+    return null;
+  }
+
   // Remove
   public static boolean remove(User record) {
     try {
@@ -471,6 +517,8 @@ public class UserRepository {
       record.setPostalCode(rs.getString("postal_code"));
       record.setLatitude(rs.getDouble("latitude"));
       record.setLongitude(rs.getDouble("longitude"));
+      record.setMfaSecret(rs.getString("mfa_secret"));
+      record.setMfaEnabled(rs.getBoolean("mfa_enabled"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
@@ -29,4 +29,5 @@ public class SessionConstants {
   public static final String CAPTCHA_TEXT = "captchaText";
   public static final String OAUTH_USER_TOKEN = "oauthUserToken";
   public static final String OAUTH_USER_EXPIRATION_TIME = "oauthUserExpiration";
+  public static final String MFA_PENDING_USER_ID = "mfaPendingUserId";
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -20,11 +20,13 @@ import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
+import com.simisinc.platform.application.login.TotpCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.domain.model.login.UserLogin;
 import com.simisinc.platform.domain.model.login.UserToken;
 import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
 import com.simisinc.platform.presentation.controller.CookieConstants;
@@ -36,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.security.auth.login.LoginException;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpSession;
 import java.sql.Timestamp;
 import java.util.UUID;
 
@@ -60,18 +63,36 @@ public class LoginWidget extends GenericWidget {
     if (OAuthRequestCommand.isEnabled()) {
       context.getRequest().setAttribute("oAuthProvider", LoadSitePropertyCommand.loadByName("oauth.provider"));
     }
+    // If a user passed the password check and is waiting to enter an MFA code, show that prompt
+    if (context.getRequest().getSession().getAttribute(SessionConstants.MFA_PENDING_USER_ID) != null) {
+      context.getRequest().setAttribute("mfaRequired", "true");
+    }
     context.setJsp(JSP);
     return context;
   }
 
   public WidgetContext post(WidgetContext context) {
 
-    // Populate the fields
+    boolean stayLoggedIn = "on".equals(context.getParameter("stayLoggedIn"));
+    HttpSession httpSession = context.getRequest().getSession();
+
+    // Second step: a user who already passed the password check is submitting their MFA code
+    Long mfaPendingUserId = (Long) httpSession.getAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    if (mfaPendingUserId != null) {
+      User user = UserRepository.findByUserId(mfaPendingUserId);
+      String code = context.getParameter("code");
+      if (user == null || !user.getMfaEnabled() || !TotpCommand.verifyCode(user.getMfaSecret(), code)) {
+        context.setErrorMessage("The authentication code was invalid. Please try again.");
+        context.getRequest().setAttribute("mfaRequired", "true");
+        return context;
+      }
+      httpSession.removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+      return finalizeLogin(context, user, stayLoggedIn);
+    }
+
+    // First step: verify the email and password
     String email = context.getParameter("email");
     String password = context.getParameter("password");
-    boolean stayLoggedIn = "on".equals(context.getParameter("stayLoggedIn"));
-
-    // Attempt the login
     User user = null;
     try {
       if (StringUtils.isBlank(email) || StringUtils.isBlank(password)) {
@@ -83,12 +104,20 @@ public class LoginWidget extends GenericWidget {
       return context;
     }
 
+    // If MFA is enabled, do not establish the session yet -- hold the login and require a valid code first
+    if (user.getMfaEnabled() && StringUtils.isNotBlank(user.getMfaSecret())) {
+      httpSession.setAttribute(SessionConstants.MFA_PENDING_USER_ID, user.getId());
+      context.getRequest().setAttribute("mfaRequired", "true");
+      return context;
+    }
+
+    return finalizeLogin(context, user, stayLoggedIn);
+  }
+
+  private WidgetContext finalizeLogin(WidgetContext context, User user, boolean stayLoggedIn) {
+
     // Update the user's session
     UserSession userSession = (UserSession) context.getRequest().getSession().getAttribute(SessionConstants.USER);
-    if (user.getTimeZone() != null) {
-      // Override the system timezone for this user session
-//      Config.set(context.getRequest(), Config.FMT_TIME_ZONE, user.getTimeZone());
-    }
     userSession.login(user);
 
     // Track the login

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -303,7 +303,9 @@ CREATE TABLE users (
   description_text TEXT,
   image_url VARCHAR(255),
   video_url VARCHAR(255),
-  field_values JSONB
+  field_values JSONB,
+  mfa_secret VARCHAR(64),
+  mfa_enabled BOOLEAN DEFAULT false
 );
 CREATE UNIQUE INDEX users_lc_email ON users (LOWER(email));
 CREATE UNIQUE INDEX users_lc_username ON users (LOWER(username));

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
@@ -1,0 +1,3 @@
+-- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag
+ALTER TABLE users ADD mfa_secret VARCHAR(64);
+ALTER TABLE users ADD mfa_enabled BOOLEAN DEFAULT false;

--- a/src/main/webapp/WEB-INF/jsp/login/login-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/login-form.jsp
@@ -33,20 +33,32 @@
   <%@include file="../page_messages.jspf" %>
   <div class="grid-x grid-margin-x">
     <div class="small-12 cell">
-      <label>Email
-        <input name="email" type="text" placeholder="Email" required>
-      </label>
-      <label>Password
-        <input name="password" type="password" placeholder="Password" autocomplete="off" required>
-      </label>
-      <p class="help-text text-right">
-        <a href="${ctx}/forgot-password">Forgot password</a>
-      </p>
-      <p><input type="submit" class="button primary radius expanded" value="Sign In"></input></p>
-      <c:if test="${!empty oAuthProvider}">
-        <p><a href="${ctx}/" class="button secondary radius expanded">Login with <c:out value="${oAuthProvider}" /></a></p>
-      </c:if>
-      <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+      <c:choose>
+        <c:when test="${mfaRequired eq 'true'}">
+          <p>Enter the 6-digit code from your authenticator app.</p>
+          <label>Authentication code
+            <input name="code" type="text" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" placeholder="123456" autofocus required>
+          </label>
+          <p><input type="submit" class="button primary radius expanded" value="Verify"></input></p>
+          <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+        </c:when>
+        <c:otherwise>
+          <label>Email
+            <input name="email" type="text" placeholder="Email" required>
+          </label>
+          <label>Password
+            <input name="password" type="password" placeholder="Password" autocomplete="off" required>
+          </label>
+          <p class="help-text text-right">
+            <a href="${ctx}/forgot-password">Forgot password</a>
+          </p>
+          <p><input type="submit" class="button primary radius expanded" value="Sign In"></input></p>
+          <c:if test="${!empty oAuthProvider}">
+            <p><a href="${ctx}/" class="button secondary radius expanded">Login with <c:out value="${oAuthProvider}" /></a></p>
+          </c:if>
+          <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+        </c:otherwise>
+      </c:choose>
     </div>
   </div>
 </form>

--- a/src/test/java/com/simisinc/platform/application/login/UserMfaCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/UserMfaCommandTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class UserMfaCommandTest {
+
+  private static User userWithSecret(String secret) {
+    User user = new User();
+    user.setId(7L);
+    user.setEmail("user@example.com");
+    user.setMfaSecret(secret);
+    return user;
+  }
+
+  @Test
+  void startEnrollmentStoresSecretAndReturnsUri() {
+    User user = new User();
+    user.setId(7L);
+    user.setEmail("user@example.com");
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName("site.name")).thenReturn("Test Site");
+
+      String uri = UserMfaCommand.startEnrollment(user);
+
+      assertTrue(uri.startsWith("otpauth://totp/Test%20Site:user%40example.com?"), uri);
+      assertTrue(uri.contains("secret="));
+      repo.verify(() -> UserRepository.saveMfaSecret(eq(user), anyString()));
+    }
+  }
+
+  @Test
+  void confirmEnrollmentAcceptsAValidCodeAndEnables() {
+    String secret = TotpCommand.generateSecret();
+    User user = userWithSecret(secret);
+    String valid = TotpCommand.generateCode(secret, Instant.now().getEpochSecond() / 30L);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.enableMfa(user)).thenReturn(user);
+
+      assertTrue(UserMfaCommand.confirmEnrollment(user, valid));
+      repo.verify(() -> UserRepository.enableMfa(user));
+    }
+  }
+
+  @Test
+  void confirmEnrollmentRejectsAWrongCode() {
+    String secret = TotpCommand.generateSecret();
+    User user = userWithSecret(secret);
+    String valid = TotpCommand.generateCode(secret, Instant.now().getEpochSecond() / 30L);
+    String wrong = valid.equals("000000") ? "111111" : "000000";
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      assertFalse(UserMfaCommand.confirmEnrollment(user, wrong));
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void confirmEnrollmentRejectsWhenNoSecretIsPending() {
+    assertFalse(UserMfaCommand.confirmEnrollment(new User(), "123456"));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.login;
+
+import javax.security.auth.login.LoginException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.login.AuthenticateLoginCommand;
+import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
+import com.simisinc.platform.presentation.controller.SessionConstants;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the two-step login gate: a correct password alone must not establish a session when MFA is enabled, an
+ * invalid code is rejected, a valid code completes the login, and accounts without MFA sign in as before.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class LoginWidgetTest extends WidgetBase {
+
+  // RFC 6238 reference secret; the value is irrelevant here because code verification is stubbed.
+  private static final String SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+  private static User mfaUser(long id) {
+    User user = new User();
+    user.setId(id);
+    user.setMfaEnabled(true);
+    user.setMfaSecret(SECRET);
+    return user;
+  }
+
+  @Test
+  void passwordAloneDoesNotAuthenticateWhenMfaIsEnabled() {
+    addQueryParameter(widgetContext, "email", "admin@example.com");
+    addQueryParameter(widgetContext, "password", "correct-horse-battery");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenReturn(mfaUser(42L));
+      widget.post(widgetContext);
+    }
+
+    // Held for MFA: the pending marker points at this user and the form is told to ask for a code.
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
+    // Critically, no session was established -- no landing-page redirect and no auth cookie.
+    Assertions.assertNull(widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void invalidMfaCodeIsRejectedAndDoesNotAuthenticate() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    addQueryParameter(widgetContext, "code", "000000");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      widget.post(widgetContext);
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
+    // Still pending: the marker is not cleared, and nothing was established.
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertNull(widgetContext.getRedirect());
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void validMfaCodeCompletesTheLogin() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.USER, new UserSession()); // finalizeLogin logs into this
+    addQueryParameter(widgetContext, "code", "123456");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // Logged in: pending marker cleared (removeAttribute is called), redirected, auth cookie set, no error.
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void userWithoutMfaLogsInDirectly() {
+    addQueryParameter(widgetContext, "email", "user@example.com");
+    addQueryParameter(widgetContext, "password", "hunter2hunter2");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    session.setAttribute(SessionConstants.USER, new UserSession());
+
+    User user = new User();
+    user.setId(7L);
+    user.setMfaEnabled(false);
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenReturn(user);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // No MFA -> straight to a logged-in session, never held for a code.
+    Assertions.assertNull(session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void badPasswordShowsAnErrorAndDoesNotAuthenticate() {
+    addQueryParameter(widgetContext, "email", "user@example.com");
+    addQueryParameter(widgetContext, "password", "wrong");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenThrow(new LoginException("Your sign in was incorrect"));
+      widget.post(widgetContext);
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertNull(widgetContext.getRedirect());
+    Assertions.assertNull(session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    verify(response, never()).addCookie(any());
+  }
+}


### PR DESCRIPTION
## What

Second MFA slice, **stacked on #89** (the TOTP primitive). Adds the data layer and enrollment logic; the live login flow is still untouched.

- **Schema** — `mfa_secret` and `mfa_enabled` on `users`, added to the install schema (`NEW_10000`) *and* as an upgrade migration for existing databases (`UPGRADE_20260717.1000__user_mfa.sql`). Fresh installs get the columns from install; existing databases get them from the upgrade.
- **Model + repository** — `User` carries the two fields; `UserRepository` reads them in `buildRecord` and adds targeted `saveMfaSecret` / `enableMfa` / `disableMfa` updates that mirror the existing `suspendAccount` / `restoreAccount` pattern.
- **`UserMfaCommand`** — `startEnrollment` generates and stores a secret and returns the `otpauth://` URI; `confirmEnrollment` verifies a code and enables MFA; `disable` clears it.

## Verified

- Compile, checkstyle, and the **full test suite** pass on JDK 17.
- Four new command tests pass (valid code enables; wrong code and missing secret are rejected; enrollment returns the URI and stores the secret).
- **Migration exercised in a running container**: a fresh boot comes up healthy with both columns present, and applying the upgrade migration re-adds them on a database that lacked them.

## Note

Base is `feature/mfa-totp-core` (#89) so the diff shows only this slice. Retarget to `main` once #89 merges.

## Next slice

Login integration — prompt for the code after password auth when `mfa_enabled` is set — then recovery codes.