### PR TITLE
Session hardening: rotate session id on login + SameSite=Lax cookies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -169,6 +169,12 @@
         <include name="javascript/**"/>
       </fileset>
     </copy>
+    <!-- META-INF context config (e.g. the SameSite CookieProcessor) -->
+    <copy todir="${target.dir}/${project}/META-INF">
+      <fileset dir="${web.dir}/META-INF">
+        <include name="context.xml"/>
+      </fileset>
+    </copy>
     <!-- Prepare the JSPs-->
     <copy todir="${target.dir}/${project}/WEB-INF/jsp">
       <fileset dir="${web.dir}/WEB-INF/jsp"/>

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -171,6 +171,9 @@ public class LoginWidget extends GenericWidget {
 
     // Update the user's session
     UserSession userSession = (UserSession) context.getRequest().getSession().getAttribute(SessionConstants.USER);
+    // Rotate the servlet session id now that the user has authenticated: any session id an
+    // attacker may have fixed on the browser before login is invalidated (session-fixation defense).
+    context.getRequest().changeSessionId();
     userSession.login(user);
 
     // Track the login

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context>
+  <!--
+    Apply SameSite=Lax to every cookie the application sets (JSESSIONID and the app cookies
+    userToken/visitorToken/cartToken/viewMode), which have no SameSite attribute otherwise.
+    Lax (not Strict) is deliberate: it still sends the session cookie on top-level navigations
+    from external links, so normal "click a link into the site" behavior is preserved, while
+    blocking the cookie on cross-site subrequests -- a CSRF-adjacent hardening (defense in depth
+    alongside the existing synchronizer-token check).
+  -->
+  <CookieProcessor className="org.apache.tomcat.util.http.Rfc6265CookieProcessor" sameSiteCookies="lax" />
+</Context>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -141,6 +141,8 @@ class LoginWidgetTest extends WidgetBase {
     Assertions.assertEquals("/my-page", widgetContext.getRedirect());
     Assertions.assertNull(widgetContext.getErrorMessage());
     verify(response, times(1)).addCookie(any());
+    // Session fixation defense: the servlet session id is rotated when the login is finalized.
+    verify(request).changeSessionId();
   }
 
   @Test


### PR DESCRIPTION
Two verified gaps from the security capability inventory (see `security-privacy-capability-catalog.md`), both small and both real assessor-scan findings.

## 1. Session fixation → rotate the session id on login
`LoginWidget.finalizeLogin()` reused the pre-authentication servlet session and never rotated its id — so a session id an attacker fixed on the victim's browser *before* login remained valid *after*. Now it calls `request.changeSessionId()` when finalizing the login (covers all success paths: password-only, TOTP, and recovery-code). Verified by a new test (`verify(request).changeSessionId()`).

## 2. No SameSite on any cookie → SameSite=Lax
JSESSIONID and the app cookies (`userToken`/`visitorToken`/`cartToken`/`viewMode`) had no SameSite attribute. Added `META-INF/context.xml` with `Rfc6265CookieProcessor sameSiteCookies="lax"`, applying **SameSite=Lax** to every cookie — defense-in-depth alongside the existing synchronizer-token CSRF check. **Lax** (not Strict) is deliberate: top-level navigations from external links still send the session cookie, so normal "click a link into the site" behavior is preserved.

Also fixed the ant WAR packaging, which copied `css/js/images` from the webapp root but **not** `META-INF/` — so the `context.xml` now actually ships in the WAR (verified in the packaged artifact).

## Verification
Clean `ant clean` + full `ci-test`: green. `ant package`: `META-INF/context.xml` present in the WAR. Independent, off `main`.