### PR TITLE
Hash passwords with Argon2id, keep verifying legacy Argon2i

### DIFF
--- a/src/main/java/com/simisinc/platform/application/UserPasswordCommand.java
+++ b/src/main/java/com/simisinc/platform/application/UserPasswordCommand.java
@@ -32,16 +32,23 @@ public class UserPasswordCommand {
   private static Log LOG = LogFactory.getLog(UserPasswordCommand.class);
 
   public static String hash(String password) {
-    Argon2 argon2 = Argon2Factory.create();
+    // Argon2id (RFC 9106 / OWASP default) resists both GPU and side-channel attacks; Argon2i alone is weaker
+    // against GPU cracking. Cost params: 2 iterations, 65536 KiB (64 MiB) memory, 1 lane -- above OWASP minimums.
+    Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2id);
     char[] pw = password.toCharArray();
-    return argon2.hash(2, 65536, 1, pw);
+    try {
+      return argon2.hash(2, 65536, 1, pw);
+    } finally {
+      // Wipe confidential data
+      argon2.wipeArray(pw);
+    }
   }
 
   public static boolean verify(String password, String hash) {
-    Argon2 argon2 = Argon2Factory.create();
-    // 1000 = The hash call must take at most 1000 ms
-    // 65536 = Memory cost
-    // 1 = parallelism
+    // Select the verifier matching the stored hash's variant. New hashes are $argon2id$, but hashes created
+    // before the argon2id upgrade are $argon2i$ -- the native verify requires the instance variant to match the
+    // encoded prefix, so legacy passwords would fail to verify unless we pick the right one here.
+    Argon2 argon2 = Argon2Factory.create(variantOf(hash));
     char[] pw = password.toCharArray();
     boolean verified = false;
     try {
@@ -52,6 +59,17 @@ public class UserPasswordCommand {
       argon2.wipeArray(pw);
     }
     return verified;
+  }
+
+  private static Argon2Factory.Argon2Types variantOf(String hash) {
+    if (hash != null && hash.startsWith("$argon2id$")) {
+      return Argon2Factory.Argon2Types.ARGON2id;
+    }
+    if (hash != null && hash.startsWith("$argon2d$")) {
+      return Argon2Factory.Argon2Types.ARGON2d;
+    }
+    // Legacy default: hashes produced before the upgrade are $argon2i$
+    return Argon2Factory.Argon2Types.ARGON2i;
   }
 
 }

--- a/src/test/java/com/simisinc/platform/application/UserPasswordCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/UserPasswordCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
+
+/**
+ * Tests the password hashing and verification, including backward compatibility with legacy argon2i hashes.
+ *
+ * @author elizabeth houser
+ */
+class UserPasswordCommandTest {
+
+  @Test
+  void newHashesUseArgon2id() {
+    String hash = UserPasswordCommand.hash("correct horse battery staple");
+    assertTrue(hash.startsWith("$argon2id$"), "New hashes should use the argon2id variant: " + hash);
+  }
+
+  @Test
+  void aFreshHashVerifies() {
+    String password = "correct horse battery staple";
+    String hash = UserPasswordCommand.hash(password);
+    assertTrue(UserPasswordCommand.verify(password, hash));
+    assertFalse(UserPasswordCommand.verify("wrong password", hash));
+  }
+
+  @Test
+  void legacyArgon2iHashesStillVerify() {
+    // Simulate a password stored before the argon2id upgrade
+    String password = "an existing user's password";
+    Argon2 legacy = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2i);
+    String legacyHash = legacy.hash(2, 65536, 1, password.toCharArray());
+    assertTrue(legacyHash.startsWith("$argon2i$"), "Sanity: the legacy hash should be argon2i: " + legacyHash);
+
+    // The upgraded verify() must still accept it, so existing logins are not broken
+    assertTrue(UserPasswordCommand.verify(password, legacyHash),
+        "A legacy argon2i hash must continue to verify after the argon2id upgrade");
+    assertFalse(UserPasswordCommand.verify("wrong password", legacyHash));
+  }
+}


### PR DESCRIPTION
## What
`UserPasswordCommand.hash()` used `Argon2Factory.create()`, which defaults to **Argon2i**. RFC 9106 and OWASP name **Argon2id** as the default variant — it keeps Argon2i's side-channel resistance *and* adds Argon2d's GPU/TMTO resistance. Shipping Argon2i for new password hashes is an avoidable weakness (and a routine assessment finding). This switches new hashes to Argon2id; cost params are unchanged (2 iterations, 64 MiB memory, 1 lane — already above OWASP minimums).

## The backward-compat trap (why this is more than a one-word change)
The native `argon2_verify` requires the verifier's variant to **match the encoded prefix** (`$argon2i$` vs `$argon2id$`). So an Argon2id verifier *rejects* a stored `$argon2i$` hash. A naive factory flip would therefore **break every existing login** until users reset their passwords.

`verify()` now selects the variant from the stored hash's prefix, so:
- Passwords created before this change (`$argon2i$`) **keep verifying** — no forced resets, no broken logins.
- New accounts get `$argon2id$` immediately.
- Existing hashes migrate to argon2id naturally on the next password change.

## Also
- Wipe the password `char[]` in `hash()` too (it was only wiped in `verify()`).

## Tests
New `UserPasswordCommandTest`: new hashes are `$argon2id$`, a fresh hash round-trips (and rejects a wrong password), and **a legacy `$argon2i$` hash still verifies**. Full `ci-test` green.

## Follow-up (separate card)
*Upgrade-on-login*: transparently re-hash a legacy `$argon2i$` password to argon2id on successful authentication, so the whole store migrates without waiting for password changes. Deferred because it touches the auth flow and deserves its own PR + test.