### PR TITLE
MFA: require a code at login when enabled

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
@@ -29,4 +29,5 @@ public class SessionConstants {
   public static final String CAPTCHA_TEXT = "captchaText";
   public static final String OAUTH_USER_TOKEN = "oauthUserToken";
   public static final String OAUTH_USER_EXPIRATION_TIME = "oauthUserExpiration";
+  public static final String MFA_PENDING_USER_ID = "mfaPendingUserId";
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -20,11 +20,13 @@ import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
+import com.simisinc.platform.application.login.TotpCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.domain.model.login.UserLogin;
 import com.simisinc.platform.domain.model.login.UserToken;
 import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
 import com.simisinc.platform.presentation.controller.CookieConstants;
@@ -36,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.security.auth.login.LoginException;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpSession;
 import java.sql.Timestamp;
 import java.util.UUID;
 
@@ -60,18 +63,36 @@ public class LoginWidget extends GenericWidget {
     if (OAuthRequestCommand.isEnabled()) {
       context.getRequest().setAttribute("oAuthProvider", LoadSitePropertyCommand.loadByName("oauth.provider"));
     }
+    // If a user passed the password check and is waiting to enter an MFA code, show that prompt
+    if (context.getRequest().getSession().getAttribute(SessionConstants.MFA_PENDING_USER_ID) != null) {
+      context.getRequest().setAttribute("mfaRequired", "true");
+    }
     context.setJsp(JSP);
     return context;
   }
 
   public WidgetContext post(WidgetContext context) {
 
-    // Populate the fields
+    boolean stayLoggedIn = "on".equals(context.getParameter("stayLoggedIn"));
+    HttpSession httpSession = context.getRequest().getSession();
+
+    // Second step: a user who already passed the password check is submitting their MFA code
+    Long mfaPendingUserId = (Long) httpSession.getAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    if (mfaPendingUserId != null) {
+      User user = UserRepository.findByUserId(mfaPendingUserId);
+      String code = context.getParameter("code");
+      if (user == null || !user.getMfaEnabled() || !TotpCommand.verifyCode(user.getMfaSecret(), code)) {
+        context.setErrorMessage("The authentication code was invalid. Please try again.");
+        context.getRequest().setAttribute("mfaRequired", "true");
+        return context;
+      }
+      httpSession.removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+      return finalizeLogin(context, user, stayLoggedIn);
+    }
+
+    // First step: verify the email and password
     String email = context.getParameter("email");
     String password = context.getParameter("password");
-    boolean stayLoggedIn = "on".equals(context.getParameter("stayLoggedIn"));
-
-    // Attempt the login
     User user = null;
     try {
       if (StringUtils.isBlank(email) || StringUtils.isBlank(password)) {
@@ -83,12 +104,20 @@ public class LoginWidget extends GenericWidget {
       return context;
     }
 
+    // If MFA is enabled, do not establish the session yet -- hold the login and require a valid code first
+    if (user.getMfaEnabled() && StringUtils.isNotBlank(user.getMfaSecret())) {
+      httpSession.setAttribute(SessionConstants.MFA_PENDING_USER_ID, user.getId());
+      context.getRequest().setAttribute("mfaRequired", "true");
+      return context;
+    }
+
+    return finalizeLogin(context, user, stayLoggedIn);
+  }
+
+  private WidgetContext finalizeLogin(WidgetContext context, User user, boolean stayLoggedIn) {
+
     // Update the user's session
     UserSession userSession = (UserSession) context.getRequest().getSession().getAttribute(SessionConstants.USER);
-    if (user.getTimeZone() != null) {
-      // Override the system timezone for this user session
-//      Config.set(context.getRequest(), Config.FMT_TIME_ZONE, user.getTimeZone());
-    }
     userSession.login(user);
 
     // Track the login

--- a/src/main/webapp/WEB-INF/jsp/login/login-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/login-form.jsp
@@ -33,20 +33,32 @@
   <%@include file="../page_messages.jspf" %>
   <div class="grid-x grid-margin-x">
     <div class="small-12 cell">
-      <label>Email
-        <input name="email" type="text" placeholder="Email" required>
-      </label>
-      <label>Password
-        <input name="password" type="password" placeholder="Password" autocomplete="off" required>
-      </label>
-      <p class="help-text text-right">
-        <a href="${ctx}/forgot-password">Forgot password</a>
-      </p>
-      <p><input type="submit" class="button primary radius expanded" value="Sign In"></input></p>
-      <c:if test="${!empty oAuthProvider}">
-        <p><a href="${ctx}/" class="button secondary radius expanded">Login with <c:out value="${oAuthProvider}" /></a></p>
-      </c:if>
-      <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+      <c:choose>
+        <c:when test="${mfaRequired eq 'true'}">
+          <p>Enter the 6-digit code from your authenticator app.</p>
+          <label>Authentication code
+            <input name="code" type="text" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" placeholder="123456" autofocus required>
+          </label>
+          <p><input type="submit" class="button primary radius expanded" value="Verify"></input></p>
+          <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+        </c:when>
+        <c:otherwise>
+          <label>Email
+            <input name="email" type="text" placeholder="Email" required>
+          </label>
+          <label>Password
+            <input name="password" type="password" placeholder="Password" autocomplete="off" required>
+          </label>
+          <p class="help-text text-right">
+            <a href="${ctx}/forgot-password">Forgot password</a>
+          </p>
+          <p><input type="submit" class="button primary radius expanded" value="Sign In"></input></p>
+          <c:if test="${!empty oAuthProvider}">
+            <p><a href="${ctx}/" class="button secondary radius expanded">Login with <c:out value="${oAuthProvider}" /></a></p>
+          </c:if>
+          <input id="stay-logged-in" name="stayLoggedIn" value="on" type="checkbox" checked><label for="stay-logged-in">Stay logged in</label>
+        </c:otherwise>
+      </c:choose>
     </div>
   </div>
 </form>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.login;
+
+import javax.security.auth.login.LoginException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.login.AuthenticateLoginCommand;
+import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
+import com.simisinc.platform.presentation.controller.SessionConstants;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the two-step login gate: a correct password alone must not establish a session when MFA is enabled, an
+ * invalid code is rejected, a valid code completes the login, and accounts without MFA sign in as before.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class LoginWidgetTest extends WidgetBase {
+
+  // RFC 6238 reference secret; the value is irrelevant here because code verification is stubbed.
+  private static final String SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+  private static User mfaUser(long id) {
+    User user = new User();
+    user.setId(id);
+    user.setMfaEnabled(true);
+    user.setMfaSecret(SECRET);
+    return user;
+  }
+
+  @Test
+  void passwordAloneDoesNotAuthenticateWhenMfaIsEnabled() {
+    addQueryParameter(widgetContext, "email", "admin@example.com");
+    addQueryParameter(widgetContext, "password", "correct-horse-battery");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenReturn(mfaUser(42L));
+      widget.post(widgetContext);
+    }
+
+    // Held for MFA: the pending marker points at this user and the form is told to ask for a code.
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
+    // Critically, no session was established -- no landing-page redirect and no auth cookie.
+    Assertions.assertNull(widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void invalidMfaCodeIsRejectedAndDoesNotAuthenticate() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    addQueryParameter(widgetContext, "code", "000000");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      widget.post(widgetContext);
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
+    // Still pending: the marker is not cleared, and nothing was established.
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertNull(widgetContext.getRedirect());
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void validMfaCodeCompletesTheLogin() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.USER, new UserSession()); // finalizeLogin logs into this
+    addQueryParameter(widgetContext, "code", "123456");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // Logged in: pending marker cleared (removeAttribute is called), redirected, auth cookie set, no error.
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void userWithoutMfaLogsInDirectly() {
+    addQueryParameter(widgetContext, "email", "user@example.com");
+    addQueryParameter(widgetContext, "password", "hunter2hunter2");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    session.setAttribute(SessionConstants.USER, new UserSession());
+
+    User user = new User();
+    user.setId(7L);
+    user.setMfaEnabled(false);
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenReturn(user);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // No MFA -> straight to a logged-in session, never held for a code.
+    Assertions.assertNull(session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void badPasswordShowsAnErrorAndDoesNotAuthenticate() {
+    addQueryParameter(widgetContext, "email", "user@example.com");
+    addQueryParameter(widgetContext, "password", "wrong");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenThrow(new LoginException("Your sign in was incorrect"));
+      widget.post(widgetContext);
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertNull(widgetContext.getRedirect());
+    Assertions.assertNull(session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    verify(response, never()).addCookie(any());
+  }
+}


### PR DESCRIPTION
## What

Third MFA slice, **stacked on #90**. Wires MFA into the login flow: a user with `mfa_enabled` must enter a valid TOTP code before a session is established.

- **`LoginWidget`** — `post()` is now two-step. After the password check, if the user has MFA the session is **not** established; instead a pending user is recorded in the HTTP session and the code prompt is shown. A second submit verifies the code (`TotpCommand.verifyCode`) and only then calls the extracted `finalizeLogin()`. `execute()` shows the code prompt whenever a login is MFA-pending.
- **`SessionConstants`** — `MFA_PENDING_USER_ID`.
- **`login-form.jsp`** — renders the code prompt in place of email/password when `mfaRequired`.

The security invariant: `userSession.login(user)` (the only thing that authenticates a session) is reachable **only** with no MFA, or after a verified code — never on a password alone for an MFA user.

## Verified end-to-end in a running container

Enrolled the admin with a known secret and drove the real login over HTTP:

| Scenario | `/my-page` | Result |
|---|---|---|
| MFA user, password only | 404 | not logged in — code prompt shown |
| MFA user, wrong code | 404 | rejected |
| MFA user, valid code | **200** | logged in; pending state cleared |
| Non-MFA user, password only | **200** | logs in directly (no regression) |

The valid code was computed by an independent Python HMAC-SHA1 implementation, cross-checking the Java one. Compile, checkstyle, and the full suite pass on JDK 17; JSP precompiles with 0 errors.

## Next / follow-ups

- Recovery codes (for a lost authenticator)
- A timeout on the MFA-pending state
- Enrollment UI (the `UserMfaCommand` from #90 wired to an account-settings page with a QR)

Base is `feature/mfa-schema-enrollment` (#90); retarget to `main` as the stack merges.