### PR TITLE
Honor Do-Not-Track and Global Privacy Control signals (opt-in)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/DoNotTrackCommand.java
+++ b/src/main/java/com/simisinc/platform/application/DoNotTrackCommand.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+/**
+ * Determines whether a request has asked not to be tracked, via the Do-Not-Track ({@code DNT: 1}) or
+ * Global Privacy Control ({@code Sec-GPC: 1}) request headers. Honoring is opt-in through the
+ * {@code analytics.honorDnt} site property so existing analytics behavior is unchanged by default; when
+ * enabled, visitor and page-hit tracking is skipped for a signaling request.
+ *
+ * @author elizabeth houser
+ */
+public class DoNotTrackCommand {
+
+  /**
+   * @param dntHeader the value of the {@code DNT} request header, or null
+   * @param gpcHeader the value of the {@code Sec-GPC} request header, or null
+   * @return true when honoring is enabled and the request signals do-not-track
+   */
+  public static boolean isDoNotTrack(String dntHeader, String gpcHeader) {
+    if (!LoadSitePropertyCommand.loadByNameAsBoolean("analytics.honorDnt")) {
+      return false;
+    }
+    return "1".equals(dntHeader) || "1".equals(gpcHeader);
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.controller;
 
 import com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand;
+import com.simisinc.platform.application.DoNotTrackCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.*;
 import com.simisinc.platform.application.items.LoadCategoryCommand;
@@ -249,8 +250,9 @@ public class PageServlet extends HttpServlet {
 
       // Web Page Hits
       if (pageRef != null) {
-        // Determine if this is a monitoring app
-        if (request.getHeader("X-Monitor") == null) {
+        // Skip tracking for monitoring apps, and for requests that ask not to be tracked (DNT / GPC)
+        if (request.getHeader("X-Monitor") == null
+            && !DoNotTrackCommand.isDoNotTrack(request.getHeader("DNT"), request.getHeader("Sec-GPC"))) {
           SaveWebPageHitCommand.saveHit(request.getRemoteAddr(), request.getMethod(), pagePath, webPage, userSession);
         }
       }

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -43,6 +43,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hc.core5.net.InetAddressUtils;
 
+import com.simisinc.platform.application.DoNotTrackCommand;
 import com.simisinc.platform.application.CreateSessionCommand;
 import com.simisinc.platform.application.DailyVisitorHashCommand;
 import com.simisinc.platform.application.LoadVisitorCommand;
@@ -312,8 +313,10 @@ public class WebRequestFilter implements Filter {
           userSession = CreateSessionCommand.createSession(WEB_SOURCE, httpServletRequest.getSession().getId(),
               ipAddress, referer, userAgent);
           httpServletRequest.getSession().setAttribute(SessionConstants.USER, userSession);
-          // Determine if this is a monitoring app
-          if (httpServletRequest.getHeader("X-Monitor") == null) {
+          // Skip tracking for monitoring apps, and for requests that ask not to be tracked (DNT / GPC)
+          if (httpServletRequest.getHeader("X-Monitor") == null
+              && !DoNotTrackCommand.isDoNotTrack(httpServletRequest.getHeader("DNT"),
+                  httpServletRequest.getHeader("Sec-GPC"))) {
             doSaveSession = true;
           }
         }

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -155,6 +155,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (5, 'Cookieless analytics (no visitor cookie)?', 'analytics.cookieless', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (7, 'Honor Do-Not-Track / Global Privacy Control?', 'analytics.honorDnt', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (20, 'Google Analytics GA Key', 'analytics.google.key', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (22, 'Google Tag Manager GTM Key', 'analytics.google.tagmanager', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (25, 'SimpliFi Tag Value', 'analytics.simplifi.value', '');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1004__analytics_honor_dnt.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1004__analytics_honor_dnt.sql
@@ -1,0 +1,6 @@
+-- Opt-in: when enabled, visitor and page-hit tracking is skipped for a request that sends the
+-- Do-Not-Track (DNT: 1) or Global Privacy Control (Sec-GPC: 1) header. Default off for backward
+-- compatibility (existing analytics behavior is unchanged until an operator enables it).
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (7, 'Honor Do-Not-Track / Global Privacy Control?', 'analytics.honorDnt', 'false', 'boolean')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/DoNotTrackCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/DoNotTrackCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+/**
+ * Tests honoring of the Do-Not-Track and Global Privacy Control signals
+ *
+ * @author elizabeth houser
+ */
+class DoNotTrackCommandTest {
+
+  private MockedStatic<LoadSitePropertyCommand> honoring(boolean enabled) {
+    MockedStatic<LoadSitePropertyCommand> m = mockStatic(LoadSitePropertyCommand.class);
+    m.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("analytics.honorDnt")).thenReturn(enabled);
+    return m;
+  }
+
+  @Test
+  void whenHonoringIsDisabledNothingIsDoNotTrack() {
+    try (MockedStatic<LoadSitePropertyCommand> m = honoring(false)) {
+      // Even a DNT/GPC signal is ignored when honoring is off (default behavior)
+      assertFalse(DoNotTrackCommand.isDoNotTrack("1", "1"));
+    }
+  }
+
+  @Test
+  void whenHonoringIsEnabledTheSignalsAreRespected() {
+    try (MockedStatic<LoadSitePropertyCommand> m = honoring(true)) {
+      assertTrue(DoNotTrackCommand.isDoNotTrack("1", null), "DNT: 1");
+      assertTrue(DoNotTrackCommand.isDoNotTrack(null, "1"), "Sec-GPC: 1");
+      assertFalse(DoNotTrackCommand.isDoNotTrack(null, null), "no signal");
+      assertFalse(DoNotTrackCommand.isDoNotTrack("0", "0"), "explicit not-set");
+    }
+  }
+}


### PR DESCRIPTION
Part of #133 (with #135) — the DNT/GPC piece.

## What
Opt-in **`analytics.honorDnt`** site property. When enabled, visitor and web-page-hit tracking is skipped for a request that sends **`DNT: 1`** or **`Sec-GPC: 1`** (Global Privacy Control). Default off — existing analytics behavior is unchanged until an operator enables it.

## Design
`DoNotTrackCommand.isDoNotTrack(dnt, gpc)` gates on the site property + the two header values (servlet-free — the callers pass the headers). It's applied by **mirroring the existing `X-Monitor` skip**:
- `WebRequestFilter` — the session save (`doSaveSession`).
- `PageServlet` — the web page hit (`SaveWebPageHitCommand.saveHit`).

## Compatibility
- Seeded for fresh installs + idempotent upgrade (`20260719.1004`).
- The seed line is placed away from #135's `analytics.anonymizeIp` insert so the two privacy PRs **merge without a conflict**.

## Verification
`DoNotTrackCommandTest`: honoring-off ignores the signals; honoring-on respects `DNT`/`Sec-GPC` and ignores `0`/absent. Full `ant ci-test` green.

## Milestone
Completes 2 of 3 parts of #133 (IP anonymization #135 + this). The configurable **retention window** is the remaining piece.