### PR TITLE
Make MFA recovery-code consumption atomic (fix single-use TOCTOU)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
@@ -87,8 +87,9 @@ public class UserMfaRecoveryCodeCommand {
     if (match == null) {
       return false;
     }
-    UserMfaRecoveryCodeRepository.markUsed(match);
-    return true;
+    // Consume atomically: markUsed returns true only when THIS call flips the row from unused,
+    // so a concurrent request racing on the same code cannot also succeed (single-use guarantee).
+    return UserMfaRecoveryCodeRepository.markUsed(match);
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
@@ -67,14 +67,25 @@ public class UserMfaRecoveryCodeRepository {
         UserMfaRecoveryCodeRepository::buildRecord);
   }
 
-  public static void markUsed(UserMfaRecoveryCode record) {
+  /**
+   * Atomically consumes a recovery code: flips it to used only if it is still unused. The
+   * "used = false" guard makes single-use race-safe -- if two requests submit the same code
+   * concurrently, only the update that actually flips the row affects a row (the other matches
+   * none), so exactly one login can succeed.
+   *
+   * @param record the code to consume
+   * @return true only if this call flipped the row from unused to used
+   */
+  public static boolean markUsed(UserMfaRecoveryCode record) {
     if (record == null || record.getId() < 1) {
-      return;
+      return false;
     }
-    DB.update(
+    return DB.update(
         TABLE_NAME,
         new SqlUtils().add("used", true),
-        new SqlUtils().add("recovery_code_id = ?", record.getId()));
+        new SqlUtils()
+            .add("recovery_code_id = ?", record.getId())
+            .add("used = ?", false));
   }
 
   public static long countUnusedByUserId(long userId) {

--- a/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
@@ -74,11 +74,27 @@ class UserMfaRecoveryCodeCommandTest {
     String expectedHash = DigestUtils.sha256Hex("abcdefghij"); // the normalized form of the code below
     try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
       repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+      repo.when(() -> UserMfaRecoveryCodeRepository.markUsed(stored)).thenReturn(true);
 
       // The same code, typed with a dash and in upper case, both normalize to the stored hash
       assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "abcde-fghij"));
       assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "ABCDEFGHIJ"));
       repo.verify(() -> UserMfaRecoveryCodeRepository.markUsed(stored), times(2));
+    }
+  }
+
+  @Test
+  void consumeReturnsFalseWhenTheCodeWasAlreadyConsumedConcurrently() {
+    UserMfaRecoveryCode stored = new UserMfaRecoveryCode();
+    stored.setId(5L);
+    String expectedHash = DigestUtils.sha256Hex("abcdefghij");
+    try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
+      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+      // The lookup found the code unused, but a concurrent request flipped it first:
+      // the atomic update affects no row, so this login must NOT succeed.
+      repo.when(() -> UserMfaRecoveryCodeRepository.markUsed(stored)).thenReturn(false);
+
+      assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "abcde-fghij"));
     }
   }
 


### PR DESCRIPTION
## Problem
`UserMfaRecoveryCodeCommand.consume()` was check-then-act: `findUnusedByUserIdAndHash(...)` then an **unconditional** `UPDATE ... SET used=true WHERE recovery_code_id=?`. Two requests submitting the **same valid recovery code concurrently** could both see it unused and both complete login — one code satisfying two logins.

Found in the adversarial security review of the MFA restore (#110). Low severity (the attacker must already hold a valid code; sequential replay is already blocked by the `used=false` SELECT filter), but it weakens the single-use guarantee.

## Fix
Make consumption atomic in the database, not in application logic:
- `markUsed` now guards the update with **`AND used = false`** and returns whether a row was actually flipped (`DB.update` returns `true` only when `executeUpdate() > 0`).
- `consume()` returns that result, so it succeeds only when *this* call flipped the row.

The row lock serializes the two concurrent updates: the first flips `used` and affects one row; the second's `used = false` guard now matches zero rows and returns `false`. Exactly one login can succeed.

## Tests
- Existing success test stubs `markUsed → true`.
- New `consumeReturnsFalseWhenTheCodeWasAlreadyConsumedConcurrently` — lookup finds it unused but the atomic update affects no row → login must not succeed.

Clean build + full suite green.