### PR TITLE
Validate card-count and card-size widget preferences

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -197,7 +197,9 @@ public class ContentHtmlCommand {
       context.getRequest().setAttribute("largeCardCount", largeCardCount);
     } else {
       // Stacked across by size
-      context.getRequest().setAttribute("cardSize", context.getPreferences().getOrDefault("cardSize", "200px"));
+      // cardSize is rendered into a css width, so require a css length
+      context.getRequest().setAttribute("cardSize",
+          NumberCommand.filterCssLength(context.getPreferences().getOrDefault("cardSize", "200px"), "200px"));
     }
 
     // Standardize the content

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/UpcomingCalendarEventsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/UpcomingCalendarEventsWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.calendar;
 
+import com.simisinc.platform.application.cms.NumberCommand;
+
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.cms.Calendar;
 import com.simisinc.platform.domain.model.cms.CalendarEvent;
@@ -167,9 +169,10 @@ public class UpcomingCalendarEventsWidget extends GenericWidget {
       if (StringUtils.isBlank(largeCardCount)) {
         largeCardCount = mediumCardCount;
       }
-      context.getRequest().setAttribute("smallCardCount", smallCardCount);
-      context.getRequest().setAttribute("mediumCardCount", mediumCardCount);
-      context.getRequest().setAttribute("largeCardCount", largeCardCount);
+      // These are rendered into the slider's javascript config, so require plain integers
+      context.getRequest().setAttribute("smallCardCount", NumberCommand.filterPositiveInteger(smallCardCount, "3"));
+      context.getRequest().setAttribute("mediumCardCount", NumberCommand.filterPositiveInteger(mediumCardCount, "3"));
+      context.getRequest().setAttribute("largeCardCount", NumberCommand.filterPositiveInteger(largeCardCount, "3"));
       context.getRequest().setAttribute("cardClass", context.getPreferences().get("cardClass"));
       context.getRequest().setAttribute("calendarLink", context.getPreferences().get("calendarLink"));
 

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/AlbumGalleryWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/AlbumGalleryWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.NumberCommand;
+
 import com.simisinc.platform.application.cms.LoadFolderCommand;
 import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.domain.model.cms.Folder;
@@ -65,11 +67,12 @@ public class AlbumGalleryWidget extends GenericWidget {
     context.getRequest().setAttribute("controlId", context.getPreferences().getOrDefault("controlId", "myAlbum"));
     context.getRequest().setAttribute("cardClass", context.getPreferences().get("cardClass"));
     // Card size preferences
-    String smallCardCount = context.getPreferences().getOrDefault("smallCardCount", "6");
+    // These are rendered into the slider's javascript config, so require plain integers
+    String smallCardCount = NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("smallCardCount", "6"), "6");
     context.getRequest().setAttribute("smallCardCount", smallCardCount);
-    String mediumCardCount = context.getPreferences().getOrDefault("mediumCardCount", smallCardCount);
+    String mediumCardCount = NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("mediumCardCount", smallCardCount), smallCardCount);
     context.getRequest().setAttribute("mediumCardCount", mediumCardCount);
-    context.getRequest().setAttribute("largeCardCount", context.getPreferences().getOrDefault("largeCardCount", mediumCardCount));
+    context.getRequest().setAttribute("largeCardCount", NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("largeCardCount", mediumCardCount), mediumCardCount));
 
     // Determine the folder, or all (access is checked, intent permissions are not)
     Folder folder = LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser(folderUniqueId, context.getUserId());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.NumberCommand;
+
 import com.simisinc.platform.application.cms.LoadBlogCommand;
 import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.domain.model.cms.Blog;
@@ -162,9 +164,10 @@ public class BlogPostListWidget extends GenericWidget {
       if (StringUtils.isBlank(largeCardCount)) {
         largeCardCount = mediumCardCount;
       }
-      context.getRequest().setAttribute("smallCardCount", smallCardCount);
-      context.getRequest().setAttribute("mediumCardCount", mediumCardCount);
-      context.getRequest().setAttribute("largeCardCount", largeCardCount);
+      // These are rendered into the slider's javascript config, so require plain integers
+      context.getRequest().setAttribute("smallCardCount", NumberCommand.filterPositiveInteger(smallCardCount, "3"));
+      context.getRequest().setAttribute("mediumCardCount", NumberCommand.filterPositiveInteger(mediumCardCount, "3"));
+      context.getRequest().setAttribute("largeCardCount", NumberCommand.filterPositiveInteger(largeCardCount, "3"));
       context.getRequest().setAttribute("cardClass", context.getPreferences().get("cardClass"));
 
       context.setJsp(CARDS_JSP);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.NumberCommand;
+
 import com.simisinc.platform.domain.model.socialmedia.InstagramMedia;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.socialmedia.InstagramMediaRepository;
@@ -49,11 +51,12 @@ public class InstagramWidget extends GenericWidget {
     context.getRequest().setAttribute("cardClass", context.getPreferences().get("cardClass"));
 
     // Card size preferences
-    String smallCardCount = context.getPreferences().getOrDefault("smallCardCount", "6");
+    // These are rendered into the slider's javascript config, so require plain integers
+    String smallCardCount = NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("smallCardCount", "6"), "6");
     context.getRequest().setAttribute("smallCardCount", smallCardCount);
-    String mediumCardCount = context.getPreferences().getOrDefault("mediumCardCount", smallCardCount);
+    String mediumCardCount = NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("mediumCardCount", smallCardCount), smallCardCount);
     context.getRequest().setAttribute("mediumCardCount", mediumCardCount);
-    context.getRequest().setAttribute("largeCardCount", context.getPreferences().getOrDefault("largeCardCount", mediumCardCount));
+    context.getRequest().setAttribute("largeCardCount", NumberCommand.filterPositiveInteger(context.getPreferences().getOrDefault("largeCardCount", mediumCardCount), mediumCardCount));
 
     // Determine the record paging
     int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "8"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/ProductBrowserWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/ProductBrowserWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.ecommerce;
 
+import com.simisinc.platform.application.cms.NumberCommand;
+
 import com.simisinc.platform.application.ecommerce.LoadProductListCommand;
 import com.simisinc.platform.domain.model.ecommerce.Product;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -57,9 +59,10 @@ public class ProductBrowserWidget extends GenericWidget {
     if (StringUtils.isBlank(largeCardCount)) {
       largeCardCount = mediumCardCount;
     }
-    context.getRequest().setAttribute("smallCardCount", smallCardCount);
-    context.getRequest().setAttribute("mediumCardCount", mediumCardCount);
-    context.getRequest().setAttribute("largeCardCount", largeCardCount);
+    // These are rendered into the slider's javascript config, so require plain integers
+    context.getRequest().setAttribute("smallCardCount", NumberCommand.filterPositiveInteger(smallCardCount, "3"));
+    context.getRequest().setAttribute("mediumCardCount", NumberCommand.filterPositiveInteger(mediumCardCount, "3"));
+    context.getRequest().setAttribute("largeCardCount", NumberCommand.filterPositiveInteger(largeCardCount, "3"));
     context.getRequest().setAttribute("cardClass", context.getPreferences().get("cardClass"));
     context.getRequest().setAttribute("cardImageClass", context.getPreferences().get("cardImageClass"));
     context.getRequest().setAttribute("buttonLabel", context.getPreferences().getOrDefault("button", "Shop"));

--- a/src/main/webapp/WEB-INF/jsp/cms/content-card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-card.jsp
@@ -27,7 +27,7 @@
 <jsp:useBean id="largeCardCount" class="java.lang.String" scope="request"/>
 <jsp:useBean id="gridMargin" class="java.lang.String" scope="request"/>
 <c:if test="${!empty title}">
-  <h4><c:if test="${!empty icon}"><i class="fa ${icon}"></i> </c:if><c:out value="${title}" /></h4>
+  <h4><c:if test="${!empty icon}"><i class="fa <c:out value="${icon}"/>"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <style>
 <c:if test="${!empty cardSize}">


### PR DESCRIPTION
## What
The responsive card widgets pass `smallCardCount` / `mediumCardCount` / `largeCardCount` preferences into the slider's JavaScript config as `slidesPerView: ${...}`. They were HTML-escaped with `c:out` — but that's **not sufficient in a JavaScript-number context**: a content-manager value like `1;alert(document.cookie)` has no HTML metacharacters, so it passes `c:out` and executes. `content-card`'s `cardSize` is likewise rendered into a CSS `width`.

## Fix
Validate at the source with the existing `NumberCommand` filters (added in #125):
- **`filterPositiveInteger`** for the three card counts in `ProductBrowserWidget`, `InstagramWidget`, `BlogPostListWidget`, `AlbumGalleryWidget`, `UpcomingCalendarEventsWidget` (a non-integer falls back to a safe default).
- **`filterCssLength`** for `cardSize` in `ContentHtmlCommand`.
- Also escapes the raw widget icon class in `content-card.jsp` (same fix as `content.jsp` in #128).

## Verification
Full `ant ci-test` green. Reuses the filters already unit-tested in `NumberCommandTest`.

## Cluster progress — XSS sweep nearly complete
returnPage #124 · numeric #125 · widget links #126 · high-sev sinks #127 · nav/layout sinks #128 · **card-count numeric (this)**. **Only remainder**: two non-`${ctx}` links (sticky-footer links, moodle course URL) that need `UrlCommand.sanitizeUrl` — waiting on #126 to merge, then a small final PR.