### PR TITLE
Add admin & data-change audit logging (Milestone #3, Phase 2)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.application.admin;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.cms.SaveFilePartCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
@@ -25,6 +26,8 @@ import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.UserSession;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.univocity.parsers.common.record.Record;
 import com.univocity.parsers.conversions.Conversions;
@@ -53,6 +56,23 @@ public class ProcessUserCSVFileCommand {
   public static int processCSV(WidgetContext context) throws DataException, AccountException {
 
     int userCount = 0;
+
+    // Resolve the acting admin once so the per-row audit records do not reload the actor on every row
+    long actorUserId = context.getUserId();
+    String actorUsername = null;
+    String actorIp = null;
+    String actorSessionId = null;
+    UserSession actorSession = context.getUserSession();
+    if (actorSession != null) {
+      actorSessionId = actorSession.getSessionId();
+      actorIp = actorSession.getIpAddress();
+      if (actorSession.getUserId() > -1L && actorSession.getUser() != null) {
+        actorUsername = actorSession.getUser().getEmail();
+      }
+    }
+    if (context.getRequest() != null && context.getRequest().getRemoteAddr() != null) {
+      actorIp = context.getRequest().getRemoteAddr();
+    }
 
     FileItem fileItemBean = null;
     try {
@@ -131,12 +151,20 @@ public class ProcessUserCSVFileCommand {
         user.setCreatedBy(context.getUserId());
         user.setModifiedBy(context.getUserId());
 
-        SaveUserCommand.saveUser(user);
+        User saved = SaveUserCommand.saveUser(user);
         ++userCount;
+        // Record each imported account so a bulk import is individually attributable
+        SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.create",
+            AuditEventCommand.SUCCESS, actorUserId, actorUsername, actorIp, actorSessionId,
+            "user", saved != null ? String.valueOf(saved.getId()) : null, email, "csv-import");
       }
 
     } catch (DataException | AccountException data) {
       LOG.debug("An exception occurred: " + data.getMessage());
+      // Record that the bulk import aborted (after any rows already created above)
+      SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.create",
+          AuditEventCommand.FAILURE, actorUserId, actorUsername, actorIp, actorSessionId,
+          "user", null, null, "csv-import aborted after " + userCount + " created: " + data.getMessage());
       // Let the user know
       context.setErrorMessage(data.getMessage());
       throw data;

--- a/src/main/java/com/simisinc/platform/application/audit/SaveAuditEventCommand.java
+++ b/src/main/java/com/simisinc/platform/application/audit/SaveAuditEventCommand.java
@@ -121,4 +121,28 @@ public class SaveAuditEventCommand {
     event.setDetails(details);
     return record(event);
   }
+
+  /**
+   * Convenience for an administrative or data-change event (user management, authorization, configuration,
+   * content, and data access). Unlike an authentication event, the actor is the administrator performing
+   * the action and the target fields identify the record that was changed. Presentation code should call
+   * the widget-context bridge (AuditEventCommand.record) rather than this method directly. Never throws.
+   */
+  public static AuditLog recordAdminEvent(String eventCategory, String eventType, String outcome,
+      long actorUserId, String actorUsername, String sourceIp, String sessionId,
+      String targetType, String targetId, String targetLabel, String details) {
+    AuditLog event = new AuditLog();
+    event.setEventCategory(eventCategory);
+    event.setEventType(eventType);
+    event.setOutcome(outcome);
+    event.setActorUserId(actorUserId);
+    event.setActorUsername(actorUsername);
+    event.setSourceIp(sourceIp);
+    event.setSessionId(sessionId);
+    event.setTargetType(targetType);
+    event.setTargetId(targetId);
+    event.setTargetLabel(targetLabel);
+    event.setDetails(details);
+    return record(event);
+  }
 }

--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.cms.BlogPostWidget;
 
@@ -397,19 +398,30 @@ public class ContentHtmlCommand {
   private static WidgetContext publishContent(WidgetContext context, Content content) {
     if (StringUtils.isNotBlank(content.getDraftContent())) {
       ContentRepository.publish(content);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.SUCCESS,
+          "content", String.valueOf(content.getId()), content.getUniqueId(), null);
     }
     return context;
   }
 
   private static WidgetContext deleteContent(WidgetContext context, Content content) {
+    // Capture identity before the record is removed
+    String targetId = String.valueOf(content.getId());
+    String targetLabel = content.getUniqueId();
     // Attempt to delete the content (permission was verified in performWebAction)
     try {
       if (ContentRepository.remove(content)) {
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.SUCCESS,
+            "content", targetId, targetLabel, null);
         context.setSuccessMessage("The content was deleted");
       } else {
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+            "content", targetId, targetLabel, null);
         context.setErrorMessage("The content could not be deleted");
       }
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+          "content", targetId, targetLabel, e.getMessage());
       context.setErrorMessage("The content could not be deleted: " + e.getMessage());
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/controller/AuditEventCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/AuditEventCommand.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+
+/**
+ * Bridges a widget request to the security audit log (see {@link SaveAuditEventCommand}). It pulls the
+ * acting administrator's identity -- user id, username, source IP and session id -- from the
+ * {@link WidgetContext} and records an administrative or data-change event.
+ *
+ * <p>Presentation code (widgets, and the small number of application commands that already receive a
+ * WidgetContext) should call this rather than building an {@code AuditLog} by hand, so the actor is
+ * resolved consistently. Auditing is a side effect: extracting the actor and writing the record are both
+ * guarded so a failure here can never break the admin action being observed.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditEventCommand {
+
+  // Event categories (Phase 2 -- authentication is Phase 1 and lives in SaveAuditEventCommand)
+  public static final String USER_MANAGEMENT = "user_management";
+  public static final String AUTHORIZATION = "authorization";
+  public static final String CONFIGURATION = "configuration";
+  public static final String CONTENT = "content";
+  public static final String DATA_ACCESS = "data_access";
+
+  // Outcomes
+  public static final String SUCCESS = "success";
+  public static final String FAILURE = "failure";
+
+  private AuditEventCommand() {
+    // Static utility
+  }
+
+  /**
+   * Records an admin/data-change audit event, resolving the acting admin from the widget context. Never
+   * throws. Callers that emit many events for one request (e.g. a bulk import loop) should resolve the
+   * actor once and call {@link SaveAuditEventCommand#recordAdminEvent} directly to avoid re-loading the
+   * acting user on every iteration.
+   */
+  public static void record(WidgetContext context, String eventCategory, String eventType, String outcome,
+      String targetType, String targetId, String targetLabel, String details) {
+    long actorUserId = -1L;
+    String actorUsername = null;
+    String sourceIp = null;
+    String sessionId = null;
+    try {
+      actorUserId = context.getUserId();
+      UserSession userSession = context.getUserSession();
+      if (userSession != null) {
+        sessionId = userSession.getSessionId();
+        sourceIp = userSession.getIpAddress();
+        // getUser() lazily loads the acting user; skip it for an unauthenticated/unknown actor
+        if (userSession.getUserId() > -1L) {
+          User actor = userSession.getUser();
+          if (actor != null) {
+            actorUsername = actor.getEmail();
+          }
+        }
+      }
+      // Prefer the live request address, matching the Phase 1 authentication events
+      if (context.getRequest() != null && context.getRequest().getRemoteAddr() != null) {
+        sourceIp = context.getRequest().getRemoteAddr();
+      }
+    } catch (Exception e) {
+      // Never let actor extraction break the caller; record with whatever was resolved
+    }
+    SaveAuditEventCommand.recordAdminEvent(eventCategory, eventType, outcome, actorUserId, actorUsername,
+        sourceIp, sessionId, targetType, targetId, targetLabel, details);
+  }
+
+  /**
+   * Summarizes a user's effective roles and groups (codes and names only) as a detail string for a
+   * user-management or authorization event, so a reviewer can see the resulting access without a second
+   * lookup. Null-safe.
+   */
+  public static String describeRolesAndGroups(User user) {
+    StringBuilder sb = new StringBuilder("roles=[");
+    if (user != null && user.getRoleList() != null) {
+      boolean first = true;
+      for (Role role : user.getRoleList()) {
+        if (!first) {
+          sb.append(",");
+        }
+        sb.append(role.getCode());
+        first = false;
+      }
+    }
+    sb.append("]; groups=[");
+    if (user != null && user.getGroupList() != null) {
+      boolean first = true;
+      for (Group group : user.getGroupList()) {
+        if (!first) {
+          sb.append(",");
+        }
+        sb.append(group.getName());
+        first = false;
+      }
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
@@ -25,6 +25,7 @@ import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import java.io.File;
@@ -73,11 +74,18 @@ public class BlockedIPListWidget extends GenericWidget {
     long recordId = context.getParameterAsLong("blockedIPListId");
     if (recordId > -1) {
       BlockedIP blockedIP = BlockedIPRepository.findById(recordId);
+      // Capture the address before removal; removing a block un-blocks that IP (a security control change)
+      String targetLabel = blockedIP != null ? blockedIP.getIpAddress() : null;
       try {
-        DeleteBlockedIPListCommand.delete(blockedIP);
+        boolean removed = DeleteBlockedIPListCommand.delete(blockedIP);
+        AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.remove",
+            removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+            "blocked_ip", String.valueOf(recordId), targetLabel, null);
         context.setSuccessMessage("Record deleted");
         return context;
       } catch (Exception e) {
+        AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.remove",
+            AuditEventCommand.FAILURE, "blocked_ip", String.valueOf(recordId), targetLabel, e.getMessage());
         context.setErrorMessage("Error. Record could not be deleted.");
         return context;
       }
@@ -117,8 +125,13 @@ public class BlockedIPListWidget extends GenericWidget {
           .withMimeType(mimeType)
           .withFilename(displayFilename)
           .serveResource();
+      // Record the export of the security block list
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          "blocked_ip_list", "all", displayFilename, "format=" + extension);
     } catch (Exception e) {
       LOG.error("Download CSV Error", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          "blocked_ip_list", "all", displayFilename, "format=" + extension);
     } finally {
       if (tempFile.exists()) {
         LOG.warn("Deleting a temporary file: " + tempFile.getAbsolutePath());
@@ -133,8 +146,12 @@ public class BlockedIPListWidget extends GenericWidget {
     LOG.info("User is uploading a CSV file...");
     try {
       int recordCount = ProcessBlockListCSVFileCommand.processCSV(context);
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.import", AuditEventCommand.SUCCESS,
+          "blocked_ip", null, null, "records=" + recordCount);
       context.setSuccessMessage(recordCount + " record" + (recordCount != 1 ? "s" : "") + " added");
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.import", AuditEventCommand.FAILURE,
+          "blocked_ip", null, null, e.getMessage());
       context.setErrorMessage(e.getMessage());
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/GroupFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/GroupFormWidget.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.application.SaveGroupCommand;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -66,6 +67,9 @@ public class GroupFormWidget extends GenericWidget {
     Group groupBean = new Group();
     BeanUtils.populate(groupBean, context.getParameterMap());
 
+    // An existing id means an edit; a new record is a create
+    String eventType = groupBean.getId() > -1 ? "group.update" : "group.create";
+
     // Save the record
     Group group = null;
     try {
@@ -74,10 +78,16 @@ public class GroupFormWidget extends GenericWidget {
         throw new GroupException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException | GroupException e) {
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, eventType, AuditEventCommand.FAILURE,
+          "group", String.valueOf(groupBean.getId()), groupBean.getName(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(groupBean);
       return context;
     }
+
+    // Record the group change (groups grant collection/folder access)
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, eventType, AuditEventCommand.SUCCESS,
+        "group", String.valueOf(group.getId()), group.getName(), null);
 
     // Determine the page to return to
     context.setSuccessMessage("Group was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/GroupsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/GroupsListWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.application.DeleteGroupCommand;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 /**
@@ -56,12 +57,18 @@ public class GroupsListWidget extends GenericWidget {
     long groupId = context.getParameterAsLong("groupId");
     if (groupId > -1) {
       Group group = GroupRepository.findById(groupId);
+      // Capture the group label before it is removed
+      String groupLabel = group != null ? group.getName() : null;
       try {
         DeleteGroupCommand.deleteGroup(group);
+        AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "group.delete", AuditEventCommand.SUCCESS,
+            "group", String.valueOf(groupId), groupLabel, null);
         context.setSuccessMessage("Group deleted");
         context.setRedirect("/admin/groups");
         return context;
       } catch (Exception e) {
+        AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "group.delete", AuditEventCommand.FAILURE,
+            "group", String.valueOf(groupId), groupLabel, e.getMessage());
         context.setErrorMessage("Error. Group could not be deleted.");
         context.setRedirect("/admin/groups");
         return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.application.admin.SecretSitePropertiesCommand;
 import com.simisinc.platform.application.cms.ColorCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.SqlTimestampConverter;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -91,6 +92,10 @@ public class SitePropertiesEditorWidget extends GenericWidget {
       }
     }
 
+    // Track which secret properties actually received a new value, to audit the rotation by name only
+    // (never the value). Non-secret names are audited as a count; no secret value is ever recorded.
+    List<String> secretsRotated = new ArrayList<>();
+
     // Populate the entries from the request and Validate the values
     for (SiteProperty siteProperty : siteProperties) {
 
@@ -104,8 +109,12 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
       // Secret values are rendered as empty masked fields; a blank submission means unchanged,
       // so keep the stored value instead of wiping it
-      if (SecretSitePropertiesCommand.isSecret(siteProperty.getName()) && StringUtils.isBlank(newValue)) {
-        continue;
+      if (SecretSitePropertiesCommand.isSecret(siteProperty.getName())) {
+        if (StringUtils.isBlank(newValue)) {
+          continue;
+        }
+        // A non-blank secret submission is a real rotation -- record the name, never the value
+        secretsRotated.add(siteProperty.getName());
       }
 
       // Handle types
@@ -152,6 +161,13 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
     // Save the entries
     boolean saved = SitePropertyRepository.saveAll(prefix, siteProperties);
+
+    // Record the settings change -- property names and any rotated secret names only, never values
+    String settingDetails = "properties=" + siteProperties.size()
+        + (secretsRotated.isEmpty() ? "" : "; secretsRotated=" + secretsRotated);
+    AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "setting.update",
+        saved ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+        "site_property", prefix, prefix, settingDetails);
 
     if (saved) {
       // Update global cached settings

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/BlogListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/BlogListWidget.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -80,8 +81,12 @@ public class BlogListWidget extends GenericWidget {
         context.setErrorMessage("Blog was not found");
       } else {
         if (BlogRepository.remove(blog)) {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.SUCCESS,
+              "blog", String.valueOf(blog.getId()), blog.getName(), null);
           context.setSuccessMessage("Blog was deleted");
         } else {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+              "blog", String.valueOf(blog.getId()), blog.getName(), null);
           context.setWarningMessage("Blog could not be deleted");
         }
       }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFormWidget.java
@@ -28,6 +28,7 @@ import com.simisinc.platform.domain.model.cms.FolderGroup;
 import com.simisinc.platform.domain.model.items.PrivacyType;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -148,6 +149,16 @@ public class FolderFormWidget extends GenericWidget {
       folderBean.setFolderCategoryList(folderCategoryList);
     }
 
+    // Summarize the submitted per-group ACL for the audit detail
+    StringBuilder aclDetails = new StringBuilder("aclGroupIds=[");
+    for (int i = 0; i < folderGroupList.size(); i++) {
+      if (i > 0) {
+        aclDetails.append(",");
+      }
+      aclDetails.append(folderGroupList.get(i).getGroupId());
+    }
+    aclDetails.append("]");
+
     // Save the folder
     Folder folder = null;
     try {
@@ -156,11 +167,19 @@ public class FolderFormWidget extends GenericWidget {
         throw new FolderException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException | FolderException e) {
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "folder.access.update",
+          AuditEventCommand.FAILURE, "folder", String.valueOf(folderBean.getId()), folderBean.getName(),
+          aclDetails.toString());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(folderBean);
       context.addSharedRequestValue("returnPage", returnPage);
       return context;
     }
+
+    // Record the folder save with its group access-control list
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "folder.access.update",
+        AuditEventCommand.SUCCESS, "folder", String.valueOf(folder.getId()), folder.getName(),
+        aclDetails.toString());
 
     // Determine the page to return to
     context.setSuccessMessage("Folder was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ThemeEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ThemeEditorWidget.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.application.cms.ThemeCommand;
 import com.simisinc.platform.domain.model.cms.Theme;
 import com.simisinc.platform.infrastructure.persistence.cms.ThemeRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -60,6 +61,8 @@ public class ThemeEditorWidget extends GenericWidget {
     }
     // Save the theme
     ThemeCommand.createSnapshotWithName(name);
+    AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "theme.create", AuditEventCommand.SUCCESS,
+        "theme", null, name, null);
     return context;
   }
 
@@ -73,7 +76,10 @@ public class ThemeEditorWidget extends GenericWidget {
     long themeId = context.getParameterAsLong("id");
     Theme theme = ThemeRepository.findById(themeId);
     if (theme != null) {
+      // Restoring a theme bulk-overwrites the theme-prefixed site settings
       ThemeCommand.restoreTheme(theme);
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "theme.restore", AuditEventCommand.SUCCESS,
+          "theme", String.valueOf(theme.getId()), theme.getName(), null);
     }
     return context;
   }
@@ -83,7 +89,10 @@ public class ThemeEditorWidget extends GenericWidget {
     long themeId = context.getParameterAsLong("id");
     Theme theme = ThemeRepository.findById(themeId);
     if (theme != null) {
+      String themeLabel = theme.getName();
       ThemeRepository.remove(theme);
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "theme.delete", AuditEventCommand.SUCCESS,
+          "theme", String.valueOf(themeId), themeLabel, null);
     }
     return context;
   }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.domain.model.cms.SitemapChangeFrequencyOptions;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.beanutils.BeanUtils;
@@ -116,6 +117,9 @@ public class WebPageFormWidget extends GenericWidget {
     webPageBean.setCreatedBy(context.getUserId());
     webPageBean.setModifiedBy(context.getUserId());
 
+    // Publishing makes the page live; saving as draft takes it out of live view
+    String eventType = webPageBean.getDraft() ? "content.unpublish" : "content.publish";
+
     // Save the record
     WebPage webPage = null;
     try {
@@ -124,10 +128,16 @@ public class WebPageFormWidget extends GenericWidget {
         throw new DataException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, eventType, AuditEventCommand.FAILURE,
+          "web_page", String.valueOf(webPageBean.getId()), webPageBean.getTitle(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(webPageBean);
       return context;
     }
+
+    // Record the publish/unpublish
+    AuditEventCommand.record(context, AuditEventCommand.CONTENT, eventType, AuditEventCommand.SUCCESS,
+        "web_page", String.valueOf(webPage.getId()), webPage.getTitle(), null);
 
     // Determine the page to return to
     String returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));
@@ -154,10 +164,16 @@ public class WebPageFormWidget extends GenericWidget {
     context.setRedirect(webPage.getLink());
     String action = context.getParameter("action");
     if ("deletePage".equals(action)) {
+      String targetId = String.valueOf(webPage.getId());
+      String targetLabel = webPage.getTitle();
       try {
         WebPageRepository.remove(webPage);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.SUCCESS,
+            "web_page", targetId, targetLabel, null);
         context.setSuccessMessage("Page was deleted");
       } catch (Exception e) {
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+            "web_page", targetId, targetLabel, e.getMessage());
         context.setErrorMessage("The page could not be deleted: " + e.getMessage());
       }
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WikiListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WikiListWidget.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.domain.model.cms.Wiki;
 import com.simisinc.platform.infrastructure.persistence.cms.WikiPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WikiPageSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.WikiRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -80,8 +81,12 @@ public class WikiListWidget extends GenericWidget {
         context.setErrorMessage("Wiki was not found");
       } else {
         if (WikiRepository.remove(wiki)) {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.SUCCESS,
+              "wiki", String.valueOf(wiki.getId()), wiki.getName(), null);
           context.setSuccessMessage("Wiki was deleted");
         } else {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+              "wiki", String.valueOf(wiki.getId()), wiki.getName(), null);
           context.setWarningMessage("Wiki could not be deleted");
         }
       }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/datasets/StreamDatasetWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/datasets/StreamDatasetWidget.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.datasets.Dataset;
 import com.simisinc.platform.infrastructure.persistence.datasets.DatasetRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -96,8 +97,14 @@ public class StreamDatasetWidget extends GenericWidget {
       }
       out.close();
       in.close();
+      // Record the dataset download -- the full dataset content leaves the system. Access here is
+      // gated by page configuration rather than a role check, so the actor may be anonymous.
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          "dataset_file", String.valueOf(fileId), record.getFilename(), "format=" + record.getFileType());
     } catch (Exception e) {
       LOG.debug("Stream error: " + e.getMessage());
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          "dataset_file", String.valueOf(fileId), record.getFilename(), "format=" + record.getFileType());
     }
     context.setHandledResponse(true);
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/ecommerce/OrderListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/ecommerce/OrderListWidget.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.infrastructure.persistence.ecommerce.OrderRepositor
 import com.simisinc.platform.infrastructure.persistence.ecommerce.OrderSpecification;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
@@ -117,6 +118,7 @@ public class OrderListWidget extends GenericWidget {
     String extension = "csv";
     String displayFilename = prefix + "-" + new SimpleDateFormat("yyyyMMdd-HHmm").format(new Date()) + "." + extension;
     File tempFile = FileSystemCommand.generateTempFile("exports", context.getUserId(), extension);
+    String exportTarget = "taxjar".equals(exportType) ? "orders_taxjar" : "orders";
     try {
       if ("taxjar".equals(exportType)) {
         // Export the data to the file
@@ -133,8 +135,13 @@ public class OrderListWidget extends GenericWidget {
           .withMimeType(mimeType)
           .withFilename(displayFilename)
           .serveResource();
+      // Record the bulk export (whole-table download of order/customer data)
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          exportTarget, "all", displayFilename, "format=" + extension);
     } catch (Exception e) {
       LOG.error("Download CSV Error", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          exportTarget, "all", displayFilename, "format=" + extension);
     } finally {
       if (tempFile.exists()) {
         LOG.warn("Deleting a temporary file: " + tempFile.getAbsolutePath());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/ecommerce/ProductListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/ecommerce/ProductListWidget.java
@@ -32,6 +32,7 @@ import com.simisinc.platform.infrastructure.persistence.ecommerce.ProductReposit
 import com.simisinc.platform.infrastructure.persistence.ecommerce.ProductSkuRepository;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 /**
@@ -93,8 +94,13 @@ public class ProductListWidget extends GenericWidget {
           .withMimeType(mimeType)
           .withFilename(displayFilename)
           .serveResource();
+      // Record the bulk export (whole product SKU catalog)
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          "product_skus", "all", displayFilename, "format=" + extension);
     } catch (Exception e) {
       LOG.error("Download CSV Error", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          "product_skus", "all", displayFilename, "format=" + extension);
     } finally {
       if (tempFile.exists()) {
         LOG.warn("Deleting a temporary file: " + tempFile.getAbsolutePath());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionFormWidget.java
@@ -31,6 +31,7 @@ import com.simisinc.platform.domain.model.items.CollectionGroup;
 import com.simisinc.platform.domain.model.items.PrivacyType;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -116,6 +117,16 @@ public class CollectionFormWidget extends GenericWidget {
       }
     }
 
+    // Summarize the submitted per-group ACL for the audit detail
+    StringBuilder aclDetails = new StringBuilder("aclGroupIds=[");
+    for (int i = 0; i < collectionGroupList.size(); i++) {
+      if (i > 0) {
+        aclDetails.append(",");
+      }
+      aclDetails.append(collectionGroupList.get(i).getGroupId());
+    }
+    aclDetails.append("]");
+
     // Save the collection
     Collection collection = null;
     try {
@@ -124,11 +135,19 @@ public class CollectionFormWidget extends GenericWidget {
         throw new CollectionException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException | CollectionException e) {
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.access.update",
+          AuditEventCommand.FAILURE, "collection", String.valueOf(collectionBean.getId()), collectionBean.getName(),
+          aclDetails.toString());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(collectionBean);
       context.addSharedRequestValue("returnPage", returnPage);
       return context;
     }
+
+    // Record the collection save with its group access-control list
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.access.update",
+        AuditEventCommand.SUCCESS, "collection", String.valueOf(collection.getId()), collection.getName(),
+        aclDetails.toString());
 
     // Determine the page to return to
     context.setSuccessMessage("Collection was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.infrastructure.persistence.RoleRepository;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import java.util.List;
@@ -98,8 +99,16 @@ public class UserDetailsWidget extends GenericWidget {
   }
 
   private WidgetContext resetPassword(WidgetContext context, User user) {
+    // Capture the target before the token replaces the reference
+    String targetId = String.valueOf(user.getId());
+    String targetLabel = user.getEmail();
     // Create an account token and send email
     user = UserRepository.createAccountToken(user);
+
+    // Record the admin-initiated password reset of another user
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.password.reset",
+        user != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+        "user", targetId, targetLabel, null);
 
     // Trigger events
     WorkflowManager.triggerWorkflowForEvent(new UserPasswordResetEvent(user, context.getUserSession().getUser()));
@@ -114,14 +123,20 @@ public class UserDetailsWidget extends GenericWidget {
       context.setErrorMessage("You cannot suspend your own account");
       return context;
     }
-    UserRepository.suspendAccount(user);
+    User result = UserRepository.suspendAccount(user);
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.disable",
+        result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+        "user", String.valueOf(user.getId()), user.getEmail(), null);
     context.setSuccessMessage("Account suspended");
     return context;
   }
 
   private WidgetContext restoreAccount(WidgetContext context, User user) {
     // Restore the account
-    UserRepository.restoreAccount(user);
+    User result = UserRepository.restoreAccount(user);
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.enable",
+        result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+        "user", String.valueOf(user.getId()), user.getEmail(), null);
     context.setSuccessMessage("Account restored");
     return context;
   }
@@ -132,13 +147,22 @@ public class UserDetailsWidget extends GenericWidget {
       context.setErrorMessage("You cannot delete your own account");
       return context;
     }
+    // Capture identity before the record is removed
+    String targetId = String.valueOf(user.getId());
+    String targetLabel = user.getEmail();
     try {
       if (UserRepository.remove(user)) {
+        AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.delete",
+            AuditEventCommand.SUCCESS, "user", targetId, targetLabel, null);
         context.setSuccessMessage("Account deleted");
       } else {
+        AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.delete",
+            AuditEventCommand.FAILURE, "user", targetId, targetLabel, "referenced in other tables");
         context.setErrorMessage("Account not deleted - this user is referenced in other database tables");
       }
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.delete",
+          AuditEventCommand.FAILURE, "user", targetId, targetLabel, e.getMessage());
       context.setErrorMessage("The account could not be deleted: " + e.getMessage());
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -29,6 +29,7 @@ import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -112,6 +113,10 @@ public class UserFormWidget extends GenericWidget {
       userBean.setGroupList(userGroupList);
     }
 
+    // An existing id means an edit; a new record is a create
+    boolean isUpdate = userBean.getId() > -1;
+    String eventType = isUpdate ? "user.update" : "user.create";
+
     // Save the user
     User user = null;
     try {
@@ -121,12 +126,18 @@ public class UserFormWidget extends GenericWidget {
       }
     } catch (Exception e) {
       LOG.error("User record error: " + e.getMessage(), e);
+      AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, eventType, AuditEventCommand.FAILURE,
+          "user", String.valueOf(userBean.getId()), userBean.getEmail(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(userBean);
       context.setRedirect("/admin/modify-user?userId=" + userBean.getId());
       //context.addSharedRequestValue("returnPage", UrlCommand.getValidReturnPage(context.getParameter("returnPage")));
       return context;
     }
+
+    // Record the change with the effective roles and groups
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, eventType, AuditEventCommand.SUCCESS,
+        "user", String.valueOf(user.getId()), user.getEmail(), AuditEventCommand.describeRolesAndGroups(user));
 
     // Determine the page to return to
     context.setSuccessMessage("User was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -34,6 +34,7 @@ import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepositor
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -228,10 +229,16 @@ public class UsersListWidget extends GenericWidget {
       }
     } catch (DataException | AccountException e) {
       LOG.error("Save user error", e);
+      AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.create", AuditEventCommand.FAILURE,
+          "user", String.valueOf(userBean.getId()), userBean.getEmail(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(userBean);
       return context;
     }
+
+    // Record the new account with its initial roles and groups
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.create", AuditEventCommand.SUCCESS,
+        "user", String.valueOf(user.getId()), user.getEmail(), AuditEventCommand.describeRolesAndGroups(user));
 
     // Trigger events
     User invitedBy = LoadUserCommand.loadUser(user.getCreatedBy());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidget.java
@@ -25,6 +25,7 @@ import com.simisinc.platform.domain.model.cms.WebPageTemplate;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageTemplateRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.beanutils.BeanUtils;
@@ -131,11 +132,13 @@ public class BlogEditorWidget extends GenericWidget {
     blogPostBean.setModifiedBy(context.getUserId());
 
     String enabled = context.getParameter("enabled");
-    if (StringUtils.isNotBlank(enabled)) {
+    boolean isPublished = StringUtils.isNotBlank(enabled);
+    if (isPublished) {
       blogPostBean.setPublished(new Timestamp(System.currentTimeMillis()));
     } else {
       blogPostBean.setPublished(null);
     }
+    String eventType = isPublished ? "content.publish" : "content.unpublish";
 
     String returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));
 
@@ -147,11 +150,17 @@ public class BlogEditorWidget extends GenericWidget {
         throw new DataException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, eventType, AuditEventCommand.FAILURE,
+          "blog_post", String.valueOf(blogPostBean.getId()), blogPostBean.getTitle(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(blogPostBean);
       context.addSharedRequestValue("returnPage", returnPage);
       return context;
     }
+
+    // Record the publish/unpublish
+    AuditEventCommand.record(context, AuditEventCommand.CONTENT, eventType, AuditEventCommand.SUCCESS,
+        "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), null);
 
     // Determine the page to return to
     context.setSuccessMessage("Blog post was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
@@ -21,6 +21,7 @@ import com.simisinc.platform.application.cms.LoadBlogPostCommand;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
@@ -130,11 +131,18 @@ public class BlogPostWidget extends GenericWidget {
   }
 
   private WidgetContext deletePost(WidgetContext context, BlogPost blogPost) {
+    String targetId = String.valueOf(blogPost.getId());
+    String targetLabel = blogPost.getTitle();
     // Attempt to delete the blog
     try {
-      BlogPostRepository.remove(blogPost);
+      // remove() returns false on a swallowed DB failure rather than throwing, so branch on its result
+      boolean removed = BlogPostRepository.remove(blogPost);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete",
+          removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE, "blog_post", targetId, targetLabel, null);
       context.setSuccessMessage("Post was deleted");
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+          "blog_post", targetId, targetLabel, e.getMessage());
       context.setErrorMessage("The post could not be deleted: " + e.getMessage());
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
@@ -31,6 +31,7 @@ import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -137,9 +138,16 @@ public class ContentEditorWidget extends GenericWidget {
       Content content = SaveContentCommand.saveSafeContent(uniqueId, contentHtml, context.getUserId(), publish);
       if (content == null) {
         LOG.warn("Content record was not saved!");
+        if (publish) {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+              "content", null, uniqueId, null);
+        }
         context.setErrorMessage("An error occurred");
       } else {
         if (publish) {
+          // Record the publish (draft saves are routine and intentionally not audited)
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.SUCCESS,
+              "content", String.valueOf(content.getId()), uniqueId, null);
           // The web page has content which was just updated
           WebPage webPage = LoadWebPageCommand.loadByLink(returnPage);
           if (webPage != null) {
@@ -158,6 +166,10 @@ public class ContentEditorWidget extends GenericWidget {
       }
     } catch (DataException e) {
       LOG.error("DEVELOPER: Content parameter was not found");
+      if (publish) {
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+            "content", null, uniqueId, e.getMessage());
+      }
       context.setErrorMessage("A system error occurred");
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.domain.model.cms.Wiki;
 import com.simisinc.platform.domain.model.cms.WikiPage;
 import com.simisinc.platform.domain.model.cms.WikiParserExtension;
 import com.simisinc.platform.infrastructure.persistence.cms.WikiPageRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
@@ -174,11 +175,18 @@ public class WikiWidget extends GenericWidget {
   }
 
   private WidgetContext deletePost(WidgetContext context, WikiPage wikiPage) {
+    String targetId = String.valueOf(wikiPage.getId());
+    String targetLabel = wikiPage.getTitle();
     // Attempt to delete the wiki page
     try {
-      WikiPageRepository.remove(wikiPage);
+      // remove() returns false on a swallowed DB failure rather than throwing, so branch on its result
+      boolean removed = WikiPageRepository.remove(wikiPage);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete",
+          removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE, "wiki_page", targetId, targetLabel, null);
       context.setSuccessMessage("Page was deleted");
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+          "wiki_page", targetId, targetLabel, e.getMessage());
       context.setErrorMessage("The page could not be deleted: " + e.getMessage());
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemMemberFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemMemberFormWidget.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.domain.model.items.Item;
 import com.simisinc.platform.domain.model.items.Member;
 import com.simisinc.platform.infrastructure.persistence.items.CollectionRoleRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -131,6 +132,8 @@ public class ItemMemberFormWidget extends GenericWidget {
     memberBean.setRoleList(memberRoleList);
     memberBean.setApprovedBy(context.getUserId());
 
+    String membershipDetails = "collectionId=" + item.getCollectionId() + "; itemId=" + item.getId();
+
     Member member = null;
     try {
       member = SaveMemberCommand.saveMember(memberBean);
@@ -138,10 +141,16 @@ public class ItemMemberFormWidget extends GenericWidget {
         throw new DataException("The information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException e) {
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.member.add",
+          AuditEventCommand.FAILURE, "user", String.valueOf(user.getId()), user.getFullName(), membershipDetails);
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(memberBean);
       return context;
     }
+
+    // Record the membership grant (confers collection access)
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.member.add",
+        AuditEventCommand.SUCCESS, "user", String.valueOf(user.getId()), user.getFullName(), membershipDetails);
 
     // Determine the page to return to
     context.setSuccessMessage("Member was added");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemMembersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemMembersListWidget.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.domain.model.items.Member;
 import com.simisinc.platform.infrastructure.persistence.items.CollectionRoleRepository;
 import com.simisinc.platform.infrastructure.persistence.items.MemberRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import java.util.List;
@@ -109,12 +110,24 @@ public class ItemMembersListWidget extends GenericWidget {
     }
 
     // Remove the member
+    String membershipDetails = "collectionId=" + item.getCollectionId() + "; itemId=" + item.getId();
     try {
       User user = LoadUserCommand.loadUser(record.getUserId());
-      MemberRepository.remove(record);
-      context.setSuccessMessage(user.getFullName() + " was removed");
+      String memberLabel = user != null ? user.getFullName() : null;
+      // remove() returns null on a swallowed DB failure rather than throwing, so branch on its result
+      boolean removed = MemberRepository.remove(record) != null;
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.member.remove",
+          removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE, "user",
+          String.valueOf(record.getUserId()), memberLabel, membershipDetails);
+      if (removed) {
+        context.setSuccessMessage((memberLabel != null ? memberLabel : "Member") + " was removed");
+      } else {
+        context.setErrorMessage("Error. Member could not be removed.");
+      }
       return context;
     } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "collection.member.remove",
+          AuditEventCommand.FAILURE, "user", String.valueOf(record.getUserId()), null, membershipDetails);
       context.setErrorMessage("Error. Member could not be removed.");
     }
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.infrastructure.persistence.mailinglists.*;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
 
@@ -126,8 +127,13 @@ public class MailingListMembersWidget extends GenericWidget {
             .withMimeType(mimeType)
             .withFilename(displayFilename)
             .serveResource();
+        // Record the export of mailing-list member PII (email, name, subscription state)
+        AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+            "mailing_list_members", String.valueOf(mailingList.getId()), displayFilename, "format=" + extension);
       } catch (Exception e) {
         LOG.error("Download CSV Error", e);
+        AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+            "mailing_list_members", String.valueOf(mailingList.getId()), displayFilename, "format=" + extension);
       } finally {
         if (tempFile.exists()) {
           LOG.warn("Deleting a temporary file: " + tempFile.getAbsolutePath());

--- a/src/test/java/com/simisinc/platform/application/audit/SaveAuditEventCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/audit/SaveAuditEventCommandTest.java
@@ -109,4 +109,28 @@ class SaveAuditEventCommandTest {
     // The value is preserved, just escaped inline
     assertTrue(json.contains("AUDIT forged line"));
   }
+
+  @Test
+  void adminEventCarriesTheTargetFields() {
+    // A Phase 2 admin/data-change event identifies the record that changed via the target fields
+    AuditLog event = baseEvent();
+    event.setEventCategory("user_management");
+    event.setEventType("user.disable");
+    event.setActorUserId(7L);
+    event.setActorUsername("admin@example.com");
+    event.setTargetType("user");
+    event.setTargetId("42");
+    event.setTargetLabel("jdoe@example.com");
+    event.setDetails("roles=[admin]; groups=[All Users]");
+
+    String json = SaveAuditEventCommand.toJson(event);
+
+    assertTrue(json.contains("\"category\":\"user_management\""));
+    assertTrue(json.contains("\"event\":\"user.disable\""));
+    assertTrue(json.contains("\"targetType\":\"user\""));
+    // targetId is a string field even when it holds a numeric id
+    assertTrue(json.contains("\"targetId\":\"42\""));
+    assertTrue(json.contains("\"targetLabel\":\"jdoe@example.com\""));
+    assertTrue(json.contains("\"details\":\"roles=[admin]; groups=[All Users]\""));
+  }
 }

--- a/src/test/java/com/simisinc/platform/presentation/controller/AuditEventCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/AuditEventCommandTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the audit detail formatting used by the Phase 2 admin audit events.
+ *
+ * @author SimIS Inc.
+ */
+class AuditEventCommandTest {
+
+  private Role role(String code) {
+    Role role = new Role();
+    role.setCode(code);
+    return role;
+  }
+
+  private Group group(String name) {
+    Group group = new Group();
+    group.setName(name);
+    return group;
+  }
+
+  @Test
+  void describesRolesAndGroupsAsCodesAndNames() {
+    User user = new User();
+    List<Role> roles = new ArrayList<>();
+    roles.add(role("admin"));
+    roles.add(role("content-manager"));
+    user.setRoleList(roles);
+    List<Group> groups = new ArrayList<>();
+    groups.add(group("All Users"));
+    user.setGroupList(groups);
+
+    assertEquals("roles=[admin,content-manager]; groups=[All Users]",
+        AuditEventCommand.describeRolesAndGroups(user));
+  }
+
+  @Test
+  void describesEmptyRolesAndGroups() {
+    User user = new User();
+    user.setRoleList(new ArrayList<>());
+    user.setGroupList(new ArrayList<>());
+
+    assertEquals("roles=[]; groups=[]", AuditEventCommand.describeRolesAndGroups(user));
+  }
+
+  @Test
+  void isNullSafeForAUserWithNoLists() {
+    // A user whose role/group lists were never populated must not throw
+    User user = new User();
+
+    assertEquals("roles=[]; groups=[]", AuditEventCommand.describeRolesAndGroups(user));
+  }
+}


### PR DESCRIPTION
Closes #161. **Phase 2 of the Audit Logging & Security Telemetry milestone (#3)** — builds directly on the Phase 1 pipeline merged in #167.

## What this does
Extends audit capture from authentication (Phase 1) to **security-relevant admin and data-change actions** across the admin surface. Each instrumented action writes a record through the existing dual-sink, never-throwing sink (`SaveAuditEventCommand`). A new presentation-layer bridge, `AuditEventCommand.record(context, …)`, resolves the acting admin's identity (user id, email, source IP, session id) from the `WidgetContext` so every call site is a uniform ~2-line addition.

**No database migration** — Phase 0 designed the `audit_log` target columns (`target_type` / `target_id` / `target_label` / `details`) forward-compatibly, so Phase 2 is pure capture wiring plus one convenience method.

## Instrumented events (~33 call sites)
| Category | Events |
|---|---|
| **user_management** | create, update, enable, disable, delete, admin password-reset, bulk CSV import (one attributable event per row) |
| **authorization** | group create/edit/delete, collection membership add/remove, collection & folder ACL changes. *User role/group changes ride on the user-management event's `details` (effective roles/groups) rather than fragile before/after diffing.* |
| **configuration** | site-settings saves, theme restore/create/delete, blocked-IP add/remove/import |
| **content** | publish / unpublish / delete for content blocks, web pages, blog posts, wiki pages, and whole blog/wiki containers |
| **data_access** | mailing-list, order, TaxJar, product, and blocked-IP CSV exports; dataset file downloads |

## Design decisions
- **🔒 Secrets are never logged.** The settings audit records `secretsRotated=[<property names>]` only when a *non-blank* secret value was actually submitted (a real rotation) — never a value, plaintext or encrypted.
- **Fail-safe.** An audit write can never alter the action it observes: actor extraction is guarded and the sink never throws.
- **Correct attribution.** Outcome is branched on the repository result. Several delete repositories *swallow* SQL errors and return `false`/`null` rather than throwing, so a failed delete is recorded as `failure`, not a false `success`. Target id/label for deletes are captured *before* removal.
- **Performance.** The CSV bulk import resolves the acting admin **once** before the loop, not per row.

## Adversarial review
The change was put through a multi-agent adversarial review (correctness, secret/PII leakage, completeness, fail-safety), which surfaced and this PR **fixes** 4 real issues:
- `ItemMembersListWidget`, `BlogPostWidget`, `WikiWidget` — delete recorded `success` even on a swallowed DB failure → now branch on the repository return value.
- `BlockedIPListWidget` — the block-list *export* was audited but the *delete*/import (writes to a security control) were not → now instrumented.

Leakage and fail-safety dimensions came back clean.

## Testing
- `ant clean compile` → BUILD SUCCESSFUL
- `ant -lib lib/tests ci-test` → BUILD SUCCESSFUL (full suite, incl. Testcontainers; the 3 pre-existing tests on touched widgets still pass)
- New unit tests: admin-event target-field serialization (`SaveAuditEventCommandTest`) and the role/group detail formatter (`AuditEventCommandTest`)

## Notes / follow-ups
- A handful of deletes call `void` repository methods (e.g. `WebPageRepository.remove`, `GroupRepository.remove` via `DeleteGroupCommand`) that expose no success/failure signal — these record `success` after a non-throwing call, the best available without a repository change. Noted for a future repository-return-value cleanup.
- Fine-grained per-grant `role.grant`/`role.revoke` diffing remains a possible later refinement (Phase 3/4).
