### PR TITLE
Add a design-token layer and an opt-in light/dark color scheme

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -7,7 +7,7 @@ description: SimIS CMS topics for customization
 
 ## Content Management System
 
-- Site Theme
+- Site Theme (Design Tokens, Light/Dark Color Scheme)
 - Site CSS
 - Site Map
 - Web Pages

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,70 @@
+---
+id: theming
+title: Theming and Color Scheme
+# prettier-ignore
+description: SimIS CMS design tokens, dark mode, and the theme.ui.mode site property
+---
+
+## Color scheme
+
+The site property **Theme > Color Scheme** (`theme.ui.mode`) selects how the site renders:
+
+| Value  | Behavior                                                                 |
+| ------ | ------------------------------------------------------------------------ |
+| `light` | Forced light. No toggle. **This is the default.**                        |
+| `dark`  | Forced dark. No toggle.                                                  |
+| `auto`  | Follows the visitor's operating system setting.                          |
+| `user`  | Follows the operating system, and the visitor can override it.           |
+
+The default is `light` on purpose: upgrading an existing site never changes how it looks. Dark mode is opt-in.
+
+In `user` mode, place the **colorSchemeToggle** widget where the control should appear (the utility bar is the usual spot). The widget renders nothing in any other mode, because a toggle that contradicts a forced setting would be an inert control.
+
+```xml
+<widget name="colorSchemeToggle"/>
+```
+
+The visitor's choice is kept in `localStorage`, not a cookie — it is a display preference the server never needs, so it stays out of the request and out of the analytics surface. A small inline script in the document head applies the stored choice before the first paint, so switching schemes does not flash.
+
+## Design tokens
+
+`css/platform-tokens.css` defines the semantic tokens the platform styles against. Use these instead of hard-coded values in new components:
+
+| Group    | Tokens                                                                           |
+| -------- | -------------------------------------------------------------------------------- |
+| Surfaces | `--sc-surface`, `--sc-surface-raised`, `--sc-surface-sunken`, `--sc-surface-overlay` |
+| Text     | `--sc-text`, `--sc-text-muted`, `--sc-text-inverse`, `--sc-link`, `--sc-link-hover` |
+| Lines    | `--sc-border` (decorative), `--sc-border-control` (form controls)                 |
+| Fields   | `--sc-field-bg`, `--sc-field-text`, `--sc-field-placeholder`, `--sc-field-disabled-bg` |
+| Focus    | `--sc-focus-ring`, `--sc-focus-ring-width`, `--sc-focus-ring-offset`             |
+| Elevation| `--sc-shadow-sm`, `--sc-shadow-md`, `--sc-shadow-lg`                             |
+| Radius   | `--sc-radius-sm`, `--sc-radius-md`, `--sc-radius-lg`, `--sc-radius-pill`          |
+| Spacing  | `--sc-space-1` … `--sc-space-6`                                                   |
+| Motion   | `--sc-motion-fast`, `--sc-motion-base`, `--sc-motion-ease`                        |
+
+Every site theme color is also published as a token, named after the site property it comes from — `theme.button.primary.backgroundColor` becomes `--sc-button-primary-background-color`. These are emitted per request into the page's inline style block, so a widget or page stylesheet can reference the site's own colors:
+
+```css
+.my-component {
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-text);
+  border: 1px solid var(--sc-border-control);
+  border-radius: var(--sc-radius-md);
+  padding: var(--sc-space-4);
+}
+```
+
+### Accessibility
+
+Token pairings are chosen against WCAG 2.2: text meets 1.4.3 at 4.5:1 or better, and `--sc-border-control` meets 1.4.11 at 3:1 against both the page and raised surfaces. `--sc-border` is for decorative separators, which 1.4.11 exempts — do not use it to outline a control.
+
+Two rules in `platform-tokens.css` apply in **both** schemes:
+
+- A `:focus-visible` outline, so keyboard focus is visible without showing a ring to mouse users (2.4.11, 2.4.13).
+- A `prefers-reduced-motion` block that collapses animation and transition durations (2.3.3).
+
+### Dark mode and site colors
+
+Dark mode repaints neutral chrome — page, cards, tables, form fields, overlays. It deliberately leaves the site's configured theme colors alone: buttons, semantic callouts, the top bar and the footer keep the colors an administrator chose, because those are brand decisions and lightening them can break their own contrast. A site turning dark mode on should review those theme colors against the dark page.
+
+Add `platform-invert-on-dark` to an image that is authored for a light background (a logo on a white plate, say) to have it inverted in dark mode.

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ColorSchemeToggleWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ColorSchemeToggleWidget.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Renders a light/dark color scheme toggle for the visitor.
+ *
+ * <p>The widget only renders when the site property <code>theme.ui.mode</code> is set to
+ * <code>user</code>. In every other mode the scheme is fixed by the administrator or follows the
+ * operating system, so a control would either do nothing or contradict the configured setting, and
+ * showing an inert button is worse than showing none.
+ *
+ * <p>The scheme itself is applied by platform-tokens.css from the data-theme attribute on the html
+ * element; this widget contributes only the control and its live region.
+ *
+ * @author SimIS
+ * @created 7/21/2026 9:00 AM
+ */
+public class ColorSchemeToggleWidget extends GenericWidget {
+
+  static final long serialVersionUID = 2571863240943382178L;
+
+  static String JSP = "/cms/color-scheme-toggle.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    String uiMode = LoadSitePropertyCommand.loadByName("theme.ui.mode");
+    if (!"user".equals(uiMode)) {
+      return context;
+    }
+
+    // Optional label shown beside the icon, for placements with room for it
+    String label = context.getPreferences().get("label");
+    if (label != null) {
+      context.getRequest().setAttribute("colorSchemeToggleLabel", label);
+    }
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -65,6 +65,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 -- Theme
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (5, 'Menu Theme', 'theme.menu.location', 'custom', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (6, 'Color Scheme', 'theme.ui.mode', 'light', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (7, 'Logo Color', 'theme.logo.color', 'text-only', 'text');
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (10, 'Headlines Font', 'theme.fonts.headlines', '', 'font');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260721.1000__color_scheme_mode.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260721.1000__color_scheme_mode.sql
@@ -1,0 +1,10 @@
+-- Adds the site-wide color scheme setting used by platform-tokens.css via the data-theme attribute.
+--   light  forced light, no toggle (the default, so an existing site looks exactly as it did)
+--   dark   forced dark, no toggle
+--   auto   follows the visitor's operating system setting
+--   user   follows the operating system, and the colorSchemeToggle widget lets the visitor override
+-- Defaults to 'light' deliberately: dark mode is opt-in, never applied to a running site by an upgrade.
+-- The value is mapped through a whitelist in main.jsp before it reaches the markup.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (6, 'Color Scheme', 'theme.ui.mode', 'light', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -101,6 +101,14 @@
                 <option value="none"<c:if test="${siteProperty.value eq 'none'}"> selected</c:if>>No logo</option>
               </select>
             </c:when>
+            <c:when test="${siteProperty.name eq 'theme.ui.mode'}">
+              <select name="${siteProperty.name}">
+                <option value="light"<c:if test="${siteProperty.value ne 'dark' && siteProperty.value ne 'auto' && siteProperty.value ne 'user'}"> selected</c:if>>Light only</option>
+                <option value="dark"<c:if test="${siteProperty.value eq 'dark'}"> selected</c:if>>Dark only</option>
+                <option value="auto"<c:if test="${siteProperty.value eq 'auto'}"> selected</c:if>>Match visitor's device</option>
+                <option value="user"<c:if test="${siteProperty.value eq 'user'}"> selected</c:if>>Match device, let visitor choose</option>
+              </select>
+            </c:when>
             <c:when test="${siteProperty.name eq 'theme.menu.location'}">
               <select name="${siteProperty.name}">
                 <option value="center"<c:if test="${siteProperty.value eq 'center'}"> selected</c:if>>Centered</option>

--- a/src/main/webapp/WEB-INF/jsp/cms/color-scheme-toggle.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/color-scheme-toggle.jsp
@@ -1,0 +1,38 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<%--
+  The button carries no visible text by default, so the accessible name comes from aria-label.
+  platform-theme.js rewrites that label on every change, because the name describes the action the
+  button will perform ("Switch to dark theme"), not the state it is in. A label alone is not
+  announced when it changes under a focused button, so the status region below carries the
+  confirmation. Both icons are always in the markup; platform-tokens.css shows whichever matches
+  the active scheme, and aria-hidden keeps them out of the accessibility tree either way.
+
+  The starting aria-label assumes light, which is correct for the server-rendered attribute in
+  every case except a visitor whose stored preference or OS setting is dark. platform-theme.js
+  corrects it on DOMContentLoaded, before the control can be reached by keyboard.
+--%>
+<button type="button"
+        class="platform-color-scheme-toggle"
+        aria-label="Switch to dark theme"
+        title="Switch to dark theme">
+  <i class="fa fa-moon platform-icon-light" aria-hidden="true"></i>
+  <i class="fa fa-sun platform-icon-dark" aria-hidden="true"></i>
+  <c:if test="${!empty colorSchemeToggleLabel}"><span><c:out value="${colorSchemeToggleLabel}" /></span></c:if>
+</button>
+<div class="platform-color-scheme-status show-for-sr" role="status" aria-live="polite"></div>

--- a/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
@@ -25,8 +25,17 @@
 <jsp:useBean id="systemPropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="sitePropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="themePropertyMap" class="java.util.HashMap" scope="request"/>
+<%-- Color scheme. Mirrors main.jsp so an embedded page does not stay light while the rest of the
+     site is dark. No visitor toggle here: this layout is for embedding, where the surrounding
+     document owns the chrome, so the scheme follows the site setting only. --%>
+<c:set var="colorSchemeMode" value="${empty themePropertyMap['theme.ui.mode'] ? 'light' : themePropertyMap['theme.ui.mode']}" />
+<c:choose>
+  <c:when test="${colorSchemeMode eq 'dark'}"><c:set var="colorScheme" value="dark" /></c:when>
+  <c:when test="${colorSchemeMode eq 'auto' || colorSchemeMode eq 'user'}"><c:set var="colorScheme" value="auto" /></c:when>
+  <c:otherwise><c:set var="colorScheme" value="light" /></c:otherwise>
+</c:choose>
 <!doctype html>
-<html class="no-js" lang="en">
+<html class="no-js" lang="en" data-theme="${colorScheme}">
 <head>
   <meta charset="UTF-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -65,10 +74,39 @@
     <link rel="stylesheet" type="text/css" href="${ctx}/javascript/autocomplete-1.0.7/auto-complete.css" />
     <link rel="stylesheet" type="text/css" href="${ctx}/javascript/swiper-12.1.2/swiper-bundle.min.css" />
     <link rel="stylesheet" type="text/css" href="${ctx}/css/platform.css" />
+    <link rel="stylesheet" type="text/css" href="${ctx}/css/platform-tokens.css" />
   </g:compress>
   <c:if test="${!empty themePropertyMap}">
     <g:compress>
       <style><%-- Prevent top-bar flicker --%>
+        :root {
+          <c:if test="${!empty themePropertyMap['theme.body.text.color']}">--sc-body-text-color:<c:out value="${themePropertyMap['theme.body.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">--sc-body-background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">--sc-utilitybar-background-color:<c:out value="${themePropertyMap['theme.utilitybar.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">--sc-topbar-background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">--sc-topbar-menu-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">--sc-topbar-menu-arrow-color:<c:out value="${themePropertyMap['theme.topbar.menu.arrow.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">--sc-topbar-menu-dropdown-background-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">--sc-topbar-menu-dropdown-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">--sc-topbar-menu-text-hover-background-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">--sc-topbar-menu-hover-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.hoverTextColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.text.color']}">--sc-button-text-color:<c:out value="${themePropertyMap['theme.button.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">--sc-button-default-background-color:<c:out value="${themePropertyMap['theme.button.default.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">--sc-button-default-hover-background-color:<c:out value="${themePropertyMap['theme.button.default.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">--sc-button-primary-background-color:<c:out value="${themePropertyMap['theme.button.primary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">--sc-button-primary-hover-background-color:<c:out value="${themePropertyMap['theme.button.primary.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">--sc-button-secondary-background-color:<c:out value="${themePropertyMap['theme.button.secondary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">--sc-button-secondary-hover-background-color:<c:out value="${themePropertyMap['theme.button.secondary.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">--sc-button-success-background-color:<c:out value="${themePropertyMap['theme.button.success.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">--sc-button-success-hover-background-color:<c:out value="${themePropertyMap['theme.button.success.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">--sc-button-warning-background-color:<c:out value="${themePropertyMap['theme.button.warning.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">--sc-button-warning-hover-background-color:<c:out value="${themePropertyMap['theme.button.warning.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">--sc-button-alert-background-color:<c:out value="${themePropertyMap['theme.button.alert.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">--sc-button-alert-hover-background-color:<c:out value="${themePropertyMap['theme.button.alert.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">--sc-footer-background-color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">--sc-footer-text-color:<c:out value="${themePropertyMap['theme.footer.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">--sc-footer-links-color:<c:out value="${themePropertyMap['theme.footer.links.color']}" />;</c:if>
+        }
         .no-js .top-bar { display: none; }
         @media screen and (min-width: 40em) {
           .no-js .top-bar { display: block; }
@@ -108,34 +146,34 @@
             <c:when test="${themePropertyMap['theme.fonts.headlines'] eq 'source-sans-pro'}">h1, h2, h3, h4, h5, h6 { font-family: 'Source Sans Pro', sans-serif;font-weight: 400; }</c:when>
           </c:choose>
         </c:if>
-        <c:if test="${!empty themePropertyMap['theme.body.text.color']}">body{color:<c:out value="${themePropertyMap['theme.body.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">body{background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">#platform-menu .utility-bar{background-color:<c:out value="${themePropertyMap['theme.utilitybar.backgroundColor']}" />}</c:if>
-      <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">#platform-menu,#platform-small-menu,#platform-small-menu .title-bar,#platform-small-toggle-menu .drilldown a{background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">.callout.header{background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">#platform-menu ul.menu li a,#platform-small-menu ul.menu li a,#platform-small-menu .title-bar-title{color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">.callout.header{color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">.dropdown.menu>li.is-dropdown-submenu-parent>a::after{border-color:<c:out value="${themePropertyMap['theme.topbar.menu.arrow.color']}" /> transparent transparent}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">#platform-menu .is-dropdown-submenu-item{background-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">#platform-menu .is-dropdown-submenu-item a{color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">#platform-menu ul.menu li a:hover,#platform-menu .is-active{background-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu ul.menu li > a:hover,#platform-menu ul.menu li.is-active > a,#platform-menu .is-active .is-dropdown-submenu-item a:hover{color:<c:out value="${themePropertyMap['theme.topbar.menu.hoverTextColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.text.color']}">.button{color:<c:out value="${themePropertyMap['theme.button.text.color']}" /> !important}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">.button{background-color:<c:out value="${themePropertyMap['theme.button.default.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">.button:hover, .button:focus{background-color:<c:out value="${themePropertyMap['theme.button.default.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">.button.primary{background-color:<c:out value="${themePropertyMap['theme.button.primary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">.button.primary:hover, .button.primary:focus{background-color:<c:out value="${themePropertyMap['theme.button.primary.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">.button.secondary{background-color:<c:out value="${themePropertyMap['theme.button.secondary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">.button.secondary:hover, .button.secondary:focus{background-color:<c:out value="${themePropertyMap['theme.button.secondary.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">.button.success{background-color:<c:out value="${themePropertyMap['theme.button.success.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">.button.success:hover, .button.success:focus{background-color:<c:out value="${themePropertyMap['theme.button.success.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">.button.warning{background-color:<c:out value="${themePropertyMap['theme.button.warning.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">.button.warning:hover, .button.warning:focus{background-color:<c:out value="${themePropertyMap['theme.button.warning.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">.button.alert{background-color:<c:out value="${themePropertyMap['theme.button.alert.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">.button.alert:hover, .button.alert:focus{background-color:<c:out value="${themePropertyMap['theme.button.alert.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">.platform-footer{background-color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />}.platform-footer .fa-inverse{color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">.platform-footer{color:<c:out value="${themePropertyMap['theme.footer.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">.platform-footer a{color:<c:out value="${themePropertyMap['theme.footer.links.color']}" />}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.body.text.color']}">body{color:var(--sc-body-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">body{background-color:var(--sc-body-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">#platform-menu .utility-bar{background-color:var(--sc-utilitybar-background-color)}</c:if>
+      <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">#platform-menu,#platform-small-menu,#platform-small-menu .title-bar,#platform-small-toggle-menu .drilldown a{background-color:var(--sc-topbar-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">.callout.header{background-color:var(--sc-topbar-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">#platform-menu ul.menu li a,#platform-small-menu ul.menu li a,#platform-small-menu .title-bar-title{color:var(--sc-topbar-menu-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">.callout.header{color:var(--sc-topbar-menu-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">.dropdown.menu>li.is-dropdown-submenu-parent>a::after{border-color:var(--sc-topbar-menu-arrow-color) transparent transparent}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">#platform-menu .is-dropdown-submenu-item{background-color:var(--sc-topbar-menu-dropdown-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">#platform-menu .is-dropdown-submenu-item a{color:var(--sc-topbar-menu-dropdown-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">#platform-menu ul.menu li a:hover,#platform-menu .is-active{background-color:var(--sc-topbar-menu-text-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu ul.menu li > a:hover,#platform-menu ul.menu li.is-active > a,#platform-menu .is-active .is-dropdown-submenu-item a:hover{color:var(--sc-topbar-menu-hover-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.text.color']}">.button{color:var(--sc-button-text-color) !important}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">.button{background-color:var(--sc-button-default-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">.button:hover, .button:focus{background-color:var(--sc-button-default-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">.button.primary{background-color:var(--sc-button-primary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">.button.primary:hover, .button.primary:focus{background-color:var(--sc-button-primary-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">.button.secondary{background-color:var(--sc-button-secondary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">.button.secondary:hover, .button.secondary:focus{background-color:var(--sc-button-secondary-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">.button.success{background-color:var(--sc-button-success-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">.button.success:hover, .button.success:focus{background-color:var(--sc-button-success-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">.button.warning{background-color:var(--sc-button-warning-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">.button.warning:hover, .button.warning:focus{background-color:var(--sc-button-warning-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">.button.alert{background-color:var(--sc-button-alert-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">.button.alert:hover, .button.alert:focus{background-color:var(--sc-button-alert-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">.platform-footer{background-color:var(--sc-footer-background-color)}.platform-footer .fa-inverse{color:var(--sc-footer-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">.platform-footer{color:var(--sc-footer-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">.platform-footer a{color:var(--sc-footer-links-color)}</c:if>
       </style>
     </g:compress>
   </c:if>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -31,10 +31,31 @@
 <jsp:useBean id="themePropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="analyticsPropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="ecommercePropertyMap" class="java.util.HashMap" scope="request"/>
+<%-- Color scheme. The site property theme.ui.mode selects it:
+       light  forced light, and no toggle (the default, so an existing site is unchanged)
+       dark   forced dark, and no toggle
+       auto   follows the visitor's operating system setting, no toggle
+       user   follows the operating system, plus a toggle the visitor can override with
+     The value is mapped through a whitelist rather than written to the attribute directly, so
+     a malformed site property can never inject into the markup. --%>
+<c:set var="colorSchemeMode" value="${empty themePropertyMap['theme.ui.mode'] ? 'light' : themePropertyMap['theme.ui.mode']}" />
+<c:choose>
+  <c:when test="${colorSchemeMode eq 'dark'}"><c:set var="colorScheme" value="dark" /></c:when>
+  <c:when test="${colorSchemeMode eq 'auto' || colorSchemeMode eq 'user'}"><c:set var="colorScheme" value="auto" /></c:when>
+  <c:otherwise><c:set var="colorScheme" value="light" /></c:otherwise>
+</c:choose>
 <!doctype html>
-<html class="no-js" lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html class="no-js" lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" data-theme="${colorScheme}">
 <head>
   <meta charset="UTF-8" />
+  <c:if test="${colorSchemeMode eq 'user'}">
+    <%-- Applies a stored visitor preference before the first paint, so switching schemes does not
+         flash the other one. Rendered only when the site offers the toggle, so it can never
+         override an administrator who forced light or dark. Kept inline and tiny on purpose: an
+         external script would arrive too late. If script-src is ever tightened in PageServlet,
+         this needs a nonce. --%>
+    <script>(function(){try{var s=window.localStorage.getItem('simis-cms-color-scheme');if(s==='light'||s==='dark'){document.documentElement.setAttribute('data-theme',s);}}catch(e){}})();</script>
+  </c:if>
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Language" content="en">
@@ -101,10 +122,58 @@
     <link rel="stylesheet" type="text/css" href="${ctx}/javascript/autocomplete-1.0.7/auto-complete.css" />
     <link rel="stylesheet" type="text/css" href="${ctx}/javascript/swiper-12.1.2/swiper-bundle.min.css" />
     <link rel="stylesheet" type="text/css" href="${ctx}/css/platform.css" />
+    <%-- Design tokens and dark scheme. Loaded after platform.css so it can repaint chrome, and
+         before the theme's inline <style> block so a site's own colors still win. --%>
+    <link rel="stylesheet" type="text/css" href="${ctx}/css/platform-tokens.css" />
   </g:compress>
   <c:if test="${!empty themePropertyMap}">
     <g:compress>
       <style><%-- Prevent top-bar flicker --%>
+        :root {
+          <c:if test="${!empty themePropertyMap['theme.body.text.color']}">--sc-body-text-color:<c:out value="${themePropertyMap['theme.body.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">--sc-body-background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.text.color']}">--sc-button-text-color:<c:out value="${themePropertyMap['theme.button.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">--sc-button-default-background-color:<c:out value="${themePropertyMap['theme.button.default.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">--sc-button-default-hover-background-color:<c:out value="${themePropertyMap['theme.button.default.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">--sc-button-primary-background-color:<c:out value="${themePropertyMap['theme.button.primary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">--sc-button-primary-hover-background-color:<c:out value="${themePropertyMap['theme.button.primary.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">--sc-button-secondary-background-color:<c:out value="${themePropertyMap['theme.button.secondary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">--sc-button-secondary-hover-background-color:<c:out value="${themePropertyMap['theme.button.secondary.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">--sc-button-success-background-color:<c:out value="${themePropertyMap['theme.button.success.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">--sc-button-success-hover-background-color:<c:out value="${themePropertyMap['theme.button.success.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">--sc-button-warning-background-color:<c:out value="${themePropertyMap['theme.button.warning.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">--sc-button-warning-hover-background-color:<c:out value="${themePropertyMap['theme.button.warning.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">--sc-button-alert-background-color:<c:out value="${themePropertyMap['theme.button.alert.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">--sc-button-alert-hover-background-color:<c:out value="${themePropertyMap['theme.button.alert.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.backgroundColor']}">--sc-callout-background-color:<c:out value="${themePropertyMap['theme.callout.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.text.color']}">--sc-callout-text-color:<c:out value="${themePropertyMap['theme.callout.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.primary.backgroundColor']}">--sc-callout-primary-background-color:<c:out value="${themePropertyMap['theme.callout.primary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.primary.text.color']}">--sc-callout-primary-text-color:<c:out value="${themePropertyMap['theme.callout.primary.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.secondary.backgroundColor']}">--sc-callout-secondary-background-color:<c:out value="${themePropertyMap['theme.callout.secondary.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.secondary.text.color']}">--sc-callout-secondary-text-color:<c:out value="${themePropertyMap['theme.callout.secondary.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.success.backgroundColor']}">--sc-callout-success-background-color:<c:out value="${themePropertyMap['theme.callout.success.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.success.text.color']}">--sc-callout-success-text-color:<c:out value="${themePropertyMap['theme.callout.success.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.warning.backgroundColor']}">--sc-callout-warning-background-color:<c:out value="${themePropertyMap['theme.callout.warning.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.warning.text.color']}">--sc-callout-warning-text-color:<c:out value="${themePropertyMap['theme.callout.warning.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.alert.backgroundColor']}">--sc-callout-alert-background-color:<c:out value="${themePropertyMap['theme.callout.alert.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.callout.alert.text.color']}">--sc-callout-alert-text-color:<c:out value="${themePropertyMap['theme.callout.alert.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">--sc-footer-background-color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">--sc-footer-text-color:<c:out value="${themePropertyMap['theme.footer.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.utilitybar.text.color']}">--sc-utilitybar-text-color:<c:out value="${themePropertyMap['theme.utilitybar.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.utilitybar.link.color']}">--sc-utilitybar-link-color:<c:out value="${themePropertyMap['theme.utilitybar.link.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">--sc-utilitybar-background-color:<c:out value="${themePropertyMap['theme.utilitybar.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.text.color']}">--sc-topbar-text-color:<c:out value="${themePropertyMap['theme.topbar.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">--sc-topbar-background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">--sc-topbar-menu-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">--sc-topbar-menu-arrow-color:<c:out value="${themePropertyMap['theme.topbar.menu.arrow.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">--sc-topbar-menu-text-hover-background-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">--sc-topbar-menu-hover-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.hoverTextColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">--sc-topbar-menu-dropdown-background-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">--sc-topbar-menu-dropdown-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.text.color']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeBackgroundColor']}">--sc-topbar-menu-active-background-color:<c:out value="${themePropertyMap['theme.topbar.menu.activeBackgroundColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeTextColor']}">--sc-topbar-menu-active-text-color:<c:out value="${themePropertyMap['theme.topbar.menu.activeTextColor']}" />;</c:if>
+          <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">--sc-footer-links-color:<c:out value="${themePropertyMap['theme.footer.links.color']}" />;</c:if>
+        }
         .no-js .top-bar { display: none; }
         @media screen and (min-width: 40em) {
           .no-js .top-bar { display: block; }
@@ -144,52 +213,52 @@
             <c:when test="${themePropertyMap['theme.fonts.headlines'] eq 'source-sans-pro'}">h1, h2, h3, h4, h5, h6 { font-family: 'Source Sans Pro', sans-serif;font-weight: 400; }</c:when>
           </c:choose>
         </c:if>
-        <c:if test="${!empty themePropertyMap['theme.body.text.color']}">body{color:<c:out value="${themePropertyMap['theme.body.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">body{background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.text.color']}">.button{color:<c:out value="${themePropertyMap['theme.button.text.color']}" /> !important}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">.button{background-color:<c:out value="${themePropertyMap['theme.button.default.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">.button:hover, .button:focus{background-color:<c:out value="${themePropertyMap['theme.button.default.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">.button.primary{background-color:<c:out value="${themePropertyMap['theme.button.primary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">.button.primary:hover, .button.primary:focus, #platform-menu ul.menu li a.button.primary:hover{background-color:<c:out value="${themePropertyMap['theme.button.primary.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">.button.secondary{background-color:<c:out value="${themePropertyMap['theme.button.secondary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">.button.secondary:hover, .button.secondary:focus, #platform-menu ul.menu li a.button.secondary:hover{background-color:<c:out value="${themePropertyMap['theme.button.secondary.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">.button.success{background-color:<c:out value="${themePropertyMap['theme.button.success.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">.button.success:hover, .button.success:focus{background-color:<c:out value="${themePropertyMap['theme.button.success.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">.button.warning{background-color:<c:out value="${themePropertyMap['theme.button.warning.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">.button.warning:hover, .button.warning:focus{background-color:<c:out value="${themePropertyMap['theme.button.warning.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">.button.alert{background-color:<c:out value="${themePropertyMap['theme.button.alert.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">.button.alert:hover, .button.alert:focus{background-color:<c:out value="${themePropertyMap['theme.button.alert.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.backgroundColor']}">.callout{background-color:<c:out value="${themePropertyMap['theme.callout.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.text.color']}">.callout,.callout label{color:<c:out value="${themePropertyMap['theme.callout.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.primary.backgroundColor']}">.callout.primary{background-color:<c:out value="${themePropertyMap['theme.callout.primary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.primary.text.color']}">.callout.primary,.callout.primary label{color:<c:out value="${themePropertyMap['theme.callout.primary.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.secondary.backgroundColor']}">.callout.secondary{background-color:<c:out value="${themePropertyMap['theme.callout.secondary.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.secondary.text.color']}">.callout.secondary,.callout.secondary label{color:<c:out value="${themePropertyMap['theme.callout.secondary.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.success.backgroundColor']}">.callout.success{background-color:<c:out value="${themePropertyMap['theme.callout.success.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.success.text.color']}">.callout.success,.callout.success label{color:<c:out value="${themePropertyMap['theme.callout.success.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.warning.backgroundColor']}">.callout.warning{background-color:<c:out value="${themePropertyMap['theme.callout.warning.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.warning.text.color']}">.callout.warning,.callout.warning label{color:<c:out value="${themePropertyMap['theme.callout.warning.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.alert.backgroundColor']}">.callout.alert{background-color:<c:out value="${themePropertyMap['theme.callout.alert.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.callout.alert.text.color']}">.callout.alert,.callout.alert label{color:<c:out value="${themePropertyMap['theme.callout.alert.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">.platform-footer{background-color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />}.platform-footer .fa-inverse{color:<c:out value="${themePropertyMap['theme.footer.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">.platform-footer,.platform-footer p{color:<c:out value="${themePropertyMap['theme.footer.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.utilitybar.text.color']}">#platform-menu .utility-bar{color:<c:out value="${themePropertyMap['theme.utilitybar.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.utilitybar.link.color']}">#platform-menu .utility-bar a, #platform-menu .utility-bar button.button i.fa{color:<c:out value="${themePropertyMap['theme.utilitybar.link.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">#platform-menu .utility-bar{background-color:<c:out value="${themePropertyMap['theme.utilitybar.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.text.color']}">#platform-menu, #platform-menu .menu-text, #platform-menu .menu-text a,#platform-menu .menu-text a:hover{color:<c:out value="${themePropertyMap['theme.topbar.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">#platform-menu,#platform-small-menu,#platform-small-menu .title-bar,#platform-small-toggle-menu .drilldown a{background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">.callout.header{background-color:<c:out value="${themePropertyMap['theme.topbar.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">#platform-menu ul.menu li a,#platform-small-menu ul.menu li a,#platform-small-menu .title-bar-title{color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">.callout.header, #platform-menu button.button i.fa{color:<c:out value="${themePropertyMap['theme.topbar.menu.text.color']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">.dropdown.menu>li.is-dropdown-submenu-parent>a::after{border-color:<c:out value="${themePropertyMap['theme.topbar.menu.arrow.color']}" /> transparent transparent}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">#platform-menu ul.menu li a:hover,#platform-menu .is-active{background-color:<c:out value="${themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu ul.menu li > a:hover,#platform-menu ul.menu li.is-active > a,#platform-menu .is-active .is-dropdown-submenu-item a:hover{color:<c:out value="${themePropertyMap['theme.topbar.menu.hoverTextColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu button.button i.fa:hover{color:<c:out value="${themePropertyMap['theme.topbar.menu.hoverTextColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">#platform-menu ul.is-dropdown-submenu li.is-dropdown-submenu-item{background-color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">#platform-menu ul.is-dropdown-submenu li.is-dropdown-submenu-item a{color:<c:out value="${themePropertyMap['theme.topbar.menu.dropdown.text.color']}" />;}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeBackgroundColor']}">#platform-menu ul.menu .active > a{background-color:<c:out value="${themePropertyMap['theme.topbar.menu.activeBackgroundColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeTextColor']}">#platform-menu ul.menu .active > a{color:<c:out value="${themePropertyMap['theme.topbar.menu.activeTextColor']}" />}</c:if>
-        <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">.platform-footer a{color:<c:out value="${themePropertyMap['theme.footer.links.color']}" />}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.body.text.color']}">body{color:var(--sc-body-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.body.backgroundColor']}">body{background-color:var(--sc-body-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.text.color']}">.button{color:var(--sc-button-text-color) !important}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.default.backgroundColor']}">.button{background-color:var(--sc-button-default-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.default.hoverBackgroundColor']}">.button:hover, .button:focus{background-color:var(--sc-button-default-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.primary.backgroundColor']}">.button.primary{background-color:var(--sc-button-primary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.primary.hoverBackgroundColor']}">.button.primary:hover, .button.primary:focus, #platform-menu ul.menu li a.button.primary:hover{background-color:var(--sc-button-primary-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.secondary.backgroundColor']}">.button.secondary{background-color:var(--sc-button-secondary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.secondary.hoverBackgroundColor']}">.button.secondary:hover, .button.secondary:focus, #platform-menu ul.menu li a.button.secondary:hover{background-color:var(--sc-button-secondary-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.success.backgroundColor']}">.button.success{background-color:var(--sc-button-success-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.success.hoverBackgroundColor']}">.button.success:hover, .button.success:focus{background-color:var(--sc-button-success-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.warning.backgroundColor']}">.button.warning{background-color:var(--sc-button-warning-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.warning.hoverBackgroundColor']}">.button.warning:hover, .button.warning:focus{background-color:var(--sc-button-warning-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.alert.backgroundColor']}">.button.alert{background-color:var(--sc-button-alert-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.button.alert.hoverBackgroundColor']}">.button.alert:hover, .button.alert:focus{background-color:var(--sc-button-alert-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.backgroundColor']}">.callout{background-color:var(--sc-callout-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.text.color']}">.callout,.callout label{color:var(--sc-callout-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.primary.backgroundColor']}">.callout.primary{background-color:var(--sc-callout-primary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.primary.text.color']}">.callout.primary,.callout.primary label{color:var(--sc-callout-primary-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.secondary.backgroundColor']}">.callout.secondary{background-color:var(--sc-callout-secondary-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.secondary.text.color']}">.callout.secondary,.callout.secondary label{color:var(--sc-callout-secondary-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.success.backgroundColor']}">.callout.success{background-color:var(--sc-callout-success-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.success.text.color']}">.callout.success,.callout.success label{color:var(--sc-callout-success-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.warning.backgroundColor']}">.callout.warning{background-color:var(--sc-callout-warning-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.warning.text.color']}">.callout.warning,.callout.warning label{color:var(--sc-callout-warning-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.alert.backgroundColor']}">.callout.alert{background-color:var(--sc-callout-alert-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.callout.alert.text.color']}">.callout.alert,.callout.alert label{color:var(--sc-callout-alert-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.backgroundColor']}">.platform-footer{background-color:var(--sc-footer-background-color)}.platform-footer .fa-inverse{color:var(--sc-footer-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.text.color']}">.platform-footer,.platform-footer p{color:var(--sc-footer-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.utilitybar.text.color']}">#platform-menu .utility-bar{color:var(--sc-utilitybar-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.utilitybar.link.color']}">#platform-menu .utility-bar a, #platform-menu .utility-bar button.button i.fa{color:var(--sc-utilitybar-link-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.utilitybar.backgroundColor']}">#platform-menu .utility-bar{background-color:var(--sc-utilitybar-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.text.color']}">#platform-menu, #platform-menu .menu-text, #platform-menu .menu-text a,#platform-menu .menu-text a:hover{color:var(--sc-topbar-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">#platform-menu,#platform-small-menu,#platform-small-menu .title-bar,#platform-small-toggle-menu .drilldown a{background-color:var(--sc-topbar-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.backgroundColor']}">.callout.header{background-color:var(--sc-topbar-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">#platform-menu ul.menu li a,#platform-small-menu ul.menu li a,#platform-small-menu .title-bar-title{color:var(--sc-topbar-menu-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.color']}">.callout.header, #platform-menu button.button i.fa{color:var(--sc-topbar-menu-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.arrow.color']}">.dropdown.menu>li.is-dropdown-submenu-parent>a::after{border-color:var(--sc-topbar-menu-arrow-color) transparent transparent}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.text.hoverBackgroundColor']}">#platform-menu ul.menu li a:hover,#platform-menu .is-active{background-color:var(--sc-topbar-menu-text-hover-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu ul.menu li > a:hover,#platform-menu ul.menu li.is-active > a,#platform-menu .is-active .is-dropdown-submenu-item a:hover{color:var(--sc-topbar-menu-hover-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.hoverTextColor']}">#platform-menu button.button i.fa:hover{color:var(--sc-topbar-menu-hover-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.backgroundColor']}">#platform-menu ul.is-dropdown-submenu li.is-dropdown-submenu-item{background-color:var(--sc-topbar-menu-dropdown-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.dropdown.text.color']}">#platform-menu ul.is-dropdown-submenu li.is-dropdown-submenu-item a{color:var(--sc-topbar-menu-dropdown-text-color);}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeBackgroundColor']}">#platform-menu ul.menu .active > a{background-color:var(--sc-topbar-menu-active-background-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.topbar.menu.activeTextColor']}">#platform-menu ul.menu .active > a{color:var(--sc-topbar-menu-active-text-color)}</c:if>
+        <c:if test="${!empty themePropertyMap['theme.footer.links.color']}">.platform-footer a{color:var(--sc-footer-links-color)}</c:if>
         #site-newsletter-overlay, #site-promo-overlay {
           position: fixed;
           bottom: 0;
@@ -255,6 +324,9 @@
     <script src="${ctx}/javascript/autocomplete-1.0.7/auto-complete.js"></script>
     <script src="${ctx}/javascript/js-cookie-3.0.5/js.cookie.min.js"></script>
     <script src="${ctx}/javascript/swiper-12.1.2/swiper-bundle.min.js"></script>
+    <c:if test="${colorSchemeMode eq 'user'}">
+      <script src="${ctx}/javascript/platform-theme.js"></script>
+    </c:if>
   </g:compress>
 </head>
 <body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty pageRenderInfo.cssClass}"> class="<c:out value="${pageRenderInfo.cssClass}" />"</c:if>>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -28,6 +28,7 @@
   <widget name="copyright" class="com.simisinc.platform.presentation.widgets.cms.CopyrightWidget" />
   <widget name="systemAlert" class="com.simisinc.platform.presentation.widgets.cms.SystemAlertWidget" />
   <widget name="toggleMenu" class="com.simisinc.platform.presentation.widgets.cms.ToggleMenuWidget" />
+  <widget name="colorSchemeToggle" class="com.simisinc.platform.presentation.widgets.cms.ColorSchemeToggleWidget" />
   <widget name="mainMenu" class="com.simisinc.platform.presentation.widgets.cms.MainMenuWidget" />
   <widget name="globalMessage" class="com.simisinc.platform.presentation.widgets.cms.GlobalMessageWidget" />
   <widget name="breadcrumbs" class="com.simisinc.platform.presentation.widgets.cms.BreadCrumbsWidget" />

--- a/src/main/webapp/css/platform-tokens.css
+++ b/src/main/webapp/css/platform-tokens.css
@@ -1,0 +1,759 @@
+/*
+ * SimIS CMS - Design tokens and color scheme support
+ *
+ * Loaded after platform.css and before the theme's inline <style> block.
+ *
+ * Layer 1  Semantic design tokens (--sc-*) with light-mode values.
+ * Layer 2  Dark-mode token overrides.
+ * Layer 3  Chrome that consumes the tokens.
+ *
+ * IMPORTANT - light mode is intentionally left alone. Foundation and
+ * platform.css already paint every surface in light mode, so Layer 3 only
+ * repaints under [data-theme="dark"]. A site that never opts in renders
+ * exactly as it did before this file existed. The handful of rules that do
+ * apply in both modes (focus ring, reduced motion) are additive
+ * accessibility fixes, called out individually below.
+ *
+ * Color scheme is selected by the data-theme attribute on <html>:
+ *   data-theme="light"  forced light (the default; see theme.ui.mode)
+ *   data-theme="dark"   forced dark
+ *   data-theme="auto"   follow the operating system preference
+ * A missing attribute is treated as light.
+ *
+ * Contrast: every token pairing below was checked against WCAG 2.2.
+ * Text pairings meet 1.4.3 Contrast (Minimum) at 4.5:1. Control borders
+ * meet 1.4.11 Non-text Contrast at 3:1. Purely decorative separators are
+ * exempt from 1.4.11 and use the lower-contrast --sc-border on purpose.
+ */
+
+/* ==========================================================================
+   Layer 1 - Semantic tokens (light)
+   ========================================================================== */
+
+:root {
+  /* Surfaces */
+  --sc-surface: #ffffff;
+  --sc-surface-raised: #ffffff;
+  --sc-surface-sunken: #f4f6f8;
+  --sc-surface-overlay: #ffffff;
+
+  /* Text - contrast vs --sc-surface: text 19.80:1, muted 6.00:1, link 5.97:1 */
+  --sc-text: #0a0a0a;
+  --sc-text-muted: #5b6470;
+  --sc-text-inverse: #ffffff;
+  --sc-link: #1468a0;
+  --sc-link-hover: #0f4f7a;
+
+  /* Lines. --sc-border is decorative (1.4.11 exempt).
+     --sc-border-control outlines real controls: 3.40:1 on white,
+     3.14:1 on --sc-surface-sunken. */
+  --sc-border: #d7dce2;
+  --sc-border-control: #858c95;
+
+  /* Form fields */
+  --sc-field-bg: #ffffff;
+  --sc-field-text: #0a0a0a;
+  --sc-field-placeholder: #5b6470;
+  --sc-field-disabled-bg: #eef1f4;
+
+  /* Focus ring - 5.97:1 on white, comfortably past the 3:1 that
+     1.4.11 asks of a focus indicator. */
+  --sc-focus-ring: #1468a0;
+  --sc-focus-ring-width: 2px;
+  --sc-focus-ring-offset: 2px;
+
+  /* Elevation */
+  --sc-shadow-sm: 0 1px 2px rgba(10, 10, 10, 0.08);
+  --sc-shadow-md: 0 2px 8px rgba(10, 10, 10, 0.10);
+  --sc-shadow-lg: 0 8px 24px rgba(10, 10, 10, 0.14);
+
+  /* Radii and spacing - a small scale, so future components stop
+     inventing one-off pixel values. */
+  --sc-radius-sm: 3px;
+  --sc-radius-md: 6px;
+  --sc-radius-lg: 10px;
+  --sc-radius-pill: 999px;
+
+  --sc-space-1: 0.25rem;
+  --sc-space-2: 0.5rem;
+  --sc-space-3: 0.75rem;
+  --sc-space-4: 1rem;
+  --sc-space-5: 1.5rem;
+  --sc-space-6: 2rem;
+
+  /* Motion - referenced so prefers-reduced-motion has a single lever. */
+  --sc-motion-fast: 120ms;
+  --sc-motion-base: 200ms;
+  --sc-motion-ease: cubic-bezier(0.2, 0, 0.2, 1);
+
+  /* Tells the browser to render native widgets (scrollbars, date pickers,
+     select popups, form controls) in the matching scheme. */
+  color-scheme: light;
+}
+
+/* ==========================================================================
+   Layer 2 - Dark token overrides
+   ==========================================================================
+   Note what is NOT overridden: brand accent colors. Foundation's primary
+   (#1779ba) carries white text at 4.69:1 and sits on the dark page at
+   3.76:1, so it stays legible. Lightening it would actually break the
+   button label (#2f8fd0 with white text is only 3.52:1) as well as losing
+   the site's brand color. Accents are left to the theme.
+   ========================================================================== */
+
+:root[data-theme="dark"] {
+  --sc-surface: #16191d;
+  --sc-surface-raised: #1e2228;
+  --sc-surface-sunken: #101317;
+  --sc-surface-overlay: #1e2228;
+
+  /* contrast vs --sc-surface: text 14.49:1, muted 8.05:1, link 8.37:1 */
+  --sc-text: #e6e9ee;
+  --sc-text-muted: #a7b0bd;
+  --sc-text-inverse: #0a0a0a;
+  --sc-link: #7cb8f0;
+  --sc-link-hover: #a5cef5;
+
+  --sc-border: #333a44;
+  --sc-border-control: #6a7585; /* 3.78:1 on page, 3.42:1 on raised */
+
+  --sc-field-bg: #1b1f25;
+  --sc-field-text: #e6e9ee;
+  --sc-field-placeholder: #97a1af; /* 6.33:1 on --sc-field-bg */
+  --sc-field-disabled-bg: #23282f;
+
+  --sc-focus-ring: #8ab4f8;
+
+  /* Shadows read as noise on a dark page; lean on borders instead. */
+  --sc-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --sc-shadow-md: 0 2px 8px rgba(0, 0, 0, 0.55);
+  --sc-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.6);
+
+  color-scheme: dark;
+}
+
+/* Follow the OS only when the site has opted into "auto". An absent
+   data-theme stays light, which is what every pre-existing site gets. */
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    --sc-surface: #16191d;
+    --sc-surface-raised: #1e2228;
+    --sc-surface-sunken: #101317;
+    --sc-surface-overlay: #1e2228;
+
+    --sc-text: #e6e9ee;
+    --sc-text-muted: #a7b0bd;
+    --sc-text-inverse: #0a0a0a;
+    --sc-link: #7cb8f0;
+    --sc-link-hover: #a5cef5;
+
+    --sc-border: #333a44;
+    --sc-border-control: #6a7585;
+
+    --sc-field-bg: #1b1f25;
+    --sc-field-text: #e6e9ee;
+    --sc-field-placeholder: #97a1af;
+    --sc-field-disabled-bg: #23282f;
+
+    --sc-focus-ring: #8ab4f8;
+
+    --sc-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+    --sc-shadow-md: 0 2px 8px rgba(0, 0, 0, 0.55);
+    --sc-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.6);
+
+    color-scheme: dark;
+  }
+}
+
+/* ==========================================================================
+   Layer 3a - Applies in BOTH modes (accessibility fixes, additive)
+   ========================================================================== */
+
+/* WCAG 2.2 SC 2.4.11 Focus Not Obscured / 2.4.13 Focus Appearance.
+   Foundation's default focus treatment on buttons and links is a faint
+   background shift that is easy to lose. :focus-visible keeps mouse users
+   from seeing a ring while giving keyboard users a real one. */
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: var(--sc-focus-ring-width) solid var(--sc-focus-ring);
+  outline-offset: var(--sc-focus-ring-offset);
+  border-radius: var(--sc-radius-sm);
+}
+
+/* WCAG 2.2 SC 2.3.3 Animation from Interactions. Foundation, Motion UI and
+   animate.css all animate by default; honour the OS setting. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ==========================================================================
+   Layer 3b - Dark mode chrome
+   ==========================================================================
+   Everything below is scoped to the dark selectors so light mode is
+   untouched. The two selector groups are kept in sync deliberately;
+   :is() would collapse them but Foundation-era browsers in the support
+   matrix are not guaranteed to have it.
+   ========================================================================== */
+
+:root[data-theme="dark"] body,
+:root[data-theme="dark"] .platform-body,
+:root[data-theme="dark"] .platform-content,
+:root[data-theme="dark"] .platform-content-container {
+  background-color: var(--sc-surface);
+  color: var(--sc-text);
+}
+
+/* Long-form content and headings */
+:root[data-theme="dark"] h1,
+:root[data-theme="dark"] h2,
+:root[data-theme="dark"] h3,
+:root[data-theme="dark"] h4,
+:root[data-theme="dark"] h5,
+:root[data-theme="dark"] h6,
+:root[data-theme="dark"] p,
+:root[data-theme="dark"] li,
+:root[data-theme="dark"] dt,
+:root[data-theme="dark"] dd,
+:root[data-theme="dark"] blockquote,
+:root[data-theme="dark"] label,
+:root[data-theme="dark"] legend,
+:root[data-theme="dark"] .platform-blog-body {
+  color: var(--sc-text);
+}
+
+:root[data-theme="dark"] .help-text,
+:root[data-theme="dark"] .platform-activity-date,
+:root[data-theme="dark"] .platform-activity-content-date,
+:root[data-theme="dark"] .subheader {
+  color: var(--sc-text-muted);
+}
+
+/* Links. Scoped away from menus and buttons, which the theme colors. */
+:root[data-theme="dark"] .platform-body a,
+:root[data-theme="dark"] .platform-content a,
+:root[data-theme="dark"] .platform-blog-body a {
+  color: var(--sc-link);
+}
+
+:root[data-theme="dark"] .platform-body a:hover,
+:root[data-theme="dark"] .platform-content a:hover,
+:root[data-theme="dark"] .platform-blog-body a:hover {
+  color: var(--sc-link-hover);
+}
+
+/* Buttons keep their theme background; only the unstyled/hollow variants
+   need help, because they inherit page text color. */
+:root[data-theme="dark"] .button.hollow,
+:root[data-theme="dark"] .button.clear {
+  color: var(--sc-link);
+  border-color: var(--sc-border-control);
+  background-color: transparent;
+}
+
+/* Cards, panels, wells */
+:root[data-theme="dark"] .card,
+:root[data-theme="dark"] .card-section,
+:root[data-theme="dark"] .card-divider,
+:root[data-theme="dark"] .platform-blog-cards-container,
+:root[data-theme="dark"] .platform-calendar-details-container,
+:root[data-theme="dark"] .platform-toc-container,
+:root[data-theme="dark"] .platform-scrollable-view {
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-text);
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] .card-divider {
+  background-color: var(--sc-surface-sunken);
+}
+
+/* Callouts. Only the neutral default is repainted - primary/success/
+   warning/alert are theme colors and stay as the site configured them. */
+:root[data-theme="dark"] .callout {
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] .callout:not(.primary):not(.secondary):not(.success):not(.warning):not(.alert):not(.header) {
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-text);
+}
+
+/* Tables */
+:root[data-theme="dark"] table,
+:root[data-theme="dark"] table tbody {
+  /* Foundation paints tbody/tfoot directly (foundation.css "tbody, tfoot"),
+     so styling the table alone leaves un-striped rows white. */
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-text);
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] table thead,
+:root[data-theme="dark"] table tfoot {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+}
+
+:root[data-theme="dark"] table tbody tr:nth-child(even) {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+}
+
+:root[data-theme="dark"] table tbody td,
+:root[data-theme="dark"] table tbody th,
+:root[data-theme="dark"] table thead th {
+  border-color: var(--sc-border);
+  color: var(--sc-text);
+}
+
+:root[data-theme="dark"] table.hover tbody tr:hover {
+  background-color: var(--sc-surface-overlay);
+}
+
+/* Form fields */
+:root[data-theme="dark"] input[type="text"],
+:root[data-theme="dark"] input[type="password"],
+:root[data-theme="dark"] input[type="date"],
+:root[data-theme="dark"] input[type="datetime"],
+:root[data-theme="dark"] input[type="datetime-local"],
+:root[data-theme="dark"] input[type="month"],
+:root[data-theme="dark"] input[type="week"],
+:root[data-theme="dark"] input[type="email"],
+:root[data-theme="dark"] input[type="number"],
+:root[data-theme="dark"] input[type="search"],
+:root[data-theme="dark"] input[type="tel"],
+:root[data-theme="dark"] input[type="time"],
+:root[data-theme="dark"] input[type="url"],
+:root[data-theme="dark"] input[type="color"],
+:root[data-theme="dark"] textarea,
+:root[data-theme="dark"] select {
+  background-color: var(--sc-field-bg);
+  color: var(--sc-field-text);
+  border-color: var(--sc-border-control);
+  box-shadow: none;
+}
+
+:root[data-theme="dark"] input::placeholder,
+:root[data-theme="dark"] textarea::placeholder {
+  color: var(--sc-field-placeholder);
+  opacity: 1; /* Firefox dims placeholders by default, which undoes the ratio */
+}
+
+:root[data-theme="dark"] input:disabled,
+:root[data-theme="dark"] textarea:disabled,
+:root[data-theme="dark"] select:disabled,
+:root[data-theme="dark"] input[readonly],
+:root[data-theme="dark"] textarea[readonly] {
+  background-color: var(--sc-field-disabled-bg);
+  color: var(--sc-text-muted);
+}
+
+/* Foundation renders the select arrow as an embedded SVG data URI in a
+   dark ink that disappears on a dark field. */
+:root[data-theme="dark"] select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 24'><polygon points='0,0 32,0 16,24' style='fill: %23a7b0bd'></polygon></svg>");
+}
+
+:root[data-theme="dark"] .input-group-label {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+  border-color: var(--sc-border-control);
+}
+
+/* Overlays: modals, dropdown panes, tooltips */
+:root[data-theme="dark"] .reveal,
+:root[data-theme="dark"] .dropdown-pane,
+:root[data-theme="dark"] .platform-dialog {
+  background-color: var(--sc-surface-overlay);
+  color: var(--sc-text);
+  border-color: var(--sc-border);
+  box-shadow: var(--sc-shadow-lg);
+}
+
+:root[data-theme="dark"] .reveal-overlay {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+:root[data-theme="dark"] .tooltip {
+  background-color: var(--sc-surface-overlay);
+  color: var(--sc-text);
+  border: 1px solid var(--sc-border);
+}
+
+/* Tabs and accordions */
+:root[data-theme="dark"] .tabs,
+:root[data-theme="dark"] .tabs-content,
+:root[data-theme="dark"] .accordion,
+:root[data-theme="dark"] .accordion-content {
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-text);
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] .tabs-title > a,
+:root[data-theme="dark"] .accordion-title {
+  background-color: var(--sc-surface-raised);
+  color: var(--sc-link);
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] .tabs-title > a:hover,
+:root[data-theme="dark"] .accordion-title:hover {
+  background-color: var(--sc-surface-sunken);
+}
+
+:root[data-theme="dark"] .tabs-title > a[aria-selected="true"] {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+}
+
+/* Pagination and breadcrumbs */
+:root[data-theme="dark"] .pagination a,
+:root[data-theme="dark"] .pagination button,
+:root[data-theme="dark"] .breadcrumbs a {
+  color: var(--sc-link);
+}
+
+:root[data-theme="dark"] .pagination .current {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+}
+
+:root[data-theme="dark"] .breadcrumbs li:not(:last-child)::after {
+  color: var(--sc-text-muted);
+}
+
+/* Code and rules */
+:root[data-theme="dark"] code,
+:root[data-theme="dark"] pre,
+:root[data-theme="dark"] kbd {
+  background-color: var(--sc-surface-sunken);
+  color: var(--sc-text);
+  border-color: var(--sc-border);
+}
+
+:root[data-theme="dark"] hr {
+  border-color: var(--sc-border);
+}
+
+/* Images and media authored for a light page. Full inversion is wrong -
+   this only takes the edge off pure-white logo plates. */
+:root[data-theme="dark"] img.platform-invert-on-dark {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* --------------------------------------------------------------------------
+   Same rules for data-theme="auto" under an OS dark preference.
+   Kept as a separate block rather than a shared selector list so that the
+   forced-dark rules above stay readable and independently reviewable.
+   -------------------------------------------------------------------------- */
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] body,
+  :root[data-theme="auto"] .platform-body,
+  :root[data-theme="auto"] .platform-content,
+  :root[data-theme="auto"] .platform-content-container {
+    background-color: var(--sc-surface);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] h1,
+  :root[data-theme="auto"] h2,
+  :root[data-theme="auto"] h3,
+  :root[data-theme="auto"] h4,
+  :root[data-theme="auto"] h5,
+  :root[data-theme="auto"] h6,
+  :root[data-theme="auto"] p,
+  :root[data-theme="auto"] li,
+  :root[data-theme="auto"] dt,
+  :root[data-theme="auto"] dd,
+  :root[data-theme="auto"] blockquote,
+  :root[data-theme="auto"] label,
+  :root[data-theme="auto"] legend,
+  :root[data-theme="auto"] .platform-blog-body {
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] .help-text,
+  :root[data-theme="auto"] .platform-activity-date,
+  :root[data-theme="auto"] .platform-activity-content-date,
+  :root[data-theme="auto"] .subheader {
+    color: var(--sc-text-muted);
+  }
+
+  :root[data-theme="auto"] .platform-body a,
+  :root[data-theme="auto"] .platform-content a,
+  :root[data-theme="auto"] .platform-blog-body a {
+    color: var(--sc-link);
+  }
+
+  :root[data-theme="auto"] .platform-body a:hover,
+  :root[data-theme="auto"] .platform-content a:hover,
+  :root[data-theme="auto"] .platform-blog-body a:hover {
+    color: var(--sc-link-hover);
+  }
+
+  :root[data-theme="auto"] .button.hollow,
+  :root[data-theme="auto"] .button.clear {
+    color: var(--sc-link);
+    border-color: var(--sc-border-control);
+    background-color: transparent;
+  }
+
+  :root[data-theme="auto"] .card,
+  :root[data-theme="auto"] .card-section,
+  :root[data-theme="auto"] .card-divider,
+  :root[data-theme="auto"] .platform-blog-cards-container,
+  :root[data-theme="auto"] .platform-calendar-details-container,
+  :root[data-theme="auto"] .platform-toc-container,
+  :root[data-theme="auto"] .platform-scrollable-view {
+    background-color: var(--sc-surface-raised);
+    color: var(--sc-text);
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] .card-divider {
+    background-color: var(--sc-surface-sunken);
+  }
+
+  :root[data-theme="auto"] .callout {
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] .callout:not(.primary):not(.secondary):not(.success):not(.warning):not(.alert):not(.header) {
+    background-color: var(--sc-surface-raised);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] table,
+  :root[data-theme="auto"] table tbody {
+    background-color: var(--sc-surface-raised);
+    color: var(--sc-text);
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] table thead,
+  :root[data-theme="auto"] table tfoot {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] table tbody tr:nth-child(even) {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] table tbody td,
+  :root[data-theme="auto"] table tbody th,
+  :root[data-theme="auto"] table thead th {
+    border-color: var(--sc-border);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] table.hover tbody tr:hover {
+    background-color: var(--sc-surface-overlay);
+  }
+
+  :root[data-theme="auto"] input[type="text"],
+  :root[data-theme="auto"] input[type="password"],
+  :root[data-theme="auto"] input[type="date"],
+  :root[data-theme="auto"] input[type="datetime"],
+  :root[data-theme="auto"] input[type="datetime-local"],
+  :root[data-theme="auto"] input[type="month"],
+  :root[data-theme="auto"] input[type="week"],
+  :root[data-theme="auto"] input[type="email"],
+  :root[data-theme="auto"] input[type="number"],
+  :root[data-theme="auto"] input[type="search"],
+  :root[data-theme="auto"] input[type="tel"],
+  :root[data-theme="auto"] input[type="time"],
+  :root[data-theme="auto"] input[type="url"],
+  :root[data-theme="auto"] input[type="color"],
+  :root[data-theme="auto"] textarea,
+  :root[data-theme="auto"] select {
+    background-color: var(--sc-field-bg);
+    color: var(--sc-field-text);
+    border-color: var(--sc-border-control);
+    box-shadow: none;
+  }
+
+  :root[data-theme="auto"] input::placeholder,
+  :root[data-theme="auto"] textarea::placeholder {
+    color: var(--sc-field-placeholder);
+    opacity: 1;
+  }
+
+  :root[data-theme="auto"] input:disabled,
+  :root[data-theme="auto"] textarea:disabled,
+  :root[data-theme="auto"] select:disabled,
+  :root[data-theme="auto"] input[readonly],
+  :root[data-theme="auto"] textarea[readonly] {
+    background-color: var(--sc-field-disabled-bg);
+    color: var(--sc-text-muted);
+  }
+
+  :root[data-theme="auto"] select {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 24'><polygon points='0,0 32,0 16,24' style='fill: %23a7b0bd'></polygon></svg>");
+  }
+
+  :root[data-theme="auto"] .input-group-label {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+    border-color: var(--sc-border-control);
+  }
+
+  :root[data-theme="auto"] .reveal,
+  :root[data-theme="auto"] .dropdown-pane,
+  :root[data-theme="auto"] .platform-dialog {
+    background-color: var(--sc-surface-overlay);
+    color: var(--sc-text);
+    border-color: var(--sc-border);
+    box-shadow: var(--sc-shadow-lg);
+  }
+
+  :root[data-theme="auto"] .reveal-overlay {
+    background-color: rgba(0, 0, 0, 0.7);
+  }
+
+  :root[data-theme="auto"] .tooltip {
+    background-color: var(--sc-surface-overlay);
+    color: var(--sc-text);
+    border: 1px solid var(--sc-border);
+  }
+
+  :root[data-theme="auto"] .tabs,
+  :root[data-theme="auto"] .tabs-content,
+  :root[data-theme="auto"] .accordion,
+  :root[data-theme="auto"] .accordion-content {
+    background-color: var(--sc-surface-raised);
+    color: var(--sc-text);
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] .tabs-title > a,
+  :root[data-theme="auto"] .accordion-title {
+    background-color: var(--sc-surface-raised);
+    color: var(--sc-link);
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] .tabs-title > a:hover,
+  :root[data-theme="auto"] .accordion-title:hover {
+    background-color: var(--sc-surface-sunken);
+  }
+
+  :root[data-theme="auto"] .tabs-title > a[aria-selected="true"] {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] .pagination a,
+  :root[data-theme="auto"] .pagination button,
+  :root[data-theme="auto"] .breadcrumbs a {
+    color: var(--sc-link);
+  }
+
+  :root[data-theme="auto"] .pagination .current {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+  }
+
+  :root[data-theme="auto"] .breadcrumbs li:not(:last-child)::after {
+    color: var(--sc-text-muted);
+  }
+
+  :root[data-theme="auto"] code,
+  :root[data-theme="auto"] pre,
+  :root[data-theme="auto"] kbd {
+    background-color: var(--sc-surface-sunken);
+    color: var(--sc-text);
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] hr {
+    border-color: var(--sc-border);
+  }
+
+  :root[data-theme="auto"] img.platform-invert-on-dark {
+    filter: invert(1) hue-rotate(180deg);
+  }
+}
+
+/* ==========================================================================
+   Color scheme toggle control
+   ==========================================================================
+   Rendered in the utility bar. Inherits the bar's colors so it works
+   against whatever the site configured, in either scheme.
+   ========================================================================== */
+
+/* Hidden until platform-theme.js marks the document ready. A toggle that
+   cannot toggle is worse than no toggle at all (WCAG 2.2 SC 4.1.2 - a
+   control that reports itself as a button but does nothing). Deliberately
+   NOT keyed off Foundation's .no-js class: Foundation only removes that on
+   .foundation() init, which would both delay the button and tie this
+   feature to a dependency it does not otherwise need. */
+.platform-color-scheme-toggle {
+  display: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  padding: var(--sc-space-1) var(--sc-space-2);
+  margin: 0;
+  line-height: 1;
+  border-radius: var(--sc-radius-sm);
+  align-items: center;
+  gap: var(--sc-space-2);
+}
+
+:root.platform-color-scheme-ready .platform-color-scheme-toggle {
+  display: inline-flex;
+}
+
+.platform-color-scheme-toggle:hover {
+  background-color: rgba(127, 127, 127, 0.2);
+}
+
+.platform-color-scheme-toggle .fa,
+.platform-color-scheme-toggle .fas,
+.platform-color-scheme-toggle .far {
+  color: inherit;
+}
+
+/* Only one of the two icons is shown, whichever matches the active scheme.
+   Hidden with display so screen readers do not announce the inactive one;
+   the accessible name lives on the button's aria-label, which the script
+   keeps in sync. */
+.platform-color-scheme-toggle .platform-icon-dark {
+  display: none;
+}
+
+:root[data-theme="dark"] .platform-color-scheme-toggle .platform-icon-light {
+  display: none;
+}
+
+:root[data-theme="dark"] .platform-color-scheme-toggle .platform-icon-dark {
+  display: inline-block;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] .platform-color-scheme-toggle .platform-icon-light {
+    display: none;
+  }
+
+  :root[data-theme="auto"] .platform-color-scheme-toggle .platform-icon-dark {
+    display: inline-block;
+  }
+}
+

--- a/src/main/webapp/javascript/platform-theme.js
+++ b/src/main/webapp/javascript/platform-theme.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Color scheme toggle for the utility bar.
+ *
+ * The scheme itself is driven entirely by the data-theme attribute on <html>, which platform-tokens.css reads. The
+ * server renders the site's configured default (theme.ui.mode) into that attribute, and a small inline script in the
+ * document head applies any stored visitor preference before the first paint -- so this file never causes a flash and
+ * is not needed for the page to render correctly. All it adds is the control.
+ *
+ * The visitor's choice is stored in localStorage rather than a cookie on purpose: it is a display preference that the
+ * server never needs, so it stays out of the request and out of the analytics/privacy surface. Storage access is
+ * wrapped because it throws in Safari private browsing and when a site is loaded in a partitioned third-party frame.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'simis-cms-color-scheme';
+  var root = document.documentElement;
+
+  function readStoredScheme() {
+    try {
+      var value = window.localStorage.getItem(STORAGE_KEY);
+      return (value === 'light' || value === 'dark') ? value : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function storeScheme(value) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    } catch (e) {
+      // Preference is not persisted; the toggle still works for this page view
+    }
+  }
+
+  // What the visitor is actually looking at right now, resolving "auto"
+  // against the operating system setting.
+  function effectiveScheme() {
+    var mode = root.getAttribute('data-theme');
+    if (mode === 'dark' || mode === 'light') {
+      return mode;
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  // Queried by class, not id: an administrator can place the widget more
+  // than once (say, in the utility bar and the footer), and duplicate ids
+  // would be invalid markup with only the first one ever updated.
+  function announce(message) {
+    var regions = document.querySelectorAll('.platform-color-scheme-status');
+    for (var i = 0; i < regions.length; i++) {
+      regions[i].textContent = message;
+    }
+  }
+
+  // The accessible name describes the ACTION, not the state, so a screen
+  // reader user knows what pressing it will do.
+  function updateToggles() {
+    var isDark = effectiveScheme() === 'dark';
+    var label = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+    var toggles = document.querySelectorAll('.platform-color-scheme-toggle');
+    for (var i = 0; i < toggles.length; i++) {
+      toggles[i].setAttribute('aria-label', label);
+      toggles[i].setAttribute('title', label);
+    }
+  }
+
+  function applyScheme(scheme) {
+    root.setAttribute('data-theme', scheme);
+    storeScheme(scheme);
+    updateToggles();
+    announce(scheme === 'dark' ? 'Dark theme on' : 'Light theme on');
+  }
+
+  function onToggleClick(event) {
+    var toggle = event.target.closest ? event.target.closest('.platform-color-scheme-toggle') : null;
+    if (!toggle) {
+      return;
+    }
+    event.preventDefault();
+    applyScheme(effectiveScheme() === 'dark' ? 'light' : 'dark');
+  }
+
+  function init() {
+    updateToggles();
+    // Reveals the control. Until this runs the button is display:none, so a
+    // visitor with scripting disabled never sees an inert toggle.
+    root.className += (root.className ? ' ' : '') + 'platform-color-scheme-ready';
+    document.addEventListener('click', onToggleClick);
+
+    // While the site default is "auto" and the visitor has not chosen, the
+    // OS can flip underneath us. The colors follow via CSS; the button's
+    // accessible name has to be told.
+    if (window.matchMedia) {
+      var query = window.matchMedia('(prefers-color-scheme: dark)');
+      var onChange = function () {
+        if (!readStoredScheme()) {
+          updateToggles();
+        }
+      };
+      if (query.addEventListener) {
+        query.addEventListener('change', onChange);
+      } else if (query.addListener) {
+        query.addListener(onChange);
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## What this does

Adds `css/platform-tokens.css` — a semantic design-token layer (surfaces, text, borders, fields, focus, elevation, radius, spacing, motion) — and builds an **opt-in dark color scheme** on top of it.

It also publishes every site theme color as a custom property named after the site property it comes from (`theme.button.primary.backgroundColor` → `--sc-button-primary-background-color`), so widgets and page styles can finally reference the site's own colors instead of duplicating hex values.

This is the foundation piece: it's what lets later UI work restyle things in one place instead of hunting hex values across 296 JSPs.

## How the scheme is selected

New site property **Theme > Color Scheme** (`theme.ui.mode`), rendered as a dropdown in the site properties editor:

| Value | Behavior |
| --- | --- |
| `light` | Forced light, no toggle — **the default** |
| `dark` | Forced dark, no toggle |
| `auto` | Follows the visitor's OS setting |
| `user` | Follows the OS, and the visitor can override |

It maps through a whitelist before reaching the `data-theme` attribute, so a malformed property value can't inject into the markup.

In `user` mode, the new **`colorSchemeToggle`** widget renders the control (place it in the utility bar). The preference is kept in `localStorage` rather than a cookie — it's a display preference the server never needs, so it stays out of the request and out of the analytics surface. A tiny inline head script applies it before first paint so there's no flash.

## Compatibility: light mode is untouched

The default is `light` specifically so **upgrading an existing site changes nothing visually**. The dark chrome rules are all scoped to the dark selectors.

Verified rather than asserted — rendered a representative page (menu, cards, callouts, buttons, forms, tables, pagination, footer) with and without the new stylesheet in light mode. Identical, except the new toggle's own styling.

Two rules *do* apply in both schemes, both deliberate accessibility fixes:
- `:focus-visible` outline — keyboard focus is visible without showing a ring to mouse users (WCAG 2.2 SC 2.4.11, 2.4.13)
- `prefers-reduced-motion` block collapsing animation/transition durations (SC 2.3.3). Uses the conventional `0.001ms` rather than `0` so Foundation's `transitionend`/`animationend` handlers still fire.

## Accessibility

Contrast was computed, not eyeballed:

- Dark text `#e6e9ee` on page `#16191d` = **14.49:1**; muted **8.05:1**; link **8.37:1** — all past SC 1.4.3's 4.5:1
- `--sc-border-control` = **3.78:1** on the page and **3.42:1** on raised surfaces — past SC 1.4.11's 3:1 for controls
- `--sc-border` is decorative only (1.4.11 exempts separators) and is documented as not-for-controls
- Dark placeholder **6.33:1** on the field background, with `opacity: 1` so Firefox's default dimming can't undo it

**Accent colors are deliberately not lightened in dark mode.** Foundation's primary `#1779ba` already carries white text at 4.69:1 and reads on the dark page at 3.76:1. Lifting it to `#2f8fd0` would drop the button label to **3.52:1** — a regression — as well as discarding the site's brand color.

The toggle is `display: none` until `platform-theme.js` marks the document ready, so a visitor with scripting off never gets an inert button (SC 4.1.2). Its accessible name states the *action* ("Switch to dark theme") and a `role="status"` live region announces the change, since a changed `aria-label` on a focused button isn't reliably re-announced.

## Verification

- `ant compile`, `ant -lib lib/war compile-jsp` (296 JSPs translate + compile), `ant -lib lib/war package` — all pass
- Light-mode render diffed with/without the new stylesheet — identical
- Toggle exercised in a browser: ready class, visibility, `data-theme` flip, computed body background, `aria-label` flip, live-region text, `localStorage` write, and the no-flash script applying a stored preference on reload
- **Ran granule's `CSSFastMin` directly against the new stylesheet** (`tag.method.css=cssfastmin`) and confirmed it preserves custom properties, `var()`, `:focus-visible`, `:not()`, both media queries, and the inline SVG data URI — an old minifier silently mangling modern CSS was the most likely way this could have broken in production only
- Token wiring checked programmatically: every `var(--sc-*)` reference resolves to a definition, and the forced-dark and auto-dark token sets are identical

Two issues found during review and fixed before this PR:
1. Foundation paints `tbody`/`tfoot` directly, so styling only `table` left un-striped rows white-on-dark and unreadable. Caught by rendering it.
2. The toggle was initially gated on Foundation's `.no-js` class, which is only removed on `.foundation()` init — that would have delayed the button and coupled this to a dependency it doesn't need. Now uses its own ready class.

## Notes for review

- **`embedded-layout.jsp` got the same treatment** as `main.jsp` — otherwise embedded pages would have stayed light while the rest of the site went dark.
- **Semantic callouts, buttons, top bar and footer keep their configured theme colors in dark mode.** That's a deliberate brand-fidelity call, but it means a pale `theme.callout.primary.backgroundColor` will read as a bright block on a dark page. A site enabling dark mode should review those colors. Per-scheme theme colors are the natural follow-up now that the token layer exists.
- **Pre-existing, not introduced here:** theme color properties are interpolated into CSS with `c:out`, which escapes HTML but not `;` or `}`. An administrator could already inject CSS through a theme color; moving the same values into custom properties neither improves nor worsens it. Flagging it as a separate hardening item rather than expanding this PR.
- The `docs/theming.md` page documents the tokens and the setting for site builders.