### PR TITLE
Test the web-page access gate and enforce its coverage

### DIFF
--- a/.github/scripts/check-security-coverage.sh
+++ b/.github/scripts/check-security-coverage.sh
@@ -62,6 +62,12 @@ set -euo pipefail
 # floor. The class arrived with PR #136 (feature/honor-dnt), so this entry is
 # valid only once #136 is in the lineage; merging it before then fail-closes the
 # gate on a missing class. (See the PR description for merge-order details.)
+#
+# ValidateUserAccessToWebPageCommand.hasAccess() -- the page-level access gate
+# (privileged-role bypass, draft/empty/reachability checks over the real
+# role/group primitive) -- is covered by ValidateUserAccessToWebPageCommandTest
+# at ~88% and shares the 0.50 floor. The floor exists to fail the gate if those
+# tests are removed, since this is an access-control decision.
 TARGETS='
 com.simisinc.platform.application.IpAddressCommand,0.50
 com.simisinc.platform.application.SecretCryptoCommand,0.50
@@ -70,6 +76,7 @@ com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand,0.50
 com.simisinc.platform.application.cms.UrlCommand,0.50
 com.simisinc.platform.application.cms.NumberCommand,0.30
 com.simisinc.platform.application.DoNotTrackCommand,0.50
+com.simisinc.platform.application.cms.ValidateUserAccessToWebPageCommand,0.50
 '
 
 CSV="${1:-${JACOCO_CSV:-target/coverage-reports/jacoco.csv}}"

--- a/src/test/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommandTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.presentation.controller.Column;
+import com.simisinc.platform.presentation.controller.Page;
+import com.simisinc.platform.presentation.controller.Section;
+import com.simisinc.platform.presentation.controller.UserSession;
+import com.simisinc.platform.presentation.controller.Widget;
+
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Exercises the page-level access gate.
+ *
+ * <p>
+ * The role/group primitive this gate leans on ({@code WebComponentCommand.allowsUser}) is covered by
+ * WebComponentCommandTest. These tests cover what {@code hasAccess} adds on top of it: the privileged-role
+ * bypass, and the checks that a page is loadable, published (not draft), non-empty, and reachable. The
+ * data-loading boundary ({@code LoadWebPageCommand}, {@code WebPageXmlLayoutCommand}) is mocked so the real
+ * authorization logic runs against controlled page structures.
+ * </p>
+ *
+ * @author Elizabeth Houser
+ * @created 7/22/2026 4:15 PM
+ */
+class ValidateUserAccessToWebPageCommandTest {
+
+  private static final String LINK = "/some-page";
+
+  /** A logged-in session whose user holds exactly the given role codes. */
+  private UserSession sessionWithRoles(String... roleCodes) {
+    List<Role> roles = new ArrayList<>();
+    for (String code : roleCodes) {
+      roles.add(new Role(code, code));
+    }
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(roles);
+    user.setGroupList(new ArrayList<>());
+    UserSession session = new UserSession();
+    session.login(user);
+    return session;
+  }
+
+  /** A not-logged-in (guest) session. */
+  private UserSession guestSession() {
+    return new UserSession();
+  }
+
+  private WebPage publishedPage(String xml) {
+    WebPage webPage = new WebPage();
+    webPage.setDraft(false);
+    webPage.setPageXml(xml);
+    return webPage;
+  }
+
+  /** A single-widget page structure with the given roles required at the page level; everything else public. */
+  private Page pageStructure(List<String> pageRoles) {
+    Widget widget = new Widget("content");
+    Column column = new Column();
+    column.setWidgets(List.of(widget));
+    Section section = new Section();
+    section.setColumns(List.of(column));
+    Page page = new Page();
+    page.setRoles(pageRoles);
+    page.setSections(List.of(section));
+    return page;
+  }
+
+  // --- privileged bypass: returns before any page is loaded, so no mocking is needed ---
+
+  @Test
+  void administratorAlwaysHasAccess() {
+    Assertions.assertTrue(ValidateUserAccessToWebPageCommand.hasAccess(LINK, sessionWithRoles("admin")));
+  }
+
+  @Test
+  void contentManagerAlwaysHasAccess() {
+    Assertions.assertTrue(ValidateUserAccessToWebPageCommand.hasAccess(LINK, sessionWithRoles("content-manager")));
+  }
+
+  // --- non-privileged users: the page-loading and structural gates ---
+
+  @Test
+  void deniedWhenPageDoesNotExist() {
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(null);
+      Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void deniedWhenPageIsDraft() {
+    // Security property: an unpublished draft must never be served to a non-privileged user.
+    WebPage draft = publishedPage("<page/>");
+    draft.setDraft(true);
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(draft);
+      Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void deniedWhenPageXmlIsBlank() {
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(publishedPage("   "));
+      Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void deniedWhenPageStructureCannotBeBuilt() {
+    WebPage webPage = publishedPage("<page/>");
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageXmlLayoutCommand> layout = mockStatic(WebPageXmlLayoutCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(webPage);
+      layout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(webPage, LINK)).thenReturn(null);
+      Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void grantedForAPublishedPublicPage() {
+    WebPage webPage = publishedPage("<page/>");
+    Page structure = pageStructure(new ArrayList<>()); // no roles required -> public
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageXmlLayoutCommand> layout = mockStatic(WebPageXmlLayoutCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(webPage);
+      layout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(webPage, LINK)).thenReturn(structure);
+      Assertions.assertTrue(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void deniedWhenPageRequiresLoginAndUserIsGuest() {
+    // Security property: a page restricted to logged-in users ("users" role) is not reachable by a guest.
+    WebPage webPage = publishedPage("<page/>");
+    Page structure = pageStructure(List.of("users"));
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageXmlLayoutCommand> layout = mockStatic(WebPageXmlLayoutCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(webPage);
+      layout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(webPage, LINK)).thenReturn(structure);
+      Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void grantedWhenLoginRestrictedPageIsViewedByALoggedInUser() {
+    // The same "users"-restricted page IS reachable once the viewer is logged in.
+    WebPage webPage = publishedPage("<page/>");
+    Page structure = pageStructure(List.of("users"));
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageXmlLayoutCommand> layout = mockStatic(WebPageXmlLayoutCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(webPage);
+      layout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(webPage, LINK)).thenReturn(structure);
+      Assertions.assertTrue(ValidateUserAccessToWebPageCommand.hasAccess(LINK, sessionWithRoles("some-role")));
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds tests for `ValidateUserAccessToWebPageCommand.hasAccess()` — the page-level authorization gate — and registers it in the security-coverage gate. **2 files, +191.**

## Why

`hasAccess()` is an access-control decision and had **zero tests** — one of the untested authorization items in the maintenance backlog.

## What's tested — and what deliberately isn't

The low-level role/group primitive this gate leans on (`WebComponentCommand.allowsUser`) is **already thoroughly covered** by `WebComponentCommandTest` (12 cases). So these tests cover only what `hasAccess` adds *on top*, to avoid duplication:

- the **admin / content-manager bypass**
- the checks that a page is **loadable, published (not draft), non-empty, and reachable**

The data-loading boundary (`LoadWebPageCommand`, `WebPageXmlLayoutCommand`) is mocked with Mockito `mockStatic`, so the **real authorization logic runs** against controlled page structures — the test exercises the decision, not a stubbed answer.

**Nine cases**, including two named security properties worth a regression guard:

| Property | Test |
|---|---|
| A draft (unpublished) page must never be served to a non-privileged user | `deniedWhenPageIsDraft` |
| A login-restricted page must not be reachable by a guest | `deniedWhenPageRequiresLoginAndUserIsGuest` |

Plus: the privileged bypass (admin, content-manager), page-not-found, blank XML, an unbuildable structure, a public-page grant, and the same restricted page becoming reachable once the viewer logs in.

## Enforced, not just present

Adds the class to `check-security-coverage.sh` at the house **0.50** floor (actual instruction coverage **87.7%**, in line with the other tracked classes — SecretCryptoCommand sits at 88.2% on the same floor). The floor's job here is to **fail the gate if these tests are removed** — present-but-unenforced coverage on an access-control class can be deleted silently.

## Verification

- Full suite green — **367 tests, 0 failures**, the 9 new tests passing
- Security-coverage gate passes with **8 classes** tracked, the new one at 87.7% ≥ 50%

## Scope

Independent — based on `main`, no stacking. Test-only plus one gate entry; it can't change production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)