### PR TITLE
Add CodeQL config to exclude vendored third-party JavaScript

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: "SimIS CMS CodeQL config"
+
+# Vendored third-party JavaScript libraries live under src/main/webapp/javascript (mermaid, tinymce,
+# codemirror, jquery-*, swiper, jsuites, spectrum, foundation-datepicker, ...). These are shipped
+# bundles, often minified, that SimIS does not author or hand-patch -- they are managed by updating the
+# library version and are tracked in the release SBOM. CodeQL scanning of their internals produces
+# findings against library code, not first-party code, which buries any real first-party finding in noise.
+#
+# Excluding them keeps CodeQL focused on first-party code. First-party JavaScript is inline in the JSPs
+# (reviewed manually) and there is very little first-party code under this path.
+paths-ignore:
+  - src/main/webapp/javascript

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+# Advanced CodeQL setup that applies .github/codeql/codeql-config.yml so vendored third-party JavaScript
+# under src/main/webapp/javascript is excluded from scanning (see that file for the rationale).
+#
+# ADOPTION (requires a repository admin):
+#   1. Disable the repository's CodeQL *default* setup first (Settings -> Code security -> Code scanning ->
+#      CodeQL default setup -> disable). Default and advanced setup cannot both run.
+#   2. Change the `on:` triggers below from `workflow_dispatch` only to the usual push/pull_request/schedule
+#      (an example is left commented out) so it runs on every change like the previous default setup did.
+#   3. Merge, then confirm the CodeQL check runs green on a pull request and that first-party alerts still
+#      appear while the vendored-JS noise is gone.
+#
+# Until adopted, this workflow only runs on a manual dispatch, so it does not conflict with default setup.
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  # After disabling default setup (see ADOPTION above), enable these:
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
+  # schedule:
+  #   - cron: '31 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # java-kotlin uses build-mode: manual, so build the sources CodeQL should trace (mirrors ant.yml)
+      - name: Compile the source
+        if: matrix.language == 'java-kotlin'
+        run: ant -noinput -buildfile build.xml clean compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why
Every open CodeQL **JavaScript** alert (67 of them) was in a **vendored third-party library** under `src/main/webapp/javascript` — mermaid, tinymce, codemirror, jquery-*, swiper, jsuites, spectrum, foundation-datepicker. **Zero** were in first-party code. These are shipped, often-minified bundles SimIS doesn't author or hand-patch; they're managed by updating the library version and tracked in the release SBOM. Scanning their internals reports findings against *library* code and buries any real first-party finding in the noise.

(The Java CodeQL analysis is already at 0, and first-party JS is inline in the JSPs, which were manually swept for XSS.)

## What
- **`.github/codeql/codeql-config.yml`** — `paths-ignore` for the vendored JS directory.
- **`.github/workflows/codeql.yml`** — an advanced CodeQL setup that applies the config (java-kotlin with a manual ant build, javascript-typescript, actions).

## ⚠️ Adoption requires an admin (documented in the workflow header)
The workflow triggers **only on `workflow_dispatch`** for now, so it **does not conflict** with the repository's current CodeQL *default* setup. To make the exclusion live, an admin must:
1. **Disable** CodeQL default setup (default + advanced can't both run).
2. Switch the workflow `on:` triggers to `push`/`pull_request`/`schedule` (example left commented).
3. Verify the CodeQL check runs green on a PR and first-party alerts still appear.

## Interim state
The 67 already-open vendored-JS alerts have been **dismissed** (won't-fix: third-party library), so CodeQL is at **0 open** and any future first-party finding stands out immediately. This PR makes the exclusion permanent at the source.