### PR TITLE
Add cookieless analytics mode (daily rotating visitor hash)

### DIFF
--- a/src/main/java/com/simisinc/platform/ApplicationInfo.java
+++ b/src/main/java/com/simisinc/platform/ApplicationInfo.java
@@ -32,7 +32,7 @@ public class ApplicationInfo {
   // Use: Change the date, increment the decimal on same day updates
   // then reset back to 10000
   //                         VERSION = "--------.10000";
-  public static final String VERSION = "20260717.10000";
+  public static final String VERSION = "20260719.10000";
 
   /**
    * Outputs the version from the command line

--- a/src/main/java/com/simisinc/platform/application/DailyVisitorHashCommand.java
+++ b/src/main/java/com/simisinc/platform/application/DailyVisitorHashCommand.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDate;
+import java.util.Base64;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Produces a cookieless, privacy-preserving visitor identifier for analytics -- the Plausible/Fathom model. The id is
+ * a SHA-256 hash of a per-day random salt combined with the request fingerprint (IP, user agent, host). Because the
+ * salt is regenerated at midnight and never persisted, the identifier is stable within a day (so daily unique visitors
+ * can be counted) but cannot be correlated across days and cannot be reversed to an IP address. No cookie and no
+ * persistent identifier are stored -- supporting a data-minimized, consent-banner-free analytics posture.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-19
+ */
+public class DailyVisitorHashCommand {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static final int SALT_BYTES = 32;
+  private static final String PREFIX = "d:"; // marks a daily-hash visitor token (vs. a persistent UUID token)
+
+  private static final Object LOCK = new Object();
+  private static byte[] salt;
+  private static LocalDate saltDate;
+
+  private DailyVisitorHashCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * @return the salt for the current day, regenerated (and the previous day's silently discarded) at midnight
+   */
+  private static byte[] currentSalt() {
+    LocalDate today = LocalDate.now();
+    synchronized (LOCK) {
+      if (salt == null || !today.equals(saltDate)) {
+        salt = new byte[SALT_BYTES];
+        RANDOM.nextBytes(salt);
+        saltDate = today;
+      }
+      return salt;
+    }
+  }
+
+  /**
+   * Computes today's pseudonymous visitor id from the request fingerprint.
+   *
+   * @param ipAddress the client IP (used only as hash input; never stored via this id)
+   * @param userAgent the request user agent
+   * @param host      the requested host
+   * @return a {@code d:}-prefixed opaque identifier, or null when there is nothing to fingerprint
+   */
+  public static String dailyHash(String ipAddress, String userAgent, String host) {
+    if (StringUtils.isBlank(ipAddress) && StringUtils.isBlank(userAgent)) {
+      return null;
+    }
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      md.update(currentSalt());
+      md.update(StringUtils.trimToEmpty(ipAddress).getBytes(StandardCharsets.UTF_8));
+      md.update((byte) '|');
+      md.update(StringUtils.trimToEmpty(userAgent).getBytes(StandardCharsets.UTF_8));
+      md.update((byte) '|');
+      md.update(StringUtils.trimToEmpty(host).getBytes(StandardCharsets.UTF_8));
+      return PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest());
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is required for the visitor hash", e);
+    }
+  }
+
+  /**
+   * Test hook: discards the cached salt so the next call rotates it (simulating a day boundary).
+   */
+  static void resetSaltForTest() {
+    synchronized (LOCK) {
+      salt = null;
+      saltDate = null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/SaveVisitorCommand.java
+++ b/src/main/java/com/simisinc/platform/application/SaveVisitorCommand.java
@@ -39,9 +39,20 @@ public class SaveVisitorCommand {
   }
 
   public static Visitor saveVisitor(UserSession userSession) {
-    // Save the record
+    return saveVisitor(userSession, generateVisitorToken());
+  }
+
+  /**
+   * Saves a visitor with a specific token. Used by cookieless analytics, where the token is the daily rotating
+   * visitor hash rather than a persistent random token.
+   *
+   * @param userSession the current session
+   * @param token       the visitor token to store
+   * @return the saved visitor
+   */
+  public static Visitor saveVisitor(UserSession userSession, String token) {
     Visitor visitor = new Visitor();
-    visitor.setToken(generateVisitorToken());
+    visitor.setToken(token);
     visitor.setSessionId(userSession.getSessionId());
     VisitorRepository.add(visitor);
     userSession.setVisitorId(visitor.getId());

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -44,6 +44,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hc.core5.net.InetAddressUtils;
 
 import com.simisinc.platform.application.CreateSessionCommand;
+import com.simisinc.platform.application.DailyVisitorHashCommand;
 import com.simisinc.platform.application.LoadVisitorCommand;
 import com.simisinc.platform.application.SaveSessionCommand;
 import com.simisinc.platform.application.SaveVisitorCommand;
@@ -329,11 +330,17 @@ public class WebRequestFilter implements Filter {
       // Only check for the cookie once per session
       userSession.setCookieChecked(true);
 
-      // Determine if this is a visitor
+      // Determine whether analytics runs cookieless: no persistent visitor cookie, and returning visitors within
+      // the same day are recognized by a daily rotating hash of the request fingerprint instead of a stored token.
+      boolean cookielessAnalytics = LoadSitePropertyCommand.loadByNameAsBoolean("analytics.cookieless");
+      String visitorToken = cookielessAnalytics
+          ? DailyVisitorHashCommand.dailyHash(ipAddress, userAgent, httpServletRequest.getServerName())
+          : cookieVisitorToken;
+
+      // Determine if this is a returning visitor
       Visitor visitor = null;
-      if (StringUtils.isNotBlank(cookieVisitorToken)) {
-        // Found a visitor token
-        visitor = LoadVisitorCommand.loadVisitorByToken(cookieVisitorToken);
+      if (StringUtils.isNotBlank(visitorToken)) {
+        visitor = LoadVisitorCommand.loadVisitorByToken(visitorToken);
         if (visitor != null) {
           userSession.setVisitorId(visitor.getId());
         }
@@ -353,7 +360,9 @@ public class WebRequestFilter implements Filter {
       if (visitor == null) {
         // Create and store a new token
         LOG.debug("Creating a visitor token...");
-        visitor = SaveVisitorCommand.saveVisitor(userSession);
+        visitor = (cookielessAnalytics && StringUtils.isNotBlank(visitorToken))
+            ? SaveVisitorCommand.saveVisitor(userSession, visitorToken)
+            : SaveVisitorCommand.saveVisitor(userSession);
       } else {
         // Make sure the sessionId is set
         if (doSaveSession) {
@@ -361,8 +370,8 @@ public class WebRequestFilter implements Filter {
         }
       }
 
-      {
-        // Create or extend the visitor cookie
+      // Persist the visitor identity in a cookie -- skipped entirely when running cookieless
+      if (!cookielessAnalytics) {
         int oneYearSecondsInt = 365 * 24 * 60 * 60;
         Cookie cookie = new Cookie(CookieConstants.VISITOR_TOKEN, visitor.getToken());
         if (request.isSecure()) {

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -150,6 +150,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 
 -- Analytics
 
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (5, 'Cookieless analytics (no visitor cookie)?', 'analytics.cookieless', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (20, 'Google Analytics GA Key', 'analytics.google.key', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (22, 'Google Tag Manager GTM Key', 'analytics.google.tagmanager', '');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1000__cookieless_analytics.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1000__cookieless_analytics.sql
@@ -1,0 +1,5 @@
+-- Register the cookieless-analytics toggle so existing installs get the setting.
+-- Idempotent: a fresh install already seeds it via NEW_ (property_name is UNIQUE), so ON CONFLICT no-ops there.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (5, 'Cookieless analytics (no visitor cookie)?', 'analytics.cookieless', 'false', 'boolean')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/DailyVisitorHashCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/DailyVisitorHashCommandTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the cookieless visitor hash: stable within a day for the same fingerprint, sensitive to each input,
+ * opaque and prefixed, null when there is nothing to fingerprint, and rotated when the daily salt changes.
+ *
+ * @author SimIS Inc.
+ * @created 2026-07-19
+ */
+class DailyVisitorHashCommandTest {
+
+  @Test
+  void sameFingerprintSameDayYieldsTheSameHash() {
+    String a = DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "example.mil");
+    String b = DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "example.mil");
+    assertEquals(a, b, "same fingerprint within a day -> same id (so daily uniques can be counted)");
+    assertTrue(a.startsWith("d:"), "should be a daily-hash token");
+  }
+
+  @Test
+  void eachInputChangesTheHash() {
+    String base = DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "example.mil");
+    assertNotEquals(base, DailyVisitorHashCommand.dailyHash("203.0.113.8", "Mozilla/5.0", "example.mil"), "IP");
+    assertNotEquals(base, DailyVisitorHashCommand.dailyHash("203.0.113.7", "curl/8.0", "example.mil"), "user agent");
+    assertNotEquals(base, DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "other.mil"), "host");
+  }
+
+  @Test
+  void nothingToFingerprintReturnsNull() {
+    assertNull(DailyVisitorHashCommand.dailyHash(null, null, "example.mil"));
+    assertNull(DailyVisitorHashCommand.dailyHash("", "  ", "example.mil"));
+  }
+
+  @Test
+  void theHashRotatesWhenTheDailySaltRotates() {
+    String today = DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "example.mil");
+    // Simulate crossing midnight: a new salt means the same visitor no longer maps to the same id.
+    DailyVisitorHashCommand.resetSaltForTest();
+    String nextDay = DailyVisitorHashCommand.dailyHash("203.0.113.7", "Mozilla/5.0", "example.mil");
+    assertNotEquals(today, nextDay, "a new day's salt breaks cross-day correlation");
+  }
+}


### PR DESCRIPTION
## What
An opt-in **`analytics.cookieless`** site property. When enabled, the platform stops setting the persistent `VISITOR_TOKEN` cookie and instead identifies a returning visitor by a **daily rotating hash** of the request fingerprint — SHA-256 of a *per-day random salt* + IP + user agent + host. The **Plausible/Fathom model**.

The salt is regenerated at midnight and never stored, so the id is **stable within a day** (daily unique visitors still count) but **cannot be correlated across days** and **cannot be reversed to an IP**. No cookie, no persistent identifier — a data-minimized, consent-banner-free posture that strengthens the in-boundary analytics story for privacy/compliance-minded (DIB/gov) deployments. It's the move that makes the analytics SSP artifact's strongest claims true *by configuration*.

## Safety: default off, zero behavior change
With the property unset or `false`, the flow is **byte-for-byte the current persistent-cookie behavior** — the new path only runs when an operator explicitly enables it. Existing deployments are unaffected. (This is why the hot-path change is low-risk.)

## Changes
- **`DailyVisitorHashCommand`** (+ tests) — the salted rotating hash; tests cover same-day stability, per-input sensitivity, null-on-no-fingerprint, and rotation when the salt changes.
- **`SaveVisitorCommand`** — overload to store a visitor with a supplied token.
- **`WebRequestFilter`** — gated branch: use the hash and skip the cookie when cookieless.
- **DB** — seed the property (fresh install) + **idempotent** `ON CONFLICT` upgrade for existing installs; `VERSION` bumped to `20260719.10000` so a fresh install baselines above the upgrade.

## Verification
Clean `ant clean` + full `ci-test`: green.

## Follow-up (separate card)
IP anonymization at rest pairs naturally with this (the hash already avoids needing the raw IP for identification) — tracked as "Analytics: PII/retention hardening."