### PR TITLE
Replace deprecated URL(String) constructor with URI.create().toURL()

### DIFF
--- a/src/main/java/com/simisinc/platform/application/email/EmailCommand.java
+++ b/src/main/java/com/simisinc/platform/application/email/EmailCommand.java
@@ -25,6 +25,7 @@ import org.apache.commons.mail.EmailConstants;
 import org.apache.commons.mail.ImageHtmlEmail;
 import org.apache.commons.mail.resolver.DataSourceUrlResolver;
 
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -79,7 +80,7 @@ public class EmailCommand {
     // Define your base URL to resolve relative resource locations
     if (StringUtils.isNotBlank(siteUrl)) {
       try {
-        URL url = new URL(siteUrl);
+        URL url = URI.create(siteUrl).toURL();
         email.setDataSourceResolver(new DataSourceUrlResolver(url));
       } catch (Exception e) {
         LOG.error("Could not set DataSourceUrlResolver for url: " + siteUrl);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/LeaderboardWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/LeaderboardWidget.java
@@ -24,7 +24,7 @@ import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.*;
 
 /**
@@ -108,7 +108,8 @@ public class LeaderboardWidget extends GenericWidget {
           String image = null;
           try {
             image = ((String[]) rows.get(fields.indexOf("IMAGE")))[columnCount - 1];
-            new URL(image);
+            // Validate that the value parses as a URL (result intentionally discarded)
+            URI.create(image).toURL();
             int imageIdx = image.indexOf("/assets/img/");
             if (imageIdx > -1) {
               image = image.substring(imageIdx);


### PR DESCRIPTION
## What
Maintenance, not security: the move to Java 21 (#87) surfaced compiler deprecation warnings. `java.net.URL(String)` is deprecated — it does no validation and parses leniently/inconsistently. The documented replacement is `URI.create(s).toURL()`, which parses per RFC 2396 and **still throws for a malformed or non-absolute value**, so the surrounding `try/catch` behavior is unchanged.

- **`EmailCommand`** — the base URL used to resolve relative email resources.
- **`LeaderboardWidget`** — the `new URL(image)` call whose result was discarded (it exists only to throw on an invalid image value); kept as `URI.create(image).toURL()` with a comment noting the discard.

## Deliberately *not* in this PR
The third warning — `WriterOutputStream(Writer, String)` in `WidgetOutputStream` — is left alone on purpose. Its builder replacement's `.get()` throws `IOException`, which would change the signature of a **core page-rendering constructor** and ripple to callers. That deserves its own considered change (and the commons-io builder API is cleaner once the 2.22 jar bump in #115 lands) — folding it into a warnings cleanup would be the wrong call.

## Result
`ant compile` deprecation warnings: **3 → 1** (the remaining one is the deferred `WriterOutputStream`). Full `ant ci-test` green.