### PR TITLE
Anonymize stored analytics IP addresses (opt-in)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/IpAddressCommand.java
+++ b/src/main/java/com/simisinc/platform/application/IpAddressCommand.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import java.net.InetAddress;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hc.core5.net.InetAddressUtils;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+/**
+ * Anonymizes IP addresses stored for analytics (visitor sessions and page hits). The full address is
+ * geocoded upstream when a session is created, so the stored value is only an identifier -- masking the
+ * host portion keeps the coarse network for abuse analysis without retaining a value that identifies an
+ * individual visitor. Records that are legally or operationally required to keep the full address (block
+ * list, login audit, orders, form and mailing-list submissions) are intentionally not passed through here.
+ *
+ * @author elizabeth houser
+ */
+public class IpAddressCommand {
+
+  private static Log LOG = LogFactory.getLog(IpAddressCommand.class);
+
+  /**
+   * Returns the value anonymized when the {@code analytics.anonymizeIp} site property is enabled, otherwise
+   * the value unchanged (opt-in, so default behavior is preserved).
+   */
+  public static String anonymizeForStorage(String ipAddress) {
+    if (LoadSitePropertyCommand.loadByNameAsBoolean("analytics.anonymizeIp")) {
+      return anonymize(ipAddress);
+    }
+    return ipAddress;
+  }
+
+  /**
+   * Masks the host portion of an IP address: IPv4 to the /24 network (zeroes the last octet) and IPv6 to
+   * the /48 network (zeroes the last 80 bits). A blank or unparseable value is returned unchanged.
+   */
+  public static String anonymize(String ipAddress) {
+    if (StringUtils.isBlank(ipAddress)) {
+      return ipAddress;
+    }
+    try {
+      if (InetAddressUtils.isIPv4Address(ipAddress)) {
+        byte[] bytes = InetAddress.getByName(ipAddress).getAddress();
+        bytes[3] = 0;
+        return InetAddress.getByAddress(bytes).getHostAddress();
+      }
+      if (InetAddressUtils.isIPv6Address(ipAddress)) {
+        byte[] bytes = InetAddress.getByName(ipAddress).getAddress();
+        for (int i = 6; i < bytes.length; i++) {
+          bytes[i] = 0;
+        }
+        return InetAddress.getByAddress(bytes).getHostAddress();
+      }
+    } catch (Exception e) {
+      LOG.warn("Could not anonymize ip address");
+    }
+    return ipAddress;
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/SaveSessionCommand.java
+++ b/src/main/java/com/simisinc/platform/application/SaveSessionCommand.java
@@ -37,7 +37,9 @@ public class SaveSessionCommand {
     session.setSessionId(userSession.getSessionId());
     session.setSource(userSession.getSource());
     session.setAppId(userSession.getAppId());
-    session.setIpAddress(userSession.getIpAddress());
+    // The geo location was already resolved from the full ip when the session was created; only an
+    // anonymized ip is stored when analytics.anonymizeIp is enabled
+    session.setIpAddress(IpAddressCommand.anonymizeForStorage(userSession.getIpAddress()));
     session.setUserAgent(userSession.getUserAgent());
     session.setReferer(userSession.getReferer());
     if (userSession.getGeoIP() != null) {

--- a/src/main/java/com/simisinc/platform/application/cms/SaveWebPageHitCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveWebPageHitCommand.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.application.cms;
 
+import com.simisinc.platform.application.IpAddressCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.cms.WebPageHit;
@@ -37,7 +38,7 @@ public class SaveWebPageHitCommand {
 
   public static void saveHit(String ipAddress, String method, String pagePath, WebPage webPage, UserSession userSession) {
     WebPageHit webPageHit = new WebPageHit();
-    webPageHit.setIpAddress(ipAddress);
+    webPageHit.setIpAddress(IpAddressCommand.anonymizeForStorage(ipAddress));
     webPageHit.setMethod(method);
     webPageHit.setPagePath(pagePath);
     if (webPage != null) {
@@ -55,7 +56,7 @@ public class SaveWebPageHitCommand {
 
   public static void saveHit(String ipAddress, String method, String pagePath, User user) {
     WebPageHit webPageHit = new WebPageHit();
-    webPageHit.setIpAddress(ipAddress);
+    webPageHit.setIpAddress(IpAddressCommand.anonymizeForStorage(ipAddress));
     webPageHit.setMethod(method);
     webPageHit.setPagePath(pagePath);
     if (user != null) {

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -154,6 +154,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 -- Analytics
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (5, 'Cookieless analytics (no visitor cookie)?', 'analytics.cookieless', 'false', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (6, 'Anonymize analytics IP addresses?', 'analytics.anonymizeIp', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (20, 'Google Analytics GA Key', 'analytics.google.key', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (22, 'Google Tag Manager GTM Key', 'analytics.google.tagmanager', '');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1003__analytics_anonymize_ip.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1003__analytics_anonymize_ip.sql
@@ -1,0 +1,6 @@
+-- Opt-in: when enabled, stored analytics IP addresses (visitor sessions and page hits) are masked to
+-- the /24 (IPv4) or /48 (IPv6) network. Geo location is resolved from the full IP at session creation,
+-- so the map is unaffected. Default off for backward compatibility.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (6, 'Anonymize analytics IP addresses?', 'analytics.anonymizeIp', 'false', 'boolean')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/IpAddressCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/IpAddressCommandTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests masking of the host portion of an IP address for analytics storage
+ *
+ * @author elizabeth houser
+ */
+class IpAddressCommandTest {
+
+  @Test
+  void ipv4IsMaskedToTheNetwork() {
+    assertEquals("192.168.1.0", IpAddressCommand.anonymize("192.168.1.234"));
+    assertEquals("8.8.8.0", IpAddressCommand.anonymize("8.8.8.8"));
+    // Already-zeroed host is unchanged
+    assertEquals("10.0.0.0", IpAddressCommand.anonymize("10.0.0.0"));
+  }
+
+  @Test
+  void ipv6IsMaskedToTheNetwork() {
+    // /48: the first three hextets are kept, the rest zeroed
+    assertEquals("2001:db8:1234:0:0:0:0:0", IpAddressCommand.anonymize("2001:db8:1234:5678:9abc:def0:1234:5678"));
+  }
+
+  @Test
+  void blankAndUnparseableValuesAreUnchanged() {
+    assertEquals("", IpAddressCommand.anonymize(""));
+    assertEquals(null, IpAddressCommand.anonymize(null));
+    // Not an IP literal -> returned unchanged (no DNS lookup attempted)
+    assertEquals("not-an-ip", IpAddressCommand.anonymize("not-an-ip"));
+  }
+}


### PR DESCRIPTION
Part of #133 — the IP-anonymization piece (DNT/GPC + retention window follow within the same milestone).

## What
Opt-in **`analytics.anonymizeIp`** site property. When enabled, the IP stored for **visitor sessions and web page hits** is masked to the network — **IPv4 → /24** (last octet zeroed), **IPv6 → /48** — so the stored value no longer identifies an individual visitor, while the coarse network remains for abuse analysis.

## Why it's safe for the map
Geo location (country/city/lat/long) is resolved from the **full** IP once, at session creation (`CreateSessionCommand → GeoIPCommand`), and stored in dedicated columns. **Nothing re-geocodes from the stored session/page-hit IP** (verified), so masking the stored value doesn't affect the analytics location map.

## Scope — analytics IPs only
Deliberately limited to the two analytics tables. Records that need the full address — the **blocked-IP list, login audit, orders, and form/mailing-list submissions** (all of which *do* re-geocode from their stored IP) — are **not** passed through the anonymizer.

## Design
- `IpAddressCommand.anonymize` masks the host portion (string-validated as an IP literal first, so no DNS lookup); `anonymizeForStorage` gates it on the site property (**default off** — behavior unchanged until an operator enables it).
- Applied in `SaveSessionCommand` and `SaveWebPageHitCommand`.
- Seeded for fresh installs + idempotent upgrade (`20260719.1003`) for existing installs.

## Verification
`IpAddressCommandTest`: IPv4 /24, IPv6 /48, blank/unparseable pass-through. Full `ant ci-test` green.