### PR TITLE
Add opt-in trusted-proxy client-IP resolution (X-Forwarded-For)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,6 +44,7 @@ CMS_FORCE_SSL=true|false
 CMS_NODE_TYPE=<empty>|standalone|web
 CMS_PATH=<empty>|${USER_HOME}/Web/simis-cms|/opt/simis
 CMS_SECRET_KEY=<base64 256-bit key; enables encryption at rest for stored secrets (e.g. MFA seeds)>
+CMS_TRUSTED_PROXIES=<regex of trusted reverse-proxy IPs; resolves the real client IP from X-Forwarded-For>
 DB_SERVER_NAME=
 DB_NAME=
 DB_USER=
@@ -53,6 +54,8 @@ DB_PASSWORD=
 > **`CMS_SECRET_KEY`** encrypts recoverable secrets at rest with AES-256-GCM: per-user MFA/TOTP seeds and the stored integration/payment secrets in Site Settings (payment gateway keys, the SMTP password, the OAuth client secret, and mailing-list/analytics API tokens). Generate one with `openssl rand -base64 32` and supply it out-of-band (not committed). Keep a secure backup — losing the key makes encrypted secrets unrecoverable (affected users re-enroll MFA; integration keys must be re-entered). Rotating: set the new key and re-save the affected records. If unset, secrets are stored as plaintext (backward compatible), so set it for a hardened deployment.
 >
 > Integration secrets encrypt when next saved. Existing plaintext values keep working (they are read back unchanged) and are encrypted the next time they are saved through Site Settings. Values that are read-only in the admin UI (production payment keys, set directly in the database) stay plaintext until re-saved — see the release notes for the optional one-time re-encryption step.
+
+> **`CMS_TRUSTED_PROXIES`** — set this when SimIS CMS runs behind a reverse proxy, load balancer, or CDN. Without it, the client address comes from the direct connection (`getRemoteAddr()`), which behind a proxy is the *proxy's* address — so the IP firewall, rate limiting, and geo filtering all act on that one address and analytics/audit logs record it instead of the visitor. Set it to a Java regular expression matching your trusted proxy addresses (for example `10\.\d+\.\d+\.\d+` for a private-range load balancer); the real client IP is then taken from `X-Forwarded-For` **only** for requests arriving through those proxies (SimIS CMS delegates to Tomcat's `RemoteIpFilter`). Leave it unset when the container terminates client connections directly. Do not set it to match untrusted networks — that would let a client spoof its address and bypass the IP controls.
 
 ## Upgrading
 

--- a/src/main/java/com/simisinc/platform/presentation/controller/TrustedProxyIpFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/TrustedProxyIpFilter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 SimIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Opt-in resolution of the real client IP address when SimIS CMS runs behind a
+ * trusted reverse proxy or load balancer.
+ *
+ * <p>Every IP-based control in the platform (the blocked-IP firewall, rate
+ * limiting, geo filtering) and all IP logging read
+ * {@link ServletRequest#getRemoteAddr()}, which returns the immediate TCP peer.
+ * Behind a proxy that peer is the proxy, not the visitor. When the
+ * {@code CMS_TRUSTED_PROXIES} environment variable is set to a regular
+ * expression matching the trusted proxy addresses, this filter delegates to
+ * Tomcat's {@code RemoteIpFilter}, which rewrites {@code getRemoteAddr()} to the
+ * client address carried in {@code X-Forwarded-For} -- but only for requests
+ * whose immediate peer matches that expression. Requests arriving from any other
+ * address are left untouched, so an untrusted client cannot spoof its address.
+ *
+ * <p>When the variable is unset (the default), the filter is a transparent
+ * pass-through and behavior is unchanged. {@code RemoteIpFilter} is loaded
+ * reflectively because it is supplied by the servlet container rather than
+ * bundled in the web application.
+ *
+ * @author SimIS Inc.
+ */
+public class TrustedProxyIpFilter implements Filter {
+
+  public static final String TRUSTED_PROXIES_ENV = "CMS_TRUSTED_PROXIES";
+  private static final String REMOTE_IP_FILTER = "org.apache.catalina.filters.RemoteIpFilter";
+  private static Log LOG = LogFactory.getLog(TrustedProxyIpFilter.class);
+
+  private Filter delegate = null;
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    String trustedProxies = trustedProxiesSetting();
+    if (StringUtils.isBlank(trustedProxies)) {
+      LOG.info(TRUSTED_PROXIES_ENV + " is not set; the client IP is read from the direct connection");
+      return;
+    }
+    try {
+      delegate = (Filter) Class.forName(REMOTE_IP_FILTER).getDeclaredConstructor().newInstance();
+      delegate.init(new InternalProxiesConfig(filterConfig, trustedProxies.trim()));
+      LOG.info(TRUSTED_PROXIES_ENV + " is set; resolving the client IP from X-Forwarded-For for trusted proxies");
+    } catch (ReflectiveOperationException e) {
+      // A misconfiguration must not take the site down: fall back to the direct address and warn.
+      delegate = null;
+      LOG.error(TRUSTED_PROXIES_ENV + " is set but " + REMOTE_IP_FILTER
+          + " is unavailable (is this Tomcat?); the client IP will be read from the direct connection", e);
+    }
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    if (delegate != null) {
+      delegate.doFilter(request, response, chain);
+    } else {
+      chain.doFilter(request, response);
+    }
+  }
+
+  @Override
+  public void destroy() {
+    if (delegate != null) {
+      delegate.destroy();
+    }
+  }
+
+  /** The configured trusted-proxy expression; overridable for testing. */
+  protected String trustedProxiesSetting() {
+    return System.getenv(TRUSTED_PROXIES_ENV);
+  }
+
+  /**
+   * Presents the configured trusted-proxy expression to {@code RemoteIpFilter} as its
+   * {@code internalProxies} init parameter; every other parameter falls back to the filter's defaults.
+   */
+  private static class InternalProxiesConfig implements FilterConfig {
+
+    private final FilterConfig delegate;
+    private final String internalProxies;
+
+    InternalProxiesConfig(FilterConfig delegate, String internalProxies) {
+      this.delegate = delegate;
+      this.internalProxies = internalProxies;
+    }
+
+    @Override
+    public String getFilterName() {
+      return delegate.getFilterName();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+      return delegate.getServletContext();
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      if ("internalProxies".equals(name)) {
+        return internalProxies;
+      }
+      return delegate.getInitParameter(name);
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+      return Collections.enumeration(Collections.singletonList("internalProxies"));
+    }
+  }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -32,6 +32,12 @@
     <!--<listener-class>com.simisinc.platform.presentation.controller.SessionListener</listener-class>-->
   <!--</listener>-->
   <!-- Filters -->
+  <!-- Opt-in: when CMS_TRUSTED_PROXIES is set, resolve the real client IP from
+       X-Forwarded-For before any IP-based control runs. Must be mapped first. -->
+  <filter>
+    <filter-name>TrustedProxyIpFilter</filter-name>
+    <filter-class>com.simisinc.platform.presentation.controller.TrustedProxyIpFilter</filter-class>
+  </filter>
   <filter>
     <filter-name>WebRequestFilter</filter-name>
     <filter-class>com.simisinc.platform.presentation.controller.WebRequestFilter</filter-class>
@@ -40,6 +46,10 @@
     <filter-name>RestRequestFilter</filter-name>
     <filter-class>com.simisinc.platform.rest.controller.RestRequestFilter</filter-class>
   </filter>
+  <filter-mapping>
+    <filter-name>TrustedProxyIpFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
   <filter-mapping>
     <filter-name>WebRequestFilter</filter-name>
     <url-pattern>/*</url-pattern>

--- a/src/test/java/com/simisinc/platform/presentation/controller/TrustedProxyIpFilterTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/TrustedProxyIpFilterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 SimIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the safe behaviors of {@link TrustedProxyIpFilter}: it is a
+ * transparent pass-through by default, and it never takes the application down
+ * when configured in an environment where RemoteIpFilter is unavailable. The
+ * actual X-Forwarded-For resolution is provided by Tomcat's RemoteIpFilter and
+ * is exercised in a servlet container rather than here.
+ */
+class TrustedProxyIpFilterTest {
+
+  @Test
+  void passesThroughUnchangedWhenNotConfigured() throws Exception {
+    TrustedProxyIpFilter filter = new TrustedProxyIpFilter() {
+      @Override
+      protected String trustedProxiesSetting() {
+        return null; // the environment variable is not set (the default)
+      }
+    };
+    filter.init(mock(FilterConfig.class));
+
+    ServletRequest request = mock(ServletRequest.class);
+    ServletResponse response = mock(ServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+    filter.doFilter(request, response, chain);
+
+    // The original request is passed straight through, untouched
+    verify(chain, times(1)).doFilter(request, response);
+  }
+
+  @Test
+  void failsSafeWhenRemoteIpFilterIsUnavailable() throws Exception {
+    // The variable is set, but RemoteIpFilter is not on this (non-container) classpath
+    TrustedProxyIpFilter filter = new TrustedProxyIpFilter() {
+      @Override
+      protected String trustedProxiesSetting() {
+        return "10\\.\\d+\\.\\d+\\.\\d+";
+      }
+    };
+    assertDoesNotThrow(() -> filter.init(mock(FilterConfig.class))); // must not fail startup
+
+    ServletRequest request = mock(ServletRequest.class);
+    ServletResponse response = mock(ServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+    filter.doFilter(request, response, chain);
+
+    // Falls back to a transparent pass-through rather than failing
+    verify(chain, times(1)).doFilter(request, response);
+  }
+}


### PR DESCRIPTION
## Problem

Every IP-based control — the blocked-IP firewall (`WebRequestFilter.java:140`), rate limiting, geo filtering — and all IP logging (analytics, login/OAuth, audit) read `request.getRemoteAddr()`, i.e. the immediate TCP peer. Behind a reverse proxy / load balancer / CDN (the common production topology, and the one the published container invites), that peer is the **proxy**, so:

- the IP firewall and rate limiter see one shared address → blocklisting/throttling a client is ineffective, or affects everyone;
- analytics geolocation, IP anonymization, and audit logs record the proxy, not the visitor.

The platform had no `X-Forwarded-For` / trusted-proxy handling, and neither the shipped image nor the docs configured any.

## Fix

A new `TrustedProxyIpFilter`, mapped ahead of `WebRequestFilter` in `web.xml`:

- **Off by default** — when `CMS_TRUSTED_PROXIES` is unset, it's a transparent pass-through; **no behavior change**.
- **When set** (a regex matching your trusted proxy addresses), it delegates to Tomcat's `RemoteIpFilter` to resolve the client IP from `X-Forwarded-For` — but **only for requests whose immediate peer matches that expression**, so an untrusted client cannot spoof its address.
- Reuses `RemoteIpFilter` (Tomcat's battle-tested implementation) rather than re-implementing the trust walk. It's loaded reflectively because it's container-provided; if unavailable, the filter **fails safe** (logs and passes through) instead of breaking startup.

Documented `CMS_TRUSTED_PROXIES` in `docs/installation.md`, with the warning that it must match only trusted proxies (matching untrusted networks would let clients spoof — worse than today).

## Verification
- `ant -lib lib/war package` builds green; `web.xml` validates; `ant compile-test` green.
- `TrustedProxyIpFilterTest` passes — the default pass-through and the fail-safe (RemoteIpFilter unavailable) paths. The `X-Forwarded-For` resolution itself is Tomcat's `RemoteIpFilter`, exercised in a servlet container.

## Notes
- Addresses a security finding being tracked privately per `SECURITY.md` (not disclosed in a public issue).
- Reviewer: please sanity-check the filter ordering and the reflective delegation. The security-critical trust logic lives in `RemoteIpFilter`; this PR only gates it (opt-in) and scopes it to configured proxies.
