### PR TITLE
Align docs with the Java 21 and postgres 17 build

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Generate the CycloneDX SBOM

--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -16,7 +16,7 @@ The following steps will guide you through the developer tools and environment s
 1. Install [OpenJDK 21+](https://learn.microsoft.com/en-us/java/openjdk/download)
 2. Install [Apache Ant 1.10+](https://ant.apache.org) and configure your terminal's path with ANT_HOME/bin
 3. Install [Apache Tomcat 9.x](https://tomcat.apache.org/download-90.cgi) into a directory of your choice
-4. Install the PostgreSQL database server – natively on MacOS with [Postgres.app](https://postgresapp.com) or with a Docker container like (postgis/postgis:14-3.4)
+4. Install the PostgreSQL database server – natively on MacOS with [Postgres.app](https://postgresapp.com) or with a Docker container like (postgis/postgis:17-3.5)
 5. Clone the SimIS CMS repo – `git clone https://github.com/SimisRnD/simis-cms.git`
 6. In the repo directory execute `ant webapp` – this tests your environment and updates code and library changes in a working Tomcat exploded webapp directory `./out/exploded/ROOT`
 7. Open SimIS CMS in VS Code and accept the recommended extensions

--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -13,7 +13,7 @@ Developers can use [Visual Studio Code](https://code.visualstudio.com) with seve
 
 The following steps will guide you through the developer tools and environment setup so that your code changes can be compiled and copied automatically and then seen in your web browser.
 
-1. Install [OpenJDK 17+](https://learn.microsoft.com/en-us/java/openjdk/download)
+1. Install [OpenJDK 21+](https://learn.microsoft.com/en-us/java/openjdk/download)
 2. Install [Apache Ant 1.10+](https://ant.apache.org) and configure your terminal's path with ANT_HOME/bin
 3. Install [Apache Tomcat 9.x](https://tomcat.apache.org/download-90.cgi) into a directory of your choice
 4. Install the PostgreSQL database server – natively on MacOS with [Postgres.app](https://postgresapp.com) or with a Docker container like (postgis/postgis:14-3.4)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ An optimized web application archive (.war), with production settings, is releas
 
 ## System Requirements
 
-- [OpenJDK 17+](https://learn.microsoft.com/en-us/java/openjdk/download)
+- [OpenJDK 21+](https://learn.microsoft.com/en-us/java/openjdk/download)
 - [Apache Tomcat 9.0.x](https://tomcat.apache.org)
 - [PostgreSQL 14+](https://www.postgresql.org) with [PostGIS 3.2](https://postgis.net)
 - The web application and optional services have only been tested on Linux, MacOS, and Windows with WSL
@@ -25,7 +25,7 @@ An optimized web application archive (.war), with production settings, is releas
 
 ## Production Steps
 
-- Install the .war into a base container image like "tomcat:9.0-jdk17" (call it ROOT.war for a root web context)
+- Install the .war into a base container image like "tomcat:9.0-jdk21" (call it ROOT.war for a root web context)
 - Setup PostgreSQL and PostGIS using a managed service like [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) with [PostGIS extension](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.PostGIS.html); optionally use a containerized PostgreSQL like "postgres:14" and install the needed extensions
 - Create the PostgreSQL database and user credentials (the default name is "simis-cms" but it can be configured)
 - Decide on a directory location for uploaded and generated assests

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ An optimized web application archive (.war), with production settings, is releas
 ## Production Steps
 
 - Install the .war into a base container image like "tomcat:9.0-jdk21" (call it ROOT.war for a root web context)
-- Setup PostgreSQL and PostGIS using a managed service like [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) with [PostGIS extension](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.PostGIS.html); optionally use a containerized PostgreSQL like "postgres:14" and install the needed extensions
+- Setup PostgreSQL and PostGIS using a managed service like [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/) with [PostGIS extension](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.PostGIS.html); optionally use a containerized PostgreSQL like "postgres:17" and install the needed extensions
 - Create the PostgreSQL database and user credentials (the default name is "simis-cms" but it can be configured)
 - Decide on a directory location for uploaded and generated assests
 - Set the application's environment variables specific to your deployment strategy


### PR DESCRIPTION
Follow-up to #87 (Move to Java 21). Three spots still said JDK 17:

- **`sbom.yml`** — set up JDK 17. Works today only because `makeAggregateBom` analyzes the dependency tree without compiling; any future goal that compiles would fail against the 21 target. Aligned to 21.
- **`docs/installation.md`** — told installers "OpenJDK 17+" and suggested a `tomcat:9.0-jdk17` base image, while `docker/app/Dockerfile` actually ships `tomcat:9.0-jdk21`.
- **`docs/developer-environment.md`** — dev setup said "OpenJDK 17+"; the build (`build.xml` `jdk=21`) requires 21.

No behavior change today — this closes the drift before it becomes one.