### PR TITLE
Expire the MFA pending-state after 5 minutes

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
@@ -30,4 +30,5 @@ public class SessionConstants {
   public static final String OAUTH_USER_TOKEN = "oauthUserToken";
   public static final String OAUTH_USER_EXPIRATION_TIME = "oauthUserExpiration";
   public static final String MFA_PENDING_USER_ID = "mfaPendingUserId";
+  public static final String MFA_PENDING_SINCE = "mfaPendingSince";
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -58,6 +58,10 @@ public class LoginWidget extends GenericWidget {
 
   static String JSP = "/login/login-form.jsp";
 
+  // How long a user has to enter their MFA code after passing the password step before the
+  // pending state expires and they must sign in with their password again.
+  static final long MFA_PENDING_TIMEOUT_MS = 5 * 60 * 1000L;
+
   public WidgetContext execute(WidgetContext context) {
     // Standard request items
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
@@ -65,12 +69,32 @@ public class LoginWidget extends GenericWidget {
     if (OAuthRequestCommand.isEnabled()) {
       context.getRequest().setAttribute("oAuthProvider", LoadSitePropertyCommand.loadByName("oauth.provider"));
     }
-    // If a user passed the password check and is waiting to enter an MFA code, show that prompt
-    if (context.getRequest().getSession().getAttribute(SessionConstants.MFA_PENDING_USER_ID) != null) {
-      context.getRequest().setAttribute("mfaRequired", "true");
+    // If a user passed the password check and is waiting to enter an MFA code, show that prompt --
+    // unless the pending state has timed out, in which case clear it and show the normal sign-in.
+    HttpSession session = context.getRequest().getSession();
+    if (session.getAttribute(SessionConstants.MFA_PENDING_USER_ID) != null) {
+      if (isMfaPendingExpired(session)) {
+        clearMfaPending(session);
+      } else {
+        context.getRequest().setAttribute("mfaRequired", "true");
+      }
     }
     context.setJsp(JSP);
     return context;
+  }
+
+  /** True when an MFA-pending state exists but has passed the timeout window (or was never stamped). */
+  private boolean isMfaPendingExpired(HttpSession session) {
+    if (session.getAttribute(SessionConstants.MFA_PENDING_USER_ID) == null) {
+      return false;
+    }
+    Long pendingSince = (Long) session.getAttribute(SessionConstants.MFA_PENDING_SINCE);
+    return pendingSince == null || System.currentTimeMillis() - pendingSince > MFA_PENDING_TIMEOUT_MS;
+  }
+
+  private void clearMfaPending(HttpSession session) {
+    session.removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    session.removeAttribute(SessionConstants.MFA_PENDING_SINCE);
   }
 
   public WidgetContext post(WidgetContext context) {
@@ -81,6 +105,13 @@ public class LoginWidget extends GenericWidget {
     // Second step: a user who already passed the password check is submitting their MFA code
     Long mfaPendingUserId = (Long) httpSession.getAttribute(SessionConstants.MFA_PENDING_USER_ID);
     if (mfaPendingUserId != null) {
+      // Expire a stale MFA-pending state rather than leaving the second-factor gate open
+      // indefinitely -- the user must re-enter their password to start over.
+      if (isMfaPendingExpired(httpSession)) {
+        clearMfaPending(httpSession);
+        context.setErrorMessage("Your sign-in timed out. Please enter your email and password again.");
+        return context;
+      }
       // Throttle guesses so the second factor cannot be brute-forced, mirroring the password step.
       // The account is pinned by the pending user id, so key the per-account limit on that.
       String ipAddress = context.getRequest().getRemoteAddr();
@@ -107,7 +138,7 @@ public class LoginWidget extends GenericWidget {
         context.getRequest().setAttribute("mfaRequired", "true");
         return context;
       }
-      httpSession.removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+      clearMfaPending(httpSession);
       return finalizeLogin(context, user, stayLoggedIn);
     }
 
@@ -128,6 +159,7 @@ public class LoginWidget extends GenericWidget {
     // If MFA is enabled, do not establish the session yet -- hold the login and require a valid code first
     if (user.getMfaEnabled() && StringUtils.isNotBlank(user.getMfaSecret())) {
       httpSession.setAttribute(SessionConstants.MFA_PENDING_USER_ID, user.getId());
+      httpSession.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
       context.getRequest().setAttribute("mfaRequired", "true");
       return context;
     }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -296,6 +296,7 @@ class LoginWidgetTest extends WidgetBase {
     verify(session).removeAttribute(SessionConstants.MFA_PENDING_SINCE);
     Assertions.assertNotNull(widgetContext.getErrorMessage());
     Assertions.assertNull(widgetContext.getRedirect());
-    verify(response, never()).addCookie(any());
+    // The timed-out path never touches the response at all (no cookie, no redirect header)
+    verifyNoInteractions(response);
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -91,6 +91,7 @@ class LoginWidgetTest extends WidgetBase {
   @Test
   void invalidMfaCodeIsRejectedAndDoesNotAuthenticate() {
     session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
     addQueryParameter(widgetContext, "code", "000000");
 
     LoginWidget widget = new LoginWidget();
@@ -117,6 +118,7 @@ class LoginWidgetTest extends WidgetBase {
   @Test
   void validMfaCodeCompletesTheLogin() {
     session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
     session.setAttribute(SessionConstants.USER, new UserSession()); // finalizeLogin logs into this
     addQueryParameter(widgetContext, "code", "123456");
 
@@ -144,6 +146,7 @@ class LoginWidgetTest extends WidgetBase {
   @Test
   void validRecoveryCodeCompletesTheLogin() {
     session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
     session.setAttribute(SessionConstants.USER, new UserSession());
     addQueryParameter(widgetContext, "code", "abcde-fghij");
 
@@ -222,6 +225,7 @@ class LoginWidgetTest extends WidgetBase {
   @Test
   void mfaCodeStepIsRateLimitedAfterTooManyAttempts() {
     session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
     addQueryParameter(widgetContext, "code", "000000");
     when(request.getRemoteAddr()).thenReturn("203.0.113.7");
 
@@ -248,6 +252,7 @@ class LoginWidgetTest extends WidgetBase {
   @Test
   void invalidMfaCodeRecordsTheFailedAttempt() {
     session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis());
     addQueryParameter(widgetContext, "code", "000000");
     when(request.getRemoteAddr()).thenReturn("203.0.113.7");
 
@@ -273,5 +278,24 @@ class LoginWidgetTest extends WidgetBase {
     Assertions.assertEquals(42L, session.getAttribute(SessionConstants.MFA_PENDING_USER_ID));
     // No session artifacts at all: the response (cookies, headers) was never touched
     verifyNoInteractions(response);
+  }
+
+  @Test
+  void expiredMfaPendingStateFallsBackToPasswordLogin() {
+    session.setAttribute(SessionConstants.MFA_PENDING_USER_ID, 42L);
+    // Stamped an hour ago -- well beyond the 5-minute pending window
+    session.setAttribute(SessionConstants.MFA_PENDING_SINCE, System.currentTimeMillis() - (60L * 60 * 1000));
+    addQueryParameter(widgetContext, "code", "123456");
+
+    LoginWidget widget = new LoginWidget();
+    widget.post(widgetContext);
+
+    // Timed out: the pending markers are cleared, an error is shown, and nothing is established.
+    // (No repository/TOTP mocks needed -- the expiry check returns before any verification runs.)
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_USER_ID);
+    verify(session).removeAttribute(SessionConstants.MFA_PENDING_SINCE);
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertNull(widgetContext.getRedirect());
+    verify(response, never()).addCookie(any());
   }
 }


### PR DESCRIPTION
## Problem
After a correct password, `LoginWidget` holds the "awaiting MFA code" state (`SessionConstants.MFA_PENDING_USER_ID`) in the session with **no expiry**. A user who passed the password step and walked away left the second-factor gate open until the servlet session itself timed out — and on a shared/kiosk browser, someone else could walk up and complete the login by entering a code. This was the last open item on the MFA feature.

## Fix
- Stamp `MFA_PENDING_SINCE` when the pending state is set (first step, after password success).
- Expire it after **5 minutes** (`MFA_PENDING_TIMEOUT_MS`):
  - On the code-submit path, a timed-out state is cleared and the user is returned to the password form with *"Your sign-in timed out. Please enter your email and password again."* — checked **before** any rate-limit/verification work.
  - `execute()` likewise drops a stale prompt so the form doesn't show "enter your code" for an expired state.
- **Fails closed:** a pending state with no timestamp is treated as expired.

## Tests
- New `expiredMfaPendingStateFallsBackToPasswordLogin` — an hour-old pending state is cleared, an error is shown, nothing is established (no mocks needed; expiry returns before verification).
- The existing MFA-pending tests now stamp a fresh `MFA_PENDING_SINCE` so they still reach the verification path.

Clean build + full suite green. Independent of #111 (disjoint files) — merge in any order.