### PR TITLE
Drop all Linux capabilities from the app container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,17 @@ services:
       DB_PASSWORD: "${DB_PASSWORD:?err}"
       DB_NAME: "${DB_NAME:-simis-cms}"
     restart: on-failure
+    # [STIG] Runtime hardening: drop all Linux capabilities and block privilege escalation.
+    # Tomcat binds the unprivileged port 8080 and, since the non-root image (PR #219), never
+    # setuids -- so it needs no capabilities. no-new-privileges additionally blocks escalation
+    # through any setuid binary. Enforced by the container runtime here and in CI's deploy smoke
+    # test. App Service for Containers exposes no equivalent, so the control is evidenced as a
+    # verified image property rather than platform-enforced config -- see the container-runtime
+    # hardening card. Read-only root filesystem is the paired change, landing separately.
+    cap_drop:
+      - ALL
+    security_opt:
+      - "no-new-privileges:true"
     depends_on:
       - db
     networks:


### PR DESCRIPTION
## What

Adds `cap_drop: [ALL]` and `no-new-privileges` to the app service. **1 file, +11.** Item **B** of the container-runtime hardening card — the paired change to non-root (#219) and `SecurityListener` (#221).

## Why it's safe

Tomcat binds the unprivileged port 8080 and, since the image runs non-root, never `setuid`s — so it needs **no** Linux capabilities. `no-new-privileges` additionally blocks escalation through any setuid binary.

App Service for Containers exposes no `securityContext` equivalent, so this is evidenced as a **verified image property**, not platform-enforced config (per the card's App Service determination). It's enforced by the container runtime locally and in the `deploy-smoke-test` CI job.

## Verification — on the running container, not the compose file

The card is explicit that a flag being *requested* isn't proof it was *applied*. So:

| Check | Result |
|---|---|
| `docker inspect` | `CapDrop [ALL]`, `CapAdd []`, `SecurityOpt no-new-privileges:true` |
| `/proc/1/status` `CapEff` | **`0000000000000000`** — the Tomcat process has zero effective capabilities |
| Process identity | `uid=10001(simis)` |
| `/healthz` | `UP` (DB + `CMS_PATH` both reachable) |
| Homepage | `200` |
| Access log (AU-3) | written |
| SEVERE lines | `0` |

`CapEff: 0` is the ground truth — the running process, not the requested flag.

## Scope

Independent — off `main`, no stack. **Read-only root filesystem (item A)** is the remaining paired change and lands separately, since it needs the WAR pre-extracted at build time (the one non-trivial piece the card flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)