### PR TITLE
Audit REST/API authentication events (Milestone #3, fast-follow #165)

### DIFF
--- a/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
@@ -53,6 +53,7 @@ import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.SaveSessionCommand;
 import com.simisinc.platform.application.UserCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.cms.HostnameCommand;
 import com.simisinc.platform.application.json.JsonCommand;
 import com.simisinc.platform.application.login.AuthenticateLoginCommand;
@@ -281,6 +282,10 @@ public class RestRequestFilter implements Filter {
         userLogin.setSessionId(httpServletRequest.getSession().getId());
         userLogin.setUserAgent(httpServletRequest.getHeader("USER-AGENT"));
         UserLoginRepository.save(userLogin);
+
+        // Audit the token-authenticated session establishment (first API request of the day)
+        SaveAuditEventCommand.recordAuthentication("authentication.login.success", "success",
+            user.getId(), user.getEmail(), ipAddress, httpServletRequest.getSession().getId(), "api-token");
       } else {
 
         // @todo consider reasons when there is a new session
@@ -342,6 +347,11 @@ public class RestRequestFilter implements Filter {
     userLogin.setUserAgent(httpServletRequest.getHeader("USER-AGENT"));
     UserLoginRepository.save(userLogin);
 
+    // Audit the API credential login (email + password exchanged for a bearer token)
+    SaveAuditEventCommand.recordAuthentication("authentication.login.success", "success",
+        user.getId(), user.getEmail(), httpServletRequest.getRemoteAddr(),
+        httpServletRequest.getSession().getId(), "api");
+
     // Create a 30-day token
     String loginToken = "API-" + UUID.randomUUID().toString() + user.getId();
     long tokenExpirationInSeconds = 30 * 24 * 60 * 60;
@@ -402,6 +412,9 @@ public class RestRequestFilter implements Filter {
         return AuthenticateLoginCommand.getAuthenticatedUser(email, password, request.getRemoteAddr());
       } catch (DataException | LoginException e) {
         LOG.debug("Login error: " + e.getMessage());
+        // Audit the failed API credential login (records the attempted email, not the password)
+        SaveAuditEventCommand.recordAuthentication("authentication.login.failure", "failure",
+            -1L, email, request.getRemoteAddr(), null, "api");
         return null;
       }
     } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Closes #165. Fast-follow to the Audit Logging & Security Telemetry milestone (#3). Phase 1 (#167) audited the **human** login channels (interactive password/MFA, OAuth/SSO, remember-me cookie, logout) but explicitly deferred the **REST/API** auth path (Phase 0 design §11). This closes that gap.

## What this adds
Three fail-safe authentication audit events wired into `RestRequestFilter`, reusing the Phase 1 sink (`SaveAuditEventCommand.recordAuthentication`, which never throws — so it can't break an API request):

| Event | When | details |
|---|---|---|
| `authentication.login.success` | Basic credentials exchanged for a bearer token (`doReturnNewToken`) | `api` |
| `authentication.login.failure` | Basic credentials rejected (`checkBasicAuthorization`) | `api` |
| `authentication.login.success` | token-authenticated daily session establishment | `api-token` |

Because they use the same `authentication.login.*` event names as Phase 1, REST logins flow into the **same stream the Sentinel analytics rules already watch** (e.g. the repeated-failed-login / brute-force rule now covers API credential stuffing too).

## Security notes
- The failure event records the **attempted email only — never the password** (which is in scope at that point).
- Fail-safe: the audit calls don't alter the request's control flow or response.
- Source IP is `getRemoteAddr()` (the proxy peer behind a load balancer) — the known, shared #166 limitation, not specific to this change.

## Scope (v1)
Covers the credential-login paths. Routine **invalid/expired-token** and **bad-API-key** failures are intentionally left out of v1 to avoid alert noise (a tunable follow-up).

## Testing
- `ant compile` ✓ · `ant -lib lib/tests ci-test` ✓
- Adversarially reviewed for placement correctness and secret leakage — **clean** (0 findings). (`RestRequestFilter` has no existing unit-test harness in the repo; the reused sink is covered by `SaveAuditEventCommandTest`.)

No schema change.