### PR TITLE
Publish VEX for the database image

### DIFF
--- a/docker/db/README.md
+++ b/docker/db/README.md
@@ -31,6 +31,52 @@ image that surface is not reachable the way the CVEs describe: it is a
 database-only container, not internet-facing, and PostgreSQL serving SQL does
 not exercise those libraries. Real-world exploitability is low.
 
+### Machine-readable VEX
+
+The reasoning above is also published as an [OpenVEX](https://openvex.dev) document so a
+scanner can act on it without a human reading this file:
+
+    docker/db/vex/simis-cms-db.openvex.json
+
+Use it to suppress the findings we have justified, while still surfacing anything new:
+
+```sh
+trivy image --vex docker/db/vex/simis-cms-db.openvex.json \
+  --scanners vuln --severity HIGH,CRITICAL ghcr.io/simisrnd/simis-cms-db
+```
+
+**What it claims, and what it deliberately does not.** Statements are `not_affected` only
+where there is a concrete, checkable reason, and each carries an `impact_statement` saying
+what was verified:
+
+- **PostGIS/GDAL dependency chain** (gdal, libaom, libheif, libtiff, libhdf5, libsqlite3,
+  libcurl, libssh2, libexpat) — `vulnerable_code_not_in_execute_path`. The database enables
+  **vector PostGIS only** (`CREATE EXTENSION postgis`); `postgis_raster` is never created, so
+  GDAL's raster decoders and remote-dataset drivers are never loaded.
+- **Perl** (perl, perl-base, perl-modules, libperl) — `vulnerable_code_not_in_execute_path`.
+  `postgresql-17-plperl` is **not installed**, so the engine cannot invoke Perl, and the
+  entrypoint is the stock postgres shell entrypoint.
+- **libxml2** — `vulnerable_code_not_in_execute_path`. Reached only via the `xml` type and
+  `xpath()`/`xmltable()`; the shipped schema declares no xml columns.
+- **zlib1g / CVE-2023-45853** — `vulnerable_code_not_present`. The flaw is in zlib's MiniZip
+  contrib component, which Debian does not build into the shared libz shipped here (hence
+  Debian's will-not-fix).
+
+Everything else — a handful of general-purpose OS utilities (ncurses, gzip, util-linux,
+libldap, sysstat, libacl1) — is marked **`under_investigation`**, not `not_affected`. We make
+no exploitability claim we cannot support; uncertainty is never rendered as "safe".
+
+> **Scope.** These statements describe the image **as shipped and configured**. If an operator
+> installs PL/Perl, creates `postgis_raster`, or uses PostgreSQL's `xml` type, the corresponding
+> statements no longer hold and the VEX should be re-evaluated.
+
+Regenerate after any rebuild changes the finding set (this keeps the document from going
+stale, and it only ever emits statements for findings with **no** available fix):
+
+```sh
+python3 tools/generate-db-vex.py > docker/db/vex/simis-cms-db.openvex.json
+```
+
 ### They clear over time on their own
 
 `publish-images.yml` rebuilds and re-scans the image on a monthly schedule, so

--- a/docker/db/vex/simis-cms-db.openvex.json
+++ b/docker/db/vex/simis-cms-db.openvex.json
@@ -1,0 +1,1018 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db",
+  "author": "SimIS Inc. (SimIS CMS maintainers)",
+  "timestamp": "2026-07-21T12:51:42+00:00",
+  "version": 1,
+  "tooling": "tools/generate-db-vex.py",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2018-11205"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libhdf5-103-1@1.10.8+repack1-1?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libhdf5-hl-100@1.10.8+repack1-1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-2953"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libldap-2.5-0@2.5.13+dfsg-5?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-33204"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/sysstat@12.6.1-1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-39616"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45853"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/zlib1g@1:1.2.13.dfsg-1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "This vulnerability is in zlib's MiniZip contrib component (zipOpenNewFileInZip4_64), which Debian does not build into the shared libz shipped in this image - which is why Debian classifies it will-not-fix. The vulnerable code is not present in the delivered library."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-52355"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-6879"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-59375"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-68431"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-69720"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libncursesw6@6.4-4?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libtinfo6@6.4-4?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/ncurses-base@6.4-4?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/ncurses-bin@6.4-4?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-7458"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libsqlite3-0@3.40.1-2+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-12064"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-12912"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-13221"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25210"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32740"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32741"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32882"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33164"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libde265-0@1.0.11-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-36849"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41071"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41992"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/gzip@1.12-1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42496"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42497"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45186"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48962"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-49014"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53615"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/bsdutils@1:2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libblkid1@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libfdisk1@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libmount1@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libsmartcols1@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libuuid1@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/mount@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/util-linux@2.38.1-5+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/util-linux-extra@2.38.1-5+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54369"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libacl1@2.3.1-3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation",
+      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55199"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55200"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56131"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56208"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56209"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56210"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56211"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56407"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56408"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-57432"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6276"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6653"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u6?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "PostgreSQL only enters libxml2 through the `xml` data type and the xpath()/xmltable() family. The shipped schema declares no xml columns and the application issues no XML functions, so the parser is never invoked. (GDAL's XML drivers are likewise unreachable - see the PostGIS/GDAL rationale.)"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-7598"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8086"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8087"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8286"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8376"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8927"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-8932"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-9538"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    }
+  ]
+}

--- a/tools/generate-db-vex.py
+++ b/tools/generate-db-vex.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Generate an OpenVEX document for the simis-cms-db container image.
+
+WHY THIS EXISTS
+---------------
+Every HIGH/CRITICAL Trivy finding on `simis-cms-db` is a Debian bookworm OS package
+with NO fixed version available -- there is nothing to upgrade to (see docker/db/README.md).
+A customer scanning the published image therefore sees a wall of red with no context.
+VEX (Vulnerability Exploitability eXchange) is the machine-readable way to say
+"present, but not exploitable here, and here is why" so their scanner can suppress it
+honestly rather than us asking them to read a README.
+
+HONESTY RULES (the whole point -- a VEX that overclaims is worse than no VEX)
+----------------------------------------------------------------------------
+1. `not_affected` is asserted ONLY where there is a concrete, checkable reason, and every
+   claim carries an impact_statement saying what was verified.
+2. Anything not covered by the policy below falls through to `under_investigation`.
+   Silence/uncertainty is never rendered as "not affected".
+3. Claims are scoped to the image AS SHIPPED AND CONFIGURED. If an operator enables
+   PL/Perl, creates postgis_raster, or uses PostgreSQL's xml type, the corresponding
+   statements no longer hold -- this is stated in the document itself.
+
+Regenerate (keeps the document from rotting as the alert set changes):
+    python3 tools/generate-db-vex.py > docker/db/vex/simis-cms-db.openvex.json
+"""
+
+import datetime
+import json
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+
+REPO = "SimisRnD/simis-cms"
+PRODUCT_PURL = "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd"
+VEX_ID = "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db"
+AUTHOR = "SimIS Inc. (SimIS CMS maintainers)"
+
+NOT_IN_PATH = "vulnerable_code_not_in_execute_path"
+NOT_PRESENT = "vulnerable_code_not_present"
+
+# --- Justification policy -----------------------------------------------------------
+# Each entry: reason string shown as the statement's impact_statement.
+# Verified against upstream/main: the schema issues only `CREATE EXTENSION postgis`
+# (vector); postgis_raster is never created; postgresql-plperl is not installed by
+# docker/db/Dockerfile; the schema declares no xml columns and the app calls no
+# XML/xpath functions.
+
+GDAL_CHAIN = {
+    "libgdal32", "gdal-plugins", "gdal-data", "libaom3", "libheif1", "libde265-0",
+    "libtiff6", "libhdf5-103-1", "libhdf5-hl-100", "libsqlite3-0", "libcurl4",
+    "libcurl3-gnutls", "libssh2-1", "libexpat1",
+}
+GDAL_REASON = (
+    "Present only as a transitive dependency of the PostGIS package's GDAL stack. The "
+    "database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is "
+    "never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers "
+    "and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+)
+
+PERL_PKGS = {"perl", "perl-base", "perl-modules-5.36", "libperl5.36"}
+PERL_REASON = (
+    "Perl is present as a Debian base/tooling dependency but is never executed at runtime: "
+    "the image does not install postgresql-17-plperl, so the database engine cannot invoke "
+    "Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl "
+    "script. No process in the running container executes these modules."
+)
+
+LIBXML2_REASON = (
+    "PostgreSQL only enters libxml2 through the `xml` data type and the xpath()/xmltable() "
+    "family. The shipped schema declares no xml columns and the application issues no XML "
+    "functions, so the parser is never invoked. (GDAL's XML drivers are likewise unreachable "
+    "- see the PostGIS/GDAL rationale.)"
+)
+
+# CVE-specific overrides take precedence over package rules.
+CVE_POLICY = {
+    "CVE-2023-45853": (
+        NOT_PRESENT,
+        "This vulnerability is in zlib's MiniZip contrib component "
+        "(zipOpenNewFileInZip4_64), which Debian does not build into the shared libz "
+        "shipped in this image - which is why Debian classifies it will-not-fix. The "
+        "vulnerable code is not present in the delivered library.",
+    ),
+}
+
+PACKAGE_POLICY = {}
+for _p in GDAL_CHAIN:
+    PACKAGE_POLICY[_p] = (NOT_IN_PATH, GDAL_REASON)
+for _p in PERL_PKGS:
+    PACKAGE_POLICY[_p] = (NOT_IN_PATH, PERL_REASON)
+PACKAGE_POLICY["libxml2"] = (NOT_IN_PATH, LIBXML2_REASON)
+
+UNDER_INVESTIGATION_NOTE = (
+    "General-purpose OS package. Not yet individually analysed for reachability in this "
+    "image; no exploitability claim is made. Tracked for the next review."
+)
+
+
+def fetch_alerts():
+    """Open Trivy alerts for the db image, from GitHub code scanning."""
+    out = subprocess.run(
+        ["gh", "api", "repos/%s/code-scanning/alerts?state=open&per_page=100" % REPO, "--paginate"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        sys.exit("gh api failed: %s" % out.stderr.strip())
+    alerts = []
+    for chunk in re.findall(r"\[.*?\](?=\s*\[|\s*$)", out.stdout, re.S) or [out.stdout]:
+        try:
+            alerts.extend(json.loads(chunk))
+        except json.JSONDecodeError:
+            pass
+    return [a for a in alerts if a.get("tool", {}).get("name") == "Trivy"]
+
+
+def field(msg, key):
+    m = re.search(key + r":[ \t]*([^\n]*)", msg)
+    return m.group(1).strip() if m else ""
+
+
+def main():
+    alerts = fetch_alerts()
+    # vulnerability -> {package: version}
+    grouped = OrderedDict()
+    for a in alerts:
+        msg = a.get("most_recent_instance", {}).get("message", {}).get("text", "")
+        pkg, ver, fixed = field(msg, "Package"), field(msg, "Installed Version"), field(msg, "Fixed Version")
+        if fixed:
+            continue  # a fix exists -> fix it, never VEX it
+        cve = a["rule"]["id"]
+        grouped.setdefault(cve, {})[pkg] = ver
+
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
+    statements = []
+    for cve, pkgs in sorted(grouped.items()):
+        # A statement's justification must hold for every affected package in it.
+        decisions = set()
+        reasons = []
+        for pkg in pkgs:
+            if cve in CVE_POLICY:
+                st, why = CVE_POLICY[cve]
+            elif pkg in PACKAGE_POLICY:
+                st, why = PACKAGE_POLICY[pkg]
+            else:
+                st, why = None, UNDER_INVESTIGATION_NOTE
+            decisions.add(st)
+            if why not in reasons:
+                reasons.append(why)
+
+        subcomponents = [
+            {"@id": "pkg:deb/debian/%s@%s?distro=debian-12" % (p, v)} for p, v in sorted(pkgs.items())
+        ]
+        stmt = {
+            "vulnerability": {"name": cve},
+            "products": [{"@id": PRODUCT_PURL, "subcomponents": subcomponents}],
+        }
+        # Only claim not_affected when EVERY affected package in this CVE is justified.
+        if None in decisions or len(decisions) != 1:
+            stmt["status"] = "under_investigation"
+            stmt["impact_statement"] = UNDER_INVESTIGATION_NOTE
+        else:
+            stmt["status"] = "not_affected"
+            stmt["justification"] = decisions.pop()
+            stmt["impact_statement"] = " ".join(reasons)
+        statements.append(stmt)
+
+    doc = OrderedDict([
+        ("@context", "https://openvex.dev/ns/v0.2.0"),
+        ("@id", VEX_ID),
+        ("author", AUTHOR),
+        ("timestamp", now),
+        ("version", 1),
+        ("tooling", "tools/generate-db-vex.py"),
+        ("statements", statements),
+    ])
+    print(json.dumps(doc, indent=2))
+
+    n_na = sum(1 for s in statements if s["status"] == "not_affected")
+    print("generated %d statements: %d not_affected, %d under_investigation"
+          % (len(statements), n_na, len(statements) - n_na), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Publish VEX for the database image

Every open HIGH/CRITICAL Trivy finding on `simis-cms-db` is a Debian bookworm OS package with **no fixed version available** — I verified this: **0 of 93 open alerts have a `Fixed Version`**, including all 16 criticals. There is nothing to upgrade to; `docker/db/Dockerfile` already pins bookworm, rebuilds `gosu`, and runs `apt-get upgrade`, so everything patchable *is* patched.

The gap this closes: that reasoning currently lives in `docker/db/README.md`, where only a human who finds it benefits. A prospect or customer scanning the published image sees a wall of red with no context. **VEX is the machine-readable form of the same argument**, so their scanner can suppress what we've justified — and still surface anything new.

This changes **no image content and no CVE count**. It adds context.

### What it claims — and what it deliberately doesn't
49 statements: **43 `not_affected`, 6 `under_investigation`.** Every `not_affected` carries a justification *and* an `impact_statement` describing what was verified against the shipped schema:

- **PostGIS/GDAL chain** (gdal, libaom, libheif, libtiff, libhdf5, libsqlite3, libcurl, libssh2, libexpat) → `vulnerable_code_not_in_execute_path`. Verified: the schema issues only `CREATE EXTENSION postgis` (vector); **`postgis_raster` is never created**, so GDAL's raster decoders and remote-dataset drivers are never loaded.
- **Perl** (perl, perl-base, perl-modules, libperl — 28 alerts, 12 of them critical) → `vulnerable_code_not_in_execute_path`. Verified: **`postgresql-17-plperl` is not installed**, so the engine cannot invoke Perl; the entrypoint is the stock postgres shell entrypoint.
- **libxml2** → `vulnerable_code_not_in_execute_path`. Verified: reached only via the `xml` type / `xpath()`; the schema declares **no xml columns** and the app calls no XML functions.
- **zlib1g / CVE-2023-45853** → `vulnerable_code_not_present`. The flaw is in zlib's **MiniZip** contrib component, which Debian does not build into the shared libz — which is exactly why Debian marked it will-not-fix.

**The 6 I did not claim** — ncurses, gzip, util-linux, libldap, sysstat, libacl1 — are general-purpose OS packages where I have no specific reachability argument, so they are `under_investigation`, **not** `not_affected`. A VEX that overclaims is worse than no VEX; uncertainty is not rendered as "safe".

All **7 distinct critical CVEs are covered** by a justified statement.

### Anti-rot
A static VEX file goes stale exactly the way a maintenance backlog does, so the document is **generated**: `tools/generate-db-vex.py` reads the currently-open Trivy alerts and applies an auditable policy table. It **only ever emits statements for findings with no available fix** — if a fix appears, the finding drops out of the VEX and must be fixed instead. Regeneration is deterministic apart from the timestamp.

```sh
python3 tools/generate-db-vex.py > docker/db/vex/simis-cms-db.openvex.json
```

### Consuming it
```sh
trivy image --vex docker/db/vex/simis-cms-db.openvex.json \
  --scanners vuln --severity HIGH,CRITICAL ghcr.io/simisrnd/simis-cms-db
```

### Scope caveat (stated in the document and the README)
These statements describe the image **as shipped and configured**. If an operator installs PL/Perl, creates `postgis_raster`, or uses PostgreSQL's `xml` type, the corresponding statements no longer hold and the VEX must be re-evaluated.

### Follow-on
This is also the documented prerequisite for ever enforcing the Trivy gate, and a step toward attaching VEX as a signed attestation alongside the image.
