### PR TITLE
Surface top on-site search terms in analytics

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebSearchRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebSearchRepository.java
@@ -19,12 +19,16 @@ package com.simisinc.platform.infrastructure.persistence.cms;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.SqlUtils;
 import com.simisinc.platform.domain.model.cms.WebSearch;
+import com.simisinc.platform.domain.model.dashboard.StatisticsData;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Persists and retrieves web search objects
@@ -80,5 +84,33 @@ public class WebSearchRepository {
     PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
     pst.setLong(++i, record.getId());
     return pst;
+  }
+
+  /** Returns the most-searched terms over the last {@code daysToLimit} days. daysToLimit and recordLimit
+   * are ints, so placing them in the interval/limit cannot inject SQL. */
+  public static List<StatisticsData> findTopSearchTerms(int daysToLimit, int recordLimit) {
+    String SQL_QUERY =
+        "SELECT query, count(query) AS query_count " +
+            "FROM web_searches " +
+            "WHERE search_date > NOW() - INTERVAL '" + daysToLimit + " days' " +
+            "AND query IS NOT NULL AND query <> '' " +
+            "GROUP BY query " +
+            "ORDER BY query_count DESC " +
+            "LIMIT " + recordLimit;
+    List<StatisticsData> records = null;
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+         ResultSet rs = pst.executeQuery()) {
+      records = new ArrayList<>();
+      while (rs.next()) {
+        StatisticsData data = new StatisticsData();
+        data.setLabel(rs.getString("query"));
+        data.setValue(String.valueOf(rs.getLong("query_count")));
+        records.add(data);
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return records;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
@@ -23,6 +23,7 @@ import com.simisinc.platform.domain.model.maps.MapCredentials;
 import com.simisinc.platform.infrastructure.persistence.SessionRepository;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageHitRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebSearchRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.widgets.cms.PreferenceEntriesList;
@@ -220,6 +221,12 @@ public class SiteStatsWidget extends GenericWidget {
       context.getRequest().setAttribute("statisticsDataList", statisticsDataList);
       context.getRequest().setAttribute("label", context.getPreferences().getOrDefault("label", "Link"));
       context.getRequest().setAttribute("value", context.getPreferences().getOrDefault("value", "Hits"));
+      return TABLE_JSP;
+    } else if ("search-terms".equalsIgnoreCase(report)) {
+      List<StatisticsData> statisticsDataList = WebSearchRepository.findTopSearchTerms(intervalValue, limit);
+      context.getRequest().setAttribute("statisticsDataList", statisticsDataList);
+      context.getRequest().setAttribute("label", context.getPreferences().getOrDefault("label", "Search Term"));
+      context.getRequest().setAttribute("value", context.getPreferences().getOrDefault("value", "Searches"));
       return TABLE_JSP;
     } else {
       return null;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/SearchInfoWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/SearchInfoWidget.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.IpAddressCommand;
+
 import com.simisinc.platform.domain.model.cms.WebSearch;
 import com.simisinc.platform.infrastructure.persistence.cms.WebSearchRepository;
 import com.simisinc.platform.presentation.controller.RequestConstants;
@@ -52,7 +54,7 @@ public class SearchInfoWidget extends GenericWidget {
       WebSearch webSearch = new WebSearch();
       webSearch.setPagePath(pagePath);
       webSearch.setQuery(query);
-      webSearch.setIpAddress(context.getRequest().getRemoteAddr());
+      webSearch.setIpAddress(IpAddressCommand.anonymizeForStorage(context.getRequest().getRemoteAddr()));
       webSearch.setSessionId(context.getUserSession().getSessionId());
       webSearch.setIsLoggedIn(context.getUserSession().isLoggedIn());
       WebSearchRepository.save(webSearch);

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-table.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-table.jsp
@@ -68,9 +68,17 @@
   // Wait for the first query
   var updateInterval;
 
+  // Escape a label for safe insertion into the table markup (labels can be user-provided, e.g. search
+  // terms or referrers)
+  function escapeHtml${widgetContext.uniqueId}(text) {
+    var div = document.createElement('div');
+    div.textContent = text == null ? '' : text;
+    return div.innerHTML;
+  }
+
   // Update the table data
   function buildItemRow(item) {
-    return "<tr><td>" + item.label + "</td><td class=\"text-center\">" + parseFloat(item.value).toLocaleString() + "</td></tr>";
+    return "<tr><td>" + escapeHtml${widgetContext.uniqueId}(item.label) + "</td><td class=\"text-center\">" + parseFloat(item.value).toLocaleString() + "</td></tr>";
   }
 
   // Query the data

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -544,6 +544,17 @@
           <type>line</type>
         </widget>
       </column>
+      <column class="small-12 medium-6 cell">
+        <widget name="siteStats" class="stats card">
+          <icon>fa-search</icon>
+          <title>Top Search Terms</title>
+          <report>search-terms</report>
+          <label>Search Term</label>
+          <value>Searches</value>
+          <days>30</days>
+          <limit>10</limit>
+        </widget>
+      </column>
 <!--
       <column class="small-12 medium-6 cell">
         <widget name="siteStats" class="stats card">


### PR DESCRIPTION
Closes #134 (Release 2 milestone).

## What
Searches were **already captured** to `web_searches` (`SearchInfoWidget`) but never surfaced. This adds the reporting:
- **`WebSearchRepository.findTopSearchTerms(days, limit)`** — most-searched terms over a window, grouped + counted (`days`/`limit` are ints → no SQL injection).
- **`SiteStatsWidget`** — a new `search-terms` report type feeding the existing stats table.
- **Admin analytics** — a live **"Top Search Terms"** panel (last 30 days, top 10).

Content managers now see what visitors look for — content gaps and demand signals.

## Security (found while wiring it)
Search terms are user-provided. The server render already `c:out`s the label — but the AJAX/JSON path's JS row builder concatenated `item.label` into `innerHTML` **unescaped**, a latent DOM-XSS reachable by any user-controlled label on this shared stats table (notably the **referrers** report, where the label comes from the `Referer` header). Fixed with a `textContent`-based escape in `buildItemRow`.

## Privacy
Anonymizes the stored search IP via `IpAddressCommand.anonymizeForStorage` (the helper from #135), keeping the analytics-IP posture consistent.

## Verification
Full `ant ci-test` green. (Capture path unchanged; the report query mirrors the existing `findTopWebPages` pattern.)