### PR TITLE
Encrypt the MFA/TOTP secret at rest (AES-256-GCM, env-var KEK)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,11 +43,14 @@ CMS_ADMIN_PASSWORD=
 CMS_FORCE_SSL=true|false
 CMS_NODE_TYPE=<empty>|standalone|web
 CMS_PATH=<empty>|${USER_HOME}/Web/simis-cms|/opt/simis
+CMS_SECRET_KEY=<base64 256-bit key; enables encryption at rest for stored secrets (e.g. MFA seeds)>
 DB_SERVER_NAME=
 DB_NAME=
 DB_USER=
 DB_PASSWORD=
 ```
+
+> **`CMS_SECRET_KEY`** encrypts recoverable secrets (such as per-user MFA/TOTP seeds) at rest with AES-256-GCM. Generate one with `openssl rand -base64 32` and supply it out-of-band (not committed). Keep a secure backup — losing the key makes encrypted secrets unrecoverable (affected users re-enroll MFA). Rotating: set the new key and re-save affected records. If unset, secrets are stored as plaintext (backward compatible), so set it for a hardened deployment.
 
 ## Upgrading
 

--- a/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
+++ b/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Application-layer encryption for secrets that must be stored recoverably (unlike passwords, which are hashed) --
+ * currently the per-user TOTP seed, and available for integration/payment credentials. Values are wrapped with
+ * AES-256-GCM (authenticated encryption) under a key-encryption key (KEK) read from the environment, so a database
+ * dump alone does not yield usable secrets.
+ *
+ * <p>The KEK is a base64-encoded 256-bit key supplied out-of-band via the {@code CMS_SECRET_KEY} environment variable
+ * (or the {@code cms.secret.key} system property). If no key is configured, {@link #encrypt} returns the value
+ * unchanged so existing deployments keep working -- set the key to enable encryption; values are then encrypted on
+ * their next save. Encrypted values are prefixed with {@code enc:} so {@link #decrypt} can distinguish them from
+ * legacy plaintext. Key rotation: decrypt with the old key, re-save to encrypt under the new key.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-19
+ */
+public class SecretCryptoCommand {
+
+  private static final Log LOG = LogFactory.getLog(SecretCryptoCommand.class);
+
+  private static final String PREFIX = "enc:";
+  private static final String ENV_KEY = "CMS_SECRET_KEY";
+  private static final String PROP_KEY = "cms.secret.key";
+  private static final int KEY_BYTES = 32; // AES-256
+  private static final int IV_BYTES = 12;  // GCM standard nonce length
+  private static final int GCM_TAG_BITS = 128;
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private SecretCryptoCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * @return the configured AES key, or null when none is set or the value is invalid (env var wins over the property)
+   */
+  private static SecretKeySpec key() {
+    String raw = System.getenv(ENV_KEY);
+    if (StringUtils.isBlank(raw)) {
+      raw = System.getProperty(PROP_KEY);
+    }
+    if (StringUtils.isBlank(raw)) {
+      return null;
+    }
+    try {
+      byte[] bytes = Base64.getDecoder().decode(raw.trim());
+      if (bytes.length != KEY_BYTES) {
+        LOG.error(ENV_KEY + " must be a base64-encoded 256-bit (32-byte) key; secret encryption is disabled");
+        return null;
+      }
+      return new SecretKeySpec(bytes, "AES");
+    } catch (IllegalArgumentException e) {
+      LOG.error(ENV_KEY + " is not valid base64; secret encryption is disabled");
+      return null;
+    }
+  }
+
+  /**
+   * @return true when a valid encryption key is configured
+   */
+  public static boolean isEnabled() {
+    return key() != null;
+  }
+
+  /**
+   * Encrypts a secret for storage. Blank input is returned unchanged, and when no key is configured the value is
+   * returned as-is (legacy plaintext) so an unconfigured deployment keeps working.
+   *
+   * @param plaintext the secret to protect
+   * @return an {@code enc:}-prefixed ciphertext, or the input unchanged when blank / no key
+   */
+  public static String encrypt(String plaintext) {
+    if (StringUtils.isBlank(plaintext)) {
+      return plaintext;
+    }
+    SecretKeySpec k = key();
+    if (k == null) {
+      return plaintext;
+    }
+    try {
+      byte[] iv = new byte[IV_BYTES];
+      RANDOM.nextBytes(iv);
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.ENCRYPT_MODE, k, new GCMParameterSpec(GCM_TAG_BITS, iv));
+      byte[] ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+      byte[] combined = new byte[iv.length + ciphertext.length];
+      System.arraycopy(iv, 0, combined, 0, iv.length);
+      System.arraycopy(ciphertext, 0, combined, iv.length, ciphertext.length);
+      return PREFIX + Base64.getEncoder().encodeToString(combined);
+    } catch (GeneralSecurityException e) {
+      LOG.error("Secret encryption failed", e);
+      throw new IllegalStateException("Secret encryption failed", e);
+    }
+  }
+
+  /**
+   * Decrypts a stored secret. A value that is not {@code enc:}-prefixed is returned unchanged (legacy plaintext).
+   * On failure (missing key, wrong key, or a corrupt value) this returns null so the caller fails safe -- treating
+   * the account as having no usable secret rather than exposing a broken one.
+   *
+   * @param stored the stored value
+   * @return the plaintext secret, the input unchanged if it was legacy plaintext, or null on failure
+   */
+  public static String decrypt(String stored) {
+    if (StringUtils.isBlank(stored) || !stored.startsWith(PREFIX)) {
+      return stored;
+    }
+    SecretKeySpec k = key();
+    if (k == null) {
+      LOG.error("An encrypted secret was found but " + ENV_KEY + " is not configured; cannot decrypt");
+      return null;
+    }
+    try {
+      byte[] combined = Base64.getDecoder().decode(stored.substring(PREFIX.length()));
+      byte[] iv = Arrays.copyOfRange(combined, 0, IV_BYTES);
+      byte[] ciphertext = Arrays.copyOfRange(combined, IV_BYTES, combined.length);
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, k, new GCMParameterSpec(GCM_TAG_BITS, iv));
+      return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+    } catch (GeneralSecurityException | IllegalArgumentException e) {
+      LOG.error("Secret decryption failed (wrong key or corrupt value)", e);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.infrastructure.persistence;
 
+import com.simisinc.platform.application.SecretCryptoCommand;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
@@ -419,7 +420,9 @@ public class UserRepository {
 
   public static User saveMfaSecret(User record, String secret) {
     SqlUtils updateValues = new SqlUtils()
-        .add("mfa_secret", secret)
+        // Store the TOTP seed encrypted at rest (a DB dump must not yield working second factors);
+        // the in-memory record keeps the plaintext for immediate use.
+        .add("mfa_secret", SecretCryptoCommand.encrypt(secret))
         .add("mfa_enabled", false)
         .add("modified", new Timestamp(System.currentTimeMillis()));
     SqlUtils where = new SqlUtils()
@@ -517,7 +520,8 @@ public class UserRepository {
       record.setPostalCode(rs.getString("postal_code"));
       record.setLatitude(rs.getDouble("latitude"));
       record.setLongitude(rs.getDouble("longitude"));
-      record.setMfaSecret(rs.getString("mfa_secret"));
+      // Decrypt the at-rest TOTP seed so callers always see plaintext (legacy plaintext passes through unchanged)
+      record.setMfaSecret(SecretCryptoCommand.decrypt(rs.getString("mfa_secret")));
       record.setMfaEnabled(rs.getBoolean("mfa_enabled"));
       return record;
     } catch (SQLException se) {

--- a/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies at-rest secret encryption: round-trip under a key, unique ciphertext per call, legacy-plaintext and blank
+ * pass-through, and fail-safe behavior when no key or the wrong key is configured. The key is supplied via the
+ * {@code cms.secret.key} system property so no environment variable is needed under test.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-19
+ */
+class SecretCryptoCommandTest {
+
+  private static final String PROP = "cms.secret.key";
+
+  @AfterEach
+  void clearKey() {
+    System.clearProperty(PROP);
+  }
+
+  private void setKey(byte b0) {
+    byte[] key = new byte[32]; // AES-256
+    key[0] = b0;
+    System.setProperty(PROP, Base64.getEncoder().encodeToString(key));
+  }
+
+  @Test
+  void roundTripsAValueWhenAKeyIsConfigured() {
+    setKey((byte) 7);
+    String secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"; // an RFC 6238 style seed
+    String encrypted = SecretCryptoCommand.encrypt(secret);
+
+    assertTrue(encrypted.startsWith("enc:"), "should be marked as encrypted");
+    assertNotEquals(secret, encrypted, "ciphertext must differ from plaintext");
+    assertEquals(secret, SecretCryptoCommand.decrypt(encrypted), "must decrypt back to the original");
+  }
+
+  @Test
+  void producesDifferentCiphertextEachTime() {
+    setKey((byte) 7);
+    // A random IV per encryption means the same secret encrypts to different bytes, but both decrypt cleanly.
+    String a = SecretCryptoCommand.encrypt("same-secret");
+    String b = SecretCryptoCommand.encrypt("same-secret");
+    assertNotEquals(a, b);
+    assertEquals("same-secret", SecretCryptoCommand.decrypt(a));
+    assertEquals("same-secret", SecretCryptoCommand.decrypt(b));
+  }
+
+  @Test
+  void passesThroughLegacyPlaintextAndBlanks() {
+    setKey((byte) 7);
+    assertEquals("legacy-plaintext", SecretCryptoCommand.decrypt("legacy-plaintext"), "no enc: prefix -> unchanged");
+    assertNull(SecretCryptoCommand.encrypt(null));
+    assertEquals("", SecretCryptoCommand.encrypt(""));
+    assertNull(SecretCryptoCommand.decrypt(null));
+  }
+
+  @Test
+  void withoutAKeyEncryptionIsANoOpAndDecryptFailsSafe() {
+    System.clearProperty(PROP);
+    assertFalse(SecretCryptoCommand.isEnabled());
+    assertEquals("secret", SecretCryptoCommand.encrypt("secret"), "no key -> stored as-is (backward compatible)");
+    // An encrypted value cannot be read without the key: fail safe to null, never expose a broken value.
+    assertNull(SecretCryptoCommand.decrypt("enc:AAAAAAAAAAAAAAAA"));
+  }
+
+  @Test
+  void theWrongKeyFailsSafeToNull() {
+    setKey((byte) 7);
+    String encrypted = SecretCryptoCommand.encrypt("secret");
+    setKey((byte) 9); // rotate to a different key
+    assertNull(SecretCryptoCommand.decrypt(encrypted), "wrong key -> null (GCM auth fails), not garbage");
+  }
+}


### PR DESCRIPTION
## Problem (verified gap)
`users.mfa_secret` — the TOTP seed — was stored **in plaintext**. A database dump handed an attacker a **working second factor for every enrolled user**, quietly defeating the MFA we just built. Surfaced by the security capability inventory as the highest-value crypto gap.

## Fix
New `SecretCryptoCommand`: **AES-256-GCM** authenticated encryption under a **key-encryption key** read from **`CMS_SECRET_KEY`** (base64 256-bit; falls back to the `cms.secret.key` system property for tests). `UserRepository` **encrypts the seed on save** and **decrypts on read**, so every caller (TOTP verify, enrollment) still sees plaintext while the column holds ciphertext.

- Encrypted values carry an **`enc:` prefix** → legacy plaintext passes through unchanged (no migration needed; secrets encrypt on their next save).
- **Random IV per encryption** → distinct ciphertext each time.
- **Backward compatible:** with no key set, values are stored as-is, so existing deployments keep working. Set `CMS_SECRET_KEY` for the hardened posture.
- **Fails safe:** a missing/wrong key on read returns `null` rather than a broken value — verification fails cleanly and the user falls back to a recovery code, rather than exposing garbage.

The command is reusable — the same wrapper will encrypt integration/payment keys in a follow-up.

## Key management (documented in installation.md)
Generate: `openssl rand -base64 32`, supply out-of-band. **Back it up** (losing it means affected users re-enroll MFA). **Rotate** by setting the new key and re-saving affected records.

## Tests
`SecretCryptoCommandTest`: round-trip under a key, unique-ciphertext-per-call, legacy/blank pass-through, no-key no-op, and wrong-key fail-safe-to-null. Clean build + full suite green.