### PR TITLE
Enable line-number debug info in the Ant build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -94,7 +94,7 @@
   <target name="compile" depends="prepare">
     <javac srcdir="${src.dir}" source="${jdk}" target="${jdk}"
            destdir="${build.dir}"
-           debug="off"
+           debug="on" debuglevel="lines,source"
            deprecation="on"
            optimize="on"
            includeantruntime="false">
@@ -187,7 +187,7 @@
             outputDir="${target.dir}/${project}/WEB-INF/src" />
     <!-- Compile the JSPs -->
     <javac destdir="${target.dir}/${project}/WEB-INF/compiled" source="${jdk}" target="${jdk}"
-           optimize="on" debug="off"
+           optimize="on" debug="on" debuglevel="lines,source"
            srcdir="${target.dir}/${project}/WEB-INF/src"
            excludes="**/*.smap">
       <classpath>
@@ -331,7 +331,7 @@
   <target name="compile-test" depends="jar">
     <javac srcdir="${src.test.dir}" source="${jdk}" target="${jdk}"
            destdir="${build.dir}"
-           debug="off"
+           debug="on" debuglevel="lines,source"
            deprecation="on"
            optimize="on"
            includeantruntime="false">


### PR DESCRIPTION
## What

Enable line-number debug info in the Ant build by compiling with
`debug="on" debuglevel="lines,source"` in all three `javac` invocations
(main sources, JSP-generated servlets, and tests). This emits the
`LineNumberTable` and `SourceFile` attributes while still omitting the
local-variable table (`vars`), so class files grow only marginally.

```
- debug="off"
+ debug="on" debuglevel="lines,source"
```

## Why

`debug="off"` has two costs today:

1. **Production/runtime stack traces have no line numbers** — you get
   method names but not the line, which slows incident debugging.
2. **JaCoCo cannot compute LINE coverage.** Without a `LineNumberTable`
   every line counter is 0, so coverage reports can only show
   instruction / branch / method / complexity coverage — not the line
   coverage most people look for.

Both are fixed by emitting line-number debug info. This is generally
recommended even for production Java builds: line numbers in stack
traces are high value at low cost.

## History checked

`debug="off"` has been present since the **initial public code drop**
(2022) — it was never deliberately turned off in response to a problem,
it's just the inherited Ant default. Also worth noting: `optimize="on"`
is a no-op in modern `javac`, so `debug="off"` bought **no** optimization
— it only stripped useful debug information.

## Scope

The `compile` target (main sources) is the one that gates both downsides
above. I applied the same one-line change to the JSP-precompile and
`compile-test` `javac` blocks as well, so production JSP stack traces and
test-failure stack traces also carry line numbers and the build stays
internally consistent. Happy to narrow this to just the `compile` target
if preferred.

This is independent of #141 (coverage visibility), which deliberately did
not touch compilation — this PR is the compilation-touching counterpart.

## Verification

- `ant -lib lib/war package` builds green on JDK 21 (939 main + 286 JSP
  classes, WAR produced).
- `ant -lib lib/war compile-test` builds green.
- `javap -l` on a compiled class confirms `LineNumberTable` + `SourceFile`
  are present and `LocalVariableTable` is absent (i.e. `lines,source`
  without `vars`).

Line coverage is computed directly from the now-present `LineNumberTable`,
so JaCoCo's line counters will populate on the next `ant test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
