### PR TITLE
Add authentication audit logging (Milestone #3, Phase 1)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/audit/SaveAuditEventCommand.java
+++ b/src/main/java/com/simisinc/platform/application/audit/SaveAuditEventCommand.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.audit;
+
+import com.simisinc.platform.application.json.JsonCommand;
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Records a security audit event to both sinks: the audit_log database table (the source of record,
+ * for the in-app review and offline/in-boundary deployments) and a single line of structured JSON to a
+ * dedicated audit log stream. On a deployment whose container stdout is collected by Azure Monitor, that
+ * JSON flows into Log Analytics and Microsoft Sentinel with no agent; the schema aligns with Sentinel's
+ * ASIM audit model.
+ *
+ * <p>Auditing is a side effect and must never break the action it observes -- a failure in either sink is
+ * caught and logged, never thrown, so a failed audit write can never turn a successful login into an error.
+ *
+ * @author SimIS Inc.
+ */
+public class SaveAuditEventCommand {
+
+  public static final int SCHEMA_VERSION = 1;
+  public static final String SCHEMA_NAME = "simis.audit.v1";
+
+  private static Log LOG = LogFactory.getLog(SaveAuditEventCommand.class);
+
+  // A dedicated stream so audit records are separable from ordinary application logging (e.g. for a
+  // Sentinel parser). The JSON payload also carries the "schema" marker for reliable identification.
+  private static Log AUDIT = LogFactory.getLog("AUDIT");
+
+  /** Records an event to the database and the JSON audit stream. Never throws. */
+  public static AuditLog record(AuditLog event) {
+    if (event == null) {
+      return null;
+    }
+    if (event.getOccurred() == null) {
+      event.setOccurred(Timestamp.from(Instant.now()));
+    }
+    event.setSchemaVersion(SCHEMA_VERSION);
+
+    // Sink 1 -- the database (source of record)
+    AuditLog saved = null;
+    try {
+      saved = AuditLogRepository.save(event);
+    } catch (Exception e) {
+      LOG.error("Audit database write failed for event: " + event.getEventType(), e);
+    }
+
+    // Sink 2 -- the structured JSON stream (Azure Monitor / Log Analytics / Sentinel)
+    try {
+      AUDIT.info(toJson(event));
+    } catch (Exception e) {
+      LOG.error("Audit JSON emit failed for event: " + event.getEventType(), e);
+    }
+
+    return saved;
+  }
+
+  /**
+   * Builds the single-line JSON representation of an event. Field order is stable and null fields are
+   * omitted. Kept package-visible-plus so it can be unit tested without a database or logger.
+   */
+  public static String toJson(AuditLog event) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("schema", SCHEMA_NAME);
+    map.put("ts", event.getOccurred() != null ? event.getOccurred().toInstant().toString() : Instant.now().toString());
+    map.put("category", event.getEventCategory());
+    map.put("event", event.getEventType());
+    map.put("result", event.getOutcome());
+    // Omit the actor id entirely when there is no known actor (e.g. a failed login for an unknown user)
+    if (event.getActorUserId() > -1L) {
+      map.put("actorUserId", event.getActorUserId());
+    }
+    map.put("actorUsername", event.getActorUsername());
+    map.put("sourceIp", event.getSourceIp());
+    map.put("targetType", event.getTargetType());
+    map.put("targetId", event.getTargetId());
+    map.put("targetLabel", event.getTargetLabel());
+    map.put("sessionId", event.getSessionId());
+    map.put("details", event.getDetails());
+    // createJsonNode skips null values and escapes string values
+    return JsonCommand.createJsonNode(map).toString();
+  }
+
+  /**
+   * Convenience for an authentication-category event (login, logout, MFA). Pass an actorUserId of -1 when
+   * the acting user is unknown (a failed login). Never throws.
+   */
+  public static AuditLog recordAuthentication(String eventType, String outcome, long actorUserId,
+      String actorUsername, String ipAddress, String sessionId, String details) {
+    AuditLog event = new AuditLog();
+    event.setEventCategory("authentication");
+    event.setEventType(eventType);
+    event.setOutcome(outcome);
+    event.setActorUserId(actorUserId);
+    event.setActorUsername(actorUsername);
+    event.setSourceIp(ipAddress);
+    event.setSessionId(sessionId);
+    event.setDetails(details);
+    return record(event);
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/oauth/OAuthLoginCommand.java
+++ b/src/main/java/com/simisinc/platform/application/oauth/OAuthLoginCommand.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.application.oauth;
 
 import com.simisinc.platform.application.CreateSessionCommand;
 import com.simisinc.platform.application.SaveSessionCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.login.OAuthToken;
 import com.simisinc.platform.domain.model.login.UserLogin;
@@ -60,6 +61,8 @@ public class OAuthLoginCommand {
     User user = OAuthUserInfoCommand.createUser(oAuthToken);
     if (user == null) {
       LOG.warn("The user was not found");
+      SaveAuditEventCommand.recordAuthentication("authentication.login.failure", "failure", -1L,
+          null, request.getRemoteAddr(), request.getSession().getId(), "oauth: user could not be created");
       return;
     }
 
@@ -121,6 +124,8 @@ public class OAuthLoginCommand {
     userSession.login(user);
     SaveSessionCommand.saveSession(userSession);
     request.getSession().setAttribute(SessionConstants.USER, userSession);
+    SaveAuditEventCommand.recordAuthentication("authentication.login.success", "success",
+        user.getId(), user.getEmail(), ipAddress, userSession.getSessionId(), "oauth");
     LOG.debug("User has been signed in.");
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/audit/AuditLog.java
+++ b/src/main/java/com/simisinc/platform/domain/model/audit/AuditLog.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.audit;
+
+import com.simisinc.platform.domain.model.Entity;
+
+import java.sql.Timestamp;
+
+/**
+ * A security audit record: who did what, when, and from where. Written to the audit_log table and
+ * emitted as structured JSON for a SIEM (see SaveAuditEventCommand). The actor is denormalized
+ * (actor_username stored, no foreign key on actor_user_id) so records survive a user deletion, and
+ * the full source IP is retained for forensics.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLog extends Entity {
+
+  private Long id = -1L;
+
+  private Timestamp occurred = null;
+  private String eventCategory = null;
+  private String eventType = null;
+  private String outcome = null;
+  private long actorUserId = -1L;
+  private String actorUsername = null;
+  private String sourceIp = null;
+  private String targetType = null;
+  private String targetId = null;
+  private String targetLabel = null;
+  private String details = null;
+  private String sessionId = null;
+  private int schemaVersion = 1;
+
+  public AuditLog() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Timestamp getOccurred() {
+    return occurred;
+  }
+
+  public void setOccurred(Timestamp occurred) {
+    this.occurred = occurred;
+  }
+
+  public String getEventCategory() {
+    return eventCategory;
+  }
+
+  public void setEventCategory(String eventCategory) {
+    this.eventCategory = eventCategory;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public String getOutcome() {
+    return outcome;
+  }
+
+  public void setOutcome(String outcome) {
+    this.outcome = outcome;
+  }
+
+  public long getActorUserId() {
+    return actorUserId;
+  }
+
+  public void setActorUserId(long actorUserId) {
+    this.actorUserId = actorUserId;
+  }
+
+  public String getActorUsername() {
+    return actorUsername;
+  }
+
+  public void setActorUsername(String actorUsername) {
+    this.actorUsername = actorUsername;
+  }
+
+  public String getSourceIp() {
+    return sourceIp;
+  }
+
+  public void setSourceIp(String sourceIp) {
+    this.sourceIp = sourceIp;
+  }
+
+  public String getTargetType() {
+    return targetType;
+  }
+
+  public void setTargetType(String targetType) {
+    this.targetType = targetType;
+  }
+
+  public String getTargetId() {
+    return targetId;
+  }
+
+  public void setTargetId(String targetId) {
+    this.targetId = targetId;
+  }
+
+  public String getTargetLabel() {
+    return targetLabel;
+  }
+
+  public void setTargetLabel(String targetLabel) {
+    this.targetLabel = targetLabel;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public void setDetails(String details) {
+    this.details = details;
+  }
+
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public int getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(int schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.audit;
+
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Persists and retrieves security audit records. Records are append-only (insert, never update) so the
+ * trail cannot be silently rewritten; there is no foreign key on actor_user_id so a record survives the
+ * deletion of the user it references.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLogRepository {
+
+  private static Log LOG = LogFactory.getLog(AuditLogRepository.class);
+
+  private static String TABLE_NAME = "audit_log";
+  private static String[] PRIMARY_KEY = new String[]{"audit_id"};
+
+  public static AuditLog save(AuditLog record) {
+    return add(record);
+  }
+
+  private static AuditLog add(AuditLog record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("occurred", record.getOccurred())
+        .add("event_category", record.getEventCategory(), 50)
+        .add("event_type", record.getEventType(), 100)
+        .add("outcome", record.getOutcome(), 20)
+        .add("actor_user_id", record.getActorUserId(), -1)
+        .add("actor_username", record.getActorUsername(), 255)
+        .add("source_ip", record.getSourceIp(), 200)
+        .add("target_type", record.getTargetType(), 50)
+        .add("target_id", record.getTargetId(), 255)
+        .add("target_label", record.getTargetLabel(), 255)
+        .add("details", record.getDetails())
+        .add("session_id", record.getSessionId(), 255)
+        .add("schema_version", record.getSchemaVersion());
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static List<AuditLog> findAll(DataConstraints constraints) {
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("audit_id desc");
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME, new SqlUtils(), new SqlUtils(), new SqlUtils(), constraints, AuditLogRepository::buildRecord);
+    return (List<AuditLog>) result.getRecords();
+  }
+
+  private static AuditLog buildRecord(ResultSet rs) {
+    try {
+      AuditLog record = new AuditLog();
+      record.setId(rs.getLong("audit_id"));
+      record.setOccurred(rs.getTimestamp("occurred"));
+      record.setEventCategory(rs.getString("event_category"));
+      record.setEventType(rs.getString("event_type"));
+      record.setOutcome(rs.getString("outcome"));
+      long actorUserId = rs.getLong("actor_user_id");
+      record.setActorUserId(rs.wasNull() ? -1L : actorUserId);
+      record.setActorUsername(rs.getString("actor_username"));
+      record.setSourceIp(rs.getString("source_ip"));
+      record.setTargetType(rs.getString("target_type"));
+      record.setTargetId(rs.getString("target_id"));
+      record.setTargetLabel(rs.getString("target_label"));
+      record.setDetails(rs.getString("details"));
+      record.setSessionId(rs.getString("session_id"));
+      record.setSchemaVersion(rs.getInt("schema_version"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -67,6 +67,7 @@ import com.simisinc.platform.domain.model.ecommerce.Cart;
 import com.simisinc.platform.domain.model.ecommerce.PricingRule;
 import com.simisinc.platform.domain.model.login.UserLogin;
 import com.simisinc.platform.infrastructure.persistence.SessionRepository;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
 
 /**
@@ -433,6 +434,9 @@ public class WebRequestFilter implements Filter {
           userLogin.setSessionId(userSession.getSessionId());
           userLogin.setUserAgent(httpServletRequest.getHeader("USER-AGENT"));
           UserLoginRepository.save(userLogin);
+          // Audit the cookie-token (remember-me) auto-login for the SIEM; source marker "token"
+          SaveAuditEventCommand.recordAuthentication("authentication.login.success", "success",
+              user.getId(), user.getEmail(), ipAddress, userSession.getSessionId(), "token");
           // Extend the token expiration date
           int twoWeeksSecondsInt = 14 * 24 * 60 * 60;
           AuthenticateLoginCommand.extendTokenExpiration(cookieUserToken, twoWeeksSecondsInt);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.login;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.oauth.OAuthRequestCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
@@ -129,6 +130,8 @@ public class LoginWidget extends GenericWidget {
           && (TotpCommand.verifyCode(user.getMfaSecret(), code)
               || UserMfaRecoveryCodeCommand.consume(user, code));
       if (!verified) {
+        SaveAuditEventCommand.recordAuthentication("authentication.mfa.verify.failure", "failure",
+            mfaPendingUserId, (user != null ? user.getEmail() : null), ipAddress, httpSession.getId(), null);
         // Record the failed attempt so repeated guesses get locked out
         RateLimitCommand.isUsernameAllowedRightNow(rateLimitKey, true);
         if (StringUtils.isNotBlank(ipAddress)) {
@@ -139,6 +142,8 @@ public class LoginWidget extends GenericWidget {
         return context;
       }
       clearMfaPending(httpSession);
+      SaveAuditEventCommand.recordAuthentication("authentication.mfa.verify.success", "success",
+          user.getId(), user.getEmail(), ipAddress, httpSession.getId(), null);
       return finalizeLogin(context, user, stayLoggedIn);
     }
 
@@ -152,6 +157,9 @@ public class LoginWidget extends GenericWidget {
       }
       user = AuthenticateLoginCommand.getAuthenticatedUser(email.trim().toLowerCase(), password, context.getRequest().getRemoteAddr());
     } catch (DataException | LoginException e) {
+      SaveAuditEventCommand.recordAuthentication("authentication.login.failure", "failure", -1L,
+          (email != null ? email.trim().toLowerCase() : null), context.getRequest().getRemoteAddr(),
+          httpSession.getId(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       return context;
     }
@@ -184,6 +192,11 @@ public class LoginWidget extends GenericWidget {
     userLogin.setSessionId(userSession.getSessionId());
     userLogin.setUserAgent(context.getRequest().getHeader("USER-AGENT"));
     UserLoginRepository.save(userLogin);
+
+    // Audit the successful authentication (both the database trail and the JSON stream for the SIEM);
+    // the details field carries the authentication source ("password" here, "oauth"/"token" elsewhere)
+    SaveAuditEventCommand.recordAuthentication("authentication.login.success", "success",
+        user.getId(), user.getEmail(), context.getRequest().getRemoteAddr(), userSession.getSessionId(), "password");
 
     // Optionally store a token for future access
     int twoWeeksSecondsInt = 14 * 24 * 60 * 60;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LogoutWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LogoutWidget.java
@@ -16,7 +16,10 @@
 
 package com.simisinc.platform.presentation.widgets.login;
 
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.login.LogoutCommand;
+import com.simisinc.platform.presentation.controller.SessionConstants;
+import com.simisinc.platform.presentation.controller.UserSession;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
@@ -33,6 +36,12 @@ public class LogoutWidget extends GenericWidget {
   static String JSP = "/login/logout.jsp";
 
   public WidgetContext execute(WidgetContext context) {
+    // Audit the logout while the user is still known, before the session is cleared
+    UserSession userSession = (UserSession) context.getRequest().getSession().getAttribute(SessionConstants.USER);
+    if (userSession != null && userSession.isLoggedIn()) {
+      SaveAuditEventCommand.recordAuthentication("authentication.logout", "success",
+          userSession.getUserId(), null, context.getRequest().getRemoteAddr(), userSession.getSessionId(), null);
+    }
     // Log the user out
     LogoutCommand.logout(context.getRequest(), context.getResponse());
 

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -432,6 +432,29 @@ CREATE TABLE user_tokens (
 );
 CREATE INDEX user_tokens_token_idx ON user_tokens(token);
 
+-- Security audit log (Milestone #3 / Phase 1; mirrored by UPGRADE_20260719.1006 for existing installs).
+-- Append-only; no foreign key on actor_user_id so a record survives the deletion of the user it
+-- references; the full source IP is retained for forensics.
+CREATE TABLE audit_log (
+  audit_id BIGSERIAL PRIMARY KEY,
+  occurred TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  event_category VARCHAR(50) NOT NULL,
+  event_type VARCHAR(100) NOT NULL,
+  outcome VARCHAR(20) NOT NULL,
+  actor_user_id BIGINT,
+  actor_username VARCHAR(255),
+  source_ip VARCHAR(200),
+  target_type VARCHAR(50),
+  target_id VARCHAR(255),
+  target_label VARCHAR(255),
+  details TEXT,
+  session_id VARCHAR(255),
+  schema_version INTEGER DEFAULT 1 NOT NULL
+);
+CREATE INDEX audit_log_occurred_idx ON audit_log(occurred);
+CREATE INDEX audit_log_category_type_idx ON audit_log(event_category, event_type);
+CREATE INDEX audit_log_actor_idx ON audit_log(actor_user_id);
+
 -- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
 CREATE TABLE user_mfa_recovery_codes (
   recovery_code_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1006__audit_log.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260719.1006__audit_log.sql
@@ -1,0 +1,24 @@
+-- Security audit log (Milestone #3 / Phase 1): a structured, append-only record of who did what, when,
+-- and from where -- authentication events now, admin/data-change events in later phases. Idempotent so
+-- it is safe on any existing install; fresh installs get the identical table from NEW_10000 instead.
+-- No foreign key on actor_user_id so a record survives the deletion of the user it references, and the
+-- full source IP is retained for forensics.
+CREATE TABLE IF NOT EXISTS audit_log (
+  audit_id BIGSERIAL PRIMARY KEY,
+  occurred TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  event_category VARCHAR(50) NOT NULL,
+  event_type VARCHAR(100) NOT NULL,
+  outcome VARCHAR(20) NOT NULL,
+  actor_user_id BIGINT,
+  actor_username VARCHAR(255),
+  source_ip VARCHAR(200),
+  target_type VARCHAR(50),
+  target_id VARCHAR(255),
+  target_label VARCHAR(255),
+  details TEXT,
+  session_id VARCHAR(255),
+  schema_version INTEGER DEFAULT 1 NOT NULL
+);
+CREATE INDEX IF NOT EXISTS audit_log_occurred_idx ON audit_log(occurred);
+CREATE INDEX IF NOT EXISTS audit_log_category_type_idx ON audit_log(event_category, event_type);
+CREATE INDEX IF NOT EXISTS audit_log_actor_idx ON audit_log(actor_user_id);

--- a/src/test/java/com/simisinc/platform/application/audit/SaveAuditEventCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/audit/SaveAuditEventCommandTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.audit;
+
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the JSON serialization of an audit event (the stream that feeds the SIEM)
+ *
+ * @author SimIS Inc.
+ */
+class SaveAuditEventCommandTest {
+
+  private AuditLog baseEvent() {
+    AuditLog event = new AuditLog();
+    event.setOccurred(Timestamp.from(Instant.parse("2026-07-20T14:19:22Z")));
+    event.setEventCategory("authentication");
+    event.setEventType("authentication.login.success");
+    event.setOutcome("success");
+    return event;
+  }
+
+  @Test
+  void jsonCarriesTheCoreFieldsWithCorrectTypes() {
+    AuditLog event = baseEvent();
+    event.setActorUserId(42L);
+    event.setActorUsername("jdoe@example.com");
+    event.setSourceIp("203.0.113.45");
+    event.setSessionId("abc123");
+
+    String json = SaveAuditEventCommand.toJson(event);
+
+    assertTrue(json.startsWith("{"));
+    assertTrue(json.endsWith("}"));
+    assertTrue(json.contains("\"schema\":\"simis.audit.v1\""));
+    assertTrue(json.contains("\"ts\":\"2026-07-20T14:19:22Z\""));
+    assertTrue(json.contains("\"category\":\"authentication\""));
+    assertTrue(json.contains("\"event\":\"authentication.login.success\""));
+    assertTrue(json.contains("\"result\":\"success\""));
+    // Numeric, unquoted
+    assertTrue(json.contains("\"actorUserId\":42"));
+    assertTrue(json.contains("\"actorUsername\":\"jdoe@example.com\""));
+    assertTrue(json.contains("\"sourceIp\":\"203.0.113.45\""));
+    assertTrue(json.contains("\"sessionId\":\"abc123\""));
+  }
+
+  @Test
+  void nullFieldsAndAnUnknownActorAreOmitted() {
+    AuditLog event = baseEvent();
+    event.setEventType("authentication.login.failure");
+    event.setOutcome("failure");
+    event.setActorUserId(-1L); // unknown actor (e.g. a failed login for a non-existent account)
+    event.setActorUsername("attacker@example.com");
+    // sourceIp, sessionId, targetType, details deliberately left null
+
+    String json = SaveAuditEventCommand.toJson(event);
+
+    assertFalse(json.contains("actorUserId"), "the actor id must be omitted when unknown (-1)");
+    assertFalse(json.contains("sourceIp"), "null fields must be omitted");
+    assertFalse(json.contains("targetType"));
+    assertFalse(json.contains("details"));
+    assertTrue(json.contains("\"actorUsername\":\"attacker@example.com\""));
+  }
+
+  @Test
+  void stringValuesAreJsonEscaped() {
+    AuditLog event = baseEvent();
+    // A quote in a captured value must be escaped so it cannot break out of the JSON string
+    event.setActorUsername("a\"b");
+
+    String json = SaveAuditEventCommand.toJson(event);
+
+    // The embedded quote is escaped (backslash-quote), keeping the document valid
+    assertTrue(json.contains("a\\\"b"));
+  }
+
+  @Test
+  void newlinesInAValueCannotForgeASecondLogLine() {
+    AuditLog event = baseEvent();
+    // A CR/LF in an attacker-supplied value (e.g. the email on a failed login) must not split the
+    // single-line JSON and inject a forged audit line into the stdout stream.
+    event.setActorUsername("victim\r\nAUDIT forged line");
+
+    String json = SaveAuditEventCommand.toJson(event);
+
+    assertFalse(json.contains("\n"), "the emitted line must not contain a raw newline (log-forging defense)");
+    assertFalse(json.contains("\r"), "the emitted line must not contain a raw carriage return");
+    // The value is preserved, just escaped inline
+    assertTrue(json.contains("AUDIT forged line"));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -25,6 +25,7 @@ import org.mockito.MockedStatic;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
 import com.simisinc.platform.application.login.TotpCommand;
 import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
@@ -48,7 +49,9 @@ import static org.mockito.Mockito.when;
 
 /**
  * Verifies the two-step login gate: a correct password alone must not establish a session when MFA is enabled, an
- * invalid code is rejected, a valid code completes the login, and accounts without MFA sign in as before.
+ * invalid code is rejected, a valid code completes the login, and accounts without MFA sign in as before. Also
+ * verifies that the authentication audit events are recorded at the capture points (the audit command is mocked
+ * so the unit test does not touch the database).
  *
  * @author SimIS Inc.
  * @created 2026-07-17
@@ -98,7 +101,8 @@ class LoginWidgetTest extends WidgetBase {
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
         MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
-        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
@@ -127,13 +131,20 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
         MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
         MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
-        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
       widget.post(widgetContext);
+
+      // A completed MFA login records both the second-factor success and the login itself
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(
+          eq("authentication.mfa.verify.success"), eq("success"), anyLong(), any(), any(), any(), any()));
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(
+          eq("authentication.login.success"), eq("success"), anyLong(), any(), any(), any(), any()));
     }
 
     // Logged in: pending marker cleared (removeAttribute is called), redirected, auth cookie set, no error.
@@ -158,7 +169,8 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
         MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
         MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
-        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       // TOTP fails, but a recovery code is accepted
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
@@ -191,11 +203,16 @@ class LoginWidgetTest extends WidgetBase {
     LoginWidget widget = new LoginWidget();
     try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class);
         MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
-        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
           .thenReturn(user);
       siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
       widget.post(widgetContext);
+
+      // A direct (no-MFA) login records a single login.success audit event
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(
+          eq("authentication.login.success"), eq("success"), anyLong(), any(), any(), any(), any()));
     }
 
     // No MFA -> straight to a logged-in session, never held for a code.
@@ -212,10 +229,15 @@ class LoginWidgetTest extends WidgetBase {
     when(request.getRemoteAddr()).thenReturn("127.0.0.1");
 
     LoginWidget widget = new LoginWidget();
-    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class)) {
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
           .thenThrow(new LoginException("Your sign in was incorrect"));
       widget.post(widgetContext);
+
+      // A failed password is audited as a login.failure
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(
+          eq("authentication.login.failure"), eq("failure"), anyLong(), any(), any(), any(), any()));
     }
 
     Assertions.assertNotNull(widgetContext.getErrorMessage());
@@ -262,7 +284,8 @@ class LoginWidgetTest extends WidgetBase {
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<TotpCommand> totp = mockStatic(TotpCommand.class);
         MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
-        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class)) {
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
@@ -273,6 +296,9 @@ class LoginWidgetTest extends WidgetBase {
       // A wrong code is recorded against both the account and the IP so repeated guesses lock out
       rateLimit.verify(() -> RateLimitCommand.isUsernameAllowedRightNow("mfa:42", true));
       rateLimit.verify(() -> RateLimitCommand.isIpAllowedRightNow("203.0.113.7", true));
+      // ...and the failed second factor is audited
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(
+          eq("authentication.mfa.verify.failure"), eq("failure"), anyLong(), any(), any(), any(), any()));
     }
 
     Assertions.assertNotNull(widgetContext.getErrorMessage());


### PR DESCRIPTION
Implements **Phase 1** of the Audit Logging & Security Telemetry milestone (closes #160): a structured, tamper-evident record of *who authenticated, when, and from where*.

## Design
- **Dual sink** — every event is written to the new `audit_log` table (source of record; powers the future in-app review and works offline / in-boundary) **and** emitted as one line of structured JSON to a dedicated `AUDIT` stream. On Azure App Service / Container Apps that JSON is auto-collected by Azure Monitor → Log Analytics → **Microsoft Sentinel** (Path A); the field shape aligns with Sentinel's **ASIM** audit model.
- **Append-only**, **no foreign key on `actor_user_id`** (records survive a user deletion), and **fail-safe** — `SaveAuditEventCommand` never throws, so a failed audit write can't turn a successful login into an error.
- **Full source IP** retained for forensics (an ISSM-approved, scoped exception to the analytics IP-anonymization control).

## Captured (all human authentication channels)
`login.success` / `login.failure` for **interactive password**, **OAuth/SSO**, and **remember-me cookie** logins; `mfa.verify.success` / `mfa.verify.failure`; and `logout`.

## Migration
`audit_log` is created in `NEW_10000` (fresh installs) and via an **idempotent** `UPGRADE_20260719.1006` (existing installs); the DDL is byte-identical between the two tracks, and the serial sits under the `20260719.10000` baseline.

## Review
Ran an adversarial pre-PR review (four dimensions, per-finding verification). It caught two **high** gaps I'd missed — **OAuth and remember-me logins were un-audited** — both now fixed here. Correctness and migration-safety came back clean. Two lower findings are tracked as fast-follows: **REST/API auth auditing (#165)** and **proxy-aware client-IP resolution for the forensic IP (#166)**.

## Tests
- `SaveAuditEventCommandTest` — JSON field mapping/types, null & unknown-actor omission, quote-escaping, and a **log-forging** case (a CR/LF in an attacker-supplied value cannot inject a second stdout line).
- `LoginWidgetTest` — now asserts the capture points fire (login.success/failure, mfa.verify.failure) and mocks the audit sink for isolation.

Full green: `ant -lib lib/tests ci-test` passes (Testcontainers applies both migration tracks).

Decisions locked in Phase 0: 1-year retention · all logins captured · full forensic IP · Sentinel Path A. Design doc in the private governance runbooks.