### PR TITLE
Escape high-severity content-authored values at their JSP sinks

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list.jsp
@@ -85,7 +85,7 @@
           </div>
           <c:if test="${!empty blogPost.imageUrl}">
             <div class="platform-blog-image">
-              <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}${blogPost.imageUrl}"/></a>
+              <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="<c:out value="${ctx}${blogPost.imageUrl}"/>"/></a>
             </div>
           </c:if>
           <c:if test="${showAuthor eq 'true' || (showDate eq 'true' && !empty blogPost.startDate) || !empty blogPost.tagsList}">

--- a/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
@@ -48,9 +48,9 @@
       <td align="center" class="leaderboard-rank">${status.count}</td>
       <td align="left" width="100%" class="leaderboard-name">
         <c:if test="${!empty player['IMAGE']}">
-          <img class="leaderboard-photo" src="${player['IMAGE']}" />
+          <img class="leaderboard-photo" src="<c:out value="${player['IMAGE']}" />" />
         </c:if>
-        ${player['NAME']}
+        <c:out value="${player['NAME']}" />
       </td>
       <td class="leaderboard-points"><fmt:formatNumber value="${player['VALUE']}"/></td>
     </tr>

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
@@ -39,7 +39,7 @@
           <div class="card-image">
             <c:choose>
               <c:when test="${!empty productImageMap[product.uniqueId]}">
-                <a href="${ctx}${product.productUrl}"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" /></a>
+                <a href="<c:out value="${ctx}${product.productUrl}"/>"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" /></a>
               </c:when>
               <c:when test="${!empty product.imageUrl}">
                 <a href="${ctx}${product.productUrl}"><img alt="product image" src="<c:out value="${product.imageUrl}"/>" /></a>

--- a/src/main/webapp/WEB-INF/jsp/portal/custom-fields.jsp
+++ b/src/main/webapp/WEB-INF/jsp/portal/custom-fields.jsp
@@ -37,7 +37,7 @@
       <p><img src="<c:out value="${field.value}" />" /></p>
     </c:when>
     <c:when test="${'url' eq field.type && (fn:startsWith(field.value, 'http://') || fn:startsWith(field.value, 'https://'))}">
-      <p><a class="button small no-gap" href="${url:encode(field.value)}" target="_blank" rel="nofollow">${field.label} <i class="fa fa-external-link"></i></a></p>
+      <p><a class="button small no-gap" href="${url:encode(field.value)}" target="_blank" rel="nofollow"><c:out value="${field.label}" /> <i class="fa fa-external-link"></i></a></p>
     </c:when>
     <c:otherwise>
       <c:if test="${!empty field.label}">


### PR DESCRIPTION
## What
The XSS sweep flagged several content-authored values rendered into element/attribute contexts with **raw JSP EL and no escaping** — the remaining *high*-severity findings (the reflected `returnPage` highs were fixed in #124):

| File | Value | Context |
|---|---|---|
| `leaderboard.jsp` | dataset row `NAME` | element text |
| `leaderboard.jsp` | dataset row `IMAGE` | `<img src>` |
| `custom-fields.jsp` | custom field definition `label` | link text |
| `blog-post-list.jsp` | blog post `imageUrl` | `<img src>` |
| `product-card-slider.jsp` | product `productUrl` | anchor `href` |

Each is content-manager-authored, so a value like `<img src=x onerror=alert(1)>` (element) or one containing a `"` (attribute) executed as stored XSS.

## Fix
Wrap each in **`<c:out>`** — HTML-entity encoding, the *correct* escaper for element and attribute text (it neutralizes the `"` that would break out of `src`/`href`). The URL-attribute values are already `${ctx}`-prefixed, so scheme injection wasn't possible; this closes the attribute-breakout vector. Matches the `<c:out>` usage already present in each file.

## Verification
Each edited line read back and checked against the file's existing `<c:out>` pattern (including the nested-quote attribute form already used there). Full `ant ci-test` green.

## Cluster progress
returnPage → #124 ✅ · numeric → #125 ✅ · widget links → #126 ✅ · **high-sev content sinks (this) ✅**. Remaining: medium content-authored link/menu/CSS-class/color sinks (defense-in-depth, admin/content-author privilege) — documented in the private inventory.