### PR TITLE
Add GitHub issue templates (bug, feature) with security/discussions routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: 🐞 Bug report
+description: Report a defect in SimIS CMS
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please search [existing issues](https://github.com/SimisRnD/simis-cms/issues?q=is%3Aissue) first to avoid duplicates.
+
+        ⚠️ **Do not report security vulnerabilities here.** Report them privately as a [security advisory](https://github.com/SimisRnD/simis-cms/security/advisories/new) — see [SECURITY.md](https://github.com/SimisRnD/simis-cms/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including any error message.
+      placeholder: When I …, the CMS …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so a maintainer can reproduce the problem.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / release
+      description: The release (for example `20260719.10000`) or the git commit SHA you are running.
+      placeholder: "20260719.10000"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything relevant about where it runs.
+      value: |
+        - Deployment (Docker image / WAR on Tomcat / other):
+        - Java version:
+        - PostgreSQL version:
+        - Browser (if a UI bug):
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or stack trace
+      description: Paste any stack trace or log excerpt. This is rendered as code, so no backticks needed.
+      render: text
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go through a [private advisory](https://github.com/SimisRnD/simis-cms/security/advisories/new)).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Report a security vulnerability (private)
+    url: https://github.com/SimisRnD/simis-cms/security/advisories/new
+    about: >-
+      Never open a public issue for a security problem. Report it privately as a
+      security advisory. See SECURITY.md for the policy.
+  - name: 💬 Questions & ideas
+    url: https://github.com/SimisRnD/simis-cms/discussions
+    about: Ask a question or float an early-stage idea in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: ✨ Feature request / enhancement
+description: Propose a new capability or an improvement to an existing one
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question or a rough, early-stage idea instead? Please start in [Discussions](https://github.com/SimisRnD/simis-cms/discussions). Concrete proposals are welcome here.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, and who benefits?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you would like to see. Include behavior, defaults, and any opt-in / site-property considerations.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the platform does this touch? (helps triage)
+      options:
+        - Analytics / privacy
+        - Authentication / MFA
+        - Security hardening
+        - CMS / content
+        - E-commerce
+        - Build / CI / infrastructure
+        - Documentation
+        - Other / not sure
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / affected areas
+      description: Optionally, the components, tables, or commands you think are involved.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
## What

Adds GitHub issue templates under `.github/ISSUE_TEMPLATE/` — the repo had none. Two YAML issue forms plus a chooser config, encoding the routing already written in `CONTRIBUTING.md`.

| File | Purpose | Auto-label |
|---|---|---|
| `bug_report.yml` | Structured bug report (what / expected / steps / version required; env + logs optional) | `bug` |
| `feature_request.yml` | Feature / enhancement proposal (problem / proposal required; area dropdown for triage) | `enhancement` |
| `config.yml` | Chooser routing + blank-issue toggle | — |

## Routing (matches CONTRIBUTING.md)

The chooser funnels the two things that should never be a public bug report:

- 🔒 **Security vulnerabilities → a private [security advisory](https://github.com/SimisRnD/simis-cms/security/advisories/new)** (private vulnerability reporting is enabled), reinforced by a required checkbox in the bug form.
- 💬 **Questions & early ideas → [Discussions](https://github.com/SimisRnD/simis-cms/discussions).**

`blank_issues_enabled: true` is kept so maintainers can still open freeform roadmap/tracking issues (e.g. the audit-logging phase issues) without a template.

## Choices

- **YAML issue forms** (not classic Markdown) for required fields, a triage dropdown, and auto-labeling. Easy to switch to Markdown templates if preferred — one commit.
- Both auto-labels (`bug`, `enhancement`) already exist, so labeling applies on submit.
- Preview after merge via **New issue**, or the template editor at `/issues/templates/edit`.

Validated: all three files parse as YAML with the expected issue-form structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
