### PR TITLE
Digest-pin the database image's base images

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -4,16 +4,33 @@
 # Bookworm's packages are more fully triaged by Debian security, so the image
 # ships with materially fewer open CVEs. See docker/db/README.md for the image's
 # CVE posture and why the residual findings are not fixable here.
+#
+# Both FROM lines are pinned by DIGEST as well as tag. A tag is mutable: the
+# content behind `postgres:17-bookworm` changes whenever upstream rebuilds, so a
+# tag-only pin means the image can change underneath a scan result or an accepted
+# risk without anything in this repo changing. Pinning the digest makes the build
+# reproducible and makes an upstream change an explicit, reviewable commit --
+# which is the CM-2 baseline evidence, not just hygiene.
+#
+# The tag is kept alongside the digest deliberately: it is what tells a human
+# which upstream line this is, and Dependabot uses it to raise the update PR.
+#
+# Both digests are multi-arch OCI indexes (linux/amd64 + linux/arm64/v8 among
+# others), so the same pin builds on CI runners and on Apple Silicon.
+#
+# To refresh (do this as its own reviewed commit, not silently):
+#   docker buildx imagetools inspect postgres:17-bookworm --format '{{.Manifest.Digest}}'
+#   docker buildx imagetools inspect golang:1.26-bookworm --format '{{.Manifest.Digest}}'
 
 # Rebuild gosu with a current Go toolchain. The base image's gosu is built
 # against an older Go and carries that Go's stdlib CVEs; a fresh static build
 # clears them without changing gosu's behavior.
-FROM golang:1.26-bookworm AS gosu
+FROM golang:1.26-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651 AS gosu
 ENV CGO_ENABLED=0
 RUN go install github.com/tianon/gosu@1.17
 
-# Pull official base image
-FROM postgres:17-bookworm
+# Pull official base image (digest-pinned -- see the header note)
+FROM postgres:17-bookworm@sha256:4f736ae292687621d4dbe0d499ffd024a36bd2ee7d8ca6f2ccd4c800f047b394
 
 # Replace the base image's gosu with the freshly built, patched-stdlib binary.
 COPY --from=gosu /go/bin/gosu /usr/local/bin/gosu


### PR DESCRIPTION
## What

Pins both `FROM` lines in `docker/db/Dockerfile` by **digest** as well as tag. One file, 20 lines — most of it the explanatory header.

## Why

A tag is mutable. The content behind `postgres:17-bookworm` changes whenever upstream rebuilds, so today's image is **not necessarily** the image a Trivy result or an accepted residual risk was recorded against — and nothing in this repository would change when it moves. The private STIG runbook names this "the silent-drift path."

Pinning the digest makes the build reproducible and turns an upstream change into an **explicit, reviewable commit**. That's CM-2 baseline evidence, not just hygiene.

## Two deliberate choices

**The tags stay alongside the digests.** The tag is what tells a reader which upstream line this is, and Dependabot uses it to raise the update PR. A bare digest is unreadable and unmaintainable.

**Both digests are multi-arch OCI indexes** (`linux/amd64` and `linux/arm64/v8` among others), so the same pin builds on CI runners and on Apple Silicon. Pinning a platform-specific manifest instead would have broken one or the other. The header documents the `docker buildx imagetools inspect` command to refresh them.

## Verification — built and ran the image

| Check | Result | Why it matters |
|---|---|---|
| PostgreSQL | `17.10 on Debian 12.15` | the deliberate **bookworm** pin held — not trixie |
| PostGIS | `3.6.4` | `init.sql` extension creation still works |
| `gosu` | `1.17 (go1.26.5)` | still the **rebuilt-with-current-Go** binary, so the stdlib-CVE work this image does on purpose is preserved rather than reverted to the base image's |
| Application | `/healthz` → `{"status":"UP"}` | the app reached and migrated the database |

## Scope

Independent of the open PR stack — nothing else in flight touches `docker/db/`. The app image's `FROM` is deliberately **not** pinned here: it's being rewritten by #216 and #219, so pinning it belongs in a follow-up once those land, to avoid a pointless conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)