### PR TITLE
Upgrade legacy argon2i password hashes to argon2id on login

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.application.UserPasswordCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.login.UserToken;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -94,6 +95,10 @@ public class AuthenticateLoginCommand {
     if (verified) {
       // Hash matches password
       LOG.debug("User validated");
+      // Upgrade-on-login: now that the plaintext is confirmed, migrate an older hash to argon2id
+      if (!user.getPassword().startsWith("$argon2id$")) {
+        upgradeLegacyPasswordHash(user, password);
+      }
       cache.put(user.getId(), username + ":" + password);
       return user;
     }
@@ -105,6 +110,27 @@ public class AuthenticateLoginCommand {
     RateLimitCommand.isIpAllowedRightNow(ipAddress, true);
     LOG.debug("Password incorrect");
     throw new LoginException(INVALID_CREDENTIALS);
+  }
+
+  /**
+   * Transparently migrates a just-verified legacy password hash to argon2id.
+   *
+   * <p>PR #117 switched new hashes to argon2id while keeping verification of older $argon2i$ hashes, so existing
+   * users would otherwise keep their weaker hash until they happened to change their password. Once the supplied
+   * plaintext has been confirmed against the stored hash, it is re-hashed with the current algorithm and persisted
+   * through the same path the password-reset flow uses, so the whole store migrates during ordinary logins.
+   *
+   * <p>A persistence failure must never turn a valid login into a failed one, so any error is logged and swallowed;
+   * the user is still authenticated and the upgrade is simply retried on a later login.
+   */
+  private static void upgradeLegacyPasswordHash(User user, String password) {
+    try {
+      user.setPassword(UserPasswordCommand.hash(password));
+      UserRepository.updatePassword(user);
+      LOG.info("Upgraded password hash to argon2id for user id: " + user.getId());
+    } catch (Exception e) {
+      LOG.error("Unable to upgrade password hash to argon2id for user id: " + user.getId(), e);
+    }
   }
 
   public static UserToken getValidToken(String token) {

--- a/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
+
+/**
+ * Verifies upgrade-on-login: a user whose password predates the argon2id switch (PR #117) has their stored hash
+ * transparently migrated to argon2id the next time they sign in, while a user already on argon2id is left untouched.
+ *
+ * @author elizabeth houser
+ * @created 2026-07-19
+ */
+class AuthenticateLoginCommandTest {
+
+  private static final String IP_ADDRESS = "127.0.0.1";
+
+  private static User enabledUser(long id, String storedHash) {
+    User user = new User();
+    user.setId(id);
+    user.setEnabled(true);
+    user.setValidated(new Timestamp(System.currentTimeMillis()));
+    user.setPassword(storedHash);
+    return user;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void legacyArgon2iHashIsUpgradedToArgon2idOnSuccessfulLogin() throws Exception {
+    String username = "legacy@example.com";
+    String password = "an existing user's password";
+
+    // Simulate a password stored before the argon2id upgrade
+    Argon2 legacy = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2i);
+    String legacyHash = legacy.hash(2, 65536, 1, password.toCharArray());
+    assertTrue(legacyHash.startsWith("$argon2i$"), "Sanity: the stored hash should start as argon2i: " + legacyHash);
+    assertFalse(legacyHash.startsWith("$argon2id$"), "Sanity: a legacy hash is not yet argon2id");
+
+    User user = enabledUser(7L, legacyHash);
+
+    // A cache miss forces the real verify() path to run
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(any())).thenReturn(null);
+
+    ArgumentCaptor<User> persisted = ArgumentCaptor.forClass(User.class);
+
+    User result;
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser(username)).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
+      userRepo.when(() -> UserRepository.updatePassword(any(User.class))).thenReturn(user);
+
+      result = AuthenticateLoginCommand.getAuthenticatedUser(username, password, IP_ADDRESS);
+
+      // The migrated hash was persisted through the same path the password-reset flow uses, exactly once
+      userRepo.verify(() -> UserRepository.updatePassword(persisted.capture()), times(1));
+    }
+
+    // The correct legacy password still authenticates
+    assertNotNull(result, "A correct legacy password must still authenticate");
+
+    // The hash handed to the persistence layer is now argon2id
+    String storedHash = persisted.getValue().getPassword();
+    assertTrue(storedHash.startsWith("$argon2id$"),
+        "After one successful login, the stored hash must be migrated to argon2id: " + storedHash);
+    // The same in-memory user reflects the migrated hash
+    assertTrue(result.getPassword().startsWith("$argon2id$"), "The authenticated user carries the upgraded hash");
+    // The migrated hash still verifies the user's original password
+    assertTrue(UserPasswordCommand.verify(password, storedHash),
+        "The re-hashed password must still verify the original plaintext");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void currentArgon2idHashIsNotReUpgraded() throws Exception {
+    String username = "current@example.com";
+    String password = "an already migrated password";
+
+    User user = enabledUser(9L, UserPasswordCommand.hash(password));
+    assertTrue(user.getPassword().startsWith("$argon2id$"), "Sanity: this user is already on argon2id");
+
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(any())).thenReturn(null);
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser(username)).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
+
+      User result = AuthenticateLoginCommand.getAuthenticatedUser(username, password, IP_ADDRESS);
+      assertNotNull(result, "A correct password must authenticate");
+
+      // No migration is needed, so the password-update path is never touched
+      userRepo.verify(() -> UserRepository.updatePassword(any(User.class)), never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

[PR #117](https://github.com/SimisRnD/simis-cms/pull/117) switched new password hashes to Argon2id while keeping verification of legacy `$argon2i$` hashes. Existing users, however, keep their older `$argon2i$` hash until they next change their password, so the store never fully migrates.

This adds **upgrade-on-login**: in `AuthenticateLoginCommand.getAuthenticatedUser`, immediately after a successful `UserPasswordCommand.verify`, if the stored hash does not start with `$argon2id$`, the just-verified plaintext is re-hashed with `UserPasswordCommand.hash()` and persisted through the existing `UserRepository.updatePassword(...)` path (the same writer used by the password-reset / account-validation flows). The whole password store therefore migrates transparently during ordinary logins, with no user action required.

## Details

- The upgrade runs only on the verify path (a credentials-cache hit returns early, so it simply happens on the next cache miss).
- Persistence is best-effort: any failure is caught and logged, so a database hiccup can never turn an otherwise-valid login into a failed one — the upgrade is retried on a later login.
- `UserRepository.updatePassword(...)` invalidates existing user tokens, exactly as a password reset does. This is a one-time effect per legacy user (once migrated, the `$argon2id$` check skips the path), and the fresh login token is issued afterward by `LoginWidget`, so it is not affected.
- Users already on `$argon2id$` are left untouched.

## Testing

`AuthenticateLoginCommandTest` (JUnit 5 + Mockito static mocks):

- `legacyArgon2iHashIsUpgradedToArgon2idOnSuccessfulLogin` — a user whose stored hash is a real `$argon2i$` hash logs in successfully; the hash handed to `UserRepository.updatePassword` now starts with `$argon2id$`, still verifies the original password, and the update path is called exactly once.
- `currentArgon2idHashIsNotReUpgraded` — an already-`argon2id` user authenticates without any call to the password-update path.

Built and run with JDK 21: `ant clean` then `ant -lib lib/tests ci-test` — full suite green.
