### PR TITLE
Match whitespace in script end tags in the unescaped-EL scanner

### DIFF
--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -182,7 +182,10 @@ CONTEXT_JS = "JS"
 
 TAG = re.compile(r"<[^>]*>", re.S)
 COMMENT = re.compile(r"<%--.*?--%>", re.S)
-SCRIPT = re.compile(r"<script\b[^>]*>(.*?)</script>", re.S | re.I)
+# The end tag allows whitespace before ">" per the HTML spec (</script >, </script\n>),
+# so match \s* -- otherwise a script block closed that way is not recognised, and an
+# unescaped EL expression in its JS context could slip past this gate (CodeQL py/bad-tag-filter).
+SCRIPT = re.compile(r"<script\b[^>]*>(.*?)</script\s*>", re.S | re.I)
 EL = re.compile(r"\$\{[^}]+\}")
 # A backtick-delimited JS template literal, including newlines.
 TEMPLATE_LITERAL = re.compile(r"`[^`]*`", re.S)


### PR DESCRIPTION
## What

Fixes the script-block regex in `tools/check-unescaped-el.py` to match end tags that contain whitespace. **1 line changed.**

## Why

This is the repository's **only open CodeQL source-code alert** (`py/bad-tag-filter`, high). The regex:

```python
SCRIPT = re.compile(r"<script\b[^>]*>(.*?)</script>", re.S | re.I)
```

`</script>` doesn't match `</script >` or `</script\n>`, which the HTML spec permits and browsers honor.

**Why it matters in this file specifically:** the tool uses this regex to locate `<script>` blocks so it can apply JS-context escaping rules to EL expressions inside them (where a `"` breaks out of a JS string — different rules than HTML context). A block closed with whitespace in its end tag wouldn't be recognized, and an unescaped `${...}` in that JS context could **slip past this security gate as a false negative.** It's a robustness hole in a tool the project relies on for XSS prevention.

## Fix

```python
</script\s*>
```

## Verification

Old vs new against the closing-tag variants:

| Input | old | new |
|---|---|---|
| `</script>` | match | match |
| `</script >` | **miss** | match |
| `</script\n>` | **miss** | match |
| `</SCRIPT >` | **miss** | match |

And the tool still runs **clean on the current tree** — exit 0, the same 106 allowlisted sites, no regression.

Clears the repo's only open CodeQL alert to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)