### PR TITLE
Validate numeric map/calendar/dashboard widget preferences

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/NumberCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/NumberCommand.java
@@ -16,6 +16,10 @@
 
 package com.simisinc.platform.application.cms;
 
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Methods for working with numbers
  *
@@ -23,6 +27,38 @@ package com.simisinc.platform.application.cms;
  * @created 7/11/18 5:18 PM
  */
 public class NumberCommand {
+
+  // A signed decimal coordinate, e.g. 38.9, -77.03
+  private static final Pattern COORDINATE = Pattern.compile("^-?\\d{1,3}(\\.\\d{1,15})?$");
+  // Digits only, for a pixel dimension the template renders as ${value}px
+  private static final Pattern POSITIVE_INTEGER = Pattern.compile("^\\d{1,6}$");
+  // A CSS length: digits, optional decimal, optional unit (px, em, rem, %, vh, vw)
+  private static final Pattern CSS_LENGTH = Pattern.compile("^\\d{1,6}(\\.\\d{1,3})?(px|em|rem|%|vh|vw)?$");
+
+  /** Returns the value when it is a valid geo coordinate, otherwise null. These values are rendered into
+   * page javascript, so anything non-numeric must not reach the template. */
+  public static String filterCoordinate(String value) {
+    if (StringUtils.isNotBlank(value) && COORDINATE.matcher(value).matches()) {
+      return value;
+    }
+    return null;
+  }
+
+  /** Returns the value when it is a plain positive integer, otherwise the default. */
+  public static String filterPositiveInteger(String value, String defaultValue) {
+    if (StringUtils.isNotBlank(value) && POSITIVE_INTEGER.matcher(value).matches()) {
+      return value;
+    }
+    return defaultValue;
+  }
+
+  /** Returns the value when it is a valid CSS length (number + optional unit), otherwise the default. */
+  public static String filterCssLength(String value, String defaultValue) {
+    if (StringUtils.isNotBlank(value) && CSS_LENGTH.matcher(value).matches()) {
+      return value;
+    }
+    return defaultValue;
+  }
 
   /**
    * Returns a string value of a number, with a suffix

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarWidget.java
@@ -29,6 +29,7 @@ import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
+import com.simisinc.platform.application.cms.NumberCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;
@@ -65,10 +66,13 @@ public class CalendarWidget extends GenericWidget {
     String view = context.getPreferences().getOrDefault("view", null);
     if ("small".equals(view)) {
       context.setJsp(SMALL_JSP);
-      context.getRequest().setAttribute("height", context.getPreferences().getOrDefault("height", "550"));
+      // height is rendered into a style value, so require a CSS length
+      context.getRequest().setAttribute("height",
+          NumberCommand.filterCssLength(context.getPreferences().getOrDefault("height", "550"), "550"));
     } else {
       context.setJsp(JSP);
-      context.getRequest().setAttribute("height", context.getPreferences().getOrDefault("height", null));
+      context.getRequest().setAttribute("height",
+          NumberCommand.filterCssLength(context.getPreferences().getOrDefault("height", null), null));
     }
     context.getRequest().setAttribute("defaultView", context.getPreferences().getOrDefault("default", "month"));
     context.getRequest().setAttribute("showEvents", context.getPreferences().getOrDefault("showEvents", "true"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/SupersetWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/SupersetWidget.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.dashboard;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.application.cms.NumberCommand;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -49,7 +50,9 @@ public class SupersetWidget extends GenericWidget {
     context.getRequest().setAttribute("dashboardValue", dashboardValue);
     context.getRequest().setAttribute("dashboardEmbeddedId", dashboardEmbeddedId);
     context.getRequest().setAttribute("supersetDomain", supersetDomain);
-    context.getRequest().setAttribute("height", context.getPreferences().getOrDefault("height", "300px"));
+    // height is rendered into a style value, so require a CSS length
+    context.getRequest().setAttribute("height",
+        NumberCommand.filterCssLength(context.getPreferences().getOrDefault("height", "300px"), "300px"));
     boolean hideChartTitle = "true".equals(context.getPreferences().getOrDefault("hideChartTitle", "true"));
     context.getRequest().setAttribute("hideChartTitle", hideChartTitle ? "true" : "false");
     boolean hideChartControls = "true".equals(context.getPreferences().getOrDefault("hideChartControls", "true"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsMapAppWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsMapAppWidget.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.application.cms.NumberCommand;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -95,8 +96,8 @@ public class ItemsMapAppWidget extends GenericWidget {
     context.getRequest().setAttribute("itemList", itemList);
 
     // Determine the center geo point from data, or use a preset
-    String latitude = context.getPreferences().get("latitude");
-    String longitude = context.getPreferences().get("longitude");
+    String latitude = NumberCommand.filterCoordinate(context.getPreferences().get("latitude"));
+    String longitude = NumberCommand.filterCoordinate(context.getPreferences().get("longitude"));
     if (StringUtils.isBlank(latitude) || StringUtils.isBlank(longitude)) {
       Session center = GISCommand.centerFromItems(itemList);
       if (center != null) {
@@ -119,8 +120,8 @@ public class ItemsMapAppWidget extends GenericWidget {
       LOG.debug("Items found: " + itemList.size());
     }
 
-    // Determine optional map info
-    String mapHeight = context.getPreferences().getOrDefault("mapHeight", "290px");
+    // Determine optional map info (mapHeight is rendered into a style attribute, so require a CSS length)
+    String mapHeight = NumberCommand.filterCssLength(context.getPreferences().getOrDefault("mapHeight", "290px"), "290px");
     context.getRequest().setAttribute("mapHeight", mapHeight);
     int mapZoomLevelValue = Integer.parseInt(context.getPreferences().getOrDefault("mapZoomLevel", "13"));
     context.getRequest().setAttribute("mapZoomLevel", String.valueOf(mapZoomLevelValue));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/maps/MapWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/maps/MapWidget.java
@@ -21,6 +21,7 @@ import com.simisinc.platform.domain.model.maps.MapCredentials;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
+import com.simisinc.platform.application.cms.NumberCommand;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -46,9 +47,9 @@ public class MapWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("mapCredentials", mapCredentials);
 
-    // Determine the geo point
-    String latitude = context.getPreferences().get("latitude");
-    String longitude = context.getPreferences().get("longitude");
+    // Determine the geo point (must be numeric coordinates -- they are rendered into page javascript)
+    String latitude = NumberCommand.filterCoordinate(context.getPreferences().get("latitude"));
+    String longitude = NumberCommand.filterCoordinate(context.getPreferences().get("longitude"));
     if (StringUtils.isBlank(latitude) || StringUtils.isBlank(longitude) ||
         "-1".equals(latitude) || "-1".equals(longitude) ||
         "0.0".equals(latitude) || "0.0".equals(longitude) ||
@@ -59,8 +60,8 @@ public class MapWidget extends GenericWidget {
     context.getRequest().setAttribute("latitude", latitude);
     context.getRequest().setAttribute("longitude", longitude);
 
-    // Determine optional map info
-    String mapHeight = context.getPreferences().getOrDefault("mapHeight", "290");
+    // Determine optional map info (mapHeight is rendered as ${mapHeight}px, so require a plain integer)
+    String mapHeight = NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("mapHeight", "290"), "290");
     context.getRequest().setAttribute("mapHeight", mapHeight);
     int mapZoomLevelValue = Integer.parseInt(context.getPreferences().getOrDefault("mapZoomLevel", "12"));
     context.getRequest().setAttribute("mapZoomLevel", String.valueOf(mapZoomLevelValue));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/maps/PropertyMapAppWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/maps/PropertyMapAppWidget.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.domain.model.maps.MapCredentials;
 import com.simisinc.platform.infrastructure.persistence.datasets.DatasetRepository;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.application.cms.NumberCommand;
 import org.apache.commons.lang3.StringUtils;
 import org.geojson.Feature;
 import org.geojson.GeoJsonObject;
@@ -109,8 +110,8 @@ public class PropertyMapAppWidget extends GenericWidget {
 
     // Determine the center geo point from data, or a preset
 
-    String latitude = context.getPreferences().get("latitude");
-    String longitude = context.getPreferences().get("longitude");
+    String latitude = NumberCommand.filterCoordinate(context.getPreferences().get("latitude"));
+    String longitude = NumberCommand.filterCoordinate(context.getPreferences().get("longitude"));
     if (StringUtils.isBlank(latitude) || StringUtils.isBlank(longitude) ||
         "-1".equals(latitude) || "-1".equals(longitude) ||
         "0.0".equals(latitude) || "0.0".equals(longitude) ||
@@ -121,8 +122,8 @@ public class PropertyMapAppWidget extends GenericWidget {
     context.getRequest().setAttribute("latitude", latitude);
     context.getRequest().setAttribute("longitude", longitude);
 
-    // Determine optional map info
-    String mapHeight = context.getPreferences().getOrDefault("mapHeight", "290px");
+    // Determine optional map info (mapHeight is rendered into a style attribute, so require a CSS length)
+    String mapHeight = NumberCommand.filterCssLength(context.getPreferences().getOrDefault("mapHeight", "290px"), "290px");
     context.getRequest().setAttribute("mapHeight", mapHeight);
     int mapZoomLevelValue = Integer.parseInt(context.getPreferences().getOrDefault("mapZoomLevel", "13"));
     context.getRequest().setAttribute("mapZoomLevel", String.valueOf(mapZoomLevelValue));

--- a/src/test/java/com/simisinc/platform/application/cms/NumberCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/NumberCommandTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests numeric filtering for values rendered into page style/script contexts
+ *
+ * @author elizabeth houser
+ */
+class NumberCommandTest {
+
+  @Test
+  void filterCoordinateAcceptsNumbersRejectsInjection() {
+    assertEquals("38.9072", NumberCommand.filterCoordinate("38.9072"));
+    assertEquals("-77.0369", NumberCommand.filterCoordinate("-77.0369"));
+    assertEquals("0", NumberCommand.filterCoordinate("0"));
+    // A coordinate is rendered into setView([${latitude}, ${longitude}], ...): reject anything that
+    // could break out of the javascript array
+    assertNull(NumberCommand.filterCoordinate("1]);alert(document.cookie);//"));
+    assertNull(NumberCommand.filterCoordinate("38.9,-77"));
+    assertNull(NumberCommand.filterCoordinate("38.9'"));
+    assertNull(NumberCommand.filterCoordinate(""));
+    assertNull(NumberCommand.filterCoordinate(null));
+  }
+
+  @Test
+  void filterPositiveIntegerAcceptsDigitsElseDefault() {
+    assertEquals("290", NumberCommand.filterPositiveInteger("290", "290"));
+    assertEquals("500", NumberCommand.filterPositiveInteger("500", "290"));
+    // Rendered as ${mapHeight}px, so no unit or breakout may pass
+    assertEquals("290", NumberCommand.filterPositiveInteger("290px", "290"));
+    assertEquals("290", NumberCommand.filterPositiveInteger("300\"><script>alert(1)</script>", "290"));
+    assertEquals("290", NumberCommand.filterPositiveInteger("", "290"));
+    assertEquals("290", NumberCommand.filterPositiveInteger(null, "290"));
+  }
+
+  @Test
+  void filterCssLengthAcceptsLengthsElseDefault() {
+    assertEquals("290px", NumberCommand.filterCssLength("290px", "290px"));
+    assertEquals("550", NumberCommand.filterCssLength("550", "550"));
+    assertEquals("80%", NumberCommand.filterCssLength("80%", "290px"));
+    assertEquals("40vh", NumberCommand.filterCssLength("40vh", "290px"));
+    // Reject CSS/attribute breakout
+    assertEquals("290px", NumberCommand.filterCssLength("290px;} body{display:none", "290px"));
+    assertEquals("290px", NumberCommand.filterCssLength("290px\"><script>alert(1)</script>", "290px"));
+    assertEquals("290px", NumberCommand.filterCssLength("expression(alert(1))", "290px"));
+    assertNull(NumberCommand.filterCssLength("bad", null));
+  }
+}


### PR DESCRIPTION
## What
Second cluster from the XSS sweep. The map, calendar, and Superset widgets pass **geo coordinates and heights** from content-manager-authored widget preferences straight into page output with no escaping:

- Map JSPs render `L.map(...).setView([${latitude}, ${longitude}], ...)` — **raw JavaScript**
- and `style="height: ${mapHeight}..."` — **raw style attribute**

A preference like `latitude=1]);alert(document.cookie);//` or `mapHeight=290" onx=...` breaks out of the script/style context — stored XSS by a content author.

## Fix at the source
Validate so only well-formed numbers reach the template (extending `NumberCommand`):
- **`filterCoordinate`** — a signed decimal, else `null`. The map widgets already skip rendering when the coordinate is blank/0, so an invalid value degrades to "no map" rather than injecting.
- **`filterPositiveInteger`** — digits only, for `mapHeight` rendered as `${mapHeight}px`.
- **`filterCssLength`** — number + optional unit, for `height` values rendered directly into a style.

Applied in `MapWidget`, `PropertyMapAppWidget`, `ItemsMapAppWidget` (lat/long, mapHeight), `CalendarWidget` and `SupersetWidget` (height). `mapZoomLevel` was already `Integer.parseInt`'d, so it was already safe.

## Verification
New `NumberCommandTest` covers accepted formats (coords, `290`, `290px`, `80%`, `40vh`) and the script/style breakout payloads. Full `ant ci-test` green.

## Cluster progress
Sweep clusters: returnPage (18) → #124 ✅ · **numeric prefs (this) ✅** · remaining: content-manager link/menu targets, CSS class/color values, dataset content — each fixed at its source next.