### PR TITLE
Add a /healthz readiness endpoint (Milestone #4 — Azure deployment)

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -9,5 +9,5 @@ FROM tomcat:9.0-jdk21
 COPY ./target/simis-cms.war /usr/local/tomcat/webapps/ROOT.war
 ENV CATALINA_OPTS="-XX:InitialRAMPercentage=10 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80 -XX:+ExitOnOutOfMemoryError"
 EXPOSE 8080
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 CMD curl -I -f --max-time 5 --header "X-Monitor: healthcheck" http://localhost:8080 || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 CMD curl -f --max-time 5 http://localhost:8080/healthz || exit 1
 CMD ["catalina.sh", "run"]

--- a/src/main/java/com/simisinc/platform/application/HealthCommand.java
+++ b/src/main/java/com/simisinc/platform/application/HealthCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import java.io.File;
+import java.sql.Connection;
+
+import javax.servlet.ServletContext;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.presentation.controller.ContextConstants;
+
+/**
+ * A lightweight readiness check for load balancers and the platform health probe (Azure App Service
+ * "Health check", container HEALTHCHECK, Kubernetes readiness). It reports UP only when the app finished
+ * startup, the database is reachable, and the file store is writable -- the three things that must hold for
+ * the app to actually serve requests. Deliberately returns no detail (avoids version/topology disclosure).
+ *
+ * <p><b>Readiness, not liveness.</b> Because the DB is a shared dependency, this must gate an instance OUT
+ * of rotation, never restart it -- do NOT wire it as a Kubernetes liveness probe (a DB outage would fail
+ * every replica at once and crash-loop the fleet). The individual checks are best-effort; a hung dependency
+ * (e.g. a stalled file mount or an exhausted pool) is bounded by the probe caller's own timeout.
+ *
+ * @author SimIS Inc.
+ */
+public class HealthCommand {
+
+  private HealthCommand() {
+    // Static utility
+  }
+
+  /** True only when every readiness check passes. Never throws. */
+  public static boolean isReady(ServletContext context) {
+    return startedUp(context) && databaseReachable() && fileStoreWritable();
+  }
+
+  /** The ContextListener finished initialization successfully (DB pool up, migrations applied). */
+  static boolean startedUp(ServletContext context) {
+    return context != null && "true".equals(context.getAttribute(ContextConstants.STARTUP_SUCCESSFUL));
+  }
+
+  /** A pooled connection is obtainable and valid (the DB has not gone away since startup). */
+  static boolean databaseReachable() {
+    try (Connection connection = DB.getConnection()) {
+      return connection != null && connection.isValid(2);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /** The file store (CMS_PATH / Azure Files mount) exists and is writable. */
+  static boolean fileStoreWritable() {
+    try {
+      String root = FileSystemCommand.getFileServerRootPath();
+      if (StringUtils.isBlank(root)) {
+        return false;
+      }
+      File dir = new File(root);
+      return dir.isDirectory() && dir.canWrite();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -23,6 +23,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Enumeration;
 import java.util.Map;
 
@@ -45,6 +46,7 @@ import org.apache.hc.core5.net.InetAddressUtils;
 
 import com.simisinc.platform.application.DoNotTrackCommand;
 import com.simisinc.platform.application.CreateSessionCommand;
+import com.simisinc.platform.application.HealthCommand;
 import com.simisinc.platform.application.DailyVisitorHashCommand;
 import com.simisinc.platform.application.LoadVisitorCommand;
 import com.simisinc.platform.application.SaveSessionCommand;
@@ -128,6 +130,14 @@ public class WebRequestFilter implements Filter {
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug(httpServletRequest.getMethod() + " uri " + resource);
+    }
+
+    // Answer the platform readiness probe early -- before host, blocked-IP, SSL, and session handling --
+    // so an internal health check (Azure App Service Health check / container HEALTHCHECK / k8s probe) is
+    // never rejected by those gates. Returns no detail (avoids version/topology disclosure).
+    if (resource.equals("/healthz")) {
+      doHealthCheck(request, servletResponse);
+      return;
     }
 
     // Check allowed host names
@@ -557,6 +567,18 @@ public class WebRequestFilter implements Filter {
       }
     }
     return requestURI;
+  }
+
+  private void doHealthCheck(ServletRequest request, ServletResponse servletResponse) throws IOException {
+    boolean ready = HealthCommand.isReady(request.getServletContext());
+    HttpServletResponse response = (HttpServletResponse) servletResponse;
+    response.setStatus(ready ? 200 : 503);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.setHeader("Cache-Control", "no-store");
+    PrintWriter out = response.getWriter();
+    out.print(ready ? "{\"status\":\"UP\"}" : "{\"status\":\"DOWN\"}");
+    out.flush();
   }
 
   private void do301(ServletResponse servletResponse, String redirectLocation) throws IOException {

--- a/src/test/java/com/simisinc/platform/application/HealthCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/HealthCommandTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.servlet.ServletContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.presentation.controller.ContextConstants;
+
+/**
+ * Tests the readiness checks behind the /healthz probe.
+ *
+ * @author SimIS Inc.
+ */
+class HealthCommandTest {
+
+  private ServletContext contextWithStartup(String value) {
+    ServletContext context = mock(ServletContext.class);
+    when(context.getAttribute(ContextConstants.STARTUP_SUCCESSFUL)).thenReturn(value);
+    return context;
+  }
+
+  @Test
+  void startedUpReflectsTheStartupAttribute() {
+    assertTrue(HealthCommand.startedUp(contextWithStartup("true")));
+    assertFalse(HealthCommand.startedUp(contextWithStartup(null)));
+    assertFalse(HealthCommand.startedUp(contextWithStartup("false")));
+    assertFalse(HealthCommand.startedUp(null));
+  }
+
+  @Test
+  void databaseReachableWhenAPooledConnectionIsValid() throws SQLException {
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(true);
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      db.when(DB::getConnection).thenReturn(connection);
+      assertTrue(HealthCommand.databaseReachable());
+    }
+  }
+
+  @Test
+  void databaseNotReachableWhenInvalidOrConnectFails() throws SQLException {
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(false);
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      db.when(DB::getConnection).thenReturn(connection);
+      assertFalse(HealthCommand.databaseReachable());
+    }
+    // A failure to obtain a connection is DOWN, never an exception out of the check
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      db.when(DB::getConnection).thenThrow(new SQLException("db is gone"));
+      assertFalse(HealthCommand.databaseReachable());
+    }
+  }
+
+  @Test
+  void fileStoreWritableChecksTheRootDirectory() {
+    try (MockedStatic<FileSystemCommand> fs = mockStatic(FileSystemCommand.class)) {
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn(System.getProperty("java.io.tmpdir"));
+      assertTrue(HealthCommand.fileStoreWritable());
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn("/no/such/simis-health-path-xyz");
+      assertFalse(HealthCommand.fileStoreWritable());
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn("");
+      assertFalse(HealthCommand.fileStoreWritable());
+    }
+  }
+
+  @Test
+  void isReadyOnlyWhenEveryCheckPasses() throws SQLException {
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(true);
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<FileSystemCommand> fs = mockStatic(FileSystemCommand.class)) {
+      db.when(DB::getConnection).thenReturn(connection);
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn(System.getProperty("java.io.tmpdir"));
+
+      assertTrue(HealthCommand.isReady(contextWithStartup("true")));
+      // A single failing check (here: startup not complete) makes the whole probe report DOWN
+      assertFalse(HealthCommand.isReady(contextWithStartup(null)));
+    }
+  }
+}


### PR DESCRIPTION
First of the buildable-now pieces for **Milestone #4 (Azure Deployment & Hardening)**, and the top item the field benchmark surfaced — every mature/gov comparable (dotCMS, Mattermost, Strapi, Directus, …) ships a health endpoint; we had none.

## What this adds
An **unauthenticated `/healthz` readiness probe** for the platform health check (Azure App Service "Health check", the container `HEALTHCHECK`, load balancers, k8s readiness).

- `WebRequestFilter` answers it **early — before the hostname, blocked-IP, SSL-redirect, and session gates** — so an internal probe (which hits the container's own address with an arbitrary Host, and shouldn't be blockable) is never rejected.
- Returns `{"status":"UP"}` (200) or `{"status":"DOWN"}` (503) from `HealthCommand.isReady`, which checks: **startup completed** + **DB reachable** (`Connection.isValid`) + **`CMS_PATH` writable**.
- **No detail disclosed** — only UP/DOWN, `Cache-Control: no-store` — so it can't leak version/topology (the field explicitly warns about status endpoints over-sharing).
- The container `HEALTHCHECK` is **repointed from `GET /`** (which rendered the entire homepage) **to `GET /healthz`** — a real readiness check, and lighter.

## Security posture
Adversarially reviewed for the unauthenticated-endpoint placement — **clean**:
- Strict `resource.equals("/healthz")` (not a prefix) and it never calls `chain.doFilter`, so there's no way to smuggle a non-health action past the security gates as `/healthz`.
- Fail-closed: `isReady` never throws; a partial/failed startup reports DOWN, not a false UP.
- Cheaper than the previous `GET /` healthcheck, so no new DoS surface.

## ⚠️ Readiness only, not liveness
Because the DB is a shared dependency, this gates an instance **out of rotation** but must **never restart it** — do not wire it as a Kubernetes *liveness* probe (a DB blip would fail every replica at once and crash-loop the fleet). Documented in the class javadoc.

## Testing
- `ant compile` ✓ · `ant -lib lib/tests ci-test` ✓ · `HealthCommandTest` covers all three checks + the composition and fail cases.
- Wire-up: on Azure, set App Service **Health check path = `/healthz`**.

No schema change.