### PR TITLE
Move the database image to postgres:17

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,10 +1,10 @@
 # Pull official base image
-FROM postgres:14
+FROM postgres:17
 
 # Install PostGIS
 RUN apt-get update \
     && apt-get install wget -y \
-    && apt-get install postgresql-14-postgis-3 -y \
+    && apt-get install postgresql-17-postgis-3 -y \
     && apt-get install postgis -y
 
 # Run init.sql


### PR DESCRIPTION
## Problem
The Trivy scan on the published `simis-cms-db` image reports **~126 OS-package CVEs, including 17 critical** — nearly all inherited from the `postgres:14` base image (older Debian package set + its bundled `gosu` build), not from anything in this repo. PostgreSQL 14 also reaches **end-of-life in November 2026**.

## Fix
- `docker/db/Dockerfile`: `postgres:14` → `postgres:17` and `postgresql-14-postgis-3` → `postgresql-17-postgis-3`
- Matching doc touch-ups in `docs/installation.md` and `docs/developer-environment.md`

## Verification
Built and smoke-tested locally: the image builds, the container boots, `init.sql` runs (creates the `simis-cms` database), and `CREATE EXTENSION postgis` succeeds (**PostGIS 3.6**). The publish workflow's Trivy scan will quantify the CVE reduction on the next `main` build.

## Timing note
No production deployment consumes these images yet (Azure setup pending), so a major-version jump costs nothing now — versus a `pg_upgrade` migration later. Anyone with a local dev data volume created under 14 will need to recreate it (`docker volume rm`), since postgres refuses an older data directory.