### PR TITLE
Rebuild and re-scan the published images monthly

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -3,7 +3,8 @@
 # the built-in GITHUB_TOKEN -- no personal credentials are stored or used.
 #
 # The first publish has to be kicked off by hand (workflow_dispatch) to create
-# the packages; after that it runs on every push to main and each release.
+# the packages; after that it runs on every push to main, each release, and
+# monthly on a schedule so the images pick up base-image security fixes.
 name: Publish container images
 
 on:
@@ -12,6 +13,10 @@ on:
     branches: [ main ]
   release:
     types: [ published ]
+  schedule:
+    # Monthly rebuild + re-scan so the published images adopt Debian security
+    # fixes as they ship, without waiting for a code push (06:00 UTC on the 1st).
+    - cron: '0 6 1 * *'
 
 permissions:
   contents: read          # read the source to build from


### PR DESCRIPTION
## What

Adds a **monthly `schedule:` trigger** (06:00 UTC on the 1st) to `publish-images.yml`.

## Why

Today the workflow builds, Trivy-scans, and republishes the app and DB images only on **push-to-main** and **release**. Between releases, the published images — and their scan results in the Security tab — go stale: the base image accumulates newly disclosed CVEs, and, separately, Debian ships fixes the image never picks up.

A monthly rebuild re-pulls a fresh base, re-scans, and republishes on a steady cadence, so base-OS security fixes flow into the published images and the code-scanning alert counts **without waiting for a code change**. Pairs with #175 (which hardens the DB image): as Debian releases fixes for the ~92 currently-unfixable CVEs, the scheduled rebuild adopts them automatically.

The existing `concurrency` group still serializes runs (a scheduled run and a push won't race), and the scan stays report-only (`exit-code: 0`).
