### PR TITLE
Make the analytics dashboard charts accessible (508/WCAG) + fix a chart-label XSS

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
@@ -25,7 +25,27 @@
 </c:if>
 <%@include file="../page_messages.jspf" %>
 <script src="${ctx}/javascript/chartjs-4.4.1/chart.umd.min.js"></script>
-<canvas id="myChart-${widgetContext.uniqueId}" width="200" height="100"></canvas>
+<%-- The canvas chart is not readable by assistive technology, so it is labeled and paired with an equivalent
+     screen-reader-only data table (WCAG 2.1 SC 1.1.1 / 1.3.1; Section 508). --%>
+<canvas id="myChart-${widgetContext.uniqueId}" width="200" height="100" role="img"
+        aria-label="<c:out value="${not empty title ? title : label}"/> chart. The data follows in a table."></canvas>
+<table class="show-for-sr">
+  <caption><c:out value="${not empty title ? title : label}"/> &ndash; data table</caption>
+  <thead>
+    <tr>
+      <th scope="col">Category</th>
+      <th scope="col"><c:out value="${label}"/></th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${statisticsDataList}" var="data">
+      <tr>
+        <th scope="row"><c:out value="${data.label}"/></th>
+        <td><c:out value="${data.value}"/></td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
 <script>
   var chartContext = document.getElementById("myChart-${widgetContext.uniqueId}").getContext('2d');
   var myChart = new Chart(chartContext, {
@@ -33,7 +53,7 @@
     data: {
       labels: [
         <c:forEach items="${statisticsDataList}" var="data" varStatus="status">
-        "${data.label}"<c:if test="${!status.last}">, </c:if>
+        "${js:escape(data.label)}"<c:if test="${!status.last}">, </c:if>
         </c:forEach>
       ],
       datasets: [{

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
@@ -25,7 +25,27 @@
 </c:if>
 <%@include file="../page_messages.jspf" %>
 <script src="${ctx}/javascript/chartjs-4.4.1/chart.umd.min.js"></script>
-<canvas id="myChart-${widgetContext.uniqueId}" width="200" height="100"></canvas>
+<%-- The canvas chart is not readable by assistive technology, so it is labeled and paired with an equivalent
+     screen-reader-only data table (WCAG 2.1 SC 1.1.1 / 1.3.1; Section 508). --%>
+<canvas id="myChart-${widgetContext.uniqueId}" width="200" height="100" role="img"
+        aria-label="<c:out value="${not empty title ? title : label}"/> chart. The data follows in a table."></canvas>
+<table class="show-for-sr">
+  <caption><c:out value="${not empty title ? title : label}"/> &ndash; data table</caption>
+  <thead>
+    <tr>
+      <th scope="col">Category</th>
+      <th scope="col"><c:out value="${label}"/></th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${statisticsDataList}" var="data">
+      <tr>
+        <th scope="row"><c:out value="${data.label}"/></th>
+        <td><c:out value="${data.value}"/></td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
 <script>
   var chartContext = document.getElementById("myChart-${widgetContext.uniqueId}").getContext('2d');
   var myChart = new Chart(chartContext, {
@@ -33,7 +53,7 @@
     data: {
       labels: [
         <c:forEach items="${statisticsDataList}" var="data" varStatus="status">
-        "${data.label}"<c:if test="${!status.last}">, </c:if>
+        "${js:escape(data.label)}"<c:if test="${!status.last}">, </c:if>
         </c:forEach>
       ],
       datasets: [{

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
@@ -31,7 +31,10 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${icon}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
-<div id="mapid${widgetContext.uniqueId}" style="height: 320px;"></div>
+<%-- role="figure" + a label name the interactive map for assistive technology without hiding Leaflet's own
+     keyboard-operable controls (Section 508 / WCAG 1.1.1). --%>
+<div id="mapid${widgetContext.uniqueId}" style="height: 320px;" role="figure"
+     aria-label="Map of visitor locations, ${fn:length(sessionList)} plotted."></div>
 <c:if test="${empty sessionList}">
   <p>No locations were found</p>
 </c:if>


### PR DESCRIPTION
## Make the analytics dashboard charts accessible

The admin analytics charts render as Chart.js `<canvas>` elements with **no text alternative**, so a screen-reader user gets *nothing* of the data — a Section 508 / WCAG 2.1 **SC 1.1.1** (Non-text Content) failure. This adds an equivalent, screen-reader-only data table to each chart and labels the graphics.

### Changes
- **Bar & line charts** (`site-stats-bar-chart.jsp`, `site-stats-line-chart.jsp`): the `<canvas>` now has `role="img"` + an `aria-label`, and is paired with a `show-for-sr` (Foundation screen-reader-only) `<table>` carrying the same label/value pairs — proper `<caption>`, `<th scope="col">` and `<th scope="row">` (SC 1.1.1 / 1.3.1). Sighted users are unaffected; the canvas still renders.
- **Locations map** (`site-stats-locations-map.jsp`): the map container gets `role="figure"` + an `aria-label` with the plotted-location count. `figure` (not `img`) is used so Leaflet's own keyboard-operable controls stay exposed to AT.

### Also fixes a stored XSS in the charts
The per-point chart label was interpolated into the Chart.js `labels` JavaScript array **unescaped** (`"${data.label}"`), unlike the dataset label right below it which already used `${js:escape(...)}`. Chart labels come from analytics data (e.g. requested page paths), which is attacker-influenceable, so a crafted path could inject script into the admin's browser. Both chart JSPs now `js:escape` the label, matching the existing pattern. The new data-table cells are `<c:out>`-escaped (HTML context).

### Scope (honest)
This closes the **biggest** dashboard accessibility gap — the charts being invisible to assistive technology — and fixes the label XSS. It is **not** a full WCAG AA audit of the admin (color contrast, end-to-end keyboard navigation, and focus management across the wider admin remain follow-ups under the `accessibility` label).

### Verification
`ant compile-jsp` (jasper precompile of all JSPs) completes with **0 errors**. Markup reviewed for correct table semantics and escaping.
