### PR TITLE
Parameterize geo-search region + verify remaining CodeQL core-infra findings

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -429,13 +429,12 @@ public class ItemRepository {
           }
           if (ValidateGeoRegion.isValidWorldCitiesRegion(region)) {
             // Use the region
-            // @todo the region is validated because a prepared statement is needed
             if (specification.getWithinMeters() > 0) {
-              //              where.add("ST_DWithin(geom::geography, (SELECT geom::geography FROM world_cities WHERE city = ? AND region = '" + region + "' ORDER BY population DESC LIMIT 1), " + specification.getWithinMeters() + ")", city);
+              //              where.add("ST_DWithin(geom::geography, (SELECT geom::geography FROM world_cities WHERE city = ? AND region = ? ORDER BY population DESC LIMIT 1), " + specification.getWithinMeters() + ")", new String[]{city, region});
             }
-            // Override the order by for closest first
-            orderBy.add("geom <-> (SELECT geom FROM world_cities WHERE city = ? AND region = '" + region
-                + "' ORDER BY population DESC LIMIT 1)", city);
+            // Override the order by for closest first; city and region are bound parameters, not concatenated into SQL
+            orderBy.add("geom <-> (SELECT geom FROM world_cities WHERE city = ? AND region = ? ORDER BY population DESC LIMIT 1)",
+                new String[]{city, region});
           } else {
             // Just use the city
             if (specification.getWithinMeters() > 0) {


### PR DESCRIPTION
Verifies the remaining "core-infra" CodeQL findings (SQL-injection, response-splitting, open-redirect) and fixes the one that's genuine.

## Fixed
**`ItemRepository` geo-search** — the world-cities search concatenated the user-supplied `region` into the SQL WHERE (`region = '<region>'`), relying on a character whitelist for safety. The original code even carried a `@todo ... a prepared statement is needed`. Now `city` and `region` are both bound parameters. This is the one genuine source behind the `DB.java` `java/sql-injection` sink findings.

## Verified as false-positive / already-mitigated (no change)
- **`DB.java` sql-injection (the two sinks)** — the layer binds values via `PreparedStatement` (`prepareValues`); the other flows are **numeric** concatenations (`total_qty + qty`, `file_count + n`, `IN(<Long ids>)`, `INTERVAL 'N days'`) which can't carry SQL syntax, or already parameterized (`ProductRepository` IN-clause). Only the region concatenation above was real.
- **Open-redirect (`WebRequestFilter` #86)** — already mitigated by #83: when the host isn't on the allow-list, the SSL redirect uses the configured `site.url` + a sanitized path, not the client `Host` header. The redirect map and OAuth targets are server-config, not user input.
- **Response-splitting (4)** — the header/redirect sources are server-config or validated, and the servlet container (Tomcat 9) rejects CR/LF in header values. No user-controlled CRLF reaches a header.

Based on `upstream/main`; independent of the MFA stack.