### PR TITLE
Encrypt integration and payment secrets at rest

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,7 +50,9 @@ DB_USER=
 DB_PASSWORD=
 ```
 
-> **`CMS_SECRET_KEY`** encrypts recoverable secrets (such as per-user MFA/TOTP seeds) at rest with AES-256-GCM. Generate one with `openssl rand -base64 32` and supply it out-of-band (not committed). Keep a secure backup — losing the key makes encrypted secrets unrecoverable (affected users re-enroll MFA). Rotating: set the new key and re-save affected records. If unset, secrets are stored as plaintext (backward compatible), so set it for a hardened deployment.
+> **`CMS_SECRET_KEY`** encrypts recoverable secrets at rest with AES-256-GCM: per-user MFA/TOTP seeds and the stored integration/payment secrets in Site Settings (payment gateway keys, the SMTP password, the OAuth client secret, and mailing-list/analytics API tokens). Generate one with `openssl rand -base64 32` and supply it out-of-band (not committed). Keep a secure backup — losing the key makes encrypted secrets unrecoverable (affected users re-enroll MFA; integration keys must be re-entered). Rotating: set the new key and re-save the affected records. If unset, secrets are stored as plaintext (backward compatible), so set it for a hardened deployment.
+>
+> Integration secrets encrypt when next saved. Existing plaintext values keep working (they are read back unchanged) and are encrypted the next time they are saved through Site Settings. Values that are read-only in the admin UI (production payment keys, set directly in the database) stay plaintext until re-saved — see the release notes for the optional one-time re-encryption step.
 
 ## Upgrading
 

--- a/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
+++ b/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
@@ -93,6 +93,13 @@ public class SecretCryptoCommand {
   }
 
   /**
+   * @return true when the value is already an {@code enc:}-prefixed ciphertext
+   */
+  public static boolean isEncrypted(String value) {
+    return value != null && value.startsWith(PREFIX);
+  }
+
+  /**
    * Encrypts a secret for storage. Blank input is returned unchanged, and when no key is configured the value is
    * returned as-is (legacy plaintext) so an unconfigured deployment keeps working.
    *
@@ -100,7 +107,9 @@ public class SecretCryptoCommand {
    * @return an {@code enc:}-prefixed ciphertext, or the input unchanged when blank / no key
    */
   public static String encrypt(String plaintext) {
-    if (StringUtils.isBlank(plaintext)) {
+    // Idempotent: a blank value or one that is already encrypted is returned unchanged, so re-encrypting
+    // a stored secret cannot double-wrap it
+    if (StringUtils.isBlank(plaintext) || isEncrypted(plaintext)) {
       return plaintext;
     }
     SecretKeySpec k = key();

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/SitePropertyRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/SitePropertyRepository.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.infrastructure.persistence;
 
+import com.simisinc.platform.application.SecretCryptoCommand;
+import com.simisinc.platform.application.admin.SecretSitePropertiesCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.database.*;
@@ -84,7 +86,13 @@ public class SitePropertyRepository {
             "WHERE property_id = ?";
     int i = 0;
     PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
-    pst.setString(++i, StringUtils.trimToEmpty(record.getValue()));
+    // Encrypt secret property values at rest (payment/integration keys, passwords, tokens). encrypt() is a
+    // no-op for non-secret names, blank values, already-encrypted values, and when no key is configured.
+    String value = StringUtils.trimToEmpty(record.getValue());
+    if (SecretSitePropertiesCommand.isSecret(record.getName())) {
+      value = SecretCryptoCommand.encrypt(value);
+    }
+    pst.setString(++i, value);
     pst.setInt(++i, record.getId());
     return pst;
   }
@@ -136,7 +144,9 @@ public class SitePropertyRepository {
       record.setId(rs.getInt("property_id"));
       record.setLabel(rs.getString("property_label"));
       record.setName(rs.getString("property_name"));
-      record.setValue(rs.getString("property_value"));
+      // Decrypt at-rest secret values. decrypt() returns legacy plaintext unchanged, so this is safe for
+      // every property; a secret that cannot be decrypted (wrong/absent key) fails safe to null.
+      record.setValue(SecretCryptoCommand.decrypt(rs.getString("property_value")));
       record.setType(rs.getString("property_type"));
       return record;
     } catch (SQLException se) {

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -15,7 +15,7 @@ CREATE TABLE site_properties (
   property_order INTEGER DEFAULT 100,
   property_label VARCHAR(50),
   property_name VARCHAR(50) UNIQUE NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value TEXT NOT NULL,
   property_type VARCHAR(100)
 );
 

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1002__encrypt_secrets_column.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1002__encrypt_secrets_column.sql
@@ -1,0 +1,4 @@
+-- Widen property_value so encrypted secret values fit. AES-256-GCM ciphertext, base64-encoded with the
+-- "enc:" prefix, is roughly 1.4-1.8x the plaintext length, which can exceed the previous VARCHAR(255)
+-- for longer integration tokens. TEXT has no practical limit and is a no-op for existing plaintext rows.
+ALTER TABLE site_properties ALTER COLUMN property_value TYPE TEXT;

--- a/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
@@ -97,4 +97,23 @@ class SecretCryptoCommandTest {
     setKey((byte) 9); // rotate to a different key
     assertNull(SecretCryptoCommand.decrypt(encrypted), "wrong key -> null (GCM auth fails), not garbage");
   }
+
+  @Test
+  void encryptIsIdempotent() {
+    setKey((byte) 7);
+    String once = SecretCryptoCommand.encrypt("a-secret-value");
+    // Re-encrypting an already-encrypted value must not double-wrap it -- it is returned unchanged, so a
+    // re-save of a stored secret stays decryptable.
+    String twice = SecretCryptoCommand.encrypt(once);
+    assertEquals(once, twice);
+    assertEquals("a-secret-value", SecretCryptoCommand.decrypt(twice));
+  }
+
+  @Test
+  void isEncryptedDetectsThePrefix() {
+    assertTrue(SecretCryptoCommand.isEncrypted("enc:AAAA"));
+    assertFalse(SecretCryptoCommand.isEncrypted("plaintext"));
+    assertFalse(SecretCryptoCommand.isEncrypted(""));
+    assertFalse(SecretCryptoCommand.isEncrypted(null));
+  }
 }


### PR DESCRIPTION
## What
Extends the at-rest encryption used for MFA secrets (#114's `SecretCryptoCommand`) to the **integration and payment secrets** stored in `site_properties`: payment gateway keys (Stripe/Square/Boxzooka/TaxJar), the SMTP password, the OAuth client secret, and mailing-list/analytics/BI API tokens. The list of secret property names is the **same one #120 introduced for admin-UI masking** (`SecretSitePropertiesCommand`) — one list now drives both masking and encryption.

## Design — one choke point per direction
`SitePropertyRepository` is the single funnel for both:
- **Write** (`createPreparedStatementForUpdate`): encrypt the value when the property name `isSecret`. `encrypt()` is a no-op for non-secret names, blank values, already-encrypted values, and when no key is configured.
- **Read** (`buildRecord`): decrypt every value. `decrypt()` returns legacy plaintext unchanged, so it's safe for all properties; a secret that can't be decrypted (wrong/absent key) fails safe to `null`.

This mirrors #114's MFA-secret pattern (encrypt at the write funnel, decrypt at `buildRecord`) exactly.

## Safety
- **`encrypt` is now idempotent** (returns an already-`enc:` value unchanged, via a new `isEncrypted()` helper), so re-saving a stored secret can't double-wrap it.
- **Backward compatible**: existing plaintext values are read back unchanged and encrypt on their next save. With no `CMS_SECRET_KEY`, everything stays plaintext (unchanged behavior).
- **Column**: `property_value` widened `VARCHAR(255)` → `TEXT` (fresh install + idempotent upgrade `20260719.1002`) because base64 AES-GCM ciphertext can exceed 255 for longer tokens.
- Complements #120: those secrets are already masked in the admin UI; now they're also encrypted at rest.

## Verification
Full `ant ci-test` green. Adds `encrypt`-idempotency and `isEncrypted` tests; reuses #114's round-trip/fail-safe coverage. Docs updated for the broadened `CMS_SECRET_KEY` scope.

## Follow-up (noted, not in this PR)
Production payment keys are `disabled`-type (read-only in the admin UI, set via SQL) and are skipped by `saveAll`, so they won't auto-encrypt on a save. A **one-time re-encryption upgrade step** for those specific rows is a clean follow-up (design is in the private encrypt-at-rest doc).