### PR TITLE
Bake in the Application Insights Java agent for APM (Milestone #4)

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -6,8 +6,22 @@
 # docker run -p 80:8080 --env-file=.env simis-cms:latest
 
 FROM tomcat:9.0-jdk21
+
+# Application Insights Java agent (APM / operational telemetry). Baked into the image because App Service
+# for Containers cannot auto-instrument a custom container. The agent auto-instruments Tomcat/JDBC/JVM/HTTP
+# and is INERT until APPLICATIONINSIGHTS_CONNECTION_STRING is supplied at deploy (from Key Vault). With no
+# connection string it logs a single startup notice ("No connection string provided") and self-disables --
+# the JVM and app are unaffected, so local/CI runs (which have no connection string) still boot normally.
+# Pinned + SHA-256 verified for supply-chain integrity; it auto-loads applicationinsights.json from /opt.
+ARG APPLICATIONINSIGHTS_VERSION=3.7.9
+ARG APPLICATIONINSIGHTS_SHA256=4ab7a442bf9defc7475d026c6b49042793ebb010c391a1db91ae07da0c04d848
+RUN curl -fsSL -o /opt/applicationinsights-agent.jar \
+      "https://repo1.maven.org/maven2/com/microsoft/azure/applicationinsights-agent/${APPLICATIONINSIGHTS_VERSION}/applicationinsights-agent-${APPLICATIONINSIGHTS_VERSION}.jar" \
+    && echo "${APPLICATIONINSIGHTS_SHA256}  /opt/applicationinsights-agent.jar" | sha256sum -c -
+COPY ./docker/app/applicationinsights.json /opt/applicationinsights.json
+
 COPY ./target/simis-cms.war /usr/local/tomcat/webapps/ROOT.war
-ENV CATALINA_OPTS="-XX:InitialRAMPercentage=10 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80 -XX:+ExitOnOutOfMemoryError"
+ENV CATALINA_OPTS="-javaagent:/opt/applicationinsights-agent.jar -XX:InitialRAMPercentage=10 -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80 -XX:+ExitOnOutOfMemoryError"
 EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 CMD curl -I -f --max-time 5 --header "X-Monitor: healthcheck" http://localhost:8080 || exit 1
 CMD ["catalina.sh", "run"]

--- a/docker/app/applicationinsights.json
+++ b/docker/app/applicationinsights.json
@@ -1,0 +1,11 @@
+{
+  "role": {
+    "name": "simis-cms"
+  },
+  "sampling": {
+    "percentage": 100
+  },
+  "selfDiagnostics": {
+    "level": "warn"
+  }
+}


### PR DESCRIPTION
Buildable-now Milestone #4 (Azure Deployment) piece, and the **highest-value gap the field benchmark surfaced**: we have strong *security* telemetry (audit → Sentinel) but **zero operational/performance telemetry** — no metrics, no request/dependency latency, no APM. Every mature comparable (dotCMS, Mattermost, XWiki, Nextcloud) ships this.

## What this adds
App Service for Containers can't auto-instrument a *custom* container, so the **Application Insights Java 3.7.9 agent** is baked into the image and attached via `-javaagent`. It auto-instruments **Tomcat / JDBC / HTTP / JVM** with **no code change**, and — the nice part — it feeds the **same Log Analytics workspace** as the audit → Sentinel stream, so security and operational signals land in one place.

- **Supply-chain integrity:** the agent is downloaded from Maven Central with a **pinned version + SHA-256 verification** (`sha256sum -c` fails the build on mismatch) — consistent with our signed-SBOM posture.
- **Inert until configured:** the agent activates only when `APPLICATIONINSIGHTS_CONNECTION_STRING` is supplied at deploy (from Key Vault). With no connection string it logs a single "No connection string provided" startup notice and self-disables — **the JVM and app boot normally**, so local/CI runs are unaffected (you'll just see that one benign line).
- `applicationinsights.json` sets the cloud role name (`simis-cms`) + 100% sampling (tunable); the connection string comes from the deploy env, never the image.

## Verification
- The image **builds** (so the pinned download + SHA-256 check pass) and the agent **attaches** to the container's JDK 21 JVM — confirmed via `java -javaagent:… -version`.
- Full in-container boot with telemetry flowing pairs naturally with a Sentinel/Log-Analytics workspace at deploy time; it also rides the existing deploy smoke test once #179 lands.

## Notes
- Touches `docker/app/Dockerfile`, as does #185 (`/healthz`), but in **different sections** (agent/`CATALINA_OPTS` vs the `HEALTHCHECK` line) — they auto-merge.
- On Azure: set `APPLICATIONINSIGHTS_CONNECTION_STRING` (from Key Vault) on the App Service. Maps to **NIST SI-4** (system monitoring).