### PR TITLE
Enforce the dependency-drift check (--strict)

### DIFF
--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -1,10 +1,10 @@
-# Reports drift between pom.xml and the vendored lib/build jars that actually ship
+# Enforces parity between pom.xml and the vendored lib/build jars that actually ship
 # in the WAR. See tools/check-dependency-drift.py for the full rationale.
 #
-# REPORT-ONLY: this workflow never fails the build. It prints the drift to the log
-# and to the PR's job summary so the divergence is visible on every change. Once the
-# one-time reconciliation has zeroed the drift, make it enforcing by adding --strict
-# to the run step below (the script then exits non-zero on any un-allowlisted drift).
+# ENFORCING (--strict): fails the build on any pom-vs-vendored version drift that is
+# not in the script's ALLOWLIST. The one-time reconciliation zeroed the drift down to
+# two documented, intentional holds (flexmark fat-jar, jackson-coreutils), which are
+# allowlisted with revisit triggers; everything else must match. New drift fails here.
 name: Dependency drift
 
 on:
@@ -22,5 +22,5 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # ubuntu-latest ships python3; no extra setup or network needed.
-      - name: Report pom vs vendored-jar drift
-        run: python3 tools/check-dependency-drift.py .
+      - name: Fail on un-allowlisted pom vs vendored-jar drift
+        run: python3 tools/check-dependency-drift.py . --strict

--- a/tools/check-dependency-drift.py
+++ b/tools/check-dependency-drift.py
@@ -40,7 +40,17 @@ import xml.etree.ElementTree as ET
 # --strict. Empty today because every current pin happens to match. Add entries
 # as: "artifactId": "reason (revisit trigger)".
 ALLOWLIST: dict[str, str] = {
-    # "commons-jexl3": "held at 3.2.1; 3.3+ throws on undefined properties (WorkflowTaskTest)",
+    "flexmark-all": (
+        "vendored 0.64.0-lib is the FAT/uber jar that bundles the flexmark.ext.* modules; "
+        "the pom's plain flexmark-all 0.64.8 is a thin aggregate, so a straight version swap "
+        "drops those modules and breaks the compile. "
+        "Revisit: a matching 0.64.x '-lib' fat jar, or a proper per-module re-vendor."
+    ),
+    "jackson-coreutils": (
+        "abandoned com.github.fge lib held at 1.0; 1.8 breaks JsonLoader.fromString "
+        "(FormDataJSONCommandTest + ecommerce JsonTest). "
+        "Revisit: replace the fge dependency, or correct the pom back to 1.0."
+    ),
 }
 
 POM_NS = "{http://maven.apache.org/POM/4.0.0}"


### PR DESCRIPTION
Closes the dependency-drift reconciliation epic. The one-time pom-vs-vendored-jar reconciliation ([#169](https://github.com/SimisRnD/simis-cms/pull/169) tool + [#171](https://github.com/SimisRnD/simis-cms/pull/171) patch/minor + [#172](https://github.com/SimisRnD/simis-cms/pull/172) majors + [#179](https://github.com/SimisRnD/simis-cms/pull/179) Jackson 3) drove the drift from **31 down to 2** documented, intentional holds.

## What this does
- **Allowlists the 2 remaining holds** in `tools/check-dependency-drift.py` (each with a revisit trigger):
  - `flexmark-all` — the vendored `0.64.0-lib` is the **fat/uber jar** bundling the `flexmark.ext.*` modules; the pom's plain `flexmark-all 0.64.8` is a thin aggregate, so a straight version swap drops those modules and breaks the compile.
  - `jackson-coreutils` — abandoned `com.github.fge` lib held at `1.0`; `1.8` breaks `JsonLoader.fromString` (`FormDataJSONCommandTest`, ecommerce `JsonTest`).
- **Flips the `dependency-drift` workflow to `--strict`**, so it now **fails the build** on any pom-vs-WAR version drift that isn't allowlisted — instead of only reporting it.

## Why
The WAR ships committed `lib/build/**` jars; the pom is used by the IDE/Dependabot/SBOM. A pom bump could previously merge while the WAR kept the old jar, silently overstating the security posture. This gate makes that impossible going forward: the shipped jars and the pom must agree (bar the 2 documented exceptions).

## Verification
- `--strict` **exits 0** today — both holds are marked `[allowlisted]`, "0 not allowlisted".
- Injecting a fake non-allowlisted drift (a pom version bump with no matching jar) makes `--strict` **exit 1** — the gate genuinely catches new drift.

## Scope note
This is the *version-parity* gate. It does not catch a missing **optional/transitive** runtime dependency (e.g. the Flyway 12 → Jackson 3 case in #179), which is invisible to a declared-jar comparison — that class is covered by the new deploy smoke test (#179). The two gates are complementary.