### PR TITLE
Harden getValidReturnPage against attribute-breakout XSS

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/UrlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/UrlCommand.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.routines.UrlValidator;
 
 import java.net.URLEncoder;
+import java.util.regex.Pattern;
 
 /**
  * Functions for encoding and validating web content
@@ -75,15 +76,23 @@ public class UrlCommand {
     return urlValidator.isValid(url);
   }
 
+  // A return page is an internal navigation target, rendered by the form JSPs into href/value
+  // attributes. Constrain it to a site-relative path + optional query/fragment built from URL-safe
+  // characters only: no quotes, angle brackets, backslash, colon, or whitespace, so a value can never
+  // break out of the attribute it is placed in or introduce a scheme. This is the defense at the
+  // source -- the sinks stay safe even where a JSP renders the value without escaping it.
+  private static final Pattern SAFE_RETURN_PAGE = Pattern.compile("^/[A-Za-z0-9/?&=#%._~+,;-]*$");
+
   public static String getValidReturnPage(String returnPage) {
     if (StringUtils.isBlank(returnPage)) {
       return null;
     }
-    if (returnPage.contains(":")) {
+    // Reject protocol-relative ("//host") targets, which are not site-relative
+    if (returnPage.startsWith("//")) {
       return null;
     }
-    if (returnPage.startsWith("/")) {
-      return returnPage;
+    if (!SAFE_RETURN_PAGE.matcher(returnPage).matches()) {
+      return null;
     }
     return returnPage;
   }

--- a/src/test/java/com/simisinc/platform/application/cms/UrlCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/UrlCommandTest.java
@@ -64,4 +64,28 @@ class UrlCommandTest {
     Assertions.assertNull(UrlCommand.getValidReturnPage("http://example.com"));
     Assertions.assertEquals("/web-page", UrlCommand.getValidReturnPage("/web-page"));
   }
+
+  @Test
+  void getValidReturnPageAcceptsLegitimatePaths() {
+    Assertions.assertEquals("/admin/blog", UrlCommand.getValidReturnPage("/admin/blog"));
+    Assertions.assertEquals("/admin/collection-details?collectionId=5",
+        UrlCommand.getValidReturnPage("/admin/collection-details?collectionId=5"));
+    Assertions.assertEquals("/show/my-page?a=b&c=d", UrlCommand.getValidReturnPage("/show/my-page?a=b&c=d"));
+    Assertions.assertEquals("/page#section", UrlCommand.getValidReturnPage("/page#section"));
+  }
+
+  @Test
+  void getValidReturnPageRejectsAttributeBreakoutAndSchemes() {
+    // Attribute breakout: the payload has no ':' but would break out of href="..." if not rejected
+    Assertions.assertNull(UrlCommand.getValidReturnPage("/x\" onmouseover=alert(document.cookie) x=\""));
+    Assertions.assertNull(UrlCommand.getValidReturnPage("/x\"><img src=x onerror=alert(1)>"));
+    Assertions.assertNull(UrlCommand.getValidReturnPage("/x' onclick='alert(1)"));
+    // Whitespace and backslash cannot appear in a return path
+    Assertions.assertNull(UrlCommand.getValidReturnPage("/path with space"));
+    Assertions.assertNull(UrlCommand.getValidReturnPage("/path\\x"));
+    // Must be site-relative: no scheme, no protocol-relative host
+    Assertions.assertNull(UrlCommand.getValidReturnPage("javascript:alert(1)"));
+    Assertions.assertNull(UrlCommand.getValidReturnPage("//evil.example.com/path"));
+    Assertions.assertNull(UrlCommand.getValidReturnPage("relative/no/leading/slash"));
+  }
 }


### PR DESCRIPTION
## What
A systematic XSS sweep found that the reflected **`returnPage`** parameter is rendered by many admin form JSPs into `href`/`value` attributes — several with **raw JSP EL and no HTML escaping** (e.g. `blog-form.jsp:51` uses `href="${returnPage}"` while line 32 correctly uses `c:out` for the *same* value — proof it's an omission, not a safe context).

The only validation, `UrlCommand.getValidReturnPage`, rejected a value only if it was blank or contained `:`. An attribute-breakout payload needs no colon:

```
/x" onmouseover=alert(document.cookie) x="
```

passes validation and, rendered unescaped into `href="..."`, injects an event handler that runs in the **authenticated admin's session** — reflected XSS delivered by luring an admin to a crafted link.

## Fix at the source (protects ~18 sinks at once)
A return page is an internal navigation target, so constrain it to a **site-relative path** plus optional query/fragment from URL-safe characters only (`^/[A-Za-z0-9/?&=#%._~+,;-]*$`), and reject protocol-relative `//host` targets. No quote, angle bracket, backslash, colon, or whitespace can survive — so **every `returnPage` sink is safe even where a JSP renders it unescaped**. This is defense at the source rather than escaping 18 sinks individually.

- Legitimate paths (`/admin/blog`, `/admin/collection-details?collectionId=5`) are unaffected.
- A rejected value returns `null`, which the JSPs already treat as "no return link" (`<c:if test="${!empty returnPage}">`), so there's no breakage — just a dropped cancel button for a malicious input.

## Verification
Extended `UrlCommandTest` with attribute-breakout, scheme (`javascript:`), protocol-relative (`//evil`), and legitimate-path cases. Full `ant ci-test` green.

## Context
This is the largest single cluster (18 of 64) from a broader sweep for the "admin/user data reaching an output sink without context-correct escaping" bug class (the same class as the analytics-tracking-id XSS in #121). The remaining findings — mostly content-manager-authored values (CSS classes, links, numeric map/calendar preferences) — are being triaged separately; several are also best fixed at their source rather than per-sink.