### PR TITLE
Fix DOM-based XSS in the calendar event script

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -382,14 +382,19 @@
       if (!confirm("Are you sure you want to DELETE this event?")) {
         return;
       }
-      window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + document.getElementById('id').value;
+      window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + encodeURIComponent(document.getElementById('id').value);
     }
     // Handle the modal and click event
     var eventLink = $('#eventLink');
     eventLink.on('click', function () {
       var $modal = $('#modalReveal');
       $modal.foundation('close');
-      window.location.href = document.getElementById('eventLinkInput').value;
+      // Only follow http(s) or relative links; block javascript:/data: URLs that would run as script
+      var target = document.getElementById('eventLinkInput').value.trim();
+      var scheme = target.match(/^([a-z][a-z0-9+.-]*):/i);
+      if (target && (!scheme || /^https?$/i.test(scheme[1]))) {
+        window.location.href = target;
+      }
     });
   </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -391,9 +391,15 @@
       $modal.foundation('close');
       // Only follow http(s) or relative links; block javascript:/data: URLs that would run as script
       var target = document.getElementById('eventLinkInput').value.trim();
-      var scheme = target.match(/^([a-z][a-z0-9+.-]*):/i);
-      if (target && (!scheme || /^https?$/i.test(scheme[1]))) {
-        window.location.href = target;
+      if (target) {
+        try {
+          var url = new URL(target, window.location.origin);
+          if (url.protocol === 'http:' || url.protocol === 'https:') {
+            window.location.href = url.href;
+          }
+        } catch (e) {
+          // Not a valid URL; ignore
+        }
       }
     });
   </script>


### PR DESCRIPTION
Fixes the two `js/xss-through-dom` findings in `full-calendar.jsp`.

- **Line 392 (genuine)** — the event-link click handler assigned `document.getElementById('eventLinkInput').value` straight to `window.location.href`. An event link of `javascript:...` would execute as script on navigation (DOM-based XSS). Now guarded with a scheme allowlist: only `http`/`https` or relative links are followed; `javascript:`, `data:`, etc. are blocked.
- **Line 385 (hardening)** — the delete URL appended the `id` field unescaped. The fixed path prefix prevents a `javascript:` scheme, but the value is now wrapped in `encodeURIComponent(...)` so it can't inject query parameters and the finding clears.

JSP/JavaScript only — no server code touched. Based on `upstream/main`.