### PR TITLE
Enable the coverage gate for DoNotTrackCommand (after #136)

### DIFF
--- a/.github/scripts/check-security-coverage.sh
+++ b/.github/scripts/check-security-coverage.sh
@@ -57,10 +57,11 @@ set -euo pipefail
 # that dilute the class-level ratio to ~40%. A 0.30 floor keeps regression
 # protection on the tested paths without demanding coverage of the legacy code.
 #
-# NOTE: com.simisinc.platform.application.DoNotTrackCommand (test:
-# DoNotTrackCommandTest) belongs on this list, but it arrives with PR #136
-# (feature/honor-dnt), which is not yet merged into this lineage. Uncomment the
-# line below once #136 lands, or the gate will fail-closed on the missing class.
+# DoNotTrackCommand.isDoNotTrack() -- the Do-Not-Track / Global Privacy Control
+# honoring logic -- is covered by DoNotTrackCommandTest and shares the 0.50
+# floor. The class arrived with PR #136 (feature/honor-dnt), so this entry is
+# valid only once #136 is in the lineage; merging it before then fail-closes the
+# gate on a missing class. (See the PR description for merge-order details.)
 TARGETS='
 com.simisinc.platform.application.IpAddressCommand,0.50
 com.simisinc.platform.application.SecretCryptoCommand,0.50
@@ -68,9 +69,8 @@ com.simisinc.platform.application.UserPasswordCommand,0.50
 com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand,0.50
 com.simisinc.platform.application.cms.UrlCommand,0.50
 com.simisinc.platform.application.cms.NumberCommand,0.30
+com.simisinc.platform.application.DoNotTrackCommand,0.50
 '
-# Pending PR #136 (feature/honor-dnt) -- enable when merged:
-# com.simisinc.platform.application.DoNotTrackCommand,0.50
 
 CSV="${1:-${JACOCO_CSV:-target/coverage-reports/jacoco.csv}}"
 FLOOR_MIN="${COVERAGE_FLOOR_MIN:-0}"


### PR DESCRIPTION
**Draft — do not merge until both #148 and #136 are in the base branch.** See _Merge order_ below.

Follow-up to #148 (the security-critical coverage gate). This adds `com.simisinc.platform.application.DoNotTrackCommand` to the gate's class list at the **0.50** floor shared by the other hardened command classes.

`DoNotTrackCommand.isDoNotTrack()` — the Do-Not-Track / Global Privacy Control honoring logic — is covered by `DoNotTrackCommandTest` (branch-complete: honoring on/off, `DNT: 1`, `Sec-GPC: 1`, and the negatives). It's a single-method class, so 0.50 leaves large headroom; the exact baseline will surface on the first CI run once #136 is merged.

## Merge order (important)

`DoNotTrackCommand` and its test arrive in **#136** (`feature/honor-dnt`), which is not in this lineage yet. Until #136 is present, the gate is **fail-closed** on this class (reports it `MISSING` and fails). So:

1. Merge **#141** (coverage report) and **#136** (Do-Not-Track) to `main`.
2. Merge **#148** (the gate) — GitHub retargets it to `main` automatically.
3. Merge **this PR** last — it only becomes correct once both the gate and `DoNotTrackCommand` are on `main`.

Stacked on #148 (`maint/security-coverage-gate`), so the diff is just the one enabling line plus a comment refresh.

## Verified

- Against the current report (no `DoNotTrackCommand`): the class is reported **`MISSING`** and the gate fails — exactly the fail-closed behavior that enforces the merge order.
- With a `DoNotTrackCommand` row present (~91%): all **seven** classes **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
