### PR TITLE
Limit GITHUB_TOKEN permissions in the Java CI workflow

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - name: Set up JDK


### PR DESCRIPTION
Adds an explicit least-privilege `permissions: { contents: read }` block to the `build` job in `ant.yml`, resolving the CodeQL **actions/missing-workflow-permissions** finding. The workflow only checks out and builds, so read access is sufficient.