### PR TITLE
Resolve upload temp files within the file server root

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveFilePartCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFilePartCommand.java
@@ -43,7 +43,6 @@ public class SaveFilePartCommand {
     // Prepare to save the file
     String serverRootPath = FileSystemCommand.getFileServerRootPath();
     String serverSubPath = FileSystemCommand.generateFileServerSubPath("uploads");
-    String serverCompletePath = serverRootPath + serverSubPath;
     String uniqueFilename = FileSystemCommand.generateUniqueFilename(context.getUserId());
 
     // Find the file in the request and save it
@@ -65,16 +64,20 @@ public class SaveFilePartCommand {
       LOG.debug("Found a file...");
       submittedFilename = Paths.get(filePart.getSubmittedFileName()).getFileName().toString(); // MSIE fix.
       extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(submittedFilename));
-      tempFile = new File(serverCompletePath + uniqueFilename + "." + extension);
+      // Resolve the target inside the file server root so user-derived values cannot traverse outside it
+      tempFile = FileSystemCommand.resolveWithinRoot(serverRootPath, serverSubPath + uniqueFilename + "." + extension);
+      if (tempFile == null) {
+        throw new DataException("There was an issue with the file");
+      }
 
       LOG.debug("Writing file " + fileLength + " bytes");
-      filePart.write(serverCompletePath + uniqueFilename + "." + extension);
+      filePart.write(tempFile.getAbsolutePath());
 
     } catch (Exception e) {
       LOG.warn("Could not handle file: " + e.getMessage());
       // Clean up the file
       if (tempFile != null && tempFile.exists()) {
-        LOG.warn("Deleting an uploaded file: " + serverCompletePath + uniqueFilename + "." + extension);
+        LOG.warn("Deleting an uploaded file: " + tempFile.getPath());
         tempFile.delete();
       }
       throw new DataException("There was an issue with the file");

--- a/src/main/java/com/simisinc/platform/application/items/SaveItemFilePartCommand.java
+++ b/src/main/java/com/simisinc/platform/application/items/SaveItemFilePartCommand.java
@@ -44,7 +44,6 @@ public class SaveItemFilePartCommand {
     // Prepare to save the file
     String serverRootPath = FileSystemCommand.getFileServerRootPath();
     String serverSubPath = FileSystemCommand.generateFileServerSubPath("item-uploads");
-    String serverCompletePath = serverRootPath + serverSubPath;
     String uniqueFilename = FileSystemCommand.generateUniqueFilename(context.getUserId());
 
     // Find the file in the request and save it
@@ -66,16 +65,20 @@ public class SaveItemFilePartCommand {
       LOG.debug("Found a file...");
       submittedFilename = Paths.get(filePart.getSubmittedFileName()).getFileName().toString(); // MSIE fix.
       extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(submittedFilename));
-      tempFile = new File(serverCompletePath + uniqueFilename + "." + extension);
+      // Resolve the target inside the file server root so user-derived values cannot traverse outside it
+      tempFile = FileSystemCommand.resolveWithinRoot(serverRootPath, serverSubPath + uniqueFilename + "." + extension);
+      if (tempFile == null) {
+        throw new DataException("There was an issue with the file");
+      }
 
       LOG.debug("Writing file " + fileLength + " bytes");
-      filePart.write(serverCompletePath + uniqueFilename + "." + extension);
+      filePart.write(tempFile.getAbsolutePath());
 
     } catch (Exception e) {
       LOG.warn("Could not handle file: " + e.getMessage());
       // Clean up the file
       if (tempFile != null && tempFile.exists()) {
-        LOG.warn("Deleting an uploaded file: " + serverCompletePath + uniqueFilename + "." + extension);
+        LOG.warn("Deleting an uploaded file: " + tempFile.getPath());
         tempFile.delete();
       }
       throw new DataException("There was an issue with the file");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageUploadWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageUploadWidget.java
@@ -52,7 +52,6 @@ public class ImageUploadWidget extends GenericWidget {
     // Prepare to save the file
     String serverRootPath = FileSystemCommand.getFileServerRootPath();
     String serverSubPath = FileSystemCommand.generateFileServerSubPath("images");
-    String serverCompletePath = serverRootPath + serverSubPath;
     String uniqueFilename = FileSystemCommand.generateUniqueFilename(context.getUserId());
 
     // Find the file in the request and save it
@@ -71,15 +70,20 @@ public class ImageUploadWidget extends GenericWidget {
         submittedFilename = StringUtils.replace(submittedFilename, "mceclip0", "clip");
       }
       extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(submittedFilename));
-      tempFile = new File(serverCompletePath + uniqueFilename + "." + extension);
+      // Resolve the target inside the file server root so user-derived values cannot traverse outside it
+      tempFile = FileSystemCommand.resolveWithinRoot(serverRootPath, serverSubPath + uniqueFilename + "." + extension);
+      if (tempFile == null) {
+        context.setErrorMessage("The file could not be saved");
+        return context;
+      }
       fileLength = filePart.getSize();
       if (fileLength > 0) {
-        filePart.write(serverCompletePath + uniqueFilename + "." + extension);
+        filePart.write(tempFile.getAbsolutePath());
       }
     } catch (Exception e) {
       // Clean up the file
       if (tempFile != null && tempFile.exists()) {
-        LOG.warn("Deleting an uploaded file: " + serverCompletePath + uniqueFilename + "." + extension);
+        LOG.warn("Deleting an uploaded file: " + tempFile.getPath());
         tempFile.delete();
       }
       return context;
@@ -88,7 +92,7 @@ public class ImageUploadWidget extends GenericWidget {
     // Make sure a file was processed
     if (fileLength <= 0) {
       if (tempFile.exists()) {
-        LOG.warn("Deleting an uploaded file: " + serverCompletePath + uniqueFilename + "." + extension);
+        LOG.warn("Deleting an uploaded file: " + tempFile.getPath());
         tempFile.delete();
       }
       context.setErrorMessage("The file size was 0 and could not be saved");
@@ -113,7 +117,7 @@ public class ImageUploadWidget extends GenericWidget {
     } catch (DataException e) {
       // Clean up the file
       if (tempFile.exists()) {
-        LOG.warn("Deleting an uploaded file: " + serverCompletePath + uniqueFilename);
+        LOG.warn("Deleting an uploaded file: " + tempFile.getPath());
         tempFile.delete();
       }
       context.setErrorMessage(e.getMessage());


### PR DESCRIPTION
## Problem
The three upload paths — `ImageUploadWidget`, `SaveFilePartCommand`, `SaveItemFilePartCommand` — build the save target by string concatenation, with the extension derived from the **user-supplied filename** (`Part.getSubmittedFileName()`). `cleanExtension()` strips separators, but the assembled path never goes through a containment check, so CodeQL flags every `exists()`/`delete()` on it as `java/path-injection`. These are the 10 open **high** alerts on `main` (#92–93, #102–103, #107–112).

## Fix
Construct the temp file through `FileSystemCommand.resolveWithinRoot()` — the #96 helper that normalizes the path and verifies it stays inside the file-server root, returning `null` (upload rejected) when it escapes. This is the **same call the `cleanupFile()` halves of these very classes already make** with the identical `subPath + uniqueFilename + "." + extension` string shape, so legitimate paths resolve unchanged.

- `Part.write()` now receives the resolved absolute path (same target as the previous absolute concatenation).
- Cleanup log lines report the actual resolved file (fixes one log line that omitted the extension).
- The now-unused `serverCompletePath` locals are removed.

## Verification
- Clean `ant clean` + `ci-test`: build green, full suite passes.
- Three independent adversarial review passes (behavior regression, security completeness, pattern consistency): no findings.
- Mirrors the hardening already shipped for the same sinks in the v2 codebase.

Expected effect: clears all 10 open `java/path-injection` alerts — the only confirmed-real code vulnerabilities from the post-merge CodeQL run on `main`.