### PR TITLE
Rate-limit the MFA code step to prevent brute force

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.login;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
@@ -79,9 +80,24 @@ public class LoginWidget extends GenericWidget {
     // Second step: a user who already passed the password check is submitting their MFA code
     Long mfaPendingUserId = (Long) httpSession.getAttribute(SessionConstants.MFA_PENDING_USER_ID);
     if (mfaPendingUserId != null) {
+      // Throttle guesses so the second factor cannot be brute-forced, mirroring the password step.
+      // The account is pinned by the pending user id, so key the per-account limit on that.
+      String ipAddress = context.getRequest().getRemoteAddr();
+      String rateLimitKey = "mfa:" + mfaPendingUserId;
+      if (!RateLimitCommand.isUsernameAllowedRightNow(rateLimitKey, false)
+          || (StringUtils.isNotBlank(ipAddress) && !RateLimitCommand.isIpAllowedRightNow(ipAddress, false))) {
+        context.setErrorMessage(RateLimitCommand.INVALID_ATTEMPTS);
+        context.getRequest().setAttribute("mfaRequired", "true");
+        return context;
+      }
       User user = UserRepository.findByUserId(mfaPendingUserId);
       String code = context.getParameter("code");
       if (user == null || !user.getMfaEnabled() || !TotpCommand.verifyCode(user.getMfaSecret(), code)) {
+        // Record the failed attempt so repeated guesses get locked out
+        RateLimitCommand.isUsernameAllowedRightNow(rateLimitKey, true);
+        if (StringUtils.isNotBlank(ipAddress)) {
+          RateLimitCommand.isIpAllowedRightNow(ipAddress, true);
+        }
         context.setErrorMessage("The authentication code was invalid. Please try again.");
         context.getRequest().setAttribute("mfaRequired", "true");
         return context;

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -206,7 +207,8 @@ class LoginWidgetTest extends WidgetBase {
     Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
     Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
     Assertions.assertNull(widgetContext.getRedirect());
-    verify(response, never()).addCookie(any());
+    // No session artifacts at all: the response (cookies, headers) was never touched
+    verifyNoInteractions(response);
   }
 
   @Test
@@ -233,6 +235,7 @@ class LoginWidgetTest extends WidgetBase {
     Assertions.assertNotNull(widgetContext.getErrorMessage());
     // Still pending: a bad code does not clear the gate or establish a session
     Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
-    verify(response, never()).addCookie(any());
+    // No session artifacts at all: the response (cookies, headers) was never touched
+    verifyNoInteractions(response);
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
@@ -33,8 +34,10 @@ import com.simisinc.platform.presentation.controller.SessionConstants;
 import com.simisinc.platform.presentation.controller.UserSession;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -90,9 +93,12 @@ class LoginWidgetTest extends WidgetBase {
 
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
-        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class)) {
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       widget.post(widgetContext);
     }
 
@@ -113,10 +119,13 @@ class LoginWidgetTest extends WidgetBase {
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
         MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
       widget.post(widgetContext);
     }
@@ -172,6 +181,58 @@ class LoginWidgetTest extends WidgetBase {
     Assertions.assertNotNull(widgetContext.getErrorMessage());
     Assertions.assertNull(widgetContext.getRedirect());
     Assertions.assertNull(session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void mfaCodeStepIsRateLimitedAfterTooManyAttempts() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    addQueryParameter(widgetContext, "code", "000000");
+    when(request.getRemoteAddr()).thenReturn("203.0.113.7");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class)) {
+      // The account has used up its allowance -- the limiter says "no" before any code is checked
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(eq("mfa:42"), eq(false))).thenReturn(false);
+      widget.post(widgetContext);
+
+      // A brute-forcer never even gets to a code comparison while locked out
+      totp.verify(() -> TotpCommand.verifyCode(anyString(), anyString()), never());
+    }
+
+    // Rejected with the rate-limit message; still pending; nothing established
+    Assertions.assertEquals(RateLimitCommand.INVALID_ATTEMPTS, widgetContext.getErrorMessage());
+    Assertions.assertEquals("true", request.getAttribute("mfaRequired"));
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
+    Assertions.assertNull(widgetContext.getRedirect());
+    verify(response, never()).addCookie(any());
+  }
+
+  @Test
+  void invalidMfaCodeRecordsTheFailedAttempt() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    addQueryParameter(widgetContext, "code", "000000");
+    when(request.getRemoteAddr()).thenReturn("203.0.113.7");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      widget.post(widgetContext);
+
+      // A wrong code is recorded against both the account and the IP so repeated guesses lock out
+      rateLimit.verify(() -> RateLimitCommand.isUsernameAllowedRightNow("mfa:42", true));
+      rateLimit.verify(() -> RateLimitCommand.isIpAllowedRightNow("203.0.113.7", true));
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    // Still pending: a bad code does not clear the gate or establish a session
+    Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
     verify(response, never()).addCookie(any());
   }
 }


### PR DESCRIPTION
## Problem
The login flow throttles the **password** step (`AuthenticateLoginCommand` consults `RateLimitCommand` by username and IP), but the **second factor** does not. In `LoginWidget.post()`, the MFA-pending branch calls `TotpCommand.verifyCode(...)` with **no rate limiting**.

So an attacker who already has the password (i.e. has reached the MFA-pending state) can submit **unlimited** 6-digit code guesses against that account — the second factor is brute-forceable.

## Fix
Throttle the code step the same way the password step is throttled:

- **Before** verifying, check a per-account limiter (keyed on the pending user id, `"mfa:" + id`) and the per-IP limiter. If either is exhausted, reject with the standard "Too many attempts" message — before any code comparison.
- **On an invalid code**, record the failed attempt against both limiters, so repeated guesses lock out. Existing buckets apply **5 / 30 min per account** and **10 / 30 min per IP**.

A legitimate user entering a correct code on the first try is unaffected (buckets are only created on failures). Keying the account limit on the pending user id (rather than the email) keeps it self-contained and lets the check run before the DB lookup.

## Tests
`LoginWidgetTest` gains two cases:
- `mfaCodeStepIsRateLimitedAfterTooManyAttempts` — when the limiter is exhausted, the widget rejects with the rate-limit message, stays pending, and **never calls** `TotpCommand.verifyCode`.
- `invalidMfaCodeRecordsTheFailedAttempt` — a wrong code records the attempt against both the account and the IP limiter.

The two existing MFA tests now mock `RateLimitCommand` (the cache is not started in the unit harness). Full suite passes on a clean build.

## Context
Follow-up on the MFA stack (#89–#94), which merged before this was caught. Found during a merge-readiness review of the batch.