### PR TITLE
ci: add a standalone compile-jsp target to gate JSP syntax

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -24,6 +24,10 @@ jobs:
         java-version: 21
     - name: Compile the source
       run: ant -noinput -buildfile build.xml clean compile
+    - name: Precompile the JSPs
+      # Gate JSP syntax (unbalanced tags, unresolvable taglibs, bad EL) before the test suite.
+      # lib/war supplies the Tomcat 9 / javax Jasper used by the compile-jsp target.
+      run: ant -noinput -buildfile build.xml -lib lib/war compile-jsp
     - name: Run unit tests
       run: ant -noinput -buildfile build.xml -lib lib/tests ci-test
     - name: Package the web application

--- a/build.xml
+++ b/build.xml
@@ -21,6 +21,7 @@
   <property name="out.dir" value="${base.dir}/out" />
   <property name="exploded.dir" value="${out.dir}/exploded/ROOT" />
   <property name="exploded.work.dir" value="${out.dir}/exploded-work/ROOT" />
+  <property name="jsp.check.dir" value="${target.dir}/jsp-check" />
 
   <property name="jee.lib.dir" value="${base.dir}/lib/war" />
   <typedef resource="org/apache/catalina/ant/catalina.tasks">
@@ -102,6 +103,67 @@
         <path refid="web.classpath"/>
       </classpath>
     </javac>
+  </target>
+
+  <!-- JSP syntax gate. Translates and compiles every JSP into a throwaway directory so a JSP
+       syntax error (unbalanced tag, unresolvable taglib, bad EL) fails the build instead of only
+       surfacing at runtime when Tomcat/Jasper serves the page. This mirrors the JSP handling that
+       already runs inside `package`, but stands alone so CI can run it right after `compile`
+       (failing fast, before the test suite) and so the gate survives any future change to
+       `package`. The Tomcat 9 / javax Jasper comes from lib/war (see the catalina taskdef above),
+       so invoke as: ant -lib lib/war compile-jsp -->
+  <target name="compile-jsp" depends="compile">
+    <delete dir="${jsp.check.dir}"/>
+    <mkdir dir="${jsp.check.dir}/WEB-INF/classes"/>
+    <mkdir dir="${jsp.check.dir}/WEB-INF/lib"/>
+    <mkdir dir="${jsp.check.dir}/WEB-INF/jsp"/>
+    <mkdir dir="${jsp.check.dir}/WEB-INF/src"/>
+    <mkdir dir="${jsp.check.dir}/WEB-INF/compiled"/>
+    <!-- Compiled project classes: the EL-function impls and tag handlers the JSPs reference -->
+    <copy todir="${jsp.check.dir}/WEB-INF/classes">
+      <fileset dir="${build.dir}"><include name="**"/></fileset>
+    </copy>
+    <!-- Dependency jars: supply the bundled taglib TLDs (JSTL, granule) and referenced classes -->
+    <copy todir="${jsp.check.dir}/WEB-INF/lib" flatten="true">
+      <fileset dir="${lib.dir}"><include name="**/*.jar"/></fileset>
+    </copy>
+    <!-- web.xml plus the custom function TLDs the JSPs load via /WEB-INF/tlds/*.tld -->
+    <copy todir="${jsp.check.dir}/WEB-INF">
+      <fileset dir="${web.dir}/WEB-INF">
+        <include name="**/*.xml"/>
+        <include name="**/*.tld"/>
+      </fileset>
+    </copy>
+    <!-- The JSPs themselves -->
+    <copy todir="${jsp.check.dir}/WEB-INF/jsp">
+      <fileset dir="${web.dir}/WEB-INF/jsp"/>
+    </copy>
+    <!-- Translate JSP -> Java; Jasper fails the build on syntax and taglib-resolution errors -->
+    <jasper validateXml="false"
+            uriroot="${jsp.check.dir}"
+            webXmlFragment="${jsp.check.dir}/WEB-INF/generated_web.xml"
+            addWebXmlMappings="true"
+            outputDir="${jsp.check.dir}/WEB-INF/src" />
+    <!-- Compile the generated Java to catch errors the translation stage passes through -->
+    <javac destdir="${jsp.check.dir}/WEB-INF/compiled" source="${jdk}" target="${jdk}"
+           optimize="on" debug="off"
+           includeantruntime="false"
+           srcdir="${jsp.check.dir}/WEB-INF/src"
+           excludes="**/*.smap">
+      <classpath>
+        <pathelement location="${jsp.check.dir}/WEB-INF/classes"/>
+        <fileset dir="${jsp.check.dir}/WEB-INF/lib">
+          <include name="*.jar"/>
+        </fileset>
+        <pathelement location="${jee.lib.dir}"/>
+        <fileset dir="${jee.lib.dir}">
+          <include name="*.jar"/>
+        </fileset>
+      </classpath>
+      <include name="**" />
+      <exclude name="tags/**" />
+    </javac>
+    <echo message="JSP syntax check passed: translated and compiled all JSPs under ${web.dir}/WEB-INF/jsp"/>
   </target>
 
   <target name="jar" depends="compile">


### PR DESCRIPTION
## What

Adds a standalone `compile-jsp` Ant target and a **Precompile the JSPs** CI step that translate and `javac`-compile every JSP, so a JSP syntax error fails the build in CI.

## Why

The `package` target already runs Jasper + `javac` over the JSPs while assembling the WAR, so JSP syntax errors **do** fail CI today. This change makes that gate:

- **Explicit and fail-fast** — it runs right after *Compile the source*, before the unit-test suite, so a broken JSP fails in seconds instead of after the full test run.
- **Robust** — the gate no longer depends on `package` keeping its JSP-compile step; a future refactor of `package` can't silently drop JSP coverage.

It is purely additive — the `package` target is unchanged.

## How

`compile-jsp` assembles a throwaway `target/jsp-check` webapp (project classes → `WEB-INF/classes`, dependency jars → `WEB-INF/lib`, the custom `/WEB-INF/tlds` + `web.xml`, and the JSPs) and runs the same Jasper + `javac` pair `package` uses — but builds no WAR. It uses the Tomcat 9 / `javax` Jasper already bundled in `lib/war`, and CI invokes it with `-lib lib/war`.

## Verification (local, JDK 21)

| Scenario | Result |
| --- | --- |
| Current tree | ✅ `BUILD SUCCESSFUL` — all 286 JSPs translated & compiled |
| Unbalanced tag (`<c:if>` unterminated) | ✅ `BUILD FAILED` — `Unterminated [<c:if] tag` |
| Bad taglib (unresolvable TLD URI) | ✅ `BUILD FAILED` — `Unable to find taglib` |
