### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to SimIS CMS are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow the project's `YYYYMMDD.NNNNN` release scheme; the git tag is the
+version prefixed with `v` (for example `v20260719.10000`). Database migrations
+apply automatically on startup — always take a database backup before upgrading.
+
+## [20260719.10000] - 2026-07-19
+
+First tagged release since `v20240106.10000` (2024-01-06): a broad security,
+authentication, and platform-modernization uplift (57 merged pull requests).
+
+### Added
+- Multi-factor authentication (TOTP): self-service enrollment, enforced login,
+  recovery codes, and brute-force rate limiting (#89–#94, #101, #111, #112).
+- Opt-in cookieless analytics — a daily rotating salted visitor hash with no
+  persistent identifier (#116).
+- Self-hosted map-tile server option with a secured OpenStreetMap fallback, for
+  air-gapped / in-boundary deployments (#118).
+- Signed CycloneDX SBOM published with each release, generated from the built
+  WAR so it describes exactly what ships (#85, #123).
+- SimIS-owned container images published from CI (#88).
+- Governance docs: `SECURITY.md` (#78), `CONTRIBUTING.md` (#108), Code of
+  Conduct (#99).
+
+### Changed
+- Runtime baseline moved to Java 21 (#87, #106) and PostgreSQL 17 (#103).
+- Passwords are hashed with Argon2id; legacy Argon2i hashes still verify (#117).
+- Mermaid upgraded 10.6.1 → 10.9.6 (and wiki mermaid fences now render) (#119).
+- Deprecated `URL(String)` usages modernized to `URI.create().toURL()` (#122).
+- Least-privilege `GITHUB_TOKEN` and serialized image publishing in CI (#95, #105).
+
+### Security
+- Encryption at rest (AES-256-GCM, `CMS_SECRET_KEY`) for MFA/TOTP seeds (#114)
+  and stored integration/payment secrets (#131); secret site properties masked
+  in the admin editor (#120).
+- Transport & browser hardening: HSTS (#84), a Content-Security-Policy baseline
+  (#86), session-id rotation on login, and SameSite=Lax cookies (#113).
+- Cross-site-scripting remediation across the JSP surface — reflected, stored,
+  and attribute-context vectors — plus DOM-based and admin-input fixes
+  (#98, #121, #124–#130).
+- Injection & traversal: SQL-injection fix in the product SKU filter (#77),
+  upload paths resolved within the file-server root (#96, #102), parameterized
+  geo-search (#97), SSL redirect no longer trusts the client Host header (#83).
+- Dependency CVEs cleared: vendored jars — thymeleaf, postgresql, jackson,
+  commons (#115); unused Pushy/netty stack removed (#104); frontend npm
+  vulnerabilities (#73). Embedded Mapbox token removed from source (#82, #91).
+
+### Upgrade notes
+- Drop-in WAR replacement; database migrations run automatically on startup.
+  Take a database backup first.
+- Java 21 and PostgreSQL 17 are the supported baseline.
+- Set `CMS_SECRET_KEY` (a base64 256-bit key) to enable encryption at rest for
+  MFA seeds and stored integration/payment secrets; if unset, those are stored
+  as plaintext (backward compatible). Keep a secure backup of the key. See
+  `docs/installation.md`.
+
+## [20240106.10000] - 2024-01-06
+Earlier releases predate this changelog; see the GitHub releases page for history.
+
+[20260719.10000]: https://github.com/SimisRnD/simis-cms/releases/tag/v20260719.10000
+[20240106.10000]: https://github.com/SimisRnD/simis-cms/releases/tag/v20240106.10000


### PR DESCRIPTION
## What
Adds a `CHANGELOG.md` — a running, in-repo history of notable changes in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format — starting with the **v20260719.10000** release entry (the first tagged release since v20240106.10000).

## Why
Gives anyone browsing the repository a single, version-controlled view of what changed across releases, without going to the GitHub Releases tab. Complements (doesn't replace) the per-release GitHub release notes.

## Notes
- The v20260719.10000 entry covers the 57 PRs merged since the last release, grouped Added / Changed / Security, with upgrade notes (Java 21 / PostgreSQL 17 baseline, `CMS_SECRET_KEY`).
- Version/tag scheme documented at the top (`YYYYMMDD.NNNNN`, tag = `v` + version).
- Documentation only — no code changes.