### PR TITLE
MFA: recovery codes

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.persistence.login.UserMfaRecoveryCodeRepository;
+
+/**
+ * Generates and verifies multi-factor authentication recovery codes -- single-use backup codes a user falls back on
+ * when they can't produce a TOTP code (a lost or reset authenticator). Codes are high-entropy random strings stored
+ * only as SHA-256 hashes; the plaintext is returned once at generation and shown to the user, never persisted.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCodeCommand {
+
+  private static final int CODE_COUNT = 10;
+  private static final int CODE_LENGTH = 10;
+  // Unambiguous alphabet (no 0/O, 1/l/I) to avoid transcription errors; 31^10 is roughly 50 bits of entropy per code
+  private static final String ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private UserMfaRecoveryCodeCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * Replaces any existing codes with a fresh set, stores their hashes, and returns the formatted plaintext codes to
+   * show the user once.
+   *
+   * @param user the user to generate codes for
+   * @return the plaintext codes (formatted for display); the caller must show these immediately and not store them
+   */
+  public static List<String> generate(User user) {
+    UserMfaRecoveryCodeRepository.removeAll(user.getId());
+    List<String> plaintext = new ArrayList<>();
+    for (int i = 0; i < CODE_COUNT; i++) {
+      String raw = randomCode();
+      plaintext.add(format(raw));
+      UserMfaRecoveryCode record = new UserMfaRecoveryCode();
+      record.setUserId(user.getId());
+      record.setCodeHash(hash(raw));
+      UserMfaRecoveryCodeRepository.add(record);
+    }
+    return plaintext;
+  }
+
+  /**
+   * Verifies a user-supplied recovery code and, if it matches an unused code, consumes it (marks it used).
+   *
+   * @param user the user
+   * @param input the code entered by the user (formatting and case are ignored)
+   * @return true when a matching unused code was found and consumed
+   */
+  public static boolean consume(User user, String input) {
+    if (user == null || StringUtils.isBlank(input)) {
+      return false;
+    }
+    String normalized = normalize(input);
+    if (normalized.length() != CODE_LENGTH) {
+      return false;
+    }
+    UserMfaRecoveryCode match = UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(user.getId(), hash(normalized));
+    if (match == null) {
+      return false;
+    }
+    UserMfaRecoveryCodeRepository.markUsed(match);
+    return true;
+  }
+
+  /**
+   * @param user the user
+   * @return how many unused recovery codes the user has left
+   */
+  public static long countRemaining(User user) {
+    if (user == null) {
+      return 0;
+    }
+    return UserMfaRecoveryCodeRepository.countUnusedByUserId(user.getId());
+  }
+
+  /**
+   * Removes all of a user's recovery codes (for example when MFA is turned off).
+   *
+   * @param user the user
+   */
+  public static void clear(User user) {
+    if (user == null) {
+      return;
+    }
+    UserMfaRecoveryCodeRepository.removeAll(user.getId());
+  }
+
+  private static String randomCode() {
+    StringBuilder sb = new StringBuilder(CODE_LENGTH);
+    for (int i = 0; i < CODE_LENGTH; i++) {
+      sb.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+    }
+    return sb.toString();
+  }
+
+  private static String format(String raw) {
+    // Split into two halves for readability, e.g. abcde-fghij
+    int mid = raw.length() / 2;
+    return raw.substring(0, mid) + "-" + raw.substring(mid);
+  }
+
+  private static String normalize(String input) {
+    return input.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+  }
+
+  private static String hash(String normalizedCode) {
+    return DigestUtils.sha256Hex(normalizedCode);
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/login/UserMfaRecoveryCode.java
+++ b/src/main/java/com/simisinc/platform/domain/model/login/UserMfaRecoveryCode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.login;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A single multi-factor authentication recovery code for a user. Only the SHA-256 hash of the code is stored; the
+ * plaintext is shown to the user once at generation and never persisted. Each code is single-use.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCode extends Entity {
+
+  static final long serialVersionUID = 8484048371911908895L;
+
+  private long id = -1;
+  private long userId = -1;
+  private String codeHash;
+  private boolean used = false;
+  private Timestamp created;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+  }
+
+  public String getCodeHash() {
+    return codeHash;
+  }
+
+  public void setCodeHash(String codeHash) {
+    this.codeHash = codeHash;
+  }
+
+  public boolean getUsed() {
+    return used;
+  }
+
+  public void setUsed(boolean used) {
+    this.used = used;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.login;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves multi-factor authentication recovery codes. Codes are stored only as SHA-256 hashes and are
+ * looked up by hash, so verification is a single indexed query rather than a per-row comparison.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCodeRepository {
+
+  private static Log LOG = LogFactory.getLog(UserMfaRecoveryCodeRepository.class);
+
+  private static String TABLE_NAME = "user_mfa_recovery_codes";
+  private static String[] PRIMARY_KEY = new String[]{"recovery_code_id"};
+
+  public static UserMfaRecoveryCode add(UserMfaRecoveryCode record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("user_id", record.getUserId())
+        .add("code_hash", record.getCodeHash())
+        .add("used", false);
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static UserMfaRecoveryCode findUnusedByUserIdAndHash(long userId, String codeHash) {
+    if (userId < 1 || StringUtils.isBlank(codeHash)) {
+      return null;
+    }
+    return (UserMfaRecoveryCode) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils()
+            .add("user_id = ?", userId)
+            .add("code_hash = ?", codeHash)
+            .add("used = false"),
+        UserMfaRecoveryCodeRepository::buildRecord);
+  }
+
+  public static void markUsed(UserMfaRecoveryCode record) {
+    if (record == null || record.getId() < 1) {
+      return;
+    }
+    DB.update(
+        TABLE_NAME,
+        new SqlUtils().add("used", true),
+        new SqlUtils().add("recovery_code_id = ?", record.getId()));
+  }
+
+  public static long countUnusedByUserId(long userId) {
+    if (userId < 1) {
+      return 0;
+    }
+    return DB.selectCountFrom(
+        TABLE_NAME,
+        new SqlUtils()
+            .add("user_id = ?", userId)
+            .add("used = false"));
+  }
+
+  public static void removeAll(long userId) {
+    if (userId < 1) {
+      return;
+    }
+    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("user_id = ?", userId));
+  }
+
+  private static UserMfaRecoveryCode buildRecord(ResultSet rs) {
+    try {
+      UserMfaRecoveryCode record = new UserMfaRecoveryCode();
+      record.setId(rs.getLong("recovery_code_id"));
+      record.setUserId(rs.getLong("user_id"));
+      record.setCodeHash(rs.getString("code_hash"));
+      record.setUsed(rs.getBoolean("used"));
+      record.setCreated(rs.getTimestamp("created"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -21,6 +21,7 @@ import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.domain.model.login.UserLogin;
@@ -81,8 +82,12 @@ public class LoginWidget extends GenericWidget {
     if (mfaPendingUserId != null) {
       User user = UserRepository.findByUserId(mfaPendingUserId);
       String code = context.getParameter("code");
-      if (user == null || !user.getMfaEnabled() || !TotpCommand.verifyCode(user.getMfaSecret(), code)) {
-        context.setErrorMessage("The authentication code was invalid. Please try again.");
+      // Accept either a current TOTP code or a single-use recovery code
+      boolean verified = user != null && user.getMfaEnabled()
+          && (TotpCommand.verifyCode(user.getMfaSecret(), code)
+              || UserMfaRecoveryCodeCommand.consume(user, code));
+      if (!verified) {
+        context.setErrorMessage("That code was invalid. Enter a code from your authenticator app, or one of your recovery codes.");
         context.getRequest().setAttribute("mfaRequired", "true");
         return context;
       }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
@@ -16,9 +16,12 @@
 
 package com.simisinc.platform.presentation.widgets.userProfile;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -37,6 +40,8 @@ public class MyMfaSettingsWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908894L;
 
   static String JSP = "/userProfile/my-mfa-settings.jsp";
+
+  private static final String RECOVERY_CODES_FLASH = "mfaRecoveryCodesFlash";
 
   public WidgetContext execute(WidgetContext context) {
     // Require a logged in user
@@ -74,7 +79,9 @@ public class MyMfaSettingsWidget extends GenericWidget {
 
     if ("confirm".equals(action)) {
       if (UserMfaCommand.confirmEnrollment(user, context.getParameter("code"))) {
-        context.setSuccessMessage("Two-factor authentication is now on.");
+        // Enrollment done -- issue recovery codes and show them once on the redirect
+        flashRecoveryCodes(context, UserMfaRecoveryCodeCommand.generate(user));
+        context.setSuccessMessage("Two-factor authentication is now on. Save your recovery codes below.");
         context.setRedirect(context.getUri());
         return context;
       }
@@ -91,8 +98,19 @@ public class MyMfaSettingsWidget extends GenericWidget {
       return context;
     }
 
+    if ("regenerate".equals(action)) {
+      // Replace the recovery codes with a fresh set and show them once
+      if (user.getMfaEnabled()) {
+        flashRecoveryCodes(context, UserMfaRecoveryCodeCommand.generate(user));
+        context.setSuccessMessage("New recovery codes generated. Your previous codes no longer work.");
+      }
+      context.setRedirect(context.getUri());
+      return context;
+    }
+
     if ("disable".equals(action)) {
       UserMfaCommand.disable(user);
+      UserMfaRecoveryCodeCommand.clear(user);
       context.setSuccessMessage("Two-factor authentication has been turned off.");
       context.setRedirect(context.getUri());
       return context;
@@ -114,6 +132,19 @@ public class MyMfaSettingsWidget extends GenericWidget {
       context.getRequest().setAttribute("mfaSecret", user.getMfaSecret());
       context.getRequest().setAttribute("otpauthUri", UserMfaCommand.buildEnrollmentUri(user));
     }
+    if (enabled) {
+      context.getRequest().setAttribute("recoveryRemaining", UserMfaRecoveryCodeCommand.countRemaining(user));
+      // Show freshly generated recovery codes once (right after enabling or regenerating)
+      Object flashed = context.getRequest().getSession().getAttribute(RECOVERY_CODES_FLASH);
+      if (flashed != null) {
+        context.getRequest().setAttribute("recoveryCodes", flashed);
+        context.getRequest().getSession().removeAttribute(RECOVERY_CODES_FLASH);
+      }
+    }
     context.setJsp(JSP);
+  }
+
+  private void flashRecoveryCodes(WidgetContext context, List<String> codes) {
+    context.getRequest().getSession().setAttribute(RECOVERY_CODES_FLASH, codes);
   }
 }

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -425,6 +425,16 @@ CREATE TABLE user_tokens (
 );
 CREATE INDEX user_tokens_token_idx ON user_tokens(token);
 
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
+CREATE TABLE user_mfa_recovery_codes (
+  recovery_code_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT REFERENCES users(user_id) NOT NULL,
+  code_hash VARCHAR(64) NOT NULL,
+  used BOOLEAN DEFAULT false,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);
+
 CREATE TABLE oauth_tokens (
   token_id BIGSERIAL PRIMARY KEY,
   user_id BIGINT REFERENCES users(user_id) NOT NULL,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
@@ -1,3 +1,4 @@
--- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag
-ALTER TABLE users ADD mfa_secret VARCHAR(64);
-ALTER TABLE users ADD mfa_enabled BOOLEAN DEFAULT false;
+-- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag.
+-- Idempotent: on a fresh install the NEW_ script already added these columns, so guard with IF NOT EXISTS.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_secret VARCHAR(64);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN DEFAULT false;

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
@@ -1,0 +1,9 @@
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
+CREATE TABLE user_mfa_recovery_codes (
+  recovery_code_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT REFERENCES users(user_id) NOT NULL,
+  code_hash VARCHAR(64) NOT NULL,
+  used BOOLEAN DEFAULT false,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
@@ -1,9 +1,10 @@
--- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
-CREATE TABLE user_mfa_recovery_codes (
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes.
+-- Idempotent: on a fresh install the NEW_ script already created this table, so guard with IF NOT EXISTS.
+CREATE TABLE IF NOT EXISTS user_mfa_recovery_codes (
   recovery_code_id BIGSERIAL PRIMARY KEY,
   user_id BIGINT REFERENCES users(user_id) NOT NULL,
   code_hash VARCHAR(64) NOT NULL,
   used BOOLEAN DEFAULT false,
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);
+CREATE INDEX IF NOT EXISTS user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -24,6 +24,25 @@
   <%-- Two-factor authentication is ON --%>
   <c:when test="${mfaEnabled eq 'true'}">
     <p><i class="fa fa-lock"></i> Two-factor authentication is <strong>on</strong>. You'll be asked for a code from your authenticator app each time you sign in.</p>
+    <c:if test="${!empty recoveryCodes}">
+      <div class="callout warning radius">
+        <h5>Save your recovery codes</h5>
+        <p>Each code works once, for signing in when you can't use your authenticator app. Store them somewhere safe &mdash; you won't be able to see them again.</p>
+        <ul class="no-bullet mfa-recovery-codes">
+          <c:forEach items="${recoveryCodes}" var="recoveryCode">
+            <li><code><c:out value="${recoveryCode}"/></code></li>
+          </c:forEach>
+        </ul>
+      </div>
+    </c:if>
+    <p>Recovery codes remaining: <strong><c:out value="${recoveryRemaining}"/></strong></p>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="regenerate"/>
+      <input type="submit" class="button secondary radius" value="Generate new recovery codes"
+             onclick="return confirm('Replace your recovery codes? Your current codes will stop working.');"/>
+    </form>
     <form method="post">
       <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
       <input type="hidden" name="token" value="${userSession.formToken}"/>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -16,6 +16,14 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<style>
+  .mfa-recovery-codes { columns: 2; column-gap: 1.5rem; margin: .6rem 0 1rem; }
+  .mfa-recovery-codes li { break-inside: avoid; margin-bottom: .35rem; }
+  .mfa-recovery-codes li code { display: inline-block; }
+  .mfa-copy { margin: 0 0 0 .5rem; }
+  .mfa-recovery-actions { display: flex; gap: .5rem; margin-top: .3rem; }
+  .mfa-recovery-actions .button { margin: 0; }
+</style>
 <c:if test="${!empty title}">
   <h3><c:out value="${title}"/></h3>
 </c:if>
@@ -28,11 +36,15 @@
       <div class="callout warning radius">
         <h5>Save your recovery codes</h5>
         <p>Each code works once, for signing in when you can't use your authenticator app. Store them somewhere safe &mdash; you won't be able to see them again.</p>
-        <ul class="no-bullet mfa-recovery-codes">
+        <ul class="no-bullet mfa-recovery-codes" id="mfa-recovery-codes">
           <c:forEach items="${recoveryCodes}" var="recoveryCode">
             <li><code><c:out value="${recoveryCode}"/></code></li>
           </c:forEach>
         </ul>
+        <p class="mfa-recovery-actions">
+          <button type="button" class="button tiny secondary radius mfa-copy-codes">Copy all</button>
+          <button type="button" class="button tiny secondary radius mfa-download-codes">Download</button>
+        </p>
       </div>
     </c:if>
     <p>Recovery codes remaining: <strong><c:out value="${recoveryRemaining}"/></strong></p>
@@ -55,7 +67,7 @@
   <c:when test="${mfaEnrolling eq 'true'}">
     <p>Scan this code with an authenticator app (Google Authenticator, Authy, 1Password, and others), or enter the setup key by hand.</p>
     <div class="mfa-qrcode" data-otpauth="<c:out value='${otpauthUri}'/>"></div>
-    <p>Setup key: <code><c:out value="${mfaSecret}"/></code></p>
+    <p>Setup key: <code id="mfa-setup-key"><c:out value="${mfaSecret}"/></code><button type="button" class="button tiny secondary radius mfa-copy" data-copy-target="mfa-setup-key">Copy</button></p>
     <p class="show-for-small-only">
       <a href="<c:out value='${otpauthUri}'/>">Tap here to add it to an app on this device</a>
     </p>

--- a/src/main/webapp/javascript/mfa-qrcode.js
+++ b/src/main/webapp/javascript/mfa-qrcode.js
@@ -15,33 +15,116 @@
  */
 
 /*
- * Draws the two-factor enrollment QR code from the otpauth:// URI carried in the page. This is a progressive
- * enhancement: if no QR encoder library is present, the container is hidden and the user relies on the setup key and
- * the tap-to-add link shown alongside it. When a compatible encoder (the qrcode-generator API) is loaded before this
- * script, a scannable code is rendered.
+ * Interactions for the two-factor settings screen: draws the enrollment QR code from the otpauth:// URI (a
+ * progressive enhancement over the setup key and tap-to-add link), and wires the copy/download buttons for the setup
+ * key and the recovery codes. Button handling uses event delegation on the document so it works no matter when the
+ * script runs relative to the widget markup.
  */
 (function () {
   'use strict';
 
-  var container = document.querySelector('.mfa-qrcode[data-otpauth]');
-  if (!container) {
-    return;
+  // Briefly change a button's label to confirm the action
+  function flash(button, message) {
+    var original = button.getAttribute('data-label') || button.textContent;
+    button.setAttribute('data-label', original);
+    button.textContent = message;
+    setTimeout(function () { button.textContent = original; }, 1500);
   }
 
-  var uri = container.getAttribute('data-otpauth');
-  if (uri && typeof window.qrcode === 'function') {
-    try {
-      var qr = window.qrcode(0, 'M');        // type number 0 = auto-fit, error-correction level M
-      qr.addData(uri);
-      qr.make();
-      container.innerHTML = qr.createImgTag(5, 8);   // 5px modules, 8px quiet-zone margin
-      container.setAttribute('aria-label', 'Two-factor authentication setup QR code');
+  // Copy text to the clipboard, falling back to execCommand when the async API is unavailable or blocked
+  function copyToClipboard(text, button) {
+    var fallback = function () {
+      var textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+        flash(button, 'Copied');
+      } catch (e) {
+        // ignore
+      }
+      document.body.removeChild(textarea);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { flash(button, 'Copied'); }, fallback);
       return;
-    } catch (e) {
-      // Fall through and hide the empty container below
     }
+    fallback();
   }
 
-  // No encoder available (or rendering failed): hide the empty box; the setup key remains usable.
-  container.style.display = 'none';
+  // Collect the recovery codes shown on the page, one per line
+  function recoveryCodesText() {
+    var list = document.getElementById('mfa-recovery-codes');
+    if (!list) {
+      return '';
+    }
+    return Array.prototype.slice.call(list.querySelectorAll('code'))
+      .map(function (code) { return code.textContent.trim(); })
+      .join('\n');
+  }
+
+  function downloadRecoveryCodes(button) {
+    var blob = new Blob([recoveryCodesText() + '\n'], { type: 'text/plain' });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement('a');
+    link.href = url;
+    link.download = 'simis-cms-recovery-codes.txt';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    flash(button, 'Downloaded');
+  }
+
+  // One delegated click handler for every button on the screen
+  document.addEventListener('click', function (event) {
+    var copyKey = event.target.closest('.mfa-copy[data-copy-target]');
+    if (copyKey) {
+      var target = document.getElementById(copyKey.getAttribute('data-copy-target'));
+      if (target) {
+        copyToClipboard(target.textContent.trim(), copyKey);
+      }
+      return;
+    }
+    var copyCodes = event.target.closest('.mfa-copy-codes');
+    if (copyCodes) {
+      copyToClipboard(recoveryCodesText(), copyCodes);
+      return;
+    }
+    var download = event.target.closest('.mfa-download-codes');
+    if (download) {
+      downloadRecoveryCodes(download);
+    }
+  });
+
+  // Draw the enrollment QR code, if the encoder library is loaded
+  function renderQrCode() {
+    var container = document.querySelector('.mfa-qrcode[data-otpauth]');
+    if (!container) {
+      return;
+    }
+    var uri = container.getAttribute('data-otpauth');
+    if (uri && typeof window.qrcode === 'function') {
+      try {
+        var qr = window.qrcode(0, 'M');        // type number 0 = auto-fit, error-correction level M
+        qr.addData(uri);
+        qr.make();
+        container.innerHTML = qr.createImgTag(5, 8);   // 5px modules, 8px quiet-zone margin
+        container.setAttribute('aria-label', 'Two-factor authentication setup QR code');
+        return;
+      } catch (e) {
+        // Fall through and hide the empty container below
+      }
+    }
+    container.style.display = 'none';
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', renderQrCode);
+  } else {
+    renderQrCode();
+  }
 })();

--- a/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.persistence.login.UserMfaRecoveryCodeRepository;
+
+/**
+ * Tests recovery-code generation, verification, and lifecycle. The repository (database) layer is mocked; the command's
+ * hashing and normalization are exercised for real.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class UserMfaRecoveryCodeCommandTest {
+
+  private static User user(long id) {
+    User user = new User();
+    user.setId(id);
+    return user;
+  }
+
+  @Test
+  void generateReturnsTenUniqueFormattedCodesAndStoresThem() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      List<String> codes = UserMfaRecoveryCodeCommand.generate(user(1L));
+
+      assertEquals(10, codes.size());
+      for (String code : codes) {
+        assertEquals(11, code.length(), code); // five chars, a dash, five chars
+        assertEquals('-', code.charAt(5), code);
+      }
+      assertEquals(10, codes.stream().distinct().count(), "codes should be unique");
+      // A fresh set replaces any prior codes, and each code is stored
+      repo.verify(() -> UserMfaRecoveryCodeRepository.removeAll(1L));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.add(any()), times(10));
+    }
+  }
+
+  @Test
+  void consumeAcceptsAMatchingCodeIgnoringCaseAndDashes() {
+    UserMfaRecoveryCode stored = new UserMfaRecoveryCode();
+    stored.setId(5L);
+    String expectedHash = DigestUtils.sha256Hex("abcdefghij"); // the normalized form of the code below
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+
+      // The same code, typed with a dash and in upper case, both normalize to the stored hash
+      assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "abcde-fghij"));
+      assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "ABCDEFGHIJ"));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.markUsed(stored), times(2));
+    }
+  }
+
+  @Test
+  void consumeRejectsAnUnknownCode() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(anyLong(), anyString())).thenReturn(null);
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "zzzzz-zzzzz"));
+    }
+  }
+
+  @Test
+  void consumeRejectsBlankOrWrongLengthWithoutQueryingTheDatabase() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), ""));
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), null));
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "123456")); // a TOTP code, not a recovery code
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void clearRemovesAllCodes() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      UserMfaRecoveryCodeCommand.clear(user(1L));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.removeAll(1L));
+    }
+  }
+
+  @Test
+  void countRemainingDelegatesToRepository() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.countUnusedByUserId(1L)).thenReturn(7L);
+      assertEquals(7L, UserMfaRecoveryCodeCommand.countRemaining(user(1L)));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
@@ -90,9 +91,11 @@ class LoginWidgetTest extends WidgetBase {
 
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
-        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class)) {
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(false);
       widget.post(widgetContext);
     }
 
@@ -122,6 +125,33 @@ class LoginWidgetTest extends WidgetBase {
     }
 
     // Logged in: pending marker cleared (removeAttribute is called), redirected, auth cookie set, no error.
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void validRecoveryCodeCompletesTheLogin() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.USER, new UserSession());
+    addQueryParameter(widgetContext, "code", "abcde-fghij");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      // TOTP fails, but a recovery code is accepted
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // A valid recovery code completes the login just like a TOTP code
     verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
     Assertions.assertEquals("/my-page", widgetContext.getRedirect());
     Assertions.assertNull(widgetContext.getErrorMessage());

--- a/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
@@ -16,12 +16,15 @@
 
 package com.simisinc.platform.presentation.widgets.userProfile;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 
@@ -77,13 +80,16 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     user.setId(1L);
     user.setMfaEnabled(true);
     user.setMfaSecret(SECRET);
-    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.countRemaining(user)).thenReturn(8L);
       new MyMfaSettingsWidget().execute(widgetContext);
     }
     Assertions.assertEquals("true", request.getAttribute("mfaEnabled"));
     // Enabled means enrollment is finished, not in progress.
     Assertions.assertEquals("false", request.getAttribute("mfaEnrolling"));
+    Assertions.assertEquals(8L, request.getAttribute("recoveryRemaining"));
   }
 
   @Test
@@ -109,10 +115,14 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     User user = new User();
     user.setId(1L);
     try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
-        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
       mfa.when(() -> UserMfaCommand.confirmEnrollment(user, "123456")).thenReturn(true);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.generate(user)).thenReturn(List.of("abcde-fghij", "klmno-pqrst"));
       new MyMfaSettingsWidget().post(widgetContext);
+      // Enabling MFA issues recovery codes
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.generate(user));
     }
     Assertions.assertEquals("/my-account", widgetContext.getRedirect());
     Assertions.assertNotNull(widgetContext.getSuccessMessage());
@@ -148,10 +158,31 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     user.setId(1L);
     user.setMfaEnabled(true);
     try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
-        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
       new MyMfaSettingsWidget().post(widgetContext);
       mfa.verify(() -> UserMfaCommand.disable(user));
+      // Turning off MFA also clears the recovery codes
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(user));
+    }
+    Assertions.assertEquals("/my-account", widgetContext.getRedirect());
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+  }
+
+  @Test
+  void postRegenerateReplacesCodesAndRedirects() {
+    addQueryParameter(widgetContext, "action", "regenerate");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.generate(user)).thenReturn(List.of("abcde-fghij"));
+      new MyMfaSettingsWidget().post(widgetContext);
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.generate(user));
     }
     Assertions.assertEquals("/my-account", widgetContext.getRedirect());
     Assertions.assertNotNull(widgetContext.getSuccessMessage());


### PR DESCRIPTION
Single-use recovery codes so a lost or reset authenticator doesn't lock a user out of their account. Stacked on #93.

**Behavior**
- **On enable** — ten recovery codes are generated and shown **once** (a session flash on the redirect); only their SHA-256 hashes are stored.
- **At login** — a recovery code is accepted in place of a TOTP code and is consumed (single-use). Codes are case- and dash-insensitive.
- **Manage** — the account screen shows how many codes remain and offers "Generate new recovery codes" (invalidates the old set).
- **On disable** — all codes are cleared.

**Pieces**
- `user_mfa_recovery_codes` table — fresh-install (`NEW_10000`) and upgrade (`UPGRADE_20260717.2000`) migrations.
- `UserMfaRecoveryCode` model, `UserMfaRecoveryCodeRepository` (hash-indexed lookup — one query, not per-row), `UserMfaRecoveryCodeCommand` (generate / consume / countRemaining / clear).
- Login gate (`LoginWidget`) accepts a recovery code; enrollment screen issues, displays, counts, and regenerates them.

**Security notes**
- Codes are high-entropy random (unambiguous alphabet), stored only as SHA-256 hashes — stronger than the existing plaintext `user_tokens`.
- A 6-digit TOTP can't be mistaken for a code (length check short-circuits before any DB lookup).

**Tests** — 6 command cases + recovery-code login + regenerate/clear widget cases. Full MFA suite (31) green.

Base is `feature/mfa-enrollment-ui`; retargets to `main` as the stack merges.