### PR TITLE
Restore MFA enrollment UI + recovery codes to main (again) — #107 merged to the wrong branch

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
@@ -49,9 +49,21 @@ public class UserMfaCommand {
   public static String startEnrollment(User user) {
     String secret = TotpCommand.generateSecret();
     UserRepository.saveMfaSecret(user, secret);
+    user.setMfaSecret(secret);
+    return buildEnrollmentUri(user);
+  }
+
+  /**
+   * Builds the otpauth:// enrollment URI from the secret already stored on the user. This lets a pending enrollment be
+   * re-displayed as a QR code without generating a new secret.
+   *
+   * @param user the user with a pending (stored, not yet enabled) secret
+   * @return the otpauth:// enrollment URI
+   */
+  public static String buildEnrollmentUri(User user) {
     String issuer = StringUtils.defaultIfBlank(LoadSitePropertyCommand.loadByName("site.name"), "SimIS CMS");
     String account = StringUtils.isNotBlank(user.getEmail()) ? user.getEmail() : user.getUsername();
-    return TotpCommand.generateUri(issuer, account, secret);
+    return TotpCommand.generateUri(issuer, account, user.getMfaSecret());
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.persistence.login.UserMfaRecoveryCodeRepository;
+
+/**
+ * Generates and verifies multi-factor authentication recovery codes -- single-use backup codes a user falls back on
+ * when they can't produce a TOTP code (a lost or reset authenticator). Codes are high-entropy random strings stored
+ * only as SHA-256 hashes; the plaintext is returned once at generation and shown to the user, never persisted.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCodeCommand {
+
+  private static final int CODE_COUNT = 10;
+  private static final int CODE_LENGTH = 10;
+  // Unambiguous alphabet (no 0/O, 1/l/I) to avoid transcription errors; 31^10 is roughly 50 bits of entropy per code
+  private static final String ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private UserMfaRecoveryCodeCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * Replaces any existing codes with a fresh set, stores their hashes, and returns the formatted plaintext codes to
+   * show the user once.
+   *
+   * @param user the user to generate codes for
+   * @return the plaintext codes (formatted for display); the caller must show these immediately and not store them
+   */
+  public static List<String> generate(User user) {
+    UserMfaRecoveryCodeRepository.removeAll(user.getId());
+    List<String> plaintext = new ArrayList<>();
+    for (int i = 0; i < CODE_COUNT; i++) {
+      String raw = randomCode();
+      plaintext.add(format(raw));
+      UserMfaRecoveryCode record = new UserMfaRecoveryCode();
+      record.setUserId(user.getId());
+      record.setCodeHash(hash(raw));
+      UserMfaRecoveryCodeRepository.add(record);
+    }
+    return plaintext;
+  }
+
+  /**
+   * Verifies a user-supplied recovery code and, if it matches an unused code, consumes it (marks it used).
+   *
+   * @param user the user
+   * @param input the code entered by the user (formatting and case are ignored)
+   * @return true when a matching unused code was found and consumed
+   */
+  public static boolean consume(User user, String input) {
+    if (user == null || StringUtils.isBlank(input)) {
+      return false;
+    }
+    String normalized = normalize(input);
+    if (normalized.length() != CODE_LENGTH) {
+      return false;
+    }
+    UserMfaRecoveryCode match = UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(user.getId(), hash(normalized));
+    if (match == null) {
+      return false;
+    }
+    UserMfaRecoveryCodeRepository.markUsed(match);
+    return true;
+  }
+
+  /**
+   * @param user the user
+   * @return how many unused recovery codes the user has left
+   */
+  public static long countRemaining(User user) {
+    if (user == null) {
+      return 0;
+    }
+    return UserMfaRecoveryCodeRepository.countUnusedByUserId(user.getId());
+  }
+
+  /**
+   * Removes all of a user's recovery codes (for example when MFA is turned off).
+   *
+   * @param user the user
+   */
+  public static void clear(User user) {
+    if (user == null) {
+      return;
+    }
+    UserMfaRecoveryCodeRepository.removeAll(user.getId());
+  }
+
+  private static String randomCode() {
+    StringBuilder sb = new StringBuilder(CODE_LENGTH);
+    for (int i = 0; i < CODE_LENGTH; i++) {
+      sb.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+    }
+    return sb.toString();
+  }
+
+  private static String format(String raw) {
+    // Split into two halves for readability, e.g. abcde-fghij
+    int mid = raw.length() / 2;
+    return raw.substring(0, mid) + "-" + raw.substring(mid);
+  }
+
+  private static String normalize(String input) {
+    return input.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+  }
+
+  private static String hash(String normalizedCode) {
+    return DigestUtils.sha256Hex(normalizedCode);
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/login/UserMfaRecoveryCode.java
+++ b/src/main/java/com/simisinc/platform/domain/model/login/UserMfaRecoveryCode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.login;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A single multi-factor authentication recovery code for a user. Only the SHA-256 hash of the code is stored; the
+ * plaintext is shown to the user once at generation and never persisted. Each code is single-use.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCode extends Entity {
+
+  static final long serialVersionUID = 8484048371911908895L;
+
+  private long id = -1;
+  private long userId = -1;
+  private String codeHash;
+  private boolean used = false;
+  private Timestamp created;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+  }
+
+  public String getCodeHash() {
+    return codeHash;
+  }
+
+  public void setCodeHash(String codeHash) {
+    this.codeHash = codeHash;
+  }
+
+  public boolean getUsed() {
+    return used;
+  }
+
+  public void setUsed(boolean used) {
+    this.used = used;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.login;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves multi-factor authentication recovery codes. Codes are stored only as SHA-256 hashes and are
+ * looked up by hash, so verification is a single indexed query rather than a per-row comparison.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class UserMfaRecoveryCodeRepository {
+
+  private static Log LOG = LogFactory.getLog(UserMfaRecoveryCodeRepository.class);
+
+  private static String TABLE_NAME = "user_mfa_recovery_codes";
+  private static String[] PRIMARY_KEY = new String[]{"recovery_code_id"};
+
+  public static UserMfaRecoveryCode add(UserMfaRecoveryCode record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("user_id", record.getUserId())
+        .add("code_hash", record.getCodeHash())
+        .add("used", false);
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static UserMfaRecoveryCode findUnusedByUserIdAndHash(long userId, String codeHash) {
+    if (userId < 1 || StringUtils.isBlank(codeHash)) {
+      return null;
+    }
+    return (UserMfaRecoveryCode) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils()
+            .add("user_id = ?", userId)
+            .add("code_hash = ?", codeHash)
+            .add("used = false"),
+        UserMfaRecoveryCodeRepository::buildRecord);
+  }
+
+  public static void markUsed(UserMfaRecoveryCode record) {
+    if (record == null || record.getId() < 1) {
+      return;
+    }
+    DB.update(
+        TABLE_NAME,
+        new SqlUtils().add("used", true),
+        new SqlUtils().add("recovery_code_id = ?", record.getId()));
+  }
+
+  public static long countUnusedByUserId(long userId) {
+    if (userId < 1) {
+      return 0;
+    }
+    return DB.selectCountFrom(
+        TABLE_NAME,
+        new SqlUtils()
+            .add("user_id = ?", userId)
+            .add("used = false"));
+  }
+
+  public static void removeAll(long userId) {
+    if (userId < 1) {
+      return;
+    }
+    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("user_id = ?", userId));
+  }
+
+  private static UserMfaRecoveryCode buildRecord(ResultSet rs) {
+    try {
+      UserMfaRecoveryCode record = new UserMfaRecoveryCode();
+      record.setId(rs.getLong("recovery_code_id"));
+      record.setUserId(rs.getLong("user_id"));
+      record.setCodeHash(rs.getString("code_hash"));
+      record.setUsed(rs.getBoolean("used"));
+      record.setCreated(rs.getTimestamp("created"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -21,6 +21,7 @@ import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.domain.model.login.UserLogin;
@@ -81,8 +82,12 @@ public class LoginWidget extends GenericWidget {
     if (mfaPendingUserId != null) {
       User user = UserRepository.findByUserId(mfaPendingUserId);
       String code = context.getParameter("code");
-      if (user == null || !user.getMfaEnabled() || !TotpCommand.verifyCode(user.getMfaSecret(), code)) {
-        context.setErrorMessage("The authentication code was invalid. Please try again.");
+      // Accept either a current TOTP code or a single-use recovery code
+      boolean verified = user != null && user.getMfaEnabled()
+          && (TotpCommand.verifyCode(user.getMfaSecret(), code)
+              || UserMfaRecoveryCodeCommand.consume(user, code));
+      if (!verified) {
+        context.setErrorMessage("That code was invalid. Enter a code from your authenticator app, or one of your recovery codes.");
         context.getRequest().setAttribute("mfaRequired", "true");
         return context;
       }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.userProfile;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Lets a signed-in user manage their own two-factor authentication: turn it on by enrolling an authenticator app
+ * (scan the QR or type the key, then confirm a code) and turn it off again. The cryptography and persistence live in
+ * UserMfaCommand; this widget is the self-service screen around it.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+public class MyMfaSettingsWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/userProfile/my-mfa-settings.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    // Require a logged in user
+    if (!context.getUserSession().isLoggedIn()) {
+      return context;
+    }
+    User user = UserRepository.findByUserId(context.getUserId());
+    if (user == null) {
+      LOG.warn("Could not find current user record");
+      return context;
+    }
+    showView(context, user);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+    // Require a logged in user
+    if (!context.getUserSession().isLoggedIn()) {
+      return context;
+    }
+    User user = UserRepository.findByUserId(context.getUserId());
+    if (user == null) {
+      LOG.warn("Could not find current user record");
+      return context;
+    }
+
+    String action = context.getParameter("action");
+
+    if ("start".equals(action)) {
+      // Generate and store a pending secret, then re-display so the user can add it and confirm a code
+      UserMfaCommand.startEnrollment(user);
+      context.setRedirect(context.getUri());
+      return context;
+    }
+
+    if ("confirm".equals(action)) {
+      if (UserMfaCommand.confirmEnrollment(user, context.getParameter("code"))) {
+        context.setSuccessMessage("Two-factor authentication is now on.");
+        context.setRedirect(context.getUri());
+        return context;
+      }
+      // Wrong code: keep the pending enrollment on screen with an error
+      context.setErrorMessage("That code didn't match. Check your authenticator app and try again.");
+      showView(context, user);
+      return context;
+    }
+
+    if ("cancel".equals(action)) {
+      // Abandon a pending enrollment -- clears the stored secret
+      UserMfaCommand.disable(user);
+      context.setRedirect(context.getUri());
+      return context;
+    }
+
+    if ("disable".equals(action)) {
+      UserMfaCommand.disable(user);
+      context.setSuccessMessage("Two-factor authentication has been turned off.");
+      context.setRedirect(context.getUri());
+      return context;
+    }
+
+    // Unknown action -- just re-render the current state
+    showView(context, user);
+    return context;
+  }
+
+  private void showView(WidgetContext context, User user) {
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+    boolean enabled = user.getMfaEnabled();
+    context.getRequest().setAttribute("mfaEnabled", enabled ? "true" : "false");
+    // A stored-but-not-yet-enabled secret means an enrollment is in progress
+    boolean enrolling = !enabled && StringUtils.isNotBlank(user.getMfaSecret());
+    context.getRequest().setAttribute("mfaEnrolling", enrolling ? "true" : "false");
+    if (enrolling) {
+      context.getRequest().setAttribute("mfaSecret", user.getMfaSecret());
+      context.getRequest().setAttribute("otpauthUri", UserMfaCommand.buildEnrollmentUri(user));
+    }
+    context.setJsp(JSP);
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
@@ -16,9 +16,12 @@
 
 package com.simisinc.platform.presentation.widgets.userProfile;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -37,6 +40,8 @@ public class MyMfaSettingsWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908894L;
 
   static String JSP = "/userProfile/my-mfa-settings.jsp";
+
+  private static final String RECOVERY_CODES_FLASH = "mfaRecoveryCodesFlash";
 
   public WidgetContext execute(WidgetContext context) {
     // Require a logged in user
@@ -74,7 +79,9 @@ public class MyMfaSettingsWidget extends GenericWidget {
 
     if ("confirm".equals(action)) {
       if (UserMfaCommand.confirmEnrollment(user, context.getParameter("code"))) {
-        context.setSuccessMessage("Two-factor authentication is now on.");
+        // Enrollment done -- issue recovery codes and show them once on the redirect
+        flashRecoveryCodes(context, UserMfaRecoveryCodeCommand.generate(user));
+        context.setSuccessMessage("Two-factor authentication is now on. Save your recovery codes below.");
         context.setRedirect(context.getUri());
         return context;
       }
@@ -91,8 +98,19 @@ public class MyMfaSettingsWidget extends GenericWidget {
       return context;
     }
 
+    if ("regenerate".equals(action)) {
+      // Replace the recovery codes with a fresh set and show them once
+      if (user.getMfaEnabled()) {
+        flashRecoveryCodes(context, UserMfaRecoveryCodeCommand.generate(user));
+        context.setSuccessMessage("New recovery codes generated. Your previous codes no longer work.");
+      }
+      context.setRedirect(context.getUri());
+      return context;
+    }
+
     if ("disable".equals(action)) {
       UserMfaCommand.disable(user);
+      UserMfaRecoveryCodeCommand.clear(user);
       context.setSuccessMessage("Two-factor authentication has been turned off.");
       context.setRedirect(context.getUri());
       return context;
@@ -114,6 +132,19 @@ public class MyMfaSettingsWidget extends GenericWidget {
       context.getRequest().setAttribute("mfaSecret", user.getMfaSecret());
       context.getRequest().setAttribute("otpauthUri", UserMfaCommand.buildEnrollmentUri(user));
     }
+    if (enabled) {
+      context.getRequest().setAttribute("recoveryRemaining", UserMfaRecoveryCodeCommand.countRemaining(user));
+      // Show freshly generated recovery codes once (right after enabling or regenerating)
+      Object flashed = context.getRequest().getSession().getAttribute(RECOVERY_CODES_FLASH);
+      if (flashed != null) {
+        context.getRequest().setAttribute("recoveryCodes", flashed);
+        context.getRequest().getSession().removeAttribute(RECOVERY_CODES_FLASH);
+      }
+    }
     context.setJsp(JSP);
+  }
+
+  private void flashRecoveryCodes(WidgetContext context, List<String> codes) {
+    context.getRequest().getSession().setAttribute(RECOVERY_CODES_FLASH, codes);
   }
 }

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -425,6 +425,16 @@ CREATE TABLE user_tokens (
 );
 CREATE INDEX user_tokens_token_idx ON user_tokens(token);
 
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
+CREATE TABLE user_mfa_recovery_codes (
+  recovery_code_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT REFERENCES users(user_id) NOT NULL,
+  code_hash VARCHAR(64) NOT NULL,
+  used BOOLEAN DEFAULT false,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);
+
 CREATE TABLE oauth_tokens (
   token_id BIGSERIAL PRIMARY KEY,
   user_id BIGINT REFERENCES users(user_id) NOT NULL,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.1000__user_mfa.sql
@@ -1,3 +1,4 @@
--- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag
-ALTER TABLE users ADD mfa_secret VARCHAR(64);
-ALTER TABLE users ADD mfa_enabled BOOLEAN DEFAULT false;
+-- Multi-factor authentication (TOTP): a per-user shared secret and an enabled flag.
+-- Idempotent: on a fresh install the NEW_ script already added these columns, so guard with IF NOT EXISTS.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_secret VARCHAR(64);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN DEFAULT false;

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
@@ -1,0 +1,9 @@
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
+CREATE TABLE user_mfa_recovery_codes (
+  recovery_code_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT REFERENCES users(user_id) NOT NULL,
+  code_hash VARCHAR(64) NOT NULL,
+  used BOOLEAN DEFAULT false,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260717.2000__mfa_recovery_codes.sql
@@ -1,9 +1,10 @@
--- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
-CREATE TABLE user_mfa_recovery_codes (
+-- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes.
+-- Idempotent: on a fresh install the NEW_ script already created this table, so guard with IF NOT EXISTS.
+CREATE TABLE IF NOT EXISTS user_mfa_recovery_codes (
   recovery_code_id BIGSERIAL PRIMARY KEY,
   user_id BIGINT REFERENCES users(user_id) NOT NULL,
   code_hash VARCHAR(64) NOT NULL,
   used BOOLEAN DEFAULT false,
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);
+CREATE INDEX IF NOT EXISTS user_mfa_recovery_codes_user_idx ON user_mfa_recovery_codes(user_id);

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -1,0 +1,71 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<c:if test="${!empty title}">
+  <h3><c:out value="${title}"/></h3>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<c:choose>
+  <%-- Two-factor authentication is ON --%>
+  <c:when test="${mfaEnabled eq 'true'}">
+    <p><i class="fa fa-lock"></i> Two-factor authentication is <strong>on</strong>. You'll be asked for a code from your authenticator app each time you sign in.</p>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="disable"/>
+      <input type="submit" class="button alert radius" value="Turn off two-factor authentication"
+             onclick="return confirm('Turn off two-factor authentication for your account?');"/>
+    </form>
+  </c:when>
+  <%-- Enrollment in progress: scan/enter the secret, then confirm a code --%>
+  <c:when test="${mfaEnrolling eq 'true'}">
+    <p>Scan this code with an authenticator app (Google Authenticator, Authy, 1Password, and others), or enter the setup key by hand.</p>
+    <div class="mfa-qrcode" data-otpauth="<c:out value='${otpauthUri}'/>"></div>
+    <p>Setup key: <code><c:out value="${mfaSecret}"/></code></p>
+    <p class="show-for-small-only">
+      <a href="<c:out value='${otpauthUri}'/>">Tap here to add it to an app on this device</a>
+    </p>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="confirm"/>
+      <label>Enter the 6-digit code from your app to finish
+        <input name="code" type="text" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code"
+               placeholder="123456" autofocus required>
+      </label>
+      <p><input type="submit" class="button primary radius" value="Turn on two-factor authentication"/></p>
+    </form>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="cancel"/>
+      <input type="submit" class="button secondary radius" value="Cancel"/>
+    </form>
+  </c:when>
+  <%-- Two-factor authentication is OFF --%>
+  <c:otherwise>
+    <p>Two-factor authentication adds a second step when you sign in: a rotating code from an authenticator app on your phone. It's currently <strong>off</strong>.</p>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="start"/>
+      <input type="submit" class="button primary radius" value="Set up two-factor authentication"/>
+    </form>
+  </c:otherwise>
+</c:choose>
+<script src="${ctx}/javascript/mfa-qrcode.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -24,6 +24,25 @@
   <%-- Two-factor authentication is ON --%>
   <c:when test="${mfaEnabled eq 'true'}">
     <p><i class="fa fa-lock"></i> Two-factor authentication is <strong>on</strong>. You'll be asked for a code from your authenticator app each time you sign in.</p>
+    <c:if test="${!empty recoveryCodes}">
+      <div class="callout warning radius">
+        <h5>Save your recovery codes</h5>
+        <p>Each code works once, for signing in when you can't use your authenticator app. Store them somewhere safe &mdash; you won't be able to see them again.</p>
+        <ul class="no-bullet mfa-recovery-codes">
+          <c:forEach items="${recoveryCodes}" var="recoveryCode">
+            <li><code><c:out value="${recoveryCode}"/></code></li>
+          </c:forEach>
+        </ul>
+      </div>
+    </c:if>
+    <p>Recovery codes remaining: <strong><c:out value="${recoveryRemaining}"/></strong></p>
+    <form method="post">
+      <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+      <input type="hidden" name="token" value="${userSession.formToken}"/>
+      <input type="hidden" name="action" value="regenerate"/>
+      <input type="submit" class="button secondary radius" value="Generate new recovery codes"
+             onclick="return confirm('Replace your recovery codes? Your current codes will stop working.');"/>
+    </form>
     <form method="post">
       <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
       <input type="hidden" name="token" value="${userSession.formToken}"/>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -16,6 +16,14 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<style>
+  .mfa-recovery-codes { columns: 2; column-gap: 1.5rem; margin: .6rem 0 1rem; }
+  .mfa-recovery-codes li { break-inside: avoid; margin-bottom: .35rem; }
+  .mfa-recovery-codes li code { display: inline-block; }
+  .mfa-copy { margin: 0 0 0 .5rem; }
+  .mfa-recovery-actions { display: flex; gap: .5rem; margin-top: .3rem; }
+  .mfa-recovery-actions .button { margin: 0; }
+</style>
 <c:if test="${!empty title}">
   <h3><c:out value="${title}"/></h3>
 </c:if>
@@ -28,11 +36,15 @@
       <div class="callout warning radius">
         <h5>Save your recovery codes</h5>
         <p>Each code works once, for signing in when you can't use your authenticator app. Store them somewhere safe &mdash; you won't be able to see them again.</p>
-        <ul class="no-bullet mfa-recovery-codes">
+        <ul class="no-bullet mfa-recovery-codes" id="mfa-recovery-codes">
           <c:forEach items="${recoveryCodes}" var="recoveryCode">
             <li><code><c:out value="${recoveryCode}"/></code></li>
           </c:forEach>
         </ul>
+        <p class="mfa-recovery-actions">
+          <button type="button" class="button tiny secondary radius mfa-copy-codes">Copy all</button>
+          <button type="button" class="button tiny secondary radius mfa-download-codes">Download</button>
+        </p>
       </div>
     </c:if>
     <p>Recovery codes remaining: <strong><c:out value="${recoveryRemaining}"/></strong></p>
@@ -55,7 +67,7 @@
   <c:when test="${mfaEnrolling eq 'true'}">
     <p>Scan this code with an authenticator app (Google Authenticator, Authy, 1Password, and others), or enter the setup key by hand.</p>
     <div class="mfa-qrcode" data-otpauth="<c:out value='${otpauthUri}'/>"></div>
-    <p>Setup key: <code><c:out value="${mfaSecret}"/></code></p>
+    <p>Setup key: <code id="mfa-setup-key"><c:out value="${mfaSecret}"/></code><button type="button" class="button tiny secondary radius mfa-copy" data-copy-target="mfa-setup-key">Copy</button></p>
     <p class="show-for-small-only">
       <a href="<c:out value='${otpauthUri}'/>">Tap here to add it to an app on this device</a>
     </p>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -68,4 +68,5 @@
     </form>
   </c:otherwise>
 </c:choose>
+<script src="${ctx}/javascript/qrcode-generator-1.4.4/qrcode.js"></script>
 <script src="${ctx}/javascript/mfa-qrcode.js"></script>

--- a/src/main/webapp/WEB-INF/web-templates/page/e-commerce/My Account - E-Commerce.xml
+++ b/src/main/webapp/WEB-INF/web-templates/page/e-commerce/My Account - E-Commerce.xml
@@ -28,6 +28,9 @@
         <widget name="myAccountDetails">
           <title>Account Details</title>
         </widget>
+        <widget name="myMfaSettings" hr="true">
+          <title>Two-Factor Authentication</title>
+        </widget>
         <widget name="myEmailPreferences" hr="true">
           <title>Email Preferences</title>
           <subtitle><![CDATA[You’re in control of our communications. Please let us know how often you’d like to hear from us by clicking an option below.]]></subtitle>

--- a/src/main/webapp/WEB-INF/web-templates/page/portal/My Page - Portal.xml
+++ b/src/main/webapp/WEB-INF/web-templates/page/portal/My Page - Portal.xml
@@ -36,6 +36,9 @@
       <column class="small-12 medium-4 cell">
         <widget name="myInfo" />
         <widget name="mySiteInfo"/>
+        <widget name="myMfaSettings">
+          <title>Two-Factor Authentication</title>
+        </widget>
         <widget name="itemsList">
           <title>Favorite Spaces</title>
           <message>Areas you can access...</message>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -86,6 +86,7 @@
   <widget name="mySiteInfo" class="com.simisinc.platform.presentation.widgets.userProfile.MySiteInfoWidget" />
   <widget name="mySettings" class="com.simisinc.platform.presentation.widgets.userProfile.MySettingsWidget" />
   <widget name="myAccountDetails" class="com.simisinc.platform.presentation.widgets.userProfile.MyAccountDetailsWidget" />
+  <widget name="myMfaSettings" class="com.simisinc.platform.presentation.widgets.userProfile.MyMfaSettingsWidget" />
   <widget name="myEmailPreferences" class="com.simisinc.platform.presentation.widgets.userProfile.MyEmailPreferencesWidget" />
   <widget name="myOrderHistory" class="com.simisinc.platform.presentation.widgets.userProfile.MyOrderHistoryWidget" />
   <widget name="myProfileInfo" class="com.simisinc.platform.presentation.widgets.userProfile.MyProfileInfoWidget" />

--- a/src/main/webapp/javascript/mfa-qrcode.js
+++ b/src/main/webapp/javascript/mfa-qrcode.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Draws the two-factor enrollment QR code from the otpauth:// URI carried in the page. This is a progressive
+ * enhancement: if no QR encoder library is present, the container is hidden and the user relies on the setup key and
+ * the tap-to-add link shown alongside it. When a compatible encoder (the qrcode-generator API) is loaded before this
+ * script, a scannable code is rendered.
+ */
+(function () {
+  'use strict';
+
+  var container = document.querySelector('.mfa-qrcode[data-otpauth]');
+  if (!container) {
+    return;
+  }
+
+  var uri = container.getAttribute('data-otpauth');
+  if (uri && typeof window.qrcode === 'function') {
+    try {
+      var qr = window.qrcode(0, 'M');        // type number 0 = auto-fit, error-correction level M
+      qr.addData(uri);
+      qr.make();
+      container.innerHTML = qr.createImgTag(5, 8);   // 5px modules, 8px quiet-zone margin
+      container.setAttribute('aria-label', 'Two-factor authentication setup QR code');
+      return;
+    } catch (e) {
+      // Fall through and hide the empty container below
+    }
+  }
+
+  // No encoder available (or rendering failed): hide the empty box; the setup key remains usable.
+  container.style.display = 'none';
+})();

--- a/src/main/webapp/javascript/mfa-qrcode.js
+++ b/src/main/webapp/javascript/mfa-qrcode.js
@@ -15,33 +15,116 @@
  */
 
 /*
- * Draws the two-factor enrollment QR code from the otpauth:// URI carried in the page. This is a progressive
- * enhancement: if no QR encoder library is present, the container is hidden and the user relies on the setup key and
- * the tap-to-add link shown alongside it. When a compatible encoder (the qrcode-generator API) is loaded before this
- * script, a scannable code is rendered.
+ * Interactions for the two-factor settings screen: draws the enrollment QR code from the otpauth:// URI (a
+ * progressive enhancement over the setup key and tap-to-add link), and wires the copy/download buttons for the setup
+ * key and the recovery codes. Button handling uses event delegation on the document so it works no matter when the
+ * script runs relative to the widget markup.
  */
 (function () {
   'use strict';
 
-  var container = document.querySelector('.mfa-qrcode[data-otpauth]');
-  if (!container) {
-    return;
+  // Briefly change a button's label to confirm the action
+  function flash(button, message) {
+    var original = button.getAttribute('data-label') || button.textContent;
+    button.setAttribute('data-label', original);
+    button.textContent = message;
+    setTimeout(function () { button.textContent = original; }, 1500);
   }
 
-  var uri = container.getAttribute('data-otpauth');
-  if (uri && typeof window.qrcode === 'function') {
-    try {
-      var qr = window.qrcode(0, 'M');        // type number 0 = auto-fit, error-correction level M
-      qr.addData(uri);
-      qr.make();
-      container.innerHTML = qr.createImgTag(5, 8);   // 5px modules, 8px quiet-zone margin
-      container.setAttribute('aria-label', 'Two-factor authentication setup QR code');
+  // Copy text to the clipboard, falling back to execCommand when the async API is unavailable or blocked
+  function copyToClipboard(text, button) {
+    var fallback = function () {
+      var textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+        flash(button, 'Copied');
+      } catch (e) {
+        // ignore
+      }
+      document.body.removeChild(textarea);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () { flash(button, 'Copied'); }, fallback);
       return;
-    } catch (e) {
-      // Fall through and hide the empty container below
     }
+    fallback();
   }
 
-  // No encoder available (or rendering failed): hide the empty box; the setup key remains usable.
-  container.style.display = 'none';
+  // Collect the recovery codes shown on the page, one per line
+  function recoveryCodesText() {
+    var list = document.getElementById('mfa-recovery-codes');
+    if (!list) {
+      return '';
+    }
+    return Array.prototype.slice.call(list.querySelectorAll('code'))
+      .map(function (code) { return code.textContent.trim(); })
+      .join('\n');
+  }
+
+  function downloadRecoveryCodes(button) {
+    var blob = new Blob([recoveryCodesText() + '\n'], { type: 'text/plain' });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement('a');
+    link.href = url;
+    link.download = 'simis-cms-recovery-codes.txt';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    flash(button, 'Downloaded');
+  }
+
+  // One delegated click handler for every button on the screen
+  document.addEventListener('click', function (event) {
+    var copyKey = event.target.closest('.mfa-copy[data-copy-target]');
+    if (copyKey) {
+      var target = document.getElementById(copyKey.getAttribute('data-copy-target'));
+      if (target) {
+        copyToClipboard(target.textContent.trim(), copyKey);
+      }
+      return;
+    }
+    var copyCodes = event.target.closest('.mfa-copy-codes');
+    if (copyCodes) {
+      copyToClipboard(recoveryCodesText(), copyCodes);
+      return;
+    }
+    var download = event.target.closest('.mfa-download-codes');
+    if (download) {
+      downloadRecoveryCodes(download);
+    }
+  });
+
+  // Draw the enrollment QR code, if the encoder library is loaded
+  function renderQrCode() {
+    var container = document.querySelector('.mfa-qrcode[data-otpauth]');
+    if (!container) {
+      return;
+    }
+    var uri = container.getAttribute('data-otpauth');
+    if (uri && typeof window.qrcode === 'function') {
+      try {
+        var qr = window.qrcode(0, 'M');        // type number 0 = auto-fit, error-correction level M
+        qr.addData(uri);
+        qr.make();
+        container.innerHTML = qr.createImgTag(5, 8);   // 5px modules, 8px quiet-zone margin
+        container.setAttribute('aria-label', 'Two-factor authentication setup QR code');
+        return;
+      } catch (e) {
+        // Fall through and hide the empty container below
+      }
+    }
+    container.style.display = 'none';
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', renderQrCode);
+  } else {
+    renderQrCode();
+  }
 })();

--- a/src/main/webapp/javascript/qrcode-generator-1.4.4/README.md
+++ b/src/main/webapp/javascript/qrcode-generator-1.4.4/README.md
@@ -1,0 +1,15 @@
+# qrcode-generator 1.4.4 (vendored)
+
+Pure-JavaScript QR Code encoder, used to render the two-factor authentication
+enrollment QR code. See [`/javascript/mfa-qrcode.js`](../mfa-qrcode.js) and
+[`WEB-INF/jsp/userProfile/my-mfa-settings.jsp`](../../WEB-INF/jsp/userProfile/my-mfa-settings.jsp).
+
+- **Upstream:** https://github.com/kazuhikoarase/qrcode-generator
+- **Source:** https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz
+- **Version:** 1.4.4
+- **License:** MIT (header retained inline in `qrcode.js`)
+- **Integrity (npm dist):** `sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==`
+- **sha1:** `63f771224854759329a99048806a53ed278740e7`
+
+Only `qrcode.js` (the core encoder) is vendored — no sub-dependencies. To update,
+replace the file with a pinned upstream release and refresh the hashes above.

--- a/src/main/webapp/javascript/qrcode-generator-1.4.4/qrcode.js
+++ b/src/main/webapp/javascript/qrcode-generator-1.4.4/qrcode.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));

--- a/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.persistence.login.UserMfaRecoveryCodeRepository;
+
+/**
+ * Tests recovery-code generation, verification, and lifecycle. The repository (database) layer is mocked; the command's
+ * hashing and normalization are exercised for real.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class UserMfaRecoveryCodeCommandTest {
+
+  private static User user(long id) {
+    User user = new User();
+    user.setId(id);
+    return user;
+  }
+
+  @Test
+  void generateReturnsTenUniqueFormattedCodesAndStoresThem() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      List<String> codes = UserMfaRecoveryCodeCommand.generate(user(1L));
+
+      assertEquals(10, codes.size());
+      for (String code : codes) {
+        assertEquals(11, code.length(), code); // five chars, a dash, five chars
+        assertEquals('-', code.charAt(5), code);
+      }
+      assertEquals(10, codes.stream().distinct().count(), "codes should be unique");
+      // A fresh set replaces any prior codes, and each code is stored
+      repo.verify(() -> UserMfaRecoveryCodeRepository.removeAll(1L));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.add(any()), times(10));
+    }
+  }
+
+  @Test
+  void consumeAcceptsAMatchingCodeIgnoringCaseAndDashes() {
+    UserMfaRecoveryCode stored = new UserMfaRecoveryCode();
+    stored.setId(5L);
+    String expectedHash = DigestUtils.sha256Hex("abcdefghij"); // the normalized form of the code below
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+
+      // The same code, typed with a dash and in upper case, both normalize to the stored hash
+      assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "abcde-fghij"));
+      assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "ABCDEFGHIJ"));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.markUsed(stored), times(2));
+    }
+  }
+
+  @Test
+  void consumeRejectsAnUnknownCode() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(anyLong(), anyString())).thenReturn(null);
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "zzzzz-zzzzz"));
+    }
+  }
+
+  @Test
+  void consumeRejectsBlankOrWrongLengthWithoutQueryingTheDatabase() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), ""));
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), null));
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "123456")); // a TOTP code, not a recovery code
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void clearRemovesAllCodes() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      UserMfaRecoveryCodeCommand.clear(user(1L));
+      repo.verify(() -> UserMfaRecoveryCodeRepository.removeAll(1L));
+    }
+  }
+
+  @Test
+  void countRemainingDelegatesToRepository() {
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.countUnusedByUserId(1L)).thenReturn(7L);
+      assertEquals(7L, UserMfaRecoveryCodeCommand.countRemaining(user(1L)));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -164,11 +164,12 @@ class LoginWidgetTest extends WidgetBase {
       widget.post(widgetContext);
     }
 
-    // A valid recovery code completes the login just like a TOTP code
+    // A valid recovery code completes the login just like a TOTP code: pending marker cleared,
+    // redirected, no error. Cookie issuance on the shared finalizeLogin path is already asserted
+    // by validMfaCodeCompletesTheLogin, so it is not re-checked here.
     verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
     Assertions.assertEquals("/my-page", widgetContext.getRedirect());
     Assertions.assertNull(widgetContext.getErrorMessage());
-    verify(response, times(1)).addCookie(any());
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -150,12 +150,15 @@ class LoginWidgetTest extends WidgetBase {
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
         MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
         MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       // TOTP fails, but a recovery code is accepted
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(true);
       siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
       widget.post(widgetContext);

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
@@ -90,9 +91,11 @@ class LoginWidgetTest extends WidgetBase {
 
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
-        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class)) {
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(false);
       widget.post(widgetContext);
     }
 
@@ -122,6 +125,33 @@ class LoginWidgetTest extends WidgetBase {
     }
 
     // Logged in: pending marker cleared (removeAttribute is called), redirected, auth cookie set, no error.
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    Assertions.assertEquals("/my-page", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+    verify(response, times(1)).addCookie(any());
+  }
+
+  @Test
+  void validRecoveryCodeCompletesTheLogin() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.USER, new UserSession());
+    addQueryParameter(widgetContext, "code", "abcde-fghij");
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
+      // TOTP fails, but a recovery code is accepted
+      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // A valid recovery code completes the login just like a TOTP code
     verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
     Assertions.assertEquals("/my-page", widgetContext.getRedirect());
     Assertions.assertNull(widgetContext.getErrorMessage());

--- a/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.userProfile;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the self-service MFA settings screen: it renders the off / enrolling / on states correctly, and its
+ * actions (start, confirm, cancel, disable) drive UserMfaCommand and redirect or re-render as appropriate.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-17
+ */
+class MyMfaSettingsWidgetTest extends WidgetBase {
+
+  private static final String SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+
+  @Test
+  void executeShowsOffStateWhenNotEnrolled() {
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(false);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().execute(widgetContext);
+    }
+    Assertions.assertEquals("false", request.getAttribute("mfaEnabled"));
+    Assertions.assertEquals("false", request.getAttribute("mfaEnrolling"));
+    Assertions.assertEquals(MyMfaSettingsWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeShowsEnrollingStateWithSecretAndUri() {
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(false);
+    user.setMfaSecret(SECRET);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      mfa.when(() -> UserMfaCommand.buildEnrollmentUri(user)).thenReturn("otpauth://totp/Test:me?secret=" + SECRET);
+      new MyMfaSettingsWidget().execute(widgetContext);
+    }
+    Assertions.assertEquals("true", request.getAttribute("mfaEnrolling"));
+    Assertions.assertEquals(SECRET, request.getAttribute("mfaSecret"));
+    Assertions.assertEquals("otpauth://totp/Test:me?secret=" + SECRET, request.getAttribute("otpauthUri"));
+  }
+
+  @Test
+  void executeShowsOnStateWhenEnabled() {
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    user.setMfaSecret(SECRET);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().execute(widgetContext);
+    }
+    Assertions.assertEquals("true", request.getAttribute("mfaEnabled"));
+    // Enabled means enrollment is finished, not in progress.
+    Assertions.assertEquals("false", request.getAttribute("mfaEnrolling"));
+  }
+
+  @Test
+  void postStartBeginsEnrollmentAndRedirects() {
+    addQueryParameter(widgetContext, "action", "start");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().post(widgetContext);
+      mfa.verify(() -> UserMfaCommand.startEnrollment(user));
+    }
+    Assertions.assertEquals("/my-account", widgetContext.getRedirect());
+  }
+
+  @Test
+  void postConfirmValidCodeEnablesAndRedirects() {
+    addQueryParameter(widgetContext, "action", "confirm");
+    addQueryParameter(widgetContext, "code", "123456");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      mfa.when(() -> UserMfaCommand.confirmEnrollment(user, "123456")).thenReturn(true);
+      new MyMfaSettingsWidget().post(widgetContext);
+    }
+    Assertions.assertEquals("/my-account", widgetContext.getRedirect());
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void postConfirmInvalidCodeShowsErrorAndRerenders() {
+    addQueryParameter(widgetContext, "action", "confirm");
+    addQueryParameter(widgetContext, "code", "000000");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(false);
+    user.setMfaSecret(SECRET);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      mfa.when(() -> UserMfaCommand.confirmEnrollment(user, "000000")).thenReturn(false);
+      new MyMfaSettingsWidget().post(widgetContext);
+    }
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertNull(widgetContext.getRedirect());
+    // Re-rendered in place, still showing the enrollment panel.
+    Assertions.assertEquals(MyMfaSettingsWidget.JSP, widgetContext.getJsp());
+    Assertions.assertEquals("true", request.getAttribute("mfaEnrolling"));
+  }
+
+  @Test
+  void postDisableTurnsOffAndRedirects() {
+    addQueryParameter(widgetContext, "action", "disable");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().post(widgetContext);
+      mfa.verify(() -> UserMfaCommand.disable(user));
+    }
+    Assertions.assertEquals("/my-account", widgetContext.getRedirect());
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
@@ -16,12 +16,15 @@
 
 package com.simisinc.platform.presentation.widgets.userProfile;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 
@@ -77,13 +80,16 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     user.setId(1L);
     user.setMfaEnabled(true);
     user.setMfaSecret(SECRET);
-    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.countRemaining(user)).thenReturn(8L);
       new MyMfaSettingsWidget().execute(widgetContext);
     }
     Assertions.assertEquals("true", request.getAttribute("mfaEnabled"));
     // Enabled means enrollment is finished, not in progress.
     Assertions.assertEquals("false", request.getAttribute("mfaEnrolling"));
+    Assertions.assertEquals(8L, request.getAttribute("recoveryRemaining"));
   }
 
   @Test
@@ -109,10 +115,14 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     User user = new User();
     user.setId(1L);
     try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
-        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
       mfa.when(() -> UserMfaCommand.confirmEnrollment(user, "123456")).thenReturn(true);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.generate(user)).thenReturn(List.of("abcde-fghij", "klmno-pqrst"));
       new MyMfaSettingsWidget().post(widgetContext);
+      // Enabling MFA issues recovery codes
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.generate(user));
     }
     Assertions.assertEquals("/my-account", widgetContext.getRedirect());
     Assertions.assertNotNull(widgetContext.getSuccessMessage());
@@ -148,10 +158,31 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
     user.setId(1L);
     user.setMfaEnabled(true);
     try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
-        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class)) {
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
       repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
       new MyMfaSettingsWidget().post(widgetContext);
       mfa.verify(() -> UserMfaCommand.disable(user));
+      // Turning off MFA also clears the recovery codes
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(user));
+    }
+    Assertions.assertEquals("/my-account", widgetContext.getRedirect());
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+  }
+
+  @Test
+  void postRegenerateReplacesCodesAndRedirects() {
+    addQueryParameter(widgetContext, "action", "regenerate");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      recovery.when(() -> UserMfaRecoveryCodeCommand.generate(user)).thenReturn(List.of("abcde-fghij"));
+      new MyMfaSettingsWidget().post(widgetContext);
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.generate(user));
     }
     Assertions.assertEquals("/my-account", widgetContext.getRedirect());
     Assertions.assertNotNull(widgetContext.getSuccessMessage());


### PR DESCRIPTION
## What happened
#107 (the first restore of the MFA enrollment UI + recovery codes) shows **MERGED**, but it merged into its stacked base branch `fix/mfa-login-ratelimit` — **not `main`**. So `MyMfaSettingsWidget`, `UserMfaRecoveryCodeCommand`, the recovery-code repository/model, the enrollment JSP + QR script, and the `UPGRADE_...2000` migration are **still missing from `main`.**

This is the same failure as the original #93/#94 loss — a stacked PR merged out of order — caught again by the post-merge reachability audit (`git merge-base --is-ancestor`). The draft guard on #107 was removed and it was merged without the retarget-to-`main` step.

## This PR
Branched from **current `main`** (which now has #101, #100, and everything else) and merged the intact restore content. Because it targets `main` directly and is **not stacked**, it cannot be mis-merged into a feature branch.

Net diff is exactly the enrollment + recovery delta — `LoginWidget` is only +9 lines (the recovery-code acceptance on top of #101's rate-limiting, already in `main`). Nothing from #101/#100/#102 is re-applied.

## Verification
- Clean `ant clean` + full `ci-test`: **green**, including the restored `MyMfaSettingsWidgetTest`, `UserMfaRecoveryCodeCommandTest`, and combined `LoginWidgetTest`.
- `ApplicationInfo.VERSION` stays `20260717.10000` (#100's bump — not reverted).
- The combined MFA login logic passed an independent adversarial security review (SOUND; one low-severity pre-existing note on non-atomic recovery-code consumption — a follow-up, not a blocker).

## To merge
Plain squash-merge to `main`. Then confirm it landed: `git merge-base --is-ancestor $(gh pr view <this> --json mergeCommit -q .mergeCommit.oid) origin/main && echo landed`.