### PR TITLE
Sanitize the sticky-footer and Moodle course links

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/elearning/RemoteCourseListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/elearning/RemoteCourseListWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.elearning;
 
+import com.simisinc.platform.application.cms.UrlCommand;
+
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.elearning.*;
 import com.simisinc.platform.domain.model.elearning.CourseUserAggregate;
@@ -80,7 +82,8 @@ public class RemoteCourseListWidget extends GenericWidget {
       // Show the Add Course button
       if (showAddCourseButton) {
         context.getRequest().setAttribute("courseButtonText", context.getPreferences().getOrDefault("courseButtonText", "Add a Course"));
-        context.getRequest().setAttribute("courseButtonLink", moodleServerUrl + "/course/edit.php");
+        context.getRequest().setAttribute("courseButtonLink",
+            UrlCommand.sanitizeUrl(moodleServerUrl + "/course/edit.php"));
       }
     } else if ("any".equals(role)) {
       // Retrieve the Moodle course list for any role

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -461,10 +461,10 @@
 
             </c:when>
             <c:when test="${fn:startsWith(link.link, 'http://') || fn:startsWith(link.link, 'https://')}">
-              <a class="button secondary site-sticky-footer-button" href="${link.link}" target="_blank"><c:out value="${link.name}"/></a>
+              <a class="button secondary site-sticky-footer-button" href="<c:out value="${link.link}"/>" target="_blank"><c:out value="${link.name}"/></a>
             </c:when>
             <c:otherwise>
-              <a class="button secondary site-sticky-footer-button" href="${ctx}${link.link}"><c:out value="${link.name}"/></a>
+              <a class="button secondary site-sticky-footer-button" href="<c:out value="${ctx}${link.link}"/>"><c:out value="${link.name}"/></a>
             </c:otherwise>
           </c:choose>
         </c:forEach>


### PR DESCRIPTION
## What
The **last two** link sinks from the XSS sweep:

- **`main.jsp` sticky-footer links** — `link.link` rendered into `href` with raw EL. The `http(s)` branch is already scheme-gated and the other branch prefixes `${ctx}`, so scheme injection wasn't possible — but a value with a `"` could break out of the attribute. Both wrapped in `<c:out>`.
- **`RemoteCourseListWidget`** — `courseButtonLink` is built from the admin-configured Moodle server URL (`elearning.moodle.url`). Now run through `UrlCommand.sanitizeUrl`, so a malformed or active-scheme value can't reach the `href`.

## This completes the sweep's content-sink pass
Every remaining item from the 64-finding sweep is now either **fixed** (#124–#129 + this) or **verified already-fixed** by an earlier PR:
- map **credentials** → the mapbox `js:escape` from #118
- map **coordinates** → the numeric validation in #125
- `menu.jsp:115` → **false positive** (a shopping-cart quantity loop index)

## Verification
Full `ant ci-test` green. Sticky-link edits checked for balanced `<c:out>` tags.

## Sweep summary
| Cluster | PR |
|---|---|
| returnPage (reflected, 18) | #124 |
| numeric map/calendar prefs | #125 |
| widget link preferences | #126 |
| high-severity content sinks | #127 |
| nav/layout sinks | #128 |
| card-count/card-size numeric | #129 |
| sticky-footer + Moodle links | this |

All 8 high-severity findings and every reflected/no-privilege finding closed; the rest were content-author/admin-privilege defense-in-depth, all now source- or sink-fixed.