### PR TITLE
Fix undeployable context.xml (illegal '--' in an XML comment)

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -5,7 +5,7 @@
     userToken/visitorToken/cartToken/viewMode), which have no SameSite attribute otherwise.
     Lax (not Strict) is deliberate: it still sends the session cookie on top-level navigations
     from external links, so normal "click a link into the site" behavior is preserved, while
-    blocking the cookie on cross-site subrequests -- a CSRF-adjacent hardening (defense in depth
+    blocking the cookie on cross-site subrequests, a CSRF-adjacent hardening (defense in depth
     alongside the existing synchronizer-token check).
   -->
   <CookieProcessor className="org.apache.tomcat.util.http.Rfc6265CookieProcessor" sameSiteCookies="lax" />


### PR DESCRIPTION
## Problem
`src/main/webapp/META-INF/context.xml` has `--` (an em-dash typo) **inside an XML comment**, which is illegal XML. Tomcat 9.0-jdk21's strict parser rejects the whole file at deploy time, so the WAR **fails to deploy** in the container image:

```
SEVERE [main] ContextConfig.processContextConfig Parse error in context.xml for []
  org.xml.sax.SAXParseException; ... /META-INF/context.xml; lineNumber: 8; columnNumber: 53;
  The string "--" is not permitted within comments.
...
Error deploying web application archive [/usr/local/tomcat/webapps/ROOT.war]
```

`docker/app/Dockerfile` pins `tomcat:9.0-jdk21`, and that's also the Azure container target — so **the current `main` WAR does not deploy via the provided container**. Introduced by 983fc22 (the SameSite session-hardening change).

## Why CI didn't catch it
The `build` job compiles and **packages** the WAR but never **deploys** it to a strict-parsing Tomcat. The illegal comment only trips the parser at container startup, so a build-green WAR can still be undeployable. This surfaced only during a local `docker compose` deploy rehearsal.

## Fix
Reword the comment so the em-dash `--` becomes `,`. One line, comment-only — **no behavior change**; the `Rfc6265CookieProcessor` / `SameSite=Lax` configuration is untouched.

## Verification
- `context.xml` now parses cleanly under strict XML comment rules.
- With this change the WAR **deploys successfully** on `tomcat:9.0-jdk21`: Tomcat starts, Flyway applies all install migrations against PostgreSQL 17, and the app comes up healthy (verified in the same local rehearsal that found the bug).

## Follow-up (not in this PR)
Consider a CI step that actually **deploys** the packaged WAR to a `tomcat:9.0-jdk21` container (even just a startup smoke test) so an undeployable WAR fails the build rather than the first real deploy.
