### PR TITLE
Serialize the publish workflow to prevent a :latest tag race

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -20,6 +20,13 @@ permissions:
   id-token: write         # keyless OIDC identity for build provenance
   attestations: write     # record the signed provenance attestation
 
+# Serialize publishes: without this, two overlapping runs can race and an older
+# commit's build could finish last and win the :latest tag. Queue instead of
+# cancel so an in-flight publish is never interrupted mid-push.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
Low-severity follow-up flagged in the merge-readiness review of #88.

**Problem:** the publish workflow triggers on push-to-main, releases, and manual dispatch. Two overlapping runs can race, and an older commit's build finishing last would win the `:latest` tag.

**Fix:** a workflow-level `concurrency` group with `cancel-in-progress: false` — publishes queue and run in order. Queuing (rather than cancelling) means an in-flight publish is never interrupted mid-push, and the newest commit always publishes last.