### PR TITLE
Remove unused resilience4j-bulkhead and archunit-junit5 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <lombok.version>1.18.46</lombok.version>
     <postgresql.version>42.7.13</postgresql.version>
     <rabbitmq.version>5.34.0</rabbitmq.version>
-    <resilience4j.version>2.4.0</resilience4j.version>
     <restfb.version>2023.8.0</restfb.version>
     <rome-rss.version>2.1.0</rome-rss.version>
     <slf4j.version>2.0.18</slf4j.version>
@@ -345,11 +344,6 @@
       <version>${classgraph.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.resilience4j</groupId>
-      <artifactId>resilience4j-bulkhead</artifactId>
-      <version>${resilience4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.restfb</groupId>
       <artifactId>restfb</artifactId>
       <version>${restfb.version}</version>
@@ -460,12 +454,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5</artifactId>
-      <version>1.4.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What

Removes two dependencies declared in `pom.xml` but never actually used:

- **`io.github.resilience4j:resilience4j-bulkhead`** — 0 imports in `src`, not referenced in `build.xml`, not vendored in `lib/build`. It was the sole consumer of the `resilience4j.version` property, which is removed as well.
- **`com.tngtech.archunit:archunit-junit5`** (test scope) — 0 usages; there are no ArchUnit tests in the project.

## Why

The production WAR is assembled by ant from `lib/build/*.jar`, not from these pom declarations, so neither dependency reaches the shipped artifact — they only add noise to the dependency picture. Keeping the pom an honest description of what the project actually depends on is exactly what the dependency/SBOM-integrity work relies on.

## Verification

- `grep` across `src` (main + test): 0 usages of either library (the only "Bulkhead" match is a city name in a SQL seed file).
- Not referenced in `build.xml`; not present in `lib/build` or `lib/tests`.
- No remaining `${resilience4j.version}` references after dropping the property.
- `pom.xml` well-formed (`xmllint --noout`) and `mvn -o validate` passes.
- ant build unaffected (it does not read these declarations).

Diff is pom-only: 12 deletions.