### PR TITLE
Escape copyright site name and tag to prevent stored XSS

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/CopyrightWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/CopyrightWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -35,7 +36,7 @@ public class CopyrightWidget extends GenericWidget {
     String tag = context.getPreferences().getOrDefault("tag", "All Rights Reserved.");
     context.setHtml(
         "&copy; " + new java.text.SimpleDateFormat("yyyy").format(new java.util.Date()) + " " +
-            "<span translate=\"no\">" + name + (!name.endsWith(".") ? "." : "") + "</span>" + " " + tag);
+            "<span translate=\"no\">" + HtmlCommand.toHtml(name) + (!name.endsWith(".") ? "." : "") + "</span>" + " " + HtmlCommand.toHtml(tag));
     return context;
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/CopyrightWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/CopyrightWidgetTest.java
@@ -58,4 +58,25 @@ class CopyrightWidgetTest extends WidgetBase {
       Assertions.assertFalse(html.contains("All Rights Reserved."));
     }
   }
+
+  @Test
+  void nameAndTagAreHtmlEscaped() {
+    // The site name and tag are admin/config controlled and rendered straight into setHtml; a hostile
+    // value must be entity-encoded rather than break out into live markup
+    preferences.put("name", "<script>alert(1)</script>");
+    preferences.put("tag", "Evil & Co");
+
+    try (MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      property.when(() -> LoadSitePropertyCommand.loadByName("site.name")).thenReturn("unused");
+
+      CopyrightWidget copyrightWidget = new CopyrightWidget();
+      copyrightWidget.execute(widgetContext);
+
+      String html = widgetContext.getHtml();
+      Assertions.assertNotNull(html);
+      Assertions.assertFalse(html.contains("<script>"), html);
+      Assertions.assertTrue(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"), html);
+      Assertions.assertTrue(html.contains("Evil &amp; Co"), html);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`CopyrightWidget` builds the footer by concatenating the **site name** and **tag** directly into `setHtml(...)` with no escaping:

```java
context.setHtml("&copy; " + year + " <span translate=\"no\">" + name + ... + "</span> " + tag);
```

`name` comes from the `name` widget preference or the `site.name` site property; `tag` from the `tag` preference. Both are admin/content-manager controlled, so this is **lower severity** than external-data XSS — but it is the same unescaped-HTML-sink class, and the footer renders on every page.

## Fix

Wrap both `name` and `tag` in `HtmlCommand.toHtml(...)` (HTML entity-encoding), matching the escaping used across the codebase. Legitimate output is unchanged beyond encoding.

## Tests

Added a case to `CopyrightWidgetTest` (which already drives `execute()` via `WidgetBase` + mocked `LoadSitePropertyCommand`): a `name` of `<script>…</script>` and a `tag` containing `&` are entity-encoded in the emitted HTML, with no live `<script>` tag.

`ant -lib lib/tests ci-test` — **BUILD SUCCESSFUL**, full suite green.

## Context

Fourth fix in the server-side-HTML-construction XSS sweep (see #151 Instagram widget [merged], #153 activity item name [merged], #154 remote content image url [open]).
