### PR TITLE
Refresh the docs for accuracy (features, versions, DevSecOps pipeline)

### DIFF
--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -41,7 +41,7 @@ If not specified, the path for file assets and external configuration on Linux i
 ## Developer Resources
 
 - [SimIS CMS](https://www.simiscms.com)
-- [Java 17 SDK Documentation](https://docs.oracle.com/en/java/javase/17/)
+- [Java 21 SDK Documentation](https://docs.oracle.com/en/java/javase/21/)
 - [MVC Example with Servlets and JSP](https://www.baeldung.com/mvc-servlet-jsp)
 - [Servlet 4.0 API](https://tomcat.apache.org/tomcat-9.0-doc/servletapi/index.html)
 - [JSP 2.3 API](https://tomcat.apache.org/tomcat-9.0-doc/jspapi/index.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,14 @@ SimIS CMS comes out-of-the-box with modules, easy setup, and powerful developer 
 ## Features
 
 - **CMS**: Site Map, Web Pages (Templates, UI Designer, SEO, Searchable) with Content and Images, HTML Editor, CSS Editor, Blogs, Form Data, Calendars, Folders and Files, Mailing Lists, Videos, Wikis, Search, Site Alerts, Form Pop-Ups, Sticky Header and Buttons, Responsive, Bot Detection
-- **Analytics**: Tracking for Sessions, Hits, Geolocation, Content, Searches, Referrals; Charts; xAPI; Pixels
+- **Analytics**: Privacy-First Tracking of Sessions, Hits, Geolocation, Content, Searches, and Referrals; Cookieless Mode; IP Anonymization; Do-Not-Track / GPC Honoring; Charts; xAPI; Pixels
 - **Data Integration**: Datasets (CSV, TSV, JSON, GeoJSON, and RSS sources), Collections (Profiles, Geolocation, Multiple Categories, Relationships, Custom Fields, Indexed, Searchable), Data Sources
 - **Collaboration**: Users (Register, Validation, Login, Invite), User Groups, Collection Membership and Permissions, Chat
 - **E-commerce**: Products, SKUs, Categories, Customers, Orders, Account Management, Shipping Methods, Carriers, Tracking Numbers, Pricing Rules (Constraints, Discounts, and Promos)
 - **CRM**: Forms, Leads & Customers, Orders
 - **Settings**: Theme, Site SEO, Social Media, Mail Server, Maps, Captcha, Analytics, E-commerce, Mailing Lists
 - **Integration**: Google Analytics, Map Box, Open Street Map, Square, Stripe, Taxjar, USPS, Boxzooka
-- **Security**: OAuth, Firewall (Integration and Blocked IP lists), Spam Filter, Geo Filter, Rate Limiting, Snyk scanning
+- **Security**: Multi-Factor Authentication (TOTP, Recovery Codes), Argon2id Password Hashing, OAuth, Firewall (Integration and Blocked IP Lists), Spam Filter, Geo Filter, Rate Limiting, CSP/HSTS and Session Hardening, Encrypted Secrets at Rest, CodeQL and Snyk Scanning, Signed SBOM with Build-Provenance Attestation
 - **API**: Rest API
 - **Platform**: Micro Widgets, Connection Pool, Cache, Scheduler, Workflow, Expression Engine, Upgrades, Migrations, Record Paging
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ An optimized web application archive (.war), with production settings, is releas
 
 - [OpenJDK 21+](https://learn.microsoft.com/en-us/java/openjdk/download)
 - [Apache Tomcat 9.0.x](https://tomcat.apache.org)
-- [PostgreSQL 14+](https://www.postgresql.org) with [PostGIS 3.2](https://postgis.net)
+- [PostgreSQL 17](https://www.postgresql.org) with [PostGIS 3](https://postgis.net)
 - The web application and optional services have only been tested on Linux, MacOS, and Windows with WSL
 
 ## Typical Steps

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -7,7 +7,20 @@ description: SimIS CMS is DevSecOps friendly
 
 ## CI/CD Pipeline
 
-### Pipeline Code Dependencies Scan
+Every change runs through automated, deterministic checks in GitHub Actions
+(see `.github/workflows/`). Most stages can also be run locally with Ant.
+
+### Static Analysis (SAST)
+
+CodeQL scans the first-party code on every push and pull request
+(`.github/workflows/codeql.yml`); findings appear under the repository's
+**Security → Code scanning** tab.
+
+### Dependency and Secret Scanning
+
+Dependencies are kept current with Dependabot and checked for drift
+(`.github/workflows/dependency-drift.yml`), and GitHub secret scanning guards
+against committed credentials. A Snyk dependency scan can also be run locally:
 
 ```bash
 npm install -g snyk
@@ -15,26 +28,36 @@ snyk auth
 snyk test --all-projects
 ```
 
-### Pipeline Linting Stage
+### Linting Stage
 
 ```bash
 ant checkstyle
 ```
 
-### Pipeline Build Stage
+### Build Stage
 
 ```bash
-ant compile
+ant clean compile
+ant -lib lib/war compile-jsp   # JSP syntax gate: fails on a JSP that won't translate/compile
 ```
 
-### Pipeline Unit Tests and Coverage
+### Unit Tests and Coverage
 
 ```bash
 ant test
 ```
 
-### Pipeline Generate Web Application
+CI additionally enforces a minimum test-coverage floor on security-critical
+classes (`.github/scripts/check-security-coverage.sh`).
+
+### Generate Web Application
 
 ```bash
-ant package
+ant -lib lib/war package
 ```
+
+### Container Images, Image Scanning, and SBOM
+
+The application and database images are built, scanned with Trivy, and published
+with a signed CycloneDX SBOM and build-provenance attestation
+(`.github/workflows/publish-images.yml` and `.github/workflows/sbom.yml`).


### PR DESCRIPTION
## What

An accuracy pass over the docs, correcting places that had drifted from what the platform does today.

| File | Fix |
|------|-----|
| `docs/index.md` | Security + Analytics feature lists were the **pre-refresh copies** (mirrored the old README). Now include MFA, Argon2id, CodeQL, encrypted secrets, CSP/HSTS/session hardening, the signed SBOM, and privacy-first analytics (cookieless, IP anonymization, DNT/GPC). |
| `docs/installation.md` | System requirements said **PostgreSQL 14+ / PostGIS 3.2**, but the stated runtime baseline — and the rest of the same doc (`postgres:17`) and the images — are **PostgreSQL 17 / PostGIS 3**. Aligned to 17. |
| `docs/developer-environment.md` | JDK reference link pointed at **Java 17**; the build targets **Java 21**. |
| `docs/pipeline.md` | The "DevSecOps Pipeline" page listed only a Snyk scan. Expanded to the **actual** pipeline: CodeQL SAST, dependency/secret scanning, the JSP syntax gate, the security-coverage gate, Trivy image scanning, and the signed SBOM + provenance. |

`SECURITY.md` was reviewed and is already accurate — no change.

## Notes
- The PostgreSQL bump aligns with the stated "baseline moved to PostgreSQL 17" and the `postgres:17` references already in `installation.md`; broaden it back if older versions are still officially supported.
- `docs/index.md` and the README maintain **separate** feature lists, which is why this one drifted. Left as-is here, but worth single-sourcing later to prevent a repeat.
