### PR TITLE
Replace deprecated WriterOutputStream constructor with commons-io builder

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WidgetOutputStream.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WidgetOutputStream.java
@@ -23,6 +23,7 @@ import javax.servlet.WriteListener;
 import java.io.BufferedOutputStream;
 import java.io.CharArrayWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Description
@@ -34,8 +35,13 @@ public class WidgetOutputStream extends ServletOutputStream {
 
   private final BufferedOutputStream bufferedOut;
 
-  public WidgetOutputStream(CharArrayWriter charArray) {
-    this.bufferedOut = new BufferedOutputStream(new WriterOutputStream(charArray, "UTF-8"), 16384);
+  public WidgetOutputStream(CharArrayWriter charArray) throws IOException {
+    this.bufferedOut = new BufferedOutputStream(
+        WriterOutputStream.builder()
+            .setWriter(charArray)
+            .setCharset(StandardCharsets.UTF_8)
+            .get(),
+        16384);
   }
 
   @Override


### PR DESCRIPTION
## What

Replaces the deprecated commons-io `WriterOutputStream(Writer, String)` constructor in `WidgetOutputStream` with the builder API:

```java
WriterOutputStream.builder().setWriter(charArray).setCharset(StandardCharsets.UTF_8).get()
```

This clears the **last commons-io Java 21 deprecation warning**. It was deferred until the commons-io 2.22 bump (#115) landed, because the builder's `Writer`/origin setter and `get()` behavior are only clean on 2.22.

## Why the signature change (and why it ripples nowhere)

`builder().get()` declares `throws IOException`, so the `WidgetOutputStream(CharArrayWriter)` constructor now propagates it rather than swallowing/wrapping it as an `UncheckedIOException`. The **only** caller is `WidgetResponseWrapper`, which constructs it exclusively inside `getWriter()` and `getOutputStream()` — both already declare `throws IOException`. So **no call sites change**, and the checked exception stays honest.

Note: switching the charset `String` to a `Charset` alone does **not** clear the warning — every `WriterOutputStream` constructor is deprecated in 2.22 in favor of the builder (verified by compiling against the vendored jar with `-Xlint:deprecation`).

## Verification (JDK 21, branch cut from `main`)

- `ant compile` → **BUILD SUCCESSFUL**; commons-io deprecation warning **gone** (total deprecation warnings 6 → 5; see note below)
- `ant -lib lib/tests ci-test` → **281 tests, 0 failures** (89 classes)
- `ant -lib lib/war package` → webapp assembles; JSPs (jasper) compile with 0 errors
- Runtime smoke test of the real render path (`PrintWriter` → `OutputStreamWriter` → `WidgetOutputStream`): mixed UTF-8 content (accents, em-dash, ☕, 日本語, €) round-trips **byte-for-byte**

## Known remaining warnings (out of scope — follow-up)

`ant compile` still reports **5** unrelated deprecation warnings: `setSerializationInclusion(Include)` in the Square e-commerce classes (`SquareOrderCommand`, `SquarePaymentCommand`, `SquareProductCatalogCommand`, `SquareRefundCommand`). These are a **Jackson** deprecation introduced by the same jar-bump commit that brought commons-io 2.22 (Jackson → 2.22.1) — pre-existing on `main`, not touched here. Tracked as a separate maintenance follow-up.
