### PR TITLE
Sanitize remote content image url to prevent stored XSS

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidget.java
@@ -28,6 +28,7 @@ import org.jsoup.safety.Safelist;
 import org.jsoup.select.Elements;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.application.http.HttpGetCommand;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -64,7 +65,12 @@ public class RemoteContentWidget extends GenericWidget {
 
     // Create a wrapper for images
     if (url.endsWith(".gif") || url.endsWith(".png") || url.endsWith(".jpg")) {
-      content = "<img src=\"" + url + "\" />";
+      String imageTag = buildImageTag(url);
+      if (imageTag == null) {
+        LOG.warn("Ignoring unsafe remote content image url: " + url);
+        return null;
+      }
+      content = imageTag;
       cache.put(url, content);
       return useReturnType(context, content);
     }
@@ -147,6 +153,20 @@ public class RemoteContentWidget extends GenericWidget {
       LOG.warn("Could not get content from: " + url, e);
     }
     return null;
+  }
+
+  /**
+   * Builds the image wrapper for a remote image url. The url is a widget preference rendered straight
+   * into the src attribute, so it is run through {@link UrlCommand#sanitizeUrl(String)} first: a value
+   * carrying a quote or an active scheme (javascript:/data:) would otherwise break out of the
+   * attribute and inject markup. Returns null when the url is unsafe so the caller can skip it.
+   */
+  static String buildImageTag(String url) {
+    String safeUrl = UrlCommand.sanitizeUrl(url);
+    if (safeUrl == null) {
+      return null;
+    }
+    return "<img src=\"" + safeUrl + "\" />";
   }
 
   private WidgetContext useReturnType(WidgetContext context, String content) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidgetTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the remote-image wrapper sanitizes its url (a widget preference) before placing it
+ * into the src attribute, so a value with an embedded quote or an active scheme cannot break out of
+ * the attribute and inject markup (stored XSS).
+ *
+ * @author Elizabeth Houser
+ * @created 2026-07-19
+ */
+class RemoteContentWidgetTest {
+
+  @Test
+  void safeImageUrlProducesImgTag() {
+    Assertions.assertEquals("<img src=\"https://cdn.example.com/photo.jpg\" />",
+        RemoteContentWidget.buildImageTag("https://cdn.example.com/photo.jpg"));
+  }
+
+  @Test
+  void quoteBreakoutUrlIsRejected() {
+    // Ends with .jpg (so it reaches the image branch) but embeds a quote + event handler
+    Assertions.assertNull(RemoteContentWidget.buildImageTag("https://x/\"onerror=\"alert(1)\".jpg"));
+  }
+
+  @Test
+  void activeSchemeUrlIsRejected() {
+    Assertions.assertNull(RemoteContentWidget.buildImageTag("javascript:alert(1)//.jpg"));
+  }
+
+  @Test
+  void nullUrlIsRejected() {
+    Assertions.assertNull(RemoteContentWidget.buildImageTag(null));
+  }
+}


### PR DESCRIPTION
## Summary

`RemoteContentWidget` wraps an image URL in an `<img>` tag by concatenating the URL directly into the `src` attribute:

```java
if (url.endsWith(".gif") || url.endsWith(".png") || url.endsWith(".jpg")) {
  content = "<img src=\"" + url + "\" />";
  ...
```

`url` is a widget **preference**, so a value that ends in `.gif`/`.png`/`.jpg` (to reach this branch) but embeds a `"` — e.g. `https://x/"onerror="alert(1)".jpg` — breaks out of the attribute and injects markup. The result is returned raw (`setHtml`, or handed to the wrapper JSP), so it is **stored XSS** on every page that renders the widget.

## Fix

- Route the URL through `UrlCommand.sanitizeUrl(...)` (added in #126) before building the tag; **skip the image** (return null) when the URL is unsafe, rather than emitting raw markup.
- Extracted `buildImageTag(...)` so the sanitization is unit-tested directly.

Out of scope / unchanged: the `clean=false` "trusted content" bypass (an intentional, preference-gated escape hatch) and the normal remote-fetch path (already sanitized with Jsoup `Safelist.relaxed()`).

## Tests

New `RemoteContentWidgetTest` (4 cases): a safe URL builds the `<img>` tag; a quote-breakout URL and a `javascript:` URL are rejected; null is rejected.

`ant -lib lib/tests ci-test` — **BUILD SUCCESSFUL**, full suite green.

## Context

Third fix in the same server-side-HTML-construction XSS sweep (see #151 Instagram widget, #153 activity item name). Kept as a separate PR so each fix stays focused.
