### PR TITLE
Fix fresh-install crash from non-idempotent MFA migration

### DIFF
--- a/src/main/java/com/simisinc/platform/ApplicationInfo.java
+++ b/src/main/java/com/simisinc/platform/ApplicationInfo.java
@@ -32,7 +32,7 @@ public class ApplicationInfo {
   // Use: Change the date, increment the decimal on same day updates
   // then reset back to 10000
   //                         VERSION = "--------.10000";
-  public static final String VERSION = "20240106.10000";
+  public static final String VERSION = "20260717.10000";
 
   /**
    * Outputs the version from the command line

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
@@ -1,3 +1,5 @@
 -- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag
-ALTER TABLE users ADD mfa_secret VARCHAR(64);
-ALTER TABLE users ADD mfa_enabled BOOLEAN DEFAULT false;
+-- Guarded with IF NOT EXISTS: a fresh install already creates these columns in the
+-- NEW_ baseline, so this upgrade must be a no-op there rather than failing on a re-add.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_secret VARCHAR(64);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN DEFAULT false;


### PR DESCRIPTION
## Problem
The MFA schema migration is **not idempotent**, and on a **fresh install it crashes the app on second boot**.

- `NEW_10000__new_database.sql` (the fresh-install baseline) already creates `users.mfa_secret` and `users.mfa_enabled`.
- `UPGRADE_20260717.1000__user_mfa.sql` then does `ALTER TABLE users ADD mfa_secret ...` / `ADD mfa_enabled ...`.
- A fresh install baselines Flyway at `ApplicationInfo.VERSION`, which was left at `20240106.10000` — **below** the `20260717.1000` migration. So on the next boot the upgrade runs, tries to add columns that already exist, hits Postgres error `42701`, the migration fails, and the app won't start.

Existing installs upgrading from an older schema are **unaffected** (they don't have the columns yet, so the add succeeds).

## Fix
1. **Idempotent migration** — guard both statements with `ADD COLUMN IF NOT EXISTS`, so the upgrade is a no-op on fresh installs and still applies on existing ones.
2. **Baseline past it** — bump `ApplicationInfo.VERSION` to `20260717.10000` so a fresh install baselines *above* this migration and skips it entirely. This matches the documented convention in `ApplicationInfo` ("version must be greater than the new_db script dates ... reset back to 10000").

Either change alone prevents the crash; together they make the migration self-consistent at every step.

## Context
This is a follow-up on the MFA stack (#89–#94), which merged before this was caught. Found during a merge-readiness review of the batch.