### PR TITLE
Generate the release SBOM from the built WAR, not the pom

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,7 +1,12 @@
-# Generates a CycloneDX SBOM, signs it keylessly with Sigstore/cosign, and
-# attaches it to each published release. The cyclonedx-maven-plugin is already
-# configured in pom.xml (makeAggregateBom at the package phase); this workflow
-# runs it, signs the output, and publishes it.
+# Generates a CycloneDX SBOM from the BUILT WAR, signs it keylessly with
+# Sigstore/cosign, and attaches it to each published release.
+#
+# The SBOM is produced by scanning the built WAR with Syft rather than by
+# reading pom.xml. The shipped WAR is assembled by Ant from the vendored
+# lib/build/*.jar files, and those can differ from the pom's declared versions
+# -- so a pom-derived SBOM would describe an artifact that was never shipped.
+# Scanning the actual WAR makes the SBOM an accurate manifest of what ships.
+# The WAR name is set by the build.xml "project" property (simis-cms.war).
 name: SBOM
 
 on:
@@ -26,10 +31,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-          cache: maven
 
-      - name: Generate the CycloneDX SBOM
-        run: mvn -B -ntp org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom
+      # Build the same artifact that ships, so the SBOM describes exactly it
+      - name: Package the web application
+        run: ant -noinput -buildfile build.xml -lib lib/war package
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      # Scan the built WAR (its WEB-INF/lib/*.jar) and emit CycloneDX json + xml
+      - name: Generate the CycloneDX SBOM from the built WAR
+        run: |
+          syft target/simis-cms.war \
+            -o cyclonedx-json=target/bom.json \
+            -o cyclonedx-xml=target/bom.xml
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
## Why
The signed CycloneDX SBOM (#85) was generated by `cyclonedx-maven-plugin` — i.e. from **`pom.xml`**. But the shipped WAR is assembled by Ant from vendored **`lib/build/*.jar`** files, and several vendored versions lag the pom. The WAR actually ships:

| Library | WAR ships | pom declares |
|---|---|---|
| Flyway | **10.4.1** | 12.11.0 |
| HikariCP | **5.0.1** | 7.1.0 |
| jackson | **2.15.2** | 2.22.1 |

A pom-derived SBOM therefore describes an artifact that is **never shipped** — the opposite of the point of an SBOM.

## Fix
Build the WAR in the workflow and scan it with **Syft**, emitting CycloneDX JSON + XML from the real `WEB-INF/lib` contents. Signing (cosign, keyless), artifact upload, and release-attach are unchanged.

## Not an incident
No inaccurate SBOM has shipped: the workflow runs **only on release**, and there's been no release since **2024-01-06**. This lands the fix *before* the first tagged release (the upcoming release milestone).

## Verified locally
`syft target/simis-cms.war -o cyclonedx-json` → **122 components**, reporting the exact shipped versions (HikariCP 5.0.1, flyway-core 10.4.1, jackson-core 2.15.2, stripe-java 22.26.0 — all matched against `unzip -l` of the WAR).

## Root cause (separate track)
The vendored/pom **dual source of truth** is what let the SBOM diverge in the first place (and has caused version-drift surprises before). Converging it is tracked as a maintenance item; this PR makes the SBOM honest regardless of that split.