### PR TITLE
Validate analytics tracking ids to close an attribute-context XSS

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/AnalyticsTrackingIdCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/AnalyticsTrackingIdCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Validates third-party analytics tracking identifiers.
+ *
+ * These values (Google Analytics/Tag Manager keys, Simpli.fi and Brand CDN tag values) are rendered
+ * by the master page template into public-page script src attributes and inline script. A tracking id
+ * is a short token -- for example "G-XXXXXXXX", "UA-XXXXXX-X", "GTM-XXXXXXX" -- so anything outside a
+ * conservative character set is not a real id and must never reach the page: escaping alone is not a
+ * reliable defense there, because the values land in HTML attribute contexts where a JavaScript-string
+ * escaper does not neutralize a quote. Constraining the stored value at the source closes every sink.
+ *
+ * @author elizabeth houser
+ */
+public class AnalyticsTrackingIdCommand {
+
+  private static Log LOG = LogFactory.getLog(AnalyticsTrackingIdCommand.class);
+
+  // A tracking id: letters, digits, dot, underscore, hyphen. No quotes, whitespace, slashes, or markup.
+  private static final Pattern TRACKING_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]{1,64}$");
+
+  private static final Set<String> TRACKING_ID_PROPERTIES = Set.of(
+      "analytics.google.key",
+      "analytics.google.tagmanager",
+      "analytics.simplifi.value",
+      "analytics.brandcdn.value",
+      "analytics.brandcdn.value2");
+
+  private AnalyticsTrackingIdCommand() {
+  }
+
+  public static boolean isTrackingIdProperty(String propertyName) {
+    return propertyName != null && TRACKING_ID_PROPERTIES.contains(propertyName);
+  }
+
+  /** A blank value is allowed (the tag is simply not rendered); a non-blank value must be a well-formed id */
+  public static boolean isValid(String value) {
+    return StringUtils.isBlank(value) || TRACKING_ID_PATTERN.matcher(value).matches();
+  }
+
+  /**
+   * Removes any tracking id from the analytics property map whose value is not well-formed, so the
+   * page template only ever renders safe values -- regardless of how the value was stored.
+   */
+  public static void sanitize(Map<String, String> analyticsPropertyMap) {
+    if (analyticsPropertyMap == null) {
+      return;
+    }
+    for (String propertyName : TRACKING_ID_PROPERTIES) {
+      String value = analyticsPropertyMap.get(propertyName);
+      if (StringUtils.isNotBlank(value) && !isValid(value)) {
+        LOG.warn("Ignoring malformed analytics tracking id for " + propertyName);
+        analyticsPropertyMap.put(propertyName, "");
+      }
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.controller;
 
+import com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.*;
 import com.simisinc.platform.application.items.LoadCategoryCommand;
@@ -242,6 +243,8 @@ public class PageServlet extends HttpServlet {
       Map<String, String> themePropertyMap = LoadSitePropertyCommand.loadAsMap("theme");
       Map<String, String> socialPropertyMap = LoadSitePropertyCommand.loadAsMap("social");
       Map<String, String> analyticsPropertyMap = LoadSitePropertyCommand.loadAsMap("analytics");
+      // Never render a malformed tracking id into the public page's script tags
+      AnalyticsTrackingIdCommand.sanitize(analyticsPropertyMap);
       Map<String, String> ecommercePropertyMap = LoadSitePropertyCommand.loadAsMap("ecommerce");
 
       // Web Page Hits

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.admin;
 
+import com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.ColorCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
@@ -127,6 +128,10 @@ public class SitePropertiesEditorWidget extends GenericWidget {
       } else if ("color".equals(siteProperty.getType())) {
         if (!ColorCommand.isHexColor(newValue)) {
           context.setErrorMessage(siteProperty.getLabel() + " needs hex formatting value");
+        }
+      } else if (AnalyticsTrackingIdCommand.isTrackingIdProperty(siteProperty.getName())) {
+        if (!AnalyticsTrackingIdCommand.isValid(newValue)) {
+          context.setErrorMessage(siteProperty.getLabel() + " is not a valid tracking id");
         }
       }
     }

--- a/src/test/java/com/simisinc/platform/application/admin/AnalyticsTrackingIdCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/admin/AnalyticsTrackingIdCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests validation and sanitization of third-party analytics tracking ids
+ *
+ * @author elizabeth houser
+ */
+class AnalyticsTrackingIdCommandTest {
+
+  @Test
+  void wellFormedTrackingIdsAreValid() {
+    assertTrue(AnalyticsTrackingIdCommand.isValid("G-XXXXXXXX"));
+    assertTrue(AnalyticsTrackingIdCommand.isValid("UA-123456-1"));
+    assertTrue(AnalyticsTrackingIdCommand.isValid("GTM-ABCD123"));
+    assertTrue(AnalyticsTrackingIdCommand.isValid("AW-1234567890"));
+    assertTrue(AnalyticsTrackingIdCommand.isValid("1a2b3c4d5e"));
+    // Blank is allowed -- the tag is simply not rendered
+    assertTrue(AnalyticsTrackingIdCommand.isValid(""));
+    assertTrue(AnalyticsTrackingIdCommand.isValid(null));
+  }
+
+  @Test
+  void valuesThatCanBreakOutOfThePageAreInvalid() {
+    // The exact escaped-quote attribute-breakout class that this defends against
+    assertFalse(AnalyticsTrackingIdCommand.isValid("x\" onerror=alert(1) x=\""));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("GTM-X\" onload=alert(1)"));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("</script><script>alert(1)</script>"));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("G-XX'+alert(1)+'"));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("id with spaces"));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("a/b"));
+    assertFalse(AnalyticsTrackingIdCommand.isValid("back\\slash"));
+  }
+
+  @Test
+  void sanitizeBlanksMalformedIdsAndKeepsValidOnes() {
+    Map<String, String> analytics = new HashMap<>();
+    analytics.put("analytics.service", "google");
+    analytics.put("analytics.google.key", "G-GOOD123");
+    analytics.put("analytics.google.tagmanager", "GTM-X\" onload=alert(1)");
+    analytics.put("analytics.simplifi.value", "abc123");
+    analytics.put("analytics.brandcdn.value", "</script><script>x");
+
+    AnalyticsTrackingIdCommand.sanitize(analytics);
+
+    // Valid ids are untouched
+    assertEquals("G-GOOD123", analytics.get("analytics.google.key"));
+    assertEquals("abc123", analytics.get("analytics.simplifi.value"));
+    // Malformed ids are blanked so the page template will not render them
+    assertEquals("", analytics.get("analytics.google.tagmanager"));
+    assertEquals("", analytics.get("analytics.brandcdn.value"));
+    // Non-tracking-id properties are left alone
+    assertEquals("google", analytics.get("analytics.service"));
+  }
+
+  @Test
+  void isTrackingIdPropertyIdentifiesOnlyTheRenderedIds() {
+    assertTrue(AnalyticsTrackingIdCommand.isTrackingIdProperty("analytics.google.key"));
+    assertTrue(AnalyticsTrackingIdCommand.isTrackingIdProperty("analytics.brandcdn.value2"));
+    assertFalse(AnalyticsTrackingIdCommand.isTrackingIdProperty("analytics.service"));
+    assertFalse(AnalyticsTrackingIdCommand.isTrackingIdProperty(null));
+  }
+}


### PR DESCRIPTION
## Proven stored XSS
Admin-set analytics tracking ids (`analytics.google.key`, `analytics.google.tagmanager`, `analytics.simplifi.value`, `analytics.brandcdn.value`, `analytics.brandcdn.value2`) render in `main.jsp` into public-page `<script src="...">` / `<iframe src="...">` attributes and inline script, escaped with `js:escape` — which is `commons-text` **`escapeEcmaScript`, a JavaScript-string escaper.**

In an **HTML attribute** context that's the wrong escaper: it turns `"` into `\"`, but a backslash is literal in an attribute, so the quote still closes it. A stored value like:

```
x" onerror=alert(1) x="
```

breaks out of `src="..."` and injects a working event handler. **Browser-verified** (the injected `onerror` executed). Impact: a malicious or compromised admin account → arbitrary JavaScript on every public page, past the CSP for the already-allowed Google/Simpli.fi/Brand CDN origins.

> Note for the record: this is a *"right escaper, wrong context"* bug — `js:escape` is correct for the `'...VALUE...'` JS-string sinks on the same lines. Worth a broader sweep for the pattern (in progress separately).

## Fix — lock the value down at source and sink
A tracking id is a short token; `AnalyticsTrackingIdCommand` constrains it to `^[A-Za-z0-9._-]{1,64}$` (no quotes, whitespace, slashes, markup). Real `G-…`/`UA-…-…`/`GTM-…`/`AW-…` ids, Simpli.fi UUIDs, and Brand CDN path tokens all pass (verified against live samples).

- **`PageServlet.sanitize(...)`** blanks any malformed id **before render** — safe regardless of how the value got into the DB (the map from `loadAsMap` is freshly built per request, so mutating it can't affect other pages or the cache).
- **Editor widget** rejects a malformed id at save with an error message.

## Verification
- Browser POC of the breakout (before) and that a sanitized value can't render (after).
- New `AnalyticsTrackingIdCommandTest` includes the exact escaped-quote payload.
- Full `ant ci-test` green.
- 3-lens adversarial review (bypass / regression / plumbing): no bypass, no legitimate id broken, wiring confirmed against the exact `main.jsp` sinks and `loadAsMap` semantics.