### PR TITLE
Sanitize Instagram widget permalink and media url to prevent stored XSS

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.application.cms.NumberCommand;
+import com.simisinc.platform.application.cms.UrlCommand;
 
 import com.simisinc.platform.domain.model.socialmedia.InstagramMedia;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
@@ -82,8 +83,13 @@ public class InstagramWidget extends GenericWidget {
         break;
       }
       if ("IMAGE".equals(media.getMediaType())) {
+        // Sanitize the API-supplied urls at the sink; drop the card if either is unsafe
+        String card = buildCardHtml(media);
+        if (card == null) {
+          continue;
+        }
         ++count;
-        addCard(context, cardList, "<p><a target=\"_blank\" href=\"" + media.getPermalink() + "\"><img src=\"" + media.getMediaUrl() + "\" /></a></p>");
+        addCard(context, cardList, card);
       }
     }
     context.getRequest().setAttribute("cardList", cardList);
@@ -91,6 +97,23 @@ public class InstagramWidget extends GenericWidget {
     // Determine the view
     context.setJsp(CARD_JSP);
     return context;
+  }
+
+  /**
+   * Builds the card markup for an Instagram image. The permalink and media url are supplied by the
+   * Instagram Graph API (persisted by a background job) and are rendered straight into the href and
+   * src attributes, so both are run through {@link UrlCommand#sanitizeUrl(String)} at this sink: a
+   * value carrying a quote or an active scheme (javascript:/data:) would otherwise break out of the
+   * attribute and inject script. Returns null when either url is unsafe so the caller drops the card
+   * instead of emitting raw markup.
+   */
+  static String buildCardHtml(InstagramMedia media) {
+    String permalink = UrlCommand.sanitizeUrl(media.getPermalink());
+    String mediaUrl = UrlCommand.sanitizeUrl(media.getMediaUrl());
+    if (permalink == null || mediaUrl == null) {
+      return null;
+    }
+    return "<p><a target=\"_blank\" href=\"" + permalink + "\"><img src=\"" + mediaUrl + "\" /></a></p>";
   }
 
   private void addCard(WidgetContext context, List<String> cardList, String html) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/InstagramWidgetTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.domain.model.socialmedia.InstagramMedia;
+
+/**
+ * Verifies that the widget sanitizes the Instagram Graph API permalink and media url before building
+ * the card markup, so a hostile value cannot break out of the href/src attributes and inject script
+ * (stored XSS). The api values are persisted by a background job and rendered server-side here, which
+ * is the sink where they must be made safe.
+ *
+ * @author Elizabeth Houser
+ * @created 2026-07-19
+ */
+class InstagramWidgetTest {
+
+  private static InstagramMedia imageMedia(String permalink, String mediaUrl) {
+    InstagramMedia media = new InstagramMedia();
+    media.setMediaType("IMAGE");
+    media.setPermalink(permalink);
+    media.setMediaUrl(mediaUrl);
+    return media;
+  }
+
+  @Test
+  void safePermalinkAndMediaUrlProduceCard() {
+    String html = InstagramWidget.buildCardHtml(
+        imageMedia("https://www.instagram.com/p/ABC123/", "https://scontent.cdninstagram.com/v/t51/photo.jpg"));
+    Assertions.assertEquals(
+        "<p><a target=\"_blank\" href=\"https://www.instagram.com/p/ABC123/\">"
+            + "<img src=\"https://scontent.cdninstagram.com/v/t51/photo.jpg\" /></a></p>",
+        html);
+  }
+
+  @Test
+  void quoteBreakoutInPermalinkDropsCard() {
+    // A double quote would close href="..." and let the rest inject markup
+    Assertions.assertNull(InstagramWidget.buildCardHtml(
+        imageMedia("https://x/\"><script>alert(1)</script>", "https://scontent.cdninstagram.com/a.jpg")));
+  }
+
+  @Test
+  void quoteBreakoutInMediaUrlDropsCard() {
+    // A double quote plus event handler would break out of src="..."
+    Assertions.assertNull(InstagramWidget.buildCardHtml(
+        imageMedia("https://www.instagram.com/p/ABC123/", "https://x/a.jpg\" onerror=\"alert(1)")));
+  }
+
+  @Test
+  void activeSchemeUrlDropsCard() {
+    // javascript: in the permalink and data: in the media url are both rejected
+    Assertions.assertNull(InstagramWidget.buildCardHtml(
+        imageMedia("javascript:alert(1)", "https://scontent.cdninstagram.com/a.jpg")));
+    Assertions.assertNull(InstagramWidget.buildCardHtml(
+        imageMedia("https://www.instagram.com/p/ABC123/", "data:text/plain;base64,SGk=")));
+  }
+
+  @Test
+  void nullPermalinkOrMediaUrlDropsCard() {
+    Assertions.assertNull(
+        InstagramWidget.buildCardHtml(imageMedia(null, "https://scontent.cdninstagram.com/a.jpg")));
+    Assertions.assertNull(
+        InstagramWidget.buildCardHtml(imageMedia("https://www.instagram.com/p/ABC123/", null)));
+  }
+}


### PR DESCRIPTION
## Summary

The Instagram widget assembled each card's HTML in Java by concatenating the Instagram Graph API `permalink` and `mediaUrl` directly into `href`/`src` attributes with no escaping:

```java
addCard(context, cardList, "<p><a target=\"_blank\" href=\"" + media.getPermalink()
    + "\"><img src=\"" + media.getMediaUrl() + "\" /></a></p>");
```

Both values are fetched from Instagram by a background job and stored, then rendered on every page that shows the cards. A value containing a `"` (attribute breakout) or an active scheme (`javascript:` / `data:`) becomes **stored XSS**. Because this markup is built server-side in the widget, it was not covered by the JSP XSS sweep (#124–#130), but it is the same bug class.

## Fix

- Run both `permalink` and `mediaUrl` through `UrlCommand.sanitizeUrl(...)` (added in #126) at the sink. `sanitizeUrl` returns the value only when it is a safe `http(s)`/`mailto`/`tel`/site-relative URL with no attribute-breakout characters, otherwise `null` (it rejects `javascript:`, `data:`, and protocol-relative `//`).
- If either URL is unsafe the card is **dropped** rather than emitted raw, so hostile input never reaches the page. Legitimate Instagram URLs are unaffected.
- Extracted the card construction into a package-private `buildCardHtml(...)` so the sanitization is unit-tested directly.

## Tests

New `InstagramWidgetTest` (5 cases): safe URLs produce the expected card; a quote-breakout in the permalink or the media URL drops the card; `javascript:` / `data:` schemes drop the card; null URLs drop the card.

`ant -lib lib/tests ci-test` — **BUILD SUCCESSFUL**, full suite green.

## Scope / related

`AlbumGalleryWidget` (flagged for review) builds no HTML in Java — it hands data to a JSP — so it is not affected by this class of bug. A wider sweep for the same server-side-HTML-construction pattern surfaced a few other spots (notably `ActivityListCommand`, where a user-authored item name is concatenated unescaped); those are being handled separately to keep this PR focused.
