### PR TITLE
Modernize deprecated API calls (InetAddressUtils, RandomStringUtils)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/IpAddressCommand.java
+++ b/src/main/java/com/simisinc/platform/application/IpAddressCommand.java
@@ -58,12 +58,12 @@ public class IpAddressCommand {
       return ipAddress;
     }
     try {
-      if (InetAddressUtils.isIPv4Address(ipAddress)) {
+      if (InetAddressUtils.isIPv4(ipAddress)) {
         byte[] bytes = InetAddress.getByName(ipAddress).getAddress();
         bytes[3] = 0;
         return InetAddress.getByAddress(bytes).getHostAddress();
       }
-      if (InetAddressUtils.isIPv6Address(ipAddress)) {
+      if (InetAddressUtils.isIPv6(ipAddress)) {
         byte[] bytes = InetAddress.getByName(ipAddress).getAddress();
         for (int i = 6; i < bytes.length; i++) {
           bytes[i] = 0;

--- a/src/main/java/com/simisinc/platform/application/cms/SaveBlockedIPCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveBlockedIPCommand.java
@@ -41,8 +41,8 @@ public class SaveBlockedIPCommand {
     StringBuilder errorMessages = new StringBuilder();
     if (StringUtils.isBlank(blockedIPBean.getIpAddress())) {
       errorMessages.append("An IP address is required");
-    } else if (!InetAddressUtils.isIPv4Address(blockedIPBean.getIpAddress()) &&
-        !InetAddressUtils.isIPv6Address(blockedIPBean.getIpAddress())) {
+    } else if (!InetAddressUtils.isIPv4(blockedIPBean.getIpAddress()) &&
+        !InetAddressUtils.isIPv6(blockedIPBean.getIpAddress())) {
       errorMessages.append("A valid IPv4 or IPv6 address is required");
     }
     if (errorMessages.length() > 0) {

--- a/src/main/java/com/simisinc/platform/application/ecommerce/OrderCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/OrderCommand.java
@@ -92,7 +92,7 @@ public class OrderCommand {
     }
 
     // Generate a random string
-    String rand = StringUtils.leftPad(RandomStringUtils.randomNumeric(4), 4, '0');
+    String rand = StringUtils.leftPad(RandomStringUtils.insecure().nextNumeric(4), 4, '0');
 
     // Use the customer id after insert
     String uniqueId = (prefix + date + "-" + id + "-" + rand);

--- a/src/main/java/com/simisinc/platform/application/ecommerce/SaveCustomerCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/SaveCustomerCommand.java
@@ -43,7 +43,7 @@ public class SaveCustomerCommand {
     // Use the customer id after insert
     String prefix = "C-";
     String id = StringUtils.leftPad(String.valueOf(customer.getId()), 7, '0');
-    String rand = StringUtils.leftPad(RandomStringUtils.randomNumeric(5), 5, '0');
+    String rand = StringUtils.leftPad(RandomStringUtils.insecure().nextNumeric(5), 5, '0');
 
     CheckDigit routine = new ModulusTenCheckDigit(new int[]{1, 2}, true, true);
     String checkDigit = routine.calculate(id + rand);

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -172,8 +172,8 @@ public class WebRequestFilter implements Filter {
 
     // Redirect to SSL
     if (requireSSL && !"https".equalsIgnoreCase(scheme)) {
-      if (!"localhost".equals(request.getServerName()) && !InetAddressUtils.isIPv4Address(request.getServerName())
-          && !InetAddressUtils.isIPv6Address(request.getServerName())) {
+      if (!"localhost".equals(request.getServerName()) && !InetAddressUtils.isIPv4(request.getServerName())
+          && !InetAddressUtils.isIPv6(request.getServerName())) {
         String requestURL = httpServletRequest.getRequestURL().toString();
         requestURL = StringUtils.replace(requestURL, "http://", "https://");
         // The request URL is built from the client-supplied Host header, so it is only echoed back when the

--- a/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
@@ -124,8 +124,8 @@ public class RestRequestFilter implements Filter {
     if (requireSSL && !"https".equalsIgnoreCase(scheme)) {
       // Only redirect if a hostname was used (skip for local dev)
       if (!isLocal
-          && !InetAddressUtils.isIPv4Address(request.getServerName())
-          && !InetAddressUtils.isIPv6Address(request.getServerName())) {
+          && !InetAddressUtils.isIPv4(request.getServerName())
+          && !InetAddressUtils.isIPv6(request.getServerName())) {
         String requestURL = ((HttpServletRequest) request).getRequestURL().toString();
         requestURL = StringUtils.replace(requestURL, "http://", "https://");
         LOG.debug("Redirecting to: " + requestURL);


### PR DESCRIPTION
## What

Clears the safely-replaceable compiler deprecation warnings — **72 → 62** — with two behavior-preserving changes:

| Deprecated | Replacement | Sites |
|-----------|-------------|-------|
| `InetAddressUtils.isIPv4Address` / `isIPv6Address` (httpcore5) | `isIPv4` / `isIPv6` (renamed; same logic, takes `CharSequence`) | 8 — IpAddressCommand, SaveBlockedIPCommand, WebRequestFilter, RestRequestFilter |
| `RandomStringUtils.randomNumeric(...)` (commons-lang3 static) | `RandomStringUtils.insecure().nextNumeric(...)` | 2 — OrderCommand, SaveCustomerCommand |

`insecure()` preserves the previous non-secure behavior of the order/customer number suffixes; switch to `secure()` if you'd prefer unpredictable numbers.

## Deliberately left alone

The other ~60 warnings are the commons-lang3 `StringUtils.replace` / `equals` / `replaceIgnoreCase` / `removeEnd` family. I did **not** touch them:
- That 3.18 deprecation is contested and being partly reverted upstream.
- `StringUtils.replace` is null-safe (returns `null` on `null` input) where `String.replace` throws — a blanket swap across 50+ call sites would risk new NPEs for little gain.

## Verification
- `ant clean compile` green; deprecation warnings 72 → 62 (exactly the 10 targeted).
- `IpAddressCommandTest` passes (the IP-validation path).
- Note: `WebRequestFilterTest` has 4 pre-existing `sslRedirect*` failures under Maven (a mock returns a null header enumeration) — they fail identically on unmodified `main` and are unrelated to this change; CI runs on Ant.
