### PR TITLE
Add self-hosted map tile server option; secure the OSM fallback

### DIFF
--- a/src/main/java/com/simisinc/platform/ApplicationInfo.java
+++ b/src/main/java/com/simisinc/platform/ApplicationInfo.java
@@ -32,7 +32,7 @@ public class ApplicationInfo {
   // Use: Change the date, increment the decimal on same day updates
   // then reset back to 10000
   //                         VERSION = "--------.10000";
-  public static final String VERSION = "20260717.10000";
+  public static final String VERSION = "20260719.10000";
 
   /**
    * Outputs the version from the command line

--- a/src/main/java/com/simisinc/platform/application/maps/FindMapTilesCredentialsCommand.java
+++ b/src/main/java/com/simisinc/platform/application/maps/FindMapTilesCredentialsCommand.java
@@ -16,10 +16,14 @@
 
 package com.simisinc.platform.application.maps;
 
-import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
-import com.simisinc.platform.domain.model.maps.MapCredentials;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.maps.MapCredentials;
 
 /**
  * Methods for map tile service integration
@@ -30,6 +34,12 @@ import org.apache.commons.logging.LogFactory;
 public class FindMapTilesCredentialsCommand {
 
   private static Log LOG = LogFactory.getLog(FindMapTilesCredentialsCommand.class);
+
+  // A Leaflet tile URL template, like https://tiles.example.com/{z}/{x}/{y}.png
+  // Restricted to URL-safe characters (the value is rendered into page javascript):
+  // no quotes, whitespace, backslashes, or angle brackets
+  private static final Pattern TILE_SERVER_URL_PATTERN = Pattern
+      .compile("^https?://[A-Za-z0-9\\-._~:/?&=%,+{}]+$");
 
   public static MapCredentials getCredentials() {
     String mapService = LoadSitePropertyCommand.loadByName("maps.service.tiles");
@@ -43,8 +53,36 @@ public class FindMapTilesCredentialsCommand {
       if (accessToken != null) {
         return new MapCredentials(mapService, accessToken);
       }
+    } else if ("custom".equalsIgnoreCase(mapService)) {
+      // A self-hosted tile server, for deployments which do not use external map services
+      String tileServerUrl = validatedTileServerUrl(LoadSitePropertyCommand.loadByName("maps.custom.tileserver.url"));
+      if (tileServerUrl != null) {
+        // Use the canonical value; the JSPs compare it case-sensitively
+        MapCredentials mapCredentials = new MapCredentials("custom", null);
+        mapCredentials.setTileServerUrl(tileServerUrl);
+        return mapCredentials;
+      }
+      LOG.warn("maps.service.tiles is 'custom' but maps.custom.tileserver.url is blank or invalid; using openstreetmap");
     }
     return new MapCredentials("openstreetmap", null);
+  }
+
+  /** Returns the url when it is a well-formed tile url template, otherwise null */
+  static String validatedTileServerUrl(String url) {
+    url = StringUtils.trimToNull(url);
+    if (url == null) {
+      return null;
+    }
+    if (!TILE_SERVER_URL_PATTERN.matcher(url).matches()) {
+      LOG.warn("maps.custom.tileserver.url contains unsupported characters, ignoring it");
+      return null;
+    }
+    // Leaflet requires the tile coordinate placeholders
+    if (!url.contains("{z}") || !url.contains("{x}") || !url.contains("{y}")) {
+      LOG.warn("maps.custom.tileserver.url must contain {z}, {x} and {y} placeholders, ignoring it");
+      return null;
+    }
+    return url;
   }
 
 }

--- a/src/main/java/com/simisinc/platform/domain/model/maps/MapCredentials.java
+++ b/src/main/java/com/simisinc/platform/domain/model/maps/MapCredentials.java
@@ -28,6 +28,7 @@ public class MapCredentials extends Entity {
 
   private String service = null;
   private String accessToken = null;
+  private String tileServerUrl = null;
 
   public MapCredentials() {
   }
@@ -51,5 +52,13 @@ public class MapCredentials extends Entity {
 
   public void setAccessToken(String accessToken) {
     this.accessToken = accessToken;
+  }
+
+  public String getTileServerUrl() {
+    return tileServerUrl;
+  }
+
+  public void setTileServerUrl(String tileServerUrl) {
+    this.tileServerUrl = tileServerUrl;
   }
 }

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -145,6 +145,9 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (20, 'Map Geocoder Service', 'maps.service.geocoder', 'nominatim');
 -- UPDATE site_properties SET property_value = 'mapbox' WHERE property_name = 'maps.service.tiles';
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (30, 'Map Box Access Token', 'maps.mapbox.accesstoken', '');
+-- UPDATE site_properties SET property_value = 'custom' WHERE property_name = 'maps.service.tiles';
+-- No property_type: the url validator rejects the required {z}/{x}/{y} placeholders; FindMapTilesCredentialsCommand validates instead
+INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (40, 'Custom Map Tiles Url ({z}/{x}/{y} template)', 'maps.custom.tileserver.url', '');
 -- UPDATE site_properties SET property_value = 'google' WHERE property_name = 'maps.service.tiles';
 -- INSERT INTO site_properties (property_label, property_name, property_value) VALUES ('Google Maps Access Token', 'maps.google.accesstoken', '');
 

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1001__map_tileserver.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1001__map_tileserver.sql
@@ -1,0 +1,5 @@
+-- Adds an optional self-hosted map tile server url, used when maps.service.tiles is 'custom'
+-- No property_type: the url validator rejects the required {z}/{x}/{y} placeholders; FindMapTilesCredentialsCommand validates instead
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (40, 'Custom Map Tiles Url ({z}/{x}/{y} template)', 'maps.custom.tileserver.url', '')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
@@ -57,12 +57,19 @@
       maxZoom: 12,
       zoomOffset: -1,
       id: 'mapbox/streets-v11',
-    accessToken: '${mapCredentials.accessToken}'
+    accessToken: '${js:escape(mapCredentials.accessToken)}'
+  }).addTo(map${widgetContext.uniqueId});
+  </c:when>
+  <c:when test="${mapCredentials.service eq 'custom'}">
+  L.tileLayer('${mapCredentials.tileServerUrl}', {
+    attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+    minZoom: 1,
+    maxZoom: 10
   }).addTo(map${widgetContext.uniqueId});
   </c:when>
   <c:otherwise>
-  L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
     minZoom: 1,
     maxZoom: 10
   }).addTo(map${widgetContext.uniqueId});

--- a/src/main/webapp/WEB-INF/jsp/maps/apple_map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/apple_map.jsp
@@ -42,12 +42,19 @@ NOT IMPLEMENTED
       maxZoom: 12,
       zoomOffset: -1,
       id: 'mapbox/streets-v11',
-    accessToken: '${mapCredentials.accessToken}'
+    accessToken: '${js:escape(mapCredentials.accessToken)}'
+  }).addTo(mymap);
+  </c:when>
+  <c:when test="${mapCredentials.service eq 'custom'}">
+  L.tileLayer('${mapCredentials.tileServerUrl}', {
+    attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+    minZoom: 8,
+    maxZoom: 12
   }).addTo(mymap);
   </c:when>
   <c:otherwise>
-  L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
     minZoom: 8,
     maxZoom: 12
   }).addTo(mymap);

--- a/src/main/webapp/WEB-INF/jsp/maps/items-map-app.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/items-map-app.jsp
@@ -89,12 +89,18 @@
       maxZoom: 12,
       zoomOffset: -1,
       id: 'mapbox/streets-v11',
-      accessToken: '${mapCredentials.accessToken}'
+      accessToken: '${js:escape(mapCredentials.accessToken)}'
+    }).addTo(map${widgetContext.uniqueId});
+    </c:when>
+    <c:when test="${mapCredentials.service eq 'custom'}">
+    L.tileLayer('${mapCredentials.tileServerUrl}', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+      maxZoom: 18
     }).addTo(map${widgetContext.uniqueId});
     </c:when>
     <c:otherwise>
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
       maxZoom: 18
     }).addTo(map${widgetContext.uniqueId});
     </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/maps/leaflet-js_map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/leaflet-js_map.jsp
@@ -45,12 +45,18 @@
       maxZoom: 12,
       zoomOffset: -1,
       id: 'mapbox/streets-v11',
-      accessToken: '${mapCredentials.accessToken}'
+      accessToken: '${js:escape(mapCredentials.accessToken)}'
+    }).addTo(map${widgetContext.uniqueId});
+    </c:when>
+    <c:when test="${mapCredentials.service eq 'custom'}">
+    L.tileLayer('${mapCredentials.tileServerUrl}', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+      maxZoom: 16
     }).addTo(map${widgetContext.uniqueId});
     </c:when>
     <c:otherwise>
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
       maxZoom: 16
     }).addTo(map${widgetContext.uniqueId});
     </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/maps/property-map-app.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/property-map-app.jsp
@@ -170,12 +170,18 @@
       maxZoom: 18,
       zoomOffset: -1,
       id: 'mapbox/streets-v11',
-      accessToken: '${mapCredentials.accessToken}'
+      accessToken: '${js:escape(mapCredentials.accessToken)}'
+    }).addTo(map${widgetContext.uniqueId});
+    </c:when>
+    <c:when test="${mapCredentials.service eq 'custom'}">
+    L.tileLayer('${mapCredentials.tileServerUrl}', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+      maxZoom: 18
     }).addTo(map${widgetContext.uniqueId});
     </c:when>
     <c:otherwise>
-    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
       maxZoom: 18
     }).addTo(map${widgetContext.uniqueId});
     </c:otherwise>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -451,7 +451,7 @@
       <column class="medium-5 cell">
         <widget name="content" class="callout primary radius">
           <html><![CDATA[<h4>About Map Services</h4>
-          <ul><li>The Tiles service value can be 'openstreetmap' or 'mapbox'</li><li>The Geocoder service value can be 'nominatim' or 'mapbox'</li></ul>
+          <ul><li>The Tiles service value can be 'openstreetmap', 'mapbox', or 'custom' (a self-hosted tile server; set the Custom Map Tiles Url to a template like https://tiles.example.com/{z}/{x}/{y}.png)</li><li>The Geocoder service value can be 'nominatim' or 'mapbox'</li></ul>
 <h5>Nominatim Info</h5><p>No heavy uses; 1 request per second maximum.</p>
 <h5>Mapbox Info</h5><p>The Free to start plan allows: 50,000 map views / mo and 50,000 geocode requests / mo. Rate-limited to 600 per minute.</p>
 ]]></html>

--- a/src/test/java/com/simisinc/platform/application/maps/FindMapTilesCredentialsCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/maps/FindMapTilesCredentialsCommandTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.maps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.maps.MapCredentials;
+
+/**
+ * Tests the map tile service selection, including the self-hosted 'custom' tile server option
+ *
+ * @author elizabeth houser
+ */
+class FindMapTilesCredentialsCommandTest {
+
+  @Test
+  void customServiceUsesTheConfiguredTileServer() {
+    try (MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.service.tiles")).thenReturn("custom");
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.custom.tileserver.url"))
+          .thenReturn("https://tiles.example.com/{z}/{x}/{y}.png");
+      MapCredentials credentials = FindMapTilesCredentialsCommand.getCredentials();
+      assertEquals("custom", credentials.getService());
+      assertEquals("https://tiles.example.com/{z}/{x}/{y}.png", credentials.getTileServerUrl());
+    }
+  }
+
+  @Test
+  void customServiceMatchIsCaseInsensitiveButCanonical() {
+    try (MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.service.tiles")).thenReturn("Custom");
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.custom.tileserver.url"))
+          .thenReturn("https://tiles.example.com/{z}/{x}/{y}.png");
+      MapCredentials credentials = FindMapTilesCredentialsCommand.getCredentials();
+      // The JSPs compare the service case-sensitively, so the canonical value must be returned
+      assertEquals("custom", credentials.getService());
+    }
+  }
+
+  @Test
+  void customServiceWithoutAUrlFallsBackToOpenStreetMap() {
+    try (MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.service.tiles")).thenReturn("custom");
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.custom.tileserver.url")).thenReturn("");
+      MapCredentials credentials = FindMapTilesCredentialsCommand.getCredentials();
+      assertEquals("openstreetmap", credentials.getService());
+      assertNull(credentials.getTileServerUrl());
+    }
+  }
+
+  @Test
+  void openStreetMapRemainsTheDefault() {
+    try (MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      property.when(() -> LoadSitePropertyCommand.loadByName("maps.service.tiles")).thenReturn("openstreetmap");
+      MapCredentials credentials = FindMapTilesCredentialsCommand.getCredentials();
+      assertEquals("openstreetmap", credentials.getService());
+    }
+  }
+
+  @Test
+  void urlValidationAcceptsATileTemplate() {
+    assertEquals("https://tiles.example.com/{z}/{x}/{y}.png",
+        FindMapTilesCredentialsCommand.validatedTileServerUrl("https://tiles.example.com/{z}/{x}/{y}.png"));
+    // Subdomain templates and query parameters are allowed
+    assertEquals("https://{s}.tiles.example.com/{z}/{x}/{y}.png?key=abc123",
+        FindMapTilesCredentialsCommand.validatedTileServerUrl("https://{s}.tiles.example.com/{z}/{x}/{y}.png?key=abc123"));
+  }
+
+  @Test
+  void urlValidationRejectsUnsafeValues() {
+    // The url is rendered into page javascript, so quotes and markup must never pass
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("https://x/{z}/{x}/{y}'+alert(1)+'"));
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("https://x/{z}/{x}/{y}</script>"));
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("https://x/{z}/{x}/{y}\"onerror=\"x"));
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("javascript:alert(1)//{z}{x}{y}"));
+    // Not a url at all
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("tiles.example.com/{z}/{x}/{y}.png"));
+    // Missing the tile coordinate placeholders
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("https://tiles.example.com/tiles.png"));
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl(null));
+    assertNull(FindMapTilesCredentialsCommand.validatedTileServerUrl("   "));
+  }
+}


### PR DESCRIPTION
## What
Two related map fixes, found during the live v2 tour:

1. **Self-hosted tile server option (the air-gapped/compliance angle).** `maps.service.tiles` now accepts **`custom`**: set `maps.custom.tileserver.url` to a Leaflet template (`https://tiles.example.com/{z}/{x}/{y}.png`) and map tiles come from your own infrastructure — **no map request ever leaves the deployment boundary**. Until now every non-Mapbox map depended on openstreetmap.org.
2. **Secure the OSM fallback.** The hardcoded fallback was `http://{s}.tile.openstreetmap.org` — plaintext HTTP (mixed content on SSL sites) on OSM's **deprecated `{s}` subdomains**. Now `https://tile.openstreetmap.org` per current OSM policy.

## Security design
The custom URL is rendered into page JavaScript by the 5 map JSPs, so it's validated **server-side** in `FindMapTilesCredentialsCommand`: a strict character allowlist (no quotes, whitespace, backslashes, angle brackets — nothing that can exit a JS string or script block) **plus** required `{z}/{x}/{y}` placeholders. Invalid values are ignored with a logged warning and the maps fall back to OSM.

Adversarial review of the diff also caught and fixed:
- **`property_type='url'` would have bricked the feature**: the admin form's `UrlValidator` rejects `{z}/{x}/{y}` braces, so every valid template would fail to save (and abort the whole Maps Settings form). The property is seeded **untyped**; the command's allowlist is the validator.
- **Mapbox token escaping (pre-existing, same JSP lines)**: the mapbox access token was rendered with raw EL into the same single-quoted JS context — an admin-input stored-XSS path. Now wrapped in the existing `js:escape` taglib in all 5 JSPs.
- **Case canonicalization**: `MapCredentials.service` is stored lowercase so the JSPs' case-sensitive `eq 'custom'` always matches what the Java side accepted.

## Compatibility
- Default behavior unchanged: `openstreetmap` stays the default; existing deployments just get the HTTPS fallback fix.
- DB: seeded in `NEW_10000` (fresh installs) + idempotent `ON CONFLICT` upgrade `20260719.1001` (existing installs); `VERSION` → `20260719.10000` — the **identical string** #116 uses, so the two PRs merge cleanly in either order (Flyway runs `outOfOrder`, verified).
- Known narrow edge (documented, accepted): a *fresh install* done in the window between this PR and #116 merging bakes a baseline above the other PR's upgrade, so that instance would need the one-line INSERT run manually. Upgraded installs are unaffected. This is the repo's established same-day-serial convention.

## Verification
Full `ant ci-test` green, including new `FindMapTilesCredentialsCommandTest` (6 tests: service selection, canonical case, fallbacks, and URL validation incl. JS-breakout attempts). Diff reviewed by a 3-lens adversarial pass (injection, JSTL structure, migration semantics); all confirmed findings fixed above.