### PR TITLE
Harden file serving against stored XSS (Download/Stream widgets)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/FileDownloadCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/FileDownloadCommand.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import java.util.Set;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Sets safe response headers when serving a user-uploaded file, so that uploaded content cannot execute
+ * script in the application's own origin (stored XSS). Two things make direct-served uploads dangerous: a
+ * browser MIME-sniffing a mislabeled file into HTML, and rendering an active type (HTML, SVG) inline. This
+ * command closes both:
+ *
+ * <ul>
+ *   <li><b>{@code X-Content-Type-Options: nosniff}</b> on every response — the browser honours the declared
+ *       Content-Type instead of guessing, so an {@code application/octet-stream} can never be re-read as HTML.</li>
+ *   <li><b>Inline only for an allow-list</b> of types that are safe to render (images except SVG, PDF, plain
+ *       text, audio, video). Everything else — HTML, SVG, XML, and anything unrecognised — is sent as an
+ *       {@code attachment} (downloaded, not rendered) and with a neutral content type.</li>
+ *   <li><b>A sanitised, quoted {@code filename}</b> in the Content-Disposition header, so a crafted upload
+ *       filename cannot inject additional headers or break out of the header value.</li>
+ * </ul>
+ *
+ * @author SimIS Inc.
+ */
+public class FileDownloadCommand {
+
+  // Content types that are safe to display inline. SVG is deliberately excluded (it is an image type but
+  // can carry script), as are HTML/XML and anything not listed -- those are served as downloads instead.
+  private static final Set<String> SAFE_INLINE_TYPES = Set.of(
+      "image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp", "image/bmp",
+      "image/tiff", "image/x-icon", "image/vnd.microsoft.icon",
+      "application/pdf", "text/plain");
+
+  private FileDownloadCommand() {
+    // Static utility
+  }
+
+  /**
+   * Applies the safe download headers (nosniff, Content-Disposition, Content-Type) to the response.
+   *
+   * @param response      the servlet response
+   * @param mimeType      the file's stored content type (may be null/blank)
+   * @param filename      the file's stored name (may be null/blank)
+   * @param requestInline true if the caller wants to display the file in the browser rather than download it;
+   *                      honoured only for types on the safe-inline allow-list
+   */
+  public static void applyContentHeaders(HttpServletResponse response, String mimeType, String filename,
+      boolean requestInline) {
+    if (response == null) {
+      return;
+    }
+    // Never let the browser second-guess the declared type.
+    response.setHeader("X-Content-Type-Options", "nosniff");
+
+    boolean inline = requestInline && isSafeToDisplayInline(mimeType);
+    String disposition = inline ? "inline" : "attachment";
+    String safeName = sanitizeFilename(filename);
+    if (safeName != null) {
+      response.setHeader("Content-Disposition", disposition + "; filename=\"" + safeName + "\"");
+    } else {
+      response.setHeader("Content-Disposition", disposition);
+    }
+
+    // Inline: serve the real (allow-listed, safe) type. Download: a neutral type so a mislabeled file
+    // cannot be interpreted as active content even by a client that ignores nosniff + the attachment.
+    response.setContentType(inline ? mimeType.trim() : "application/octet-stream");
+  }
+
+  /**
+   * Headers for a resource that must render inline (e.g. an {@code <img>} source) yet might be an uploaded
+   * SVG or HTML file: {@code nosniff} plus a sandbox Content-Security-Policy. The browser still paints the
+   * image, but any script or outbound request the file carries is blocked -- so navigating directly to an
+   * uploaded SVG/HTML cannot execute in this origin. Unlike {@link #applyContentHeaders} this does not force
+   * a download, because forcing an attachment would break legitimate inline image embedding.
+   *
+   * @param response    the servlet response
+   * @param contentType the file's stored content type (set as-is when present)
+   */
+  public static void applyInlineMediaHeaders(HttpServletResponse response, String contentType) {
+    if (response == null) {
+      return;
+    }
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    response.setHeader("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox");
+    if (StringUtils.isNotBlank(contentType)) {
+      response.setContentType(contentType.trim());
+    }
+  }
+
+  /** True when a content type is on the allow-list of types safe to render inline in a browser. */
+  static boolean isSafeToDisplayInline(String mimeType) {
+    if (StringUtils.isBlank(mimeType)) {
+      return false;
+    }
+    String type = mimeType.trim().toLowerCase();
+    int semicolon = type.indexOf(';');
+    if (semicolon > -1) {
+      type = type.substring(0, semicolon).trim(); // drop any ";charset=..." parameter
+    }
+    if (SAFE_INLINE_TYPES.contains(type)) {
+      return true;
+    }
+    // Streamed media plays inline safely; SVG does not qualify (it is handled above, not here).
+    return type.startsWith("video/") || type.startsWith("audio/");
+  }
+
+  /**
+   * Reduces a stored filename to a safe value for a quoted Content-Disposition filename token: strips any
+   * path, control characters, CR/LF (header injection), and the quote/backslash that would break the token.
+   */
+  public static String sanitizeFilename(String filename) {
+    if (StringUtils.isBlank(filename)) {
+      return null;
+    }
+    String base = filename.replaceAll(".*[/\\\\]", "");   // keep only the base name (drop any path)
+    base = base.replaceAll("[\\x00-\\x1f\\x7f\"\\\\]", ""); // control chars, CR/LF, quote, backslash
+    base = base.trim();
+    return base.isEmpty() ? null : base;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/MultipartFileSender.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MultipartFileSender.java
@@ -245,7 +245,11 @@ public class MultipartFileSender {
     response.reset();
     response.setBufferSize(DEFAULT_BUFFER_SIZE);
     response.setHeader("Content-Type", contentType);
-    response.setHeader("Content-Disposition", disposition + ";filename=\"" + filename + "\"");
+    // Never let the browser sniff a streamed upload into a different (active) type.
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    String safeName = FileDownloadCommand.sanitizeFilename(filename);
+    response.setHeader("Content-Disposition",
+        safeName != null ? disposition + ";filename=\"" + safeName + "\"" : disposition);
     response.setHeader("Accept-Ranges", "bytes");
     response.setHeader("ETag", filename);
     response.setDateHeader("Last-Modified", lastModified);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/datasets/StreamDatasetWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/datasets/StreamDatasetWidget.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.datasets.Dataset;
 import com.simisinc.platform.infrastructure.persistence.datasets.DatasetRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.FileDownloadCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -72,8 +73,11 @@ public class StreamDatasetWidget extends GenericWidget {
       return null;
     }
 
-    // Set header info
-    context.getResponse().setHeader("Content-Disposition", "attachment; filename=\"" + record.getFilename() + "\"");
+    // Set header info (served as a download; nosniff so the stored type cannot be re-sniffed to active content)
+    context.getResponse().setHeader("X-Content-Type-Options", "nosniff");
+    String safeName = FileDownloadCommand.sanitizeFilename(record.getFilename());
+    context.getResponse().setHeader("Content-Disposition",
+        safeName != null ? "attachment; filename=\"" + safeName + "\"" : "attachment");
     context.getResponse().setHeader("Content-Transfer-Encoding", "binary");
     context.getResponse().setContentType(record.getFileType());
     context.getResponse().setContentLength((int) file.length());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/DownloadFileWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/DownloadFileWidget.java
@@ -30,6 +30,7 @@ import com.simisinc.platform.application.cms.LoadFileCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.presentation.controller.FileDownloadCommand;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -131,8 +132,7 @@ public class DownloadFileWidget extends GenericWidget {
         return context;
       }
 
-      // The file is being viewed (in a new window)
-      context.getResponse().setHeader("Content-Disposition", "inline; filename=" + record.getFilename() + ";");
+      // The file is being viewed (in a new window); the safe disposition + content type are set below.
 
       // Check for a last-modified header and return 304 if possible
       long headerValue = context.getRequest().getDateHeader("If-Modified-Since");
@@ -142,15 +142,12 @@ public class DownloadFileWidget extends GenericWidget {
         return context;
       }
 
-    } else {
-      // Force file to be downloaded
-      mimeType = "application/octet-stream";
     }
-    LOG.debug("Using mime type: " + mimeType);
 
-    // Set header info
+    // Set header info: nosniff, a safe inline/attachment disposition, and the content type. An uploaded
+    // HTML or SVG file is served as a download (never rendered inline), so it cannot execute in this origin.
     context.getResponse().setDateHeader("Last-Modified", lastModified);
-    context.getResponse().setContentType(mimeType);
+    FileDownloadCommand.applyContentHeaders(context.getResponse(), record.getMimeType(), record.getFilename(), doView);
     context.getResponse().setContentLength((int) file.length());
 
     // Check for head method

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/StreamImageWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/StreamImageWidget.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.cms.Image;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageRepository;
+import com.simisinc.platform.presentation.controller.FileDownloadCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
@@ -86,9 +87,10 @@ public class StreamImageWidget extends GenericWidget {
       return context;
     }
 
-    // Set header info
+    // Set header info: nosniff + a sandbox CSP so an uploaded SVG/HTML served here (an image source) still
+    // renders but cannot run script in this origin; the image content type is preserved for embedding.
     context.getResponse().setDateHeader("Last-Modified", lastModified);
-    context.getResponse().setContentType(record.getFileType());
+    FileDownloadCommand.applyInlineMediaHeaders(context.getResponse(), record.getFileType());
     context.getResponse().setContentLength((int) file.length());
 
     // Check for head method

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/DownloadItemFileWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/DownloadItemFileWidget.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
 import com.simisinc.platform.domain.model.items.ItemFileItem;
 import com.simisinc.platform.infrastructure.persistence.items.ItemFileItemRepository;
+import com.simisinc.platform.presentation.controller.FileDownloadCommand;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -162,8 +163,7 @@ public class DownloadItemFileWidget extends GenericWidget {
         return context;
       }
 
-      // The file is being viewed (in a new window)
-      context.getResponse().setHeader("Content-Disposition", "inline; filename=" + record.getFilename() + ";");
+      // The file is being viewed (in a new window); the safe disposition + content type are set below.
 
       // Check for a last-modified header and return 304 if possible
       long headerValue = context.getRequest().getDateHeader("If-Modified-Since");
@@ -173,15 +173,12 @@ public class DownloadItemFileWidget extends GenericWidget {
         return context;
       }
 
-    } else {
-      // Force file to be downloaded
-      mimeType = "application/octet-stream";
     }
-    LOG.debug("Using mime type: " + mimeType);
 
-    // Set header info
+    // Set header info: nosniff, a safe inline/attachment disposition, and the content type. An uploaded
+    // HTML or SVG file is served as a download (never rendered inline), so it cannot execute in this origin.
     context.getResponse().setDateHeader("Last-Modified", lastModified);
-    context.getResponse().setContentType(mimeType);
+    FileDownloadCommand.applyContentHeaders(context.getResponse(), record.getMimeType(), record.getFilename(), doView);
     context.getResponse().setContentLength((int) file.length());
 
     // Check for head method

--- a/src/test/java/com/simisinc/platform/presentation/controller/FileDownloadCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/FileDownloadCommandTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the file-download headers keep uploaded content from executing in the application's origin:
+ * nosniff is always set, only allow-listed types are served inline, everything else is a neutral-typed
+ * download, and the Content-Disposition filename is sanitised.
+ *
+ * @author SimIS Inc.
+ */
+class FileDownloadCommandTest {
+
+  @Test
+  void safeTypesAreInlineable() {
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("image/png"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("image/jpeg"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("application/pdf"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("text/plain"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("video/mp4"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("audio/mpeg"));
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("IMAGE/PNG"), "case-insensitive");
+    assertTrue(FileDownloadCommand.isSafeToDisplayInline("text/plain; charset=utf-8"), "charset param ignored");
+  }
+
+  @Test
+  void activeAndUnknownTypesAreNotInlineable() {
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline("text/html"));
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline("image/svg+xml"), "SVG can carry script");
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline("application/xhtml+xml"));
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline("application/xml"));
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline("application/octet-stream"));
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline(""));
+    assertFalse(FileDownloadCommand.isSafeToDisplayInline(null));
+  }
+
+  @Test
+  void sanitizeFilenameStripsPathControlCharsAndQuotes() {
+    assertNull(FileDownloadCommand.sanitizeFilename(null));
+    assertNull(FileDownloadCommand.sanitizeFilename("   "));
+    // Path is dropped, base name kept
+    assertEquals("report.pdf", FileDownloadCommand.sanitizeFilename("/var/uploads/../report.pdf"));
+    assertEquals("report.pdf", FileDownloadCommand.sanitizeFilename("C:\\files\\report.pdf"));
+    // CR/LF (header injection), quote and backslash are removed
+    String cleaned = FileDownloadCommand.sanitizeFilename("evil\r\nSet-Cookie: x=1\\\".html");
+    assertFalse(cleaned.contains("\r"), "CR removed");
+    assertFalse(cleaned.contains("\n"), "LF removed");
+    assertFalse(cleaned.contains("\""), "quote removed");
+    assertFalse(cleaned.contains("\\"), "backslash removed");
+  }
+
+  @Test
+  void inlineForSafeTypeSetsNosniffAndInlineDisposition() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FileDownloadCommand.applyContentHeaders(response, "image/png", "photo.png", true);
+    verify(response).setHeader("X-Content-Type-Options", "nosniff");
+    verify(response).setHeader("Content-Disposition", "inline; filename=\"photo.png\"");
+    verify(response).setContentType("image/png");
+  }
+
+  @Test
+  void dangerousTypeIsForcedToNeutralDownloadEvenWhenViewRequested() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FileDownloadCommand.applyContentHeaders(response, "text/html", "page.html", true);
+    verify(response).setHeader("X-Content-Type-Options", "nosniff");
+    verify(response).setHeader("Content-Disposition", "attachment; filename=\"page.html\"");
+    verify(response).setContentType("application/octet-stream");
+  }
+
+  @Test
+  void svgIsForcedToDownloadInTheDownloadPath() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FileDownloadCommand.applyContentHeaders(response, "image/svg+xml", "logo.svg", true);
+    verify(response).setHeader("Content-Disposition", "attachment; filename=\"logo.svg\"");
+    verify(response).setContentType("application/octet-stream");
+  }
+
+  @Test
+  void notViewingAlwaysDownloads() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FileDownloadCommand.applyContentHeaders(response, "image/png", "photo.png", false);
+    verify(response).setHeader("Content-Disposition", "attachment; filename=\"photo.png\"");
+    verify(response).setContentType("application/octet-stream");
+  }
+
+  @Test
+  void inlineMediaHeadersSetNosniffAndSandboxCsp() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FileDownloadCommand.applyInlineMediaHeaders(response, "image/svg+xml");
+    verify(response).setHeader("X-Content-Type-Options", "nosniff");
+    verify(response).setHeader("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox");
+    verify(response).setContentType("image/svg+xml");
+  }
+
+  @Test
+  void nullResponseIsIgnored() {
+    FileDownloadCommand.applyContentHeaders(null, "image/png", "photo.png", true);
+    FileDownloadCommand.applyInlineMediaHeaders(null, "image/png");
+  }
+}


### PR DESCRIPTION
## Harden file serving against stored XSS

User-uploaded files were served inline with their **stored MIME type and no `nosniff`**, so an uploaded `text/html` or `image/svg+xml` file rendered — and executed script — in the application's **own origin** (stored XSS). The global security headers are only set on the `PageServlet` path, not on these direct file-streaming responses. Maps to NIST **SC-18**; ASVS V12.

### The fix
A shared `FileDownloadCommand` helper that all upload-serving sinks now use:
- **`X-Content-Type-Options: nosniff` on every response** — the browser honours the declared type instead of sniffing an `octet-stream` back into HTML.
- **Inline only for a safe allow-list** (images except SVG, PDF, plain text, audio, video). Everything else — HTML, **SVG**, XML, unknown types — is served as an `attachment` with a neutral `application/octet-stream` type, so it downloads instead of rendering.
- **Sanitised, quoted `Content-Disposition` filename** (strips path, control chars, CR/LF, quote/backslash) — closes a header-injection vector in the old unquoted `filename=` .

For **`StreamImageWidget`** (which backs `<img>` sources, so it can't force a download without breaking image embedding) a second method sets `nosniff` + `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox`, keeping the image content type. Real images still embed; an SVG/HTML reached by **direct navigation** still renders but its script/network is sandboxed away.

### Sinks covered
`DownloadFileWidget`, `DownloadItemFileWidget` (allow-list + attachment), `StreamImageWidget` (nosniff + sandbox CSP), `MultipartFileSender` (video/range path: nosniff + sanitised filename), `StreamDatasetWidget` (already attachment; added nosniff + sanitised filename). A review confirmed these are all the browser-facing sinks that emit an attacker-influenced content type.

### Behaviour
No change for legitimate use: PNG/JPG/PDF/video still view inline; real images still embed. Only active/unknown types change — they now download instead of executing.

### Testing
`FileDownloadCommandTest` (9 cases: allow-list incl. SVG/charset/case, filename sanitisation incl. CRLF/quote/path, inline-vs-attachment header outcomes, sandbox CSP, null-safety). `ant -lib lib/tests ci-test` green.

### Review
An adversarial review found the hardening sound (closed allow-list, effective sandbox CSP, no NPE, no regressions, all sinks covered) and flagged one consistency gap — the filename wasn't sanitised in `MultipartFileSender`/`StreamDatasetWidget` — **fixed here** (both now route through `sanitizeFilename`).
