### PR TITLE
Sanitize content-authored link urls in the button/link/card widgets

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/UrlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/UrlCommand.java
@@ -96,4 +96,36 @@ public class UrlCommand {
     }
     return returnPage;
   }
+
+  // URL characters that cannot break out of an href/src attribute: no quotes, angle brackets,
+  // backslash, backtick, or whitespace.
+  private static final Pattern SAFE_URL = Pattern.compile("^[A-Za-z0-9/?&=#%._~:@!$()*+,;-]*$");
+
+  /**
+   * Returns the url when it is safe to place in an href/src attribute -- a site-relative path,
+   * anchor, or an http(s)/mailto/tel absolute url with no attribute-breakout characters -- otherwise
+   * null. Active schemes such as javascript: and data: are rejected, as are protocol-relative "//"
+   * targets. Content-authored link values are rendered into href attributes, so this is the defense
+   * at the source.
+   */
+  public static String sanitizeUrl(String url) {
+    if (StringUtils.isBlank(url)) {
+      return null;
+    }
+    String value = url.trim();
+    if (value.startsWith("//") || !SAFE_URL.matcher(value).matches()) {
+      return null;
+    }
+    // If the value carries a scheme, allow only the safe ones
+    String lower = value.toLowerCase();
+    if (lower.matches("^[a-z][a-z0-9+.-]*:.*")) {
+      if (lower.startsWith("http://") || lower.startsWith("https://")
+          || lower.startsWith("mailto:") || lower.startsWith("tel:")) {
+        return value;
+      }
+      return null;
+    }
+    // No scheme: a site-relative path, anchor, or query
+    return value;
+  }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ButtonWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ButtonWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.UrlCommand;
+
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +41,11 @@ public class ButtonWidget extends GenericWidget {
     }
     if (!link.contains("://") && !link.startsWith(context.getContextPath())) {
       link = context.getContextPath() + link;
+    }
+    // The link is rendered into an href attribute; drop the button for an unsafe url
+    link = UrlCommand.sanitizeUrl(link);
+    if (link == null) {
+      return context;
     }
     context.getRequest().setAttribute("link", link);
     context.getRequest().setAttribute("buttonClass", context.getPreferences().getOrDefault("class", "primary"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/LinkWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/LinkWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.UrlCommand;
+
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -57,6 +59,11 @@ public class LinkWidget extends GenericWidget {
     }
     if (!link.contains("://") && !link.startsWith(context.getContextPath())) {
       link = context.getContextPath() + link;
+    }
+    // The link is rendered into an href attribute; drop the link for an unsafe url
+    link = UrlCommand.sanitizeUrl(link);
+    if (link == null) {
+      return context;
     }
     context.getRequest().setAttribute("link", link);
     context.getRequest().setAttribute("linkClass", context.getPreferences().get("class"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/ProgressCardWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/ProgressCardWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.dashboard;
 
+import com.simisinc.platform.application.cms.UrlCommand;
+
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.dashboard.ProgressCard;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -43,7 +45,7 @@ public class ProgressCardWidget extends GenericWidget {
     progressCard.setMaxValue(Integer.parseInt(context.getPreferences().getOrDefault("maxValue", "0")));
     progressCard.setDifference(progressCard.getMaxValue() - progressCard.getProgress());
     progressCard.setMaxLabel(context.getPreferences().getOrDefault("maxLabel", "maxLabel"));
-    progressCard.setLink(context.getPreferences().getOrDefault("link", null));
+    progressCard.setLink(UrlCommand.sanitizeUrl(context.getPreferences().getOrDefault("link", null)));
     context.getRequest().setAttribute("progressCard", progressCard);
 
     context.getRequest().setAttribute("textColor", valueForColor(context.getPreferences().getOrDefault("textColor", "#ffffff")));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/StatisticCardWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/StatisticCardWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.dashboard;
 
+import com.simisinc.platform.application.cms.UrlCommand;
+
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.dashboard.StatisticCard;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -41,7 +43,7 @@ public class StatisticCardWidget extends GenericWidget {
     statisticCard.setValue(Integer.parseInt(context.getPreferences().getOrDefault("value", "0")));
     statisticCard.setLabel(context.getPreferences().getOrDefault("label", "label"));
     statisticCard.setIcon(context.getPreferences().getOrDefault("icon", null));
-    statisticCard.setLink(context.getPreferences().getOrDefault("link", null));
+    statisticCard.setLink(UrlCommand.sanitizeUrl(context.getPreferences().getOrDefault("link", null)));
     context.getRequest().setAttribute("statisticCard", statisticCard);
 
     context.getRequest().setAttribute("iconColor", valueForColor(context.getPreferences().getOrDefault("iconColor", null)));

--- a/src/test/java/com/simisinc/platform/application/cms/UrlCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/UrlCommandTest.java
@@ -75,6 +75,33 @@ class UrlCommandTest {
   }
 
   @Test
+  void sanitizeUrlAllowsSafeUrls() {
+    Assertions.assertEquals("/web/page", UrlCommand.sanitizeUrl("/web/page"));
+    Assertions.assertEquals("/web/page?a=b&c=d", UrlCommand.sanitizeUrl("/web/page?a=b&c=d"));
+    Assertions.assertEquals("#section", UrlCommand.sanitizeUrl("#section"));
+    Assertions.assertEquals("https://example.com/x", UrlCommand.sanitizeUrl("https://example.com/x"));
+    Assertions.assertEquals("http://example.com", UrlCommand.sanitizeUrl("http://example.com"));
+    Assertions.assertEquals("mailto:someone@example.com", UrlCommand.sanitizeUrl("mailto:someone@example.com"));
+    Assertions.assertEquals("tel:+15551234567", UrlCommand.sanitizeUrl("tel:+15551234567"));
+    Assertions.assertEquals("page", UrlCommand.sanitizeUrl("page"));
+  }
+
+  @Test
+  void sanitizeUrlRejectsActiveSchemesAndBreakout() {
+    Assertions.assertNull(UrlCommand.sanitizeUrl("javascript:alert(1)"));
+    Assertions.assertNull(UrlCommand.sanitizeUrl("JavaScript:alert(1)"));
+    Assertions.assertNull(UrlCommand.sanitizeUrl("data:text/html,<script>alert(1)</script>"));
+    Assertions.assertNull(UrlCommand.sanitizeUrl("vbscript:msgbox(1)"));
+    // Attribute breakout characters cannot appear in a safe url
+    Assertions.assertNull(UrlCommand.sanitizeUrl("/x\" onclick=alert(1)"));
+    Assertions.assertNull(UrlCommand.sanitizeUrl("https://x/'><img src=x onerror=alert(1)>"));
+    // Protocol-relative targets are not allowed
+    Assertions.assertNull(UrlCommand.sanitizeUrl("//evil.example.com"));
+    Assertions.assertNull(UrlCommand.sanitizeUrl(""));
+    Assertions.assertNull(UrlCommand.sanitizeUrl(null));
+  }
+
+  @Test
   void getValidReturnPageRejectsAttributeBreakoutAndSchemes() {
     // Attribute breakout: the payload has no ':' but would break out of href="..." if not rejected
     Assertions.assertNull(UrlCommand.getValidReturnPage("/x\" onmouseover=alert(document.cookie) x=\""));


### PR DESCRIPTION
## What
Third cluster from the XSS sweep (link/href values), the clean widget-preference subset. The **Button, Link, Progress Card, and Statistic Card** widgets take a `link` from content-manager-authored preferences and render it into an `href` with raw JSP EL. A link like `javascript:alert(document.cookie)` or `/x" onclick=alert(1)` executed or broke out — stored XSS by a content author.

## Fix
New **`UrlCommand.sanitizeUrl`** returns the value only when it's safe for an `href`/`src` attribute:
- **Allowed**: site-relative paths, anchors, and `http(s)`/`mailto`/`tel` absolute URLs — with no attribute-breakout characters (quotes, angle brackets, whitespace, backslash).
- **Rejected** (→ `null`): active schemes (`javascript:`, `data:`, `vbscript:`, …) and protocol-relative `//` targets.

Applied **at the source** in each widget: Button and Link skip rendering when the link is unsafe (matching their existing blank-link behavior); the two dashboard cards store `null` (their JSPs already guard on an empty link).

## Verification
`UrlCommandTest` extended: safe URLs (relative, anchor, https, mailto, tel, query strings) kept; `javascript:`/`data:`/`vbscript:`, breakout payloads, and `//host` rejected. Full `ant ci-test` green.

## Cluster progress
returnPage (18) → #124 ✅ · numeric prefs → #125 ✅ · **widget link prefs (this) ✅** · remaining link sources: menu/nav/breadcrumb/product/blog links (structural, per-source) + CSS class/color + dataset content — next.