### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot version updates for SimIS CMS.
+#
+# Routine minor/patch bumps are grouped into a single weekly PR; majors come through
+# individually so each can be evaluated on its own. The `ignore` entries below are
+# deliberate holds -- each records WHY it is held and what would justify revisiting it,
+# so the reasoning is not lost the next time a bump is proposed.
+#
+# NOTE: the shipped WAR is built by Ant from the vendored jars in lib/build/, while this
+# pom.xml drives the IDE, Dependabot and the SBOM. A merged Dependabot PR therefore updates
+# the pom only -- the jar must also be re-vendored for the change to reach the artifact.
+# tools/check-dependency-drift.py enforces that the two stay in agreement.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Held deliberately: entangled with the javax-to-jakarta migration
+      - dependency-name: "org.apache.johnzon:*"
+        update-types: ["version-update:semver-major"]
+      # Held at 3.2.x: 3.3+ throws on undefined properties (breaks WorkflowTaskTest)
+      - dependency-name: "org.apache.commons:commons-jexl3"
+        versions: [">=3.3.0"]
+      # Held: 46.x removes com.squareup.square.models entirely (58 compile errors
+      # across the Square payments integration). No CVE on the pinned version.
+      # Revisit on: a CVE, Square EOL'ing the legacy SDK, or needing new features.
+      - dependency-name: "com.squareup:square"
+        update-types: ["version-update:semver-major"]
+      # Held: Tomcat 10+ moves the servlet API from javax.* to jakarta.*, which
+      # this app is not migrated for. Revisit with the Jakarta EE migration.
+      - dependency-name: "org.apache.tomcat:tomcat-servlet-api"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Enable Dependabot version updates

Dependabot **version updates are not configured** on this repository — there is no `.github/dependabot.yml`, so routine dependency bumps are only found by hand. (Dependabot *security alerts* are a separate feature and are unaffected.) This adds the config, closing a known quick-win.

### Provenance
This file was written for this repository during the dependency-refresh work but never landed here — it survived only on an old branch. Before proposing it I re-verified it against current `main`:
- **All four `ignore` holds still apply** — `johnzon`, `commons-jexl3`, `com.squareup:square` and `tomcat-servlet-api` are all still declared in `pom.xml`, so none of the rules is dead.
- The original header comment named `netty` among the covered libraries; **netty was removed from the pom**, so that stale wording is dropped. (`kafka`, `okhttp`, `guava` are still present.)
- YAML validated (schema `version: 2`, both ecosystems, one group, four ignore rules parse).

### What it does
- **Maven**, weekly (Monday). Minor + patch bumps are **grouped into a single PR**; majors open individually so each is judged on its own.
- **GitHub Actions**, weekly.
- Four **deliberate holds, each documenting *why*** and what would justify revisiting — this is the real value, so the reasoning isn't relitigated every time a bump reappears:
  - `johnzon` — entangled with the javax→jakarta migration
  - `commons-jexl3` — 3.3+ throws on undefined properties, which breaks `WorkflowTaskTest`
  - `com.squareup:square` — 46.x removes `com.squareup.square.models` (58 compile errors); no CVE on the pinned version
  - `tomcat-servlet-api` — 10+ moves javax→jakarta, which this app is not migrated for

### Important caveat (called out in the file itself)
The shipped WAR is built by Ant from the vendored jars in `lib/build/`, while `pom.xml` drives the IDE, Dependabot and the SBOM. **A merged Dependabot PR updates the pom only — the jar must also be re-vendored for the change to reach the artifact.** `tools/check-dependency-drift.py` (now enforced via `--strict`) is what keeps the two honest, so a pom-only bump will surface as a drift failure rather than silently shipping nothing.

### Expected volume
Grouping collapses routine bumps, so this should be roughly one grouped PR per week plus the occasional major — not a flood. If it ever gets noisy, lower `open-pull-requests-limit` or widen the grouping.

### Possible follow-ups (not included here, deliberately)
`docker` (both Dockerfiles) and `npm` (`package.json`) ecosystems could be added later — left out to keep this a faithful salvage and because the vendored front-end JS is handled by its own policy.
