### PR TITLE
Make the analytics data retention window configurable

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepository.java
@@ -16,11 +16,13 @@
 
 package com.simisinc.platform.infrastructure.persistence.cms;
 
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.SqlUtils;
 import com.simisinc.platform.infrastructure.persistence.SessionRepository;
 import com.simisinc.platform.domain.model.cms.WebPageHit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -122,7 +124,33 @@ public class WebPageHitRepository {
   }
 
   public static void deleteOldWebHits() {
-    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("hit_date < NOW() - INTERVAL '365 days'"));
+    // The retention window is configurable via the analytics.retentionDays site property. The value is
+    // parsed to an int (and bounded) before it is placed in the interval, so it cannot inject SQL.
+    int days = resolveRetentionDays(LoadSitePropertyCommand.loadByName("analytics.retentionDays"));
+    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("hit_date < NOW() - INTERVAL '" + days + " days'"));
+  }
+
+  private static final int DEFAULT_RETENTION_DAYS = 365;
+
+  /** Parses the configured retention window to a bounded positive integer, defaulting to 365 days. */
+  static int resolveRetentionDays(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_RETENTION_DAYS;
+    }
+    int days;
+    try {
+      days = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_RETENTION_DAYS;
+    }
+    // Keep at least a day of data, and cap at ten years to avoid an unbounded interval
+    if (days < 1) {
+      return 1;
+    }
+    if (days > 3650) {
+      return 3650;
+    }
+    return days;
   }
 
   public static List<StatisticsData> findDailyWebHits(int daysToLimit) {

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -155,6 +155,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (5, 'Cookieless analytics (no visitor cookie)?', 'analytics.cookieless', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (6, 'Anonymize analytics IP addresses?', 'analytics.anonymizeIp', 'false', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (8, 'Analytics data retention (days)', 'analytics.retentionDays', '365');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (20, 'Google Analytics GA Key', 'analytics.google.key', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (22, 'Google Tag Manager GTM Key', 'analytics.google.tagmanager', '');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1005__analytics_retention_days.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1005__analytics_retention_days.sql
@@ -1,0 +1,5 @@
+-- Makes the web-page-hit retention window configurable (was hardcoded to 365 days). The daily cleanup
+-- job deletes hits older than this many days. Parsed to a bounded integer in code before use.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (8, 'Analytics data retention (days)', 'analytics.retentionDays', '365')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepositoryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests parsing of the configurable analytics retention window
+ *
+ * @author elizabeth houser
+ */
+class WebPageHitRepositoryTest {
+
+  @Test
+  void resolveRetentionDaysParsesAndBounds() {
+    assertEquals(30, WebPageHitRepository.resolveRetentionDays("30"));
+    assertEquals(365, WebPageHitRepository.resolveRetentionDays("365"));
+    assertEquals(90, WebPageHitRepository.resolveRetentionDays("  90  "));
+    // Defaults when blank or non-numeric (the value comes from a site property, so it must not inject SQL)
+    assertEquals(365, WebPageHitRepository.resolveRetentionDays(""));
+    assertEquals(365, WebPageHitRepository.resolveRetentionDays(null));
+    assertEquals(365, WebPageHitRepository.resolveRetentionDays("30; DROP TABLE web_page_hits"));
+    assertEquals(365, WebPageHitRepository.resolveRetentionDays("abc"));
+    // Bounded to a sane range
+    assertEquals(1, WebPageHitRepository.resolveRetentionDays("0"));
+    assertEquals(1, WebPageHitRepository.resolveRetentionDays("-5"));
+    assertEquals(3650, WebPageHitRepository.resolveRetentionDays("999999"));
+  }
+}


### PR DESCRIPTION
Completes #133 (with #135 IP anonymization and #136 DNT/GPC honoring).

## What
The daily `WebPageHitsCleanupJob` deleted web page hits older than a **hardcoded 365 days**. This adds an **`analytics.retentionDays`** site property so an operator can set the retention window — e.g. a shorter window for a privacy-forward / data-minimizing deployment.

## Injection-safe by construction
`WebPageHitRepository.resolveRetentionDays` parses the property to an `int` (365 default, **bounded to 1..3650**); the **bounded int — never the raw string — is placed in the SQL interval**, so a site-property value can't inject SQL. (Test includes a `30; DROP TABLE ...`-shaped value → falls back to the default.)

## Compatibility
- Default 365 (unchanged behavior); seeded for fresh installs + idempotent upgrade `20260719.1005`.
- Rebased on current `main`; the seed sits after #135's `analytics.anonymizeIp` and the migration slot is free.

## Verification
`WebPageHitRepositoryTest` covers parsing, bounding, and the injection-shaped rejection. Full `ant ci-test` green.

## Milestone
This closes **#133** — the analytics data is now anonymizable (#135), respects DNT/GPC (#136), and has a configurable retention window (this). The privacy-by-default story from cookieless analytics (#116) is complete.