### PR TITLE
Enable Tomcat's SecurityListener

### DIFF
--- a/docker/app/conf/server.xml
+++ b/docker/app/conf/server.xml
@@ -38,12 +38,30 @@
      lifecycle (docker stop / SIGTERM) handles shutdown instead. -->
 <Server port="-1" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
-  <!-- [STIG] The SecurityListener (umask/effective-user checks) should be enabled
-       once the image runs as a non-root user (paired container-runtime card). It
-       is left disabled here because the current image still starts as root and the
-       listener's checks would halt startup; enabling it before that would break boot.
+  <!-- [STIG] SecurityListener ENABLED. It refuses startup if Tomcat is running as a
+       root user, and if the effective umask is less restrictive than 0027.
+
+       Previously commented out because the image started as root and the listener
+       would have halted boot. PR #219 moved the container to a non-root user
+       (uid 10001), which is what makes this safe to turn on — and turning it on is
+       what makes the non-root property *enforced* rather than merely configured: if
+       a future change reintroduces a root runtime, Tomcat now fails fast instead of
+       silently regressing.
+
+       No umask configuration is needed. catalina.sh defaults UMASK to 0027 when it
+       is unset, applies it before starting the JVM, and passes the result through as
+       -Dorg.apache.catalina.security.SecurityListener.UMASK, which is the property
+       this listener reads. (The image's *shell* umask is 0022, but that is not what
+       Tomcat runs under — verified by reading catalina.sh, not assumed.)
+
+       NOTE for future edits: XML forbids a doubled hyphen inside a comment body.
+       Tomcat's parser rejects the whole server.xml at startup if one appears, and
+       it presents as "Cannot start server, server instance is not configured"
+       rather than as a comment problem, so it is easy to misdiagnose. Use an em
+       dash for parenthetical asides. This exact mistake shipped to main once
+       before (PR #178, in META-INF/context.xml) and is why the deploy smoke test
+       exists. -->
   <Listener className="org.apache.catalina.security.SecurityListener" />
-  -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" />
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />


### PR DESCRIPTION
> ### ⚠️ Stacked — merge order is **#216 → #219 → this**
>
> Based on `hardening/app-image-non-root` (#219), which is itself based on #216. GitHub can't use a fork branch as a base against this repo, so the diff below includes both. **The change here is one file, +23/−5** (`docker/app/conf/server.xml`).
>
> To review only this change:
> ```sh
> git fetch origin
> git diff origin/hardening/app-image-non-root..origin/hardening/enable-security-listener
> ```

## What

Uncomments `SecurityListener` in `server.xml`.

## Why now

It was commented out with the note that it should be enabled *"once the image runs as a non-root user"* — its checks would have halted a root-run boot. **#219 met that precondition.**

Turning it on is what moves non-root from a **configured property** to an **enforced** one. If a future change reintroduces a root runtime, Tomcat refuses to start rather than regressing silently.

## No umask work was needed

`catalina.sh` already defaults `UMASK` to `0027` when unset, applies it before starting the JVM, and passes the result through as `-Dorg.apache.catalina.security.SecurityListener.UMASK` — the property this listener reads.

The image's *shell* umask is `0022`, which would have failed the check. That's not what Tomcat runs under. Established by reading `catalina.sh`, not assumed.

## Verification — two directions

**Positive** (normal boot):

| | |
|---|---|
| identity | `uid=10001(simis)` |
| active `SecurityListener` elements | 1 |
| JVM command line | `SecurityListener.UMASK=0027` |
| `/healthz` | `{"status":"UP"}` |
| homepage | `200` |
| SEVERE lines | `0` |

**Negative** (the actual proof) — same image forced back to root with `--user 0:0`:

```
java.lang.Error: Start attempted while running as user [root]. Running Tomcat as this
user has been blocked by the Lifecycle listener
org.apache.catalina.security.SecurityListener
    at org.apache.catalina.security.SecurityListener.checkOsUser(SecurityListener.java:189)
```

It refuses to boot. That's what demonstrates the listener is genuinely active — **a silently unloaded listener would have passed the positive test too.**

## One thing worth reading

While writing the explanatory comment I introduced a **doubled hyphen inside an XML comment body**, which XML forbids. Tomcat rejected the entire `server.xml` and reported `Cannot start server, server instance is not configured` — which points nowhere near a comment.

That is the same class of failure as **#178**, and exactly what the deploy smoke test exists to catch. It caught it in under a minute.

The comment now warns future editors. **Suggested follow-up:** an XML well-formedness check on `server.xml` and `META-INF/context.xml` in CI would catch this class in about a second, versus a full image build and boot. Happy to open that separately.

## Closes

The third of four items in the Tomcat STIG profile's one 🟡 Open row. Remaining: read-only root filesystem and dropping ALL capabilities — both designed in the private `container-runtime-hardening-card`, and both gated on a question this one isn't: whether App Service for Containers can enforce them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)