### PR TITLE
Add the in-app audit review UI (Milestone #3, Phase 3)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
@@ -79,6 +79,33 @@ public class AuditLogRepository {
     return (List<AuditLog>) result.getRecords();
   }
 
+  private static SqlUtils createWhereStatement(AuditLogSpecification specification) {
+    SqlUtils where = null;
+    if (specification != null) {
+      where = new SqlUtils()
+          .addIfExists("event_category = ?", specification.getEventCategory())
+          .addIfExists("event_type = ?", specification.getEventType())
+          .addIfExists("outcome = ?", specification.getOutcome())
+          .addIfExists("actor_user_id = ?", specification.getActorUserId(), -1)
+          .addIfExists("LOWER(actor_username) LIKE ?", specification.getActorUsername() != null
+              ? "%" + specification.getActorUsername().toLowerCase() + "%" : null)
+          .addIfExists("source_ip = ?", specification.getSourceIp())
+          .addIfExists("occurred >= ?", specification.getOccurredAfter())
+          .addIfExists("occurred < ?", specification.getOccurredBefore());
+    }
+    return where;
+  }
+
+  public static List<AuditLog> findAll(AuditLogSpecification specification, DataConstraints constraints) {
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("audit_id desc");
+    SqlUtils where = createWhereStatement(specification);
+    DataResult result = DB.selectAllFrom(TABLE_NAME, where, constraints, AuditLogRepository::buildRecord);
+    return (List<AuditLog>) result.getRecords();
+  }
+
   private static AuditLog buildRecord(ResultSet rs) {
     try {
       AuditLog record = new AuditLog();

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogSpecification.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.audit;
+
+import java.sql.Timestamp;
+
+/**
+ * Filter criteria for querying the security audit log (see AuditLogRepository). Every field is optional;
+ * an unset field (null, or -1 for the actor id) does not constrain the query. Used by the in-app audit
+ * review UI to filter by category, event type, outcome, actor, source IP, and an occurred-date range.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLogSpecification {
+
+  private String eventCategory = null;
+  private String eventType = null;
+  private String outcome = null;
+  private long actorUserId = -1L;
+  private String actorUsername = null;   // partial, case-insensitive match
+  private String sourceIp = null;
+  private Timestamp occurredAfter = null;   // occurred >= this
+  private Timestamp occurredBefore = null;  // occurred < this (use the start of the day after the "to" date)
+
+  public String getEventCategory() {
+    return eventCategory;
+  }
+
+  public void setEventCategory(String eventCategory) {
+    this.eventCategory = eventCategory;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public String getOutcome() {
+    return outcome;
+  }
+
+  public void setOutcome(String outcome) {
+    this.outcome = outcome;
+  }
+
+  public long getActorUserId() {
+    return actorUserId;
+  }
+
+  public void setActorUserId(long actorUserId) {
+    this.actorUserId = actorUserId;
+  }
+
+  public String getActorUsername() {
+    return actorUsername;
+  }
+
+  public void setActorUsername(String actorUsername) {
+    this.actorUsername = actorUsername;
+  }
+
+  public String getSourceIp() {
+    return sourceIp;
+  }
+
+  public void setSourceIp(String sourceIp) {
+    this.sourceIp = sourceIp;
+  }
+
+  public Timestamp getOccurredAfter() {
+    return occurredAfter;
+  }
+
+  public void setOccurredAfter(Timestamp occurredAfter) {
+    this.occurredAfter = occurredAfter;
+  }
+
+  public Timestamp getOccurredBefore() {
+    return occurredBefore;
+  }
+
+  public void setOccurredBefore(Timestamp occurredBefore) {
+    this.occurredBefore = occurredBefore;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/audit/AuditLogListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/audit/AuditLogListWidget.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.audit;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogRepository;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The in-app security audit review UI (NIST 800-53 AU-6). Lists audit_log records with filters for
+ * category, event type, outcome, actor, and an occurred-date range. Read-only and admin-only.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLogListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/audit-log-list.jsp";
+
+  // The event categories the application emits (for the filter drop-down)
+  static final List<String> CATEGORY_LIST = Arrays.asList(
+      "authentication", "user_management", "authorization", "configuration", "content", "data_access");
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // The audit log is sensitive; require admin even if the page were mis-configured (defense in depth)
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "50"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    constraints.setColumnToSortBy("occurred", "desc");
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    // Determine the filter criteria
+    String category = context.getParameter("category");
+    String eventType = context.getParameter("eventType");
+    String outcome = context.getParameter("outcome");
+    String actor = context.getParameter("actor");
+    String fromDate = context.getParameter("fromDate");
+    String toDate = context.getParameter("toDate");
+
+    AuditLogSpecification specification = new AuditLogSpecification();
+    if (StringUtils.isNotBlank(category)) {
+      specification.setEventCategory(category);
+    }
+    if (StringUtils.isNotBlank(eventType)) {
+      specification.setEventType(eventType);
+    }
+    if (StringUtils.isNotBlank(outcome)) {
+      specification.setOutcome(outcome);
+    }
+    if (StringUtils.isNotBlank(actor)) {
+      specification.setActorUsername(actor.trim());
+    }
+    // Parse the yyyy-MM-dd date range: from = start of that day, to = start of the day AFTER (half-open)
+    Timestamp from = parseDate(fromDate, 0);
+    Timestamp to = parseDate(toDate, 1);
+    if (from != null) {
+      specification.setOccurredAfter(from);
+    }
+    if (to != null) {
+      specification.setOccurredBefore(to);
+    }
+
+    // Load the list
+    List<AuditLog> auditLogList = AuditLogRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("auditLogList", auditLogList);
+
+    // Echo the filter values back so the form keeps its state, plus the category options
+    context.getRequest().setAttribute("categoryList", CATEGORY_LIST);
+    context.getRequest().setAttribute("category", category);
+    context.getRequest().setAttribute("eventType", eventType);
+    context.getRequest().setAttribute("outcome", outcome);
+    context.getRequest().setAttribute("actor", actor);
+    context.getRequest().setAttribute("fromDate", fromDate);
+    context.getRequest().setAttribute("toDate", toDate);
+
+    // Carry the filters through pagination (paging_control.jspf appends this to each page link).
+    // URL-encoded here so the free-text values (actor, eventType) cannot break the query string or the href.
+    StringBuilder pagingParams = new StringBuilder();
+    appendParam(pagingParams, "category", category);
+    appendParam(pagingParams, "eventType", eventType);
+    appendParam(pagingParams, "outcome", outcome);
+    appendParam(pagingParams, "actor", actor);
+    appendParam(pagingParams, "fromDate", fromDate);
+    appendParam(pagingParams, "toDate", toDate);
+    context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  /** Appends {@code name=urlEncoded(value)} to the paging query string when the value is present. */
+  private void appendParam(StringBuilder sb, String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if (sb.length() > 0) {
+      sb.append("&");
+    }
+    sb.append(name).append("=").append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+  }
+
+  /** Parses a yyyy-MM-dd string to a start-of-day Timestamp plus {@code plusDays}; null when blank/invalid. */
+  private Timestamp parseDate(String value, int plusDays) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    try {
+      LocalDate date = LocalDate.parse(value.trim()).plusDays(plusDays);
+      return Timestamp.valueOf(date.atStartOfDay());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/admin/audit-log-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/audit-log-list.jsp
@@ -1,0 +1,131 @@
+<%--
+  ~ Copyright 2022 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="auditLogList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="categoryList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<jsp:useBean id="recordPagingUri" class="java.lang.String" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${icon}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<%-- Filters (GET so the criteria live in the URL and paging preserves them) --%>
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <div class="grid-x grid-margin-x">
+    <div class="cell medium-3">
+      <label>Category
+        <select name="category">
+          <option value="">Any category</option>
+          <c:forEach items="${categoryList}" var="cat">
+            <option value="<c:out value='${cat}'/>"<c:if test="${category eq cat}"> selected</c:if>><c:out value="${cat}"/></option>
+          </c:forEach>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-3">
+      <label>Event type
+        <input type="text" name="eventType" placeholder="e.g. user.disable" value="<c:out value='${eventType}'/>">
+      </label>
+    </div>
+    <div class="cell medium-2">
+      <label>Outcome
+        <select name="outcome">
+          <option value="">Any outcome</option>
+          <option value="success"<c:if test="${outcome eq 'success'}"> selected</c:if>>Success</option>
+          <option value="failure"<c:if test="${outcome eq 'failure'}"> selected</c:if>>Failure</option>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-4">
+      <label>Actor (email contains)
+        <input type="text" name="actor" placeholder="username or email" value="<c:out value='${actor}'/>">
+      </label>
+    </div>
+    <div class="cell medium-3">
+      <label>From date
+        <input type="date" name="fromDate" value="<c:out value='${fromDate}'/>">
+      </label>
+    </div>
+    <div class="cell medium-3">
+      <label>To date
+        <input type="date" name="toDate" value="<c:out value='${toDate}'/>">
+      </label>
+    </div>
+    <div class="cell medium-6">
+      <label>&nbsp;</label>
+      <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Filter</button>
+      <a href="${widgetContext.uri}" class="button small secondary radius">Clear</a>
+    </div>
+  </div>
+</form>
+<table class="unstriped hover">
+  <thead>
+    <tr>
+      <th width="150">When</th>
+      <th>Event</th>
+      <th width="70">Outcome</th>
+      <th>Actor</th>
+      <th width="120">Source IP</th>
+      <th>Target</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${auditLogList}" var="record">
+    <tr>
+      <td nowrap>
+        <span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${record.occurred}' />"><c:out value="${date:relative(record.occurred)}" /></span>
+      </td>
+      <td>
+        <c:out value="${record.eventType}" /><br />
+        <small class="subheader"><c:out value="${record.eventCategory}" /></small>
+      </td>
+      <td nowrap>
+        <c:choose>
+          <c:when test="${record.outcome eq 'success'}"><span class="label success radius">success</span></c:when>
+          <c:when test="${record.outcome eq 'failure'}"><span class="label alert radius">failure</span></c:when>
+          <c:otherwise><span class="label secondary radius"><c:out value="${record.outcome}"/></span></c:otherwise>
+        </c:choose>
+      </td>
+      <td>
+        <c:choose>
+          <c:when test="${!empty record.actorUsername}"><c:out value="${record.actorUsername}" /></c:when>
+          <c:otherwise><em class="subheader">(unknown)</em></c:otherwise>
+        </c:choose>
+      </td>
+      <td nowrap><c:out value="${record.sourceIp}" /></td>
+      <td>
+        <c:if test="${!empty record.targetLabel or !empty record.targetType}">
+          <c:out value="${record.targetLabel}" />
+          <c:if test="${!empty record.targetType}"><br /><small class="subheader"><c:out value="${record.targetType}" /></small></c:if>
+        </c:if>
+      </td>
+      <td class="break-word"><small><c:out value="${record.details}" /></small></td>
+    </tr>
+    </c:forEach>
+    <c:if test="${empty auditLogList}">
+      <tr>
+        <td colspan="7">No audit records were found</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -338,6 +338,7 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/api')}"> class="is-active"</c:if>><a href="${ctx}/admin/apis"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>APIs</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/app')}"> class="is-active"</c:if>><a href="${ctx}/admin/apps"><i class="${font:far()} fa-mobile fa-fw"></i> <span>Apps</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/blocked-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/blocked-ip-list"><i class="${font:far()} fa-shield-halved fa-fw"></i> <span>Blocked IPs</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/audit-log')}"> class="is-active"</c:if>><a href="${ctx}/admin/audit-log"><i class="${font:far()} fa-clipboard-list fa-fw"></i> <span>Audit Log</span></a></li>
             </ul>
           </c:if>
           <%-- Settings menu --%>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1234,4 +1234,14 @@
     </section>
   </page>
 
+  <page name="/admin/audit-log" role="admin" title="Security Audit Log">
+    <section>
+      <column class="small-12 cell">
+        <widget name="auditLogList">
+          <title>Security Audit Log</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
 </pages>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -247,6 +247,7 @@
   <widget name="salesTaxNexusList" class="com.simisinc.platform.presentation.widgets.admin.ecommerce.SalesTaxNexusListWidget" />
   <widget name="salesTaxNexusAddressForm" class="com.simisinc.platform.presentation.widgets.admin.ecommerce.SalesTaxNexusAddressFormWidget" />
   <widget name="xapiStatementList" class="com.simisinc.platform.presentation.widgets.admin.xapi.XapiStatementListWidget" />
+  <widget name="auditLogList" class="com.simisinc.platform.presentation.widgets.admin.audit.AuditLogListWidget" />
   <!-- Not implemented -->
   <widget name="profilePhoto" class="com.simisinc.platform.presentation.widgets.GenericWidget" />
   <widget name="profileDetails" class="com.simisinc.platform.presentation.widgets.GenericWidget" />

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/audit/AuditLogListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/audit/AuditLogListWidgetTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogRepository;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+
+/**
+ * Tests the audit review widget: filters map onto the query specification, and the log is admin-only.
+ *
+ * @author SimIS Inc.
+ */
+class AuditLogListWidgetTest extends WidgetBase {
+
+  @Test
+  void filterParametersMapOntoTheSpecification() {
+    setRoles(widgetContext, "admin");
+    addQueryParameter(widgetContext, "category", "user_management");
+    addQueryParameter(widgetContext, "eventType", "user.disable");
+    addQueryParameter(widgetContext, "outcome", "failure");
+    addQueryParameter(widgetContext, "actor", "Admin@Example.com");
+    addQueryParameter(widgetContext, "fromDate", "2026-07-01");
+    addQueryParameter(widgetContext, "toDate", "2026-07-20");
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class)) {
+      repository.when(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+
+      new AuditLogListWidget().execute(widgetContext);
+
+      ArgumentCaptor<AuditLogSpecification> captor = ArgumentCaptor.forClass(AuditLogSpecification.class);
+      repository.verify(() -> AuditLogRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      AuditLogSpecification spec = captor.getValue();
+
+      assertEquals("user_management", spec.getEventCategory());
+      assertEquals("user.disable", spec.getEventType());
+      assertEquals("failure", spec.getOutcome());
+      assertEquals("Admin@Example.com", spec.getActorUsername());
+      assertEquals(Timestamp.valueOf(LocalDate.parse("2026-07-01").atStartOfDay()), spec.getOccurredAfter());
+      // The "to" bound is half-open: the start of the day AFTER the picked date, so that whole day is included
+      assertEquals(Timestamp.valueOf(LocalDate.parse("2026-07-21").atStartOfDay()), spec.getOccurredBefore());
+
+      // Pagination must carry the filters forward (URL-encoded) so page 2+ stays filtered
+      String pagingParams = (String) widgetContext.getRequest().getAttribute("recordPagingParams");
+      assertTrue(pagingParams.contains("category=user_management"));
+      assertTrue(pagingParams.contains("eventType=user.disable"));
+      assertTrue(pagingParams.contains("outcome=failure"));
+      assertTrue(pagingParams.contains("actor=Admin%40Example.com")); // '@' is URL-encoded
+      assertTrue(pagingParams.contains("fromDate=2026-07-01"));
+      assertTrue(pagingParams.contains("toDate=2026-07-20"));
+    }
+  }
+
+  @Test
+  void aNonAdminIsNotShownTheAuditLog() {
+    setRoles(widgetContext); // logged in, but no admin role
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class)) {
+      new AuditLogListWidget().execute(widgetContext);
+
+      // The widget must return before querying or exposing any records
+      repository.verify(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)),
+          never());
+      assertNull(widgetContext.getRequest().getAttribute("auditLogList"));
+    }
+  }
+}


### PR DESCRIPTION
Closes #162. **Phase 3 of the Audit Logging & Security Telemetry milestone (#3)** — the in-app review UI, the code half of Phase 3. (The Sentinel-integration half — parser + analytics rules — is authored separately in the private governance runbooks.) Builds on Phase 1 (#167) + Phase 2 (#174), both merged. Maps to **NIST 800-53 AU-6** (audit review, analysis & reporting).

## What this adds
An **admin-only**, filterable, paginated browser of the `audit_log` at **`/admin/audit-log`**, reachable from the admin **Access** nav menu. It mirrors the platform's existing admin list-widget pattern (the xAPI statement list was the closest analog).

- **`AuditLogSpecification` + `AuditLogRepository.findAll(spec, constraints)`** — filter by category, event type, outcome, actor (email contains), source IP, and an occurred-date range. Every filter is a parameterized `SqlUtils` bind (`col = ?` / `LOWER(actor_username) LIKE ?` / `occurred >= ?`), so no user input is concatenated into SQL.
- **`AuditLogListWidget`** — maps the filter params onto the specification, uses a **half-open date range** (the "to" bound is the start of the next day, so the whole day is included), `occurred desc` paging, and a **`hasRole("admin")` gate** (defense in depth on top of the page's `role="admin"`). Carries the filters through pagination via a **URL-encoded `recordPagingParams`** so page 2+ stays filtered.
- **`audit-log-list.jsp`** — filter form + results table + pager. **Every record field is `<c:out>`-escaped**, because the audit log deliberately stores *attacker-controlled* data (a failed-login `actorUsername`, target labels, details) — this prevents stored XSS in the review table.
- **Wiring** — `auditLogList` registered in `widget-library.xml`; `/admin/audit-log` page (`role="admin"`) in `admin-layout.xml`; nav link in the admin Access menu.
- **`AuditLogListWidgetTest`** — filters map onto the spec (including the half-open date bound and the pagination-preservation), and a non-admin is shown nothing.

**No database migration** — reads the existing `audit_log` table.

## Adversarial review
Reviewed across security (XSS / access control / SQLi), correctness, and platform consistency. **Security came back clean** (escaping + admin-gating hold). The review caught one real defect, **now fixed in this PR**: pagination previously dropped the filters on page 2+ (a filtered view silently becoming unfiltered) — resolved by carrying the URL-encoded filters through `recordPagingParams`, matching the platform convention.

## Testing
- `ant compile` ✓ · JSP precompile gate ✓ · `ant -lib lib/tests ci-test` ✓ (incl. the new widget test)

## Follow-up (not in this PR)
Live UI verification pairs naturally with a docker rehearsal once #179 (the Flyway 12 / Jackson 3 fresh-install fix) is merged — until then the app won't boot in a container, though `ci-test` + this PR's tests cover the logic.