### PR TITLE
Replace deprecated setSerializationInclusion with setDefaultPropertyInclusion

### DIFF
--- a/src/main/java/com/simisinc/platform/application/ecommerce/SquareOrderCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/SquareOrderCommand.java
@@ -246,7 +246,7 @@ public class SquareOrderCommand {
     try {
       // Create the JSON string
       String data = new ObjectMapper()
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
           .writeValueAsString(createOrderRequestBuilder.build());
 
       if (LOG.isDebugEnabled()) {
@@ -346,7 +346,7 @@ public class SquareOrderCommand {
     try {
       // Create the JSON string
       String data = new ObjectMapper()
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
           .writeValueAsString(createPaymentRequestBuilder.build());
 
       if (LOG.isDebugEnabled()) {

--- a/src/main/java/com/simisinc/platform/application/ecommerce/SquarePaymentCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/SquarePaymentCommand.java
@@ -117,7 +117,7 @@ public class SquarePaymentCommand {
     try {
       // Create the JSON string
       String data = new ObjectMapper()
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
           .writeValueAsString(createPaymentRequest);
       // Send to Square
       JsonNode json = SquareApiClientCommand.sendSquareHttpPost("/v2/payments", data);

--- a/src/main/java/com/simisinc/platform/application/ecommerce/SquareProductCatalogCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/SquareProductCatalogCommand.java
@@ -192,7 +192,7 @@ public class SquareProductCatalogCommand {
     try {
       // Create the JSON string
       String data = new ObjectMapper()
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
           .writeValueAsString(batchUpsertCatalogObjectsRequest);
 
       if (LOG.isDebugEnabled()) {

--- a/src/main/java/com/simisinc/platform/application/ecommerce/SquareRefundCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/SquareRefundCommand.java
@@ -68,7 +68,7 @@ public class SquareRefundCommand {
     try {
       // Create the JSON string
       String data = new ObjectMapper()
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
           .writeValueAsString(refundPaymentRequest);
       // Send to Square
       JsonNode json = SquareApiClientCommand.sendSquareHttpPost("/v2/refunds", data);


### PR DESCRIPTION
## What

Jackson 2.22.1 (vendored in `lib/build/jackson/`) deprecated `ObjectMapper.setSerializationInclusion(Include)`. This switches the five Square ecommerce serialization sites to the non-deprecated `setDefaultPropertyInclusion(Include)`:

- `SquareOrderCommand.java` (two sites: lines 249, 349)
- `SquarePaymentCommand.java` (line 120)
- `SquareProductCatalogCommand.java` (line 195)
- `SquareRefundCommand.java` (line 71)

All five used `JsonInclude.Include.NON_EMPTY`; the value is preserved unchanged.

## Why this replacement

The two APIs are **behavior-identical**: the deprecated `setSerializationInclusion(incl)` delegated to `setDefaultPropertyInclusion(JsonInclude.Value.construct(incl, incl))` internally, and the single-arg `setDefaultPropertyInclusion(incl)` overload does the same. Only the method name changes — the `new ObjectMapper()` construction and argument are untouched, so no reuse/config semantics change.

The obvious builder alternative — `JsonMapper.builder().serializationInclusion(Include)` — is **itself deprecated** in 2.22.1 (`serializationInclusion(Include) in MapperBuilder has been deprecated`) and there is no non-deprecated `Value` overload on the builder, so it was not used. This was verified empirically by compiling each candidate against the vendored `jackson-databind-2.22.1.jar` with `-Xlint:deprecation`.

## Verification (JDK 21)

- `ant clean && ant compile` → BUILD SUCCESSFUL; the five `setSerializationInclusion` deprecation warnings are gone.
- `ant clean && ant -lib lib/tests ci-test` → BUILD SUCCESSFUL, **281 tests, 0 failures** (unchanged from baseline).

## Relationship to #143

This completes the deprecation-warning cleanup started in #143. That PR removes the remaining `WriterOutputStream(Writer, String)` warning in `WidgetOutputStream.java`; this PR removes the five `setSerializationInclusion` ones. Once both land, `ant compile` reports **zero** deprecation warnings.