### PR TITLE
Sync the pom project version and guard it against future drift

### DIFF
--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -5,6 +5,11 @@
 # not in the script's ALLOWLIST. The one-time reconciliation zeroed the drift down to
 # two documented, intentional holds (flexmark fat-jar, jackson-coreutils), which are
 # allowlisted with revisit triggers; everything else must match. New drift fails here.
+#
+# Also enforces that the pom's own project <version> tracks ApplicationInfo.VERSION,
+# the constant build.xml stamps the build with. Nothing in the build reads the pom's
+# version, so it goes stale unnoticed -- it had fallen two and a half years behind by
+# v20260719.10000. See tools/check-version-consistency.py.
 name: Dependency drift
 
 on:
@@ -24,3 +29,5 @@ jobs:
       # ubuntu-latest ships python3; no extra setup or network needed.
       - name: Fail on un-allowlisted pom vs vendored-jar drift
         run: python3 tools/check-dependency-drift.py . --strict
+      - name: Fail on pom vs ApplicationInfo project-version drift
+        run: python3 tools/check-version-consistency.py . --strict

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.simisinc</groupId>
   <artifactId>simis-cms</artifactId>
-  <version>20240106.10000-SNAPSHOT</version>
+  <version>20260719.10000-SNAPSHOT</version>
   <name>SimIS CMS</name>
   <url>https://www.simiscms.com</url>
   <description>Agile, Enterprise, Open Source Content Management System (CMS) and Web Portal</description>

--- a/tools/check-version-consistency.py
+++ b/tools/check-version-consistency.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Report drift between the pom.xml project version and ApplicationInfo.VERSION.
+
+Background
+----------
+Three places carry the project version, and only one of them is authoritative:
+
+  * ``src/main/java/com/simisinc/platform/ApplicationInfo.java`` -- the ``VERSION``
+    constant. ``build.xml`` loads it in the ``version`` target to stamp the build,
+    so this is the version that actually ships.
+  * the git release tag, ``v<VERSION>``, cut at release time.
+  * ``pom.xml`` -- the project ``<version>``, carrying a ``-SNAPSHOT`` suffix. Maven
+    plays no part in producing the WAR, so nothing fails when this one goes stale.
+
+Because no build step reads the pom's own version, it drifts silently. It has done
+so more than once: at ``v20231209.10000`` the pom still read ``20231127.10000-SNAPSHOT``,
+and by ``v20260719.10000`` it had fallen two and a half years behind at
+``20240106.10000-SNAPSHOT``. CONTRIBUTING.md already warns that the pom and the
+shipped artifact "can silently drift apart" -- this is that same failure mode
+applied to the version field itself.
+
+What it does
+------------
+Compares the pom's project version, with any ``-SNAPSHOT`` suffix removed, against
+``ApplicationInfo.VERSION``, and reports whether they agree.
+
+The git tag is deliberately NOT part of the comparison. ``ApplicationInfo.VERSION``
+is legitimately bumped ahead of the newest tag while the next release is still in
+development, so requiring tag parity would fail the build during normal work.
+
+Modes
+-----
+Default is REPORT-ONLY: it prints the finding and exits 0. Pass ``--strict`` (or set
+``STRICT=1``) to exit 1 when the two versions disagree.
+
+Exit codes: 0 = consistent (or report-only), 1 = drift under --strict, 2 = bad usage
+or a version string that could not be read.
+
+This is a read-only reporter. It changes no files.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+POM_NS = "{http://maven.apache.org/POM/4.0.0}"
+
+APPLICATION_INFO = "src/main/java/com/simisinc/platform/ApplicationInfo.java"
+VERSION_RE = re.compile(r'\bString\s+VERSION\s*=\s*"([^"]+)"')
+
+SNAPSHOT_SUFFIX = "-SNAPSHOT"
+
+
+def _fail(message: str):
+    """Exit 2 -- the version could not be read, which is distinct from finding drift.
+
+    ``SystemExit("text")`` would print the text but exit 1, colliding with the
+    --strict drift signal and hiding a broken checkout behind a "drift" result.
+    """
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def read_application_info_version(root_dir: str) -> str:
+    """Return the VERSION constant declared in ApplicationInfo.java."""
+    path = os.path.join(root_dir, APPLICATION_INFO)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        _fail(f"ERROR: cannot read {APPLICATION_INFO}: {exc}")
+
+    matches = VERSION_RE.findall(source)
+    # The file documents the constant's format in a comment above it, so match on the
+    # declaration only and require exactly one -- two would mean the shape changed.
+    if len(matches) != 1:
+        _fail(
+            f"ERROR: expected exactly one VERSION declaration in {APPLICATION_INFO}, "
+            f"found {len(matches)}. Has the constant been renamed or duplicated?"
+        )
+    return matches[0]
+
+
+def read_pom_version(root_dir: str) -> str:
+    """Return the pom's own project <version> (not a parent's, not a dependency's)."""
+    path = os.path.join(root_dir, "pom.xml")
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as exc:
+        _fail(f"ERROR: cannot parse pom.xml: {exc}")
+
+    # Direct child of <project> only -- root.iter() would also pick up every
+    # <version> under <dependencies>, <plugins>, and <properties>.
+    version = root.find(POM_NS + "version")
+    if version is None or not (version.text or "").strip():
+        _fail("ERROR: pom.xml declares no top-level <version>.")
+    return version.text.strip()
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    flags = {a for a in sys.argv[1:] if a.startswith("-")}
+
+    unknown = flags - {"--strict"}
+    if unknown or len(args) > 1:
+        print(f"usage: {os.path.basename(sys.argv[0])} [ROOT] [--strict]", file=sys.stderr)
+        return 2
+
+    root_dir = args[0] if args else "."
+    strict = "--strict" in flags or os.environ.get("STRICT") == "1"
+
+    app_version = read_application_info_version(root_dir)
+    pom_version = read_pom_version(root_dir)
+    pom_base = pom_version[: -len(SNAPSHOT_SUFFIX)] if pom_version.endswith(SNAPSHOT_SUFFIX) else pom_version
+
+    consistent = pom_base == app_version
+
+    lines = [
+        "Project version consistency (pom.xml vs ApplicationInfo.java)",
+        "",
+        f"  ApplicationInfo.VERSION : {app_version}   (authoritative -- build.xml reads this)",
+        f"  pom.xml <version>       : {pom_version}",
+        "",
+    ]
+    if consistent:
+        lines.append("Summary: consistent.")
+    else:
+        lines.append(f"Summary: DRIFT -- pom declares {pom_base}, the build ships {app_version}.")
+        lines.append(f"Fix: set the pom's project <version> to {app_version}{SNAPSHOT_SUFFIX}.")
+    report = "\n".join(lines)
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write("## Project version consistency\n\n")
+            if consistent:
+                fh.write(f"**Consistent** — both declare `{app_version}`.\n\n")
+            else:
+                fh.write("**Drift.** The pom's project version does not match the version the build ships.\n\n")
+                fh.write("| Source | Version |\n|---|---|\n")
+                fh.write(f"| `ApplicationInfo.VERSION` (authoritative) | **{app_version}** |\n")
+                fh.write(f"| `pom.xml` `<version>` | {pom_version} |\n\n")
+                fh.write(f"Set the pom's project version to `{app_version}{SNAPSHOT_SUFFIX}`.\n")
+
+    if strict and not consistent:
+        print(
+            f"\nFAIL (--strict): pom.xml project version {pom_version} does not match "
+            f"ApplicationInfo.VERSION {app_version}.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

The pom's project `<version>` read `20240106.10000-SNAPSHOT` while the build ships `20260719.10000`. This syncs it and adds a CI guard so the two cannot silently diverge again.

## Why

`build.xml` stamps the build from `ApplicationInfo.VERSION` (the `version` target), and nothing in the build reads the pom's own version — so when it goes stale, nothing notices. It had fallen two and a half years behind, and this is not the first time:

| Tag | `ApplicationInfo.VERSION` | `pom.xml` | |
|---|---|---|---|
| `v20231209.10000` | `20231209.10000` | `20231127.10000-SNAPSHOT` | drifted |
| `v20240106.10000` | `20240106.10000` | `20240106.10000-SNAPSHOT` | matched |
| `v20260719.10000` | `20260719.10000` | `20240106.10000-SNAPSHOT` | drifted |

Nothing shipping was wrong: the WAR is assembled by Ant, and the SBOM is generated by syft from that built WAR, so neither derives its version from the pom. But `CONTRIBUTING.md` already warns that the pom and what actually ships "can silently drift apart" — this is that same failure mode, applied to the pom's own version field.

## How

- `pom.xml` — version synced to `20260719.10000-SNAPSHOT`
- `tools/check-version-consistency.py` — new; compares the pom's project version (minus any `-SNAPSHOT` suffix) against `ApplicationInfo.VERSION`
- `.github/workflows/dependency-drift.yml` — runs it with `--strict`, alongside the existing vendored-jar drift check

The git tag is **deliberately excluded** from the comparison. `ApplicationInfo.VERSION` is legitimately bumped ahead of the newest tag while a release is in development, so requiring tag parity would fail during normal work.

Follows the existing `check-dependency-drift.py` idiom: report-only by default, `--strict` in CI, and a `GITHUB_STEP_SUMMARY` table when it fails.

## Verification

- Detects the drift **before** the fix — exit 1 under `--strict`, exit 0 report-only
- Passes **after** the fix
- Exit-code contract tested on all paths: `0` consistent, `1` drift under `--strict`, `2` bad usage or an unreadable version string
- `check-dependency-drift.py --strict` still exits 0
- Workflow YAML parses; job `drift` has 3 steps with triggers unchanged

Added as a step to the existing workflow rather than a new one — same concern, no extra runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)