### PR TITLE
Mask secret site properties in the admin editor

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import java.util.Set;
+
+/**
+ * The site properties whose values are secrets (passwords, API keys, tokens).
+ * These are never rendered back to the browser and an empty form submission keeps the stored value.
+ *
+ * Only exact property names belong here; do not add prefix rules -- '.key' is a secret for
+ * some services and a public publishable key for others (for example the Stripe and Square
+ * browser keys, the captcha site key, and the Mapbox access token are sent to the browser
+ * by design and must not be masked).
+ *
+ * @author elizabeth houser
+ */
+public class SecretSitePropertiesCommand {
+
+  private static final Set<String> SECRET_PROPERTY_NAMES = Set.of(
+      // Payment and fulfillment credentials
+      "ecommerce.stripe.test.secret",
+      "ecommerce.stripe.production.secret",
+      "ecommerce.square.test.secret",
+      "ecommerce.square.production.secret",
+      "ecommerce.boxzooka.production.secret",
+      "ecommerce.taxjar.apiKey",
+      // Authentication and identity secrets
+      "oauth.clientSecret",
+      "mail.password",
+      "captcha.google.secretkey",
+      // Server-side integration keys and tokens
+      "mailing-list.mailchimp.apiKey",
+      "bi.superset.secret",
+      "social.instagram.accessToken",
+      "elearning.lrs.key",
+      "elearning.lrs.secret",
+      "elearning.lrs.authHeader",
+      "elearning.moodle.token",
+      "elearning.perls.clientId",
+      "elearning.perls.secret",
+      "conferencing.bbb.secret");
+
+  private SecretSitePropertiesCommand() {
+  }
+
+  public static boolean isSecret(String propertyName) {
+    return propertyName != null && SECRET_PROPERTY_NAMES.contains(propertyName);
+  }
+
+  public static Set<String> getSecretPropertyNames() {
+    return SECRET_PROPERTY_NAMES;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.admin;
 
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.admin.SecretSitePropertiesCommand;
 import com.simisinc.platform.application.cms.ColorCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
@@ -66,6 +67,7 @@ public class SitePropertiesEditorWidget extends GenericWidget {
       }
     }
     context.getRequest().setAttribute("sitePropertyList", siteProperties);
+    context.getRequest().setAttribute("secretPropertyNames", SecretSitePropertiesCommand.getSecretPropertyNames());
 
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
@@ -97,6 +99,12 @@ public class SitePropertiesEditorWidget extends GenericWidget {
         newValue = "";
       } else {
         newValue = newValue.trim();
+      }
+
+      // Secret values are rendered as empty masked fields; a blank submission means unchanged,
+      // so keep the stored value instead of wiping it
+      if (SecretSitePropertiesCommand.isSecret(siteProperty.getName()) && StringUtils.isBlank(newValue)) {
+        continue;
       }
 
       // Handle types

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -72,6 +72,17 @@
         <td><c:out value="${siteProperty.label}" /></td>
         <td nowrap>
           <c:choose>
+            <%-- Secret values are never rendered back to the browser --%>
+            <c:when test="${secretPropertyNames.contains(siteProperty.name)}">
+              <c:choose>
+                <c:when test="${siteProperty.type eq 'disabled'}">
+                  <input type="password" class="no-gap" value="" placeholder="<c:out value="${empty siteProperty.value ? 'not set' : 'value hidden'}"/>" disabled />
+                </c:when>
+                <c:otherwise>
+                  <input type="password" class="no-gap" name="${siteProperty.name}" value="" autocomplete="new-password" placeholder="<c:out value="${empty siteProperty.value ? 'not set' : 'value hidden; leave blank to keep it'}"/>" />
+                </c:otherwise>
+              </c:choose>
+            </c:when>
             <c:when test="${siteProperty.name eq 'theme.logo.color'}">
               <select name="${siteProperty.name}">
                 <option value="full-color"<c:if test="${siteProperty.value eq 'full-color'}"> selected</c:if>>Full color</option>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidgetTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.admin.SecretSitePropertiesCommand;
+import com.simisinc.platform.domain.model.SiteProperty;
+import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
+
+/**
+ * Tests the site properties editor, including that masked secret fields do not wipe stored values
+ *
+ * @author elizabeth houser
+ */
+class SitePropertiesEditorWidgetTest extends WidgetBase {
+
+  private SiteProperty property(String name, String value, String type) {
+    SiteProperty siteProperty = new SiteProperty();
+    siteProperty.setName(name);
+    siteProperty.setValue(value);
+    siteProperty.setType(type);
+    return siteProperty;
+  }
+
+  @Test
+  void secretListMatchesKnownProperties() {
+    assertTrue(SecretSitePropertiesCommand.isSecret("mail.password"));
+    assertTrue(SecretSitePropertiesCommand.isSecret("ecommerce.stripe.production.secret"));
+    // Browser-bound publishable values must never be masked
+    assertFalse(SecretSitePropertiesCommand.isSecret("ecommerce.stripe.production.key"));
+    assertFalse(SecretSitePropertiesCommand.isSecret("captcha.google.sitekey"));
+    assertFalse(SecretSitePropertiesCommand.isSecret("maps.mapbox.accesstoken"));
+    assertFalse(SecretSitePropertiesCommand.isSecret(null));
+  }
+
+  @Test
+  void blankSecretSubmissionKeepsTheStoredValue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"sitePropertiesEditor\">\n" +
+        "  <prefix>mail</prefix>\n" +
+        "</widget>");
+
+    List<SiteProperty> stored = new ArrayList<>();
+    stored.add(property("mail.host.name", "smtp.example.com", null));
+    stored.add(property("mail.password", "existing-smtp-password", null));
+
+    // The admin edits the host but leaves the masked password field blank
+    addQueryParameter(widgetContext, "mail.host.name", "smtp2.example.com");
+    addQueryParameter(widgetContext, "mail.password", "");
+
+    try (MockedStatic<SitePropertyRepository> repository = mockStatic(SitePropertyRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      repository.when(() -> SitePropertyRepository.findAllByPrefix(anyString())).thenReturn(stored);
+      repository.when(() -> SitePropertyRepository.saveAll(eq("mail"), eq(stored))).thenReturn(true);
+
+      SitePropertiesEditorWidget widget = new SitePropertiesEditorWidget();
+      widget.post(widgetContext);
+
+      assertEquals("smtp2.example.com", stored.get(0).getValue());
+      // The blank masked field must not wipe the stored secret
+      assertEquals("existing-smtp-password", stored.get(1).getValue());
+    }
+  }
+
+  @Test
+  void aNewSecretValueIsSaved() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"sitePropertiesEditor\">\n" +
+        "  <prefix>mail</prefix>\n" +
+        "</widget>");
+
+    List<SiteProperty> stored = new ArrayList<>();
+    stored.add(property("mail.password", "old-password", null));
+
+    addQueryParameter(widgetContext, "mail.password", "new-password");
+
+    try (MockedStatic<SitePropertyRepository> repository = mockStatic(SitePropertyRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      repository.when(() -> SitePropertyRepository.findAllByPrefix(anyString())).thenReturn(stored);
+      repository.when(() -> SitePropertyRepository.saveAll(eq("mail"), eq(stored))).thenReturn(true);
+
+      SitePropertiesEditorWidget widget = new SitePropertiesEditorWidget();
+      widget.post(widgetContext);
+
+      assertEquals("new-password", stored.get(0).getValue());
+    }
+  }
+
+  @Test
+  void blankNonSecretSubmissionStillClearsTheValue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"sitePropertiesEditor\">\n" +
+        "  <prefix>site</prefix>\n" +
+        "</widget>");
+
+    List<SiteProperty> stored = new ArrayList<>();
+    stored.add(property("site.header.line1", "A header", null));
+
+    addQueryParameter(widgetContext, "site.header.line1", "");
+
+    try (MockedStatic<SitePropertyRepository> repository = mockStatic(SitePropertyRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      repository.when(() -> SitePropertyRepository.findAllByPrefix(anyString())).thenReturn(stored);
+      repository.when(() -> SitePropertyRepository.saveAll(eq("site"), eq(stored))).thenReturn(true);
+
+      SitePropertiesEditorWidget widget = new SitePropertiesEditorWidget();
+      widget.post(widgetContext);
+
+      // Pre-existing behavior for normal fields is unchanged
+      assertEquals("", stored.get(0).getValue());
+    }
+  }
+}


### PR DESCRIPTION
## What
The secret-storage mapping for the encrypt-at-rest work surfaced this adjacent gap: **all 19 secret site properties** (Stripe/Square/Boxzooka/TaxJar payment secrets, SMTP password, OAuth client secret, captcha secret, MailChimp/Superset/Instagram/e-learning/BBB tokens) render as **plain text inputs** in the admin settings pages — the full value sits in the page HTML on every visit. The production payment secrets render visible too, in `disabled` inputs.

## Changes
- **Render**: secrets now render as empty `type="password"` fields that never echo the stored value. The placeholder says whether a value is set (`not set` vs `value hidden; leave blank to keep it`). `autocomplete="new-password"` stops browsers autofilling the admin's login password. `disabled`-type production secrets show a masked, non-editable field.
- **Save**: a masked field posts blank when unchanged, so `SitePropertiesEditorWidget.post()` now **keeps the stored value** when a secret is submitted blank — no more wipe-on-save. Entering a new value replaces it. Non-secret fields keep their existing clear-on-blank behavior (tested).
- **The list**: `SecretSitePropertiesCommand` holds the canonical secret names — **exact names only**, because suffix rules are ambiguous (`.key` is a secret for LRS but a browser-bound publishable key for Stripe/Square/captcha/Mapbox, which must stay visible). This is shared groundwork for the encrypt-at-rest pass over the same properties (design ready, blocked on #114).

## Behavior notes
- One deliberate trade-off: a secret can no longer be *cleared* from the UI (blank = keep). Secrets are rotated rather than cleared in practice; clearing still works via SQL. Called out so it's a reviewed decision.
- Zero overlap with the open PR queue's files — merges cleanly in any order.

## Verification
Full `ant ci-test` green. New `SitePropertiesEditorWidgetTest` (4 tests): blank secret keeps the stored value, new secret value saves, blank non-secret still clears, publishable keys never masked.