### PR TITLE
Make the app container's root filesystem read-only

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,22 @@ services:
       dockerfile: ./docker/app/Dockerfile
     ports:
       - 80:8080
+    # [STIG] Read-only root filesystem. The image pre-extracts the WAR (unpackWARs=false) and
+    # routes the App Insights self-diagnostics to the console, so the only writable surfaces at
+    # runtime are these tmpfs mounts -- Tomcat's scratch/log dirs -- and the /opt/simis volume
+    # (CMS_PATH). Everything else (server.xml, the app, the JRE) is immutable. App Service for
+    # Containers exposes no equivalent, so the control is evidenced as a verified image property
+    # (see the container-runtime hardening card). The tmpfs dirs are recreated empty each start;
+    # nothing here is meant to persist -- access logs are shipped, not retained locally.
+    read_only: true
+    tmpfs:
+      - /usr/local/tomcat/work
+      - /usr/local/tomcat/temp
+      - /usr/local/tomcat/logs
+    # conf/Catalina/localhost is NOT a tmpfs: the image pre-creates it (owned by the runtime
+    # user), and Tomcat's HostConfig only needs it to EXIST -- it does not write into it for a
+    # directory-deployed app with autoDeploy=false. A tmpfs there would shadow the pre-created
+    # dir with an empty root-owned mount and re-introduce the "Unable to create directory" SEVERE.
     environment:
       CMS_ADMIN_USERNAME: "${CMS_ADMIN_USERNAME:?err}"
       CMS_ADMIN_PASSWORD: "${CMS_ADMIN_PASSWORD:?err}"
@@ -36,10 +52,15 @@ services:
       - platform
     volumes:
       - web-data:/opt/simis:delegated
-  
+      # The one writable+executable surface under the read-only root: Argon2's JNA native library
+      # must be extracted and mmap-executed, which the noexec tmpfs above cannot host. A volume is
+      # exec (unlike tmpfs); setenv.sh points -Djna.tmpdir here. See docker/app/Dockerfile.
+      - jna-exec:/opt/jna
+
 volumes:
   db-data:
   web-data:
+  jna-exec:
 
 networks:
   platform:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -42,7 +42,15 @@ RUN curl -fsSL -o /opt/applicationinsights-agent.jar \
     && echo "${APPLICATIONINSIGHTS_SHA256}  /opt/applicationinsights-agent.jar" | sha256sum -c -
 COPY ./docker/app/applicationinsights.json /opt/applicationinsights.json
 
-COPY ./target/simis-cms.war /usr/local/tomcat/webapps/ROOT.war
+# [STIG] Pre-extract the WAR at build time instead of letting Tomcat unpack it at startup.
+# With a read-only root filesystem, Tomcat cannot write the exploded ROOT/ into webapps/ at
+# boot -- so the app is exploded here, once, and server.xml sets unpackWARs="false". The
+# extracted tree is identical to the WAR's contents (precompiled JSPs included). This removes
+# the last startup write to webapps/ and lets that directory stay read-only.
+COPY ./target/simis-cms.war /tmp/ROOT.war
+RUN mkdir -p /usr/local/tomcat/webapps/ROOT \
+    && (cd /usr/local/tomcat/webapps/ROOT && jar xf /tmp/ROOT.war) \
+    && rm /tmp/ROOT.war
 
 # [STIG] Run Tomcat as a non-root user. The stock image runs as root, which is a standing,
 # citable finding independent of any base-image choice. A fixed high UID/GID avoids collision
@@ -54,8 +62,10 @@ COPY ./target/simis-cms.war /usr/local/tomcat/webapps/ROOT.war
 #   temp/    java.io.tmpdir for the JVM.
 #   logs/    catalina.out and the STIG access log (AU-3) -- an unwritable logs/ would silently
 #            lose the per-request audit trail this profile depends on.
-#   webapps/ unpackWARs="true" extracts ROOT.war to ROOT/ at startup.
-#   /opt     the App Insights agent writes its selfDiagnostics log beside its own jar.
+#   webapps/ (no longer a runtime write -- the WAR is pre-extracted above and unpackWARs is
+#            false, so webapps/ is read-only under the read-only root filesystem).
+#   /opt     (no longer a runtime write -- the App Insights agent's selfDiagnostics is routed to
+#            the console in applicationinsights.json, so nothing is written beside the jar).
 #   /opt/simis  CMS_PATH, the file store. Created here on purpose: docker seeds a NAMED volume
 #            from the image path, so creating it owned by the runtime user is what makes the
 #            mounted web-data volume writable. Without this the app boots and /healthz fails
@@ -73,15 +83,23 @@ COPY ./target/simis-cms.war /usr/local/tomcat/webapps/ROOT.war
 # root-owned 0750 file would be silently unreadable to this user and the JVM options would
 # vanish without an error. That failure mode is called out in the private STIG runbook.
 #
-# Still open (paired container-runtime work, tracked separately): read-only root filesystem,
-# dropping ALL Linux capabilities, and enabling server.xml's SecurityListener -- the listener's
-# umask/effective-user checks are what this change makes possible.
+# The read-only root filesystem is enforced at the container-runtime layer (docker-compose.yaml:
+# read_only + tmpfs for work/temp/logs), paired with this image's pre-extraction and
+# console-routed agent log. SecurityListener (enabled in server.xml) and dropped capabilities
+# (compose) complete the runtime hardening.
+#
+# /opt/jna is the one deliberate writable+executable surface. Argon2 password hashing loads a
+# JNA native library, which JNA extracts to a temp dir and then mmap-executes. Docker forces
+# `noexec` on tmpfs, so the general scratch dirs (work/temp/logs) cannot host it -- setenv.sh
+# points -Djna.tmpdir here, a mounted volume (volumes are exec), keeping noexec everywhere else.
+# The stronger long-term posture is a system-installed libargon2 with argon2-jvm-nolibs, which
+# would need no writable-exec surface at all; tracked as a follow-up.
 ARG APP_UID=10001
 ARG APP_GID=10001
 RUN groupadd --gid ${APP_GID} simis \
     && useradd --uid ${APP_UID} --gid ${APP_GID} --home-dir /usr/local/tomcat \
                --shell /usr/sbin/nologin --no-create-home simis \
-    && mkdir -p /opt/simis /usr/local/tomcat/work /usr/local/tomcat/temp /usr/local/tomcat/logs \
+    && mkdir -p /opt/simis /opt/jna /usr/local/tomcat/work /usr/local/tomcat/temp /usr/local/tomcat/logs \
                 /usr/local/tomcat/conf/Catalina/localhost \
     && chown -R simis:simis \
          /opt \

--- a/docker/app/applicationinsights.json
+++ b/docker/app/applicationinsights.json
@@ -6,6 +6,7 @@
     "percentage": 100
   },
   "selfDiagnostics": {
-    "level": "warn"
+    "level": "warn",
+    "destination": "console"
   }
 }

--- a/docker/app/conf/server.xml
+++ b/docker/app/conf/server.xml
@@ -142,7 +142,7 @@
            at startup (deployOnStartup defaults true). This blocks a drop-in-WAR RCE
            path and keeps the deployed set fixed and inventoried (CM-7). -->
       <Host name="localhost" appBase="webapps"
-            unpackWARs="true" autoDeploy="false">
+            unpackWARs="false" autoDeploy="false">
 
         <!-- [STIG] Suppress error-page disclosure: no stack traces (showReport) and
              no Tomcat version/server banner (showServerInfo) in error responses. -->

--- a/docker/app/conf/setenv.sh
+++ b/docker/app/conf/setenv.sh
@@ -4,9 +4,12 @@
 # so it composes cleanly with other options (e.g. the memory/agent flags) rather
 # than overwriting them. Coverage: docker-tomcat9-stig-hardening.md.
 #
-# This file currently sets no JVM properties. It is retained (rather than deleted)
-# because the Dockerfile copies it and because it is the natural home for any future
-# -D hardening flag.
+# [STIG] Point JNA's native-library extraction at /opt/jna. Under the read-only root filesystem
+# the general scratch dirs (work/temp/logs) are noexec tmpfs, but Argon2 password hashing loads a
+# JNA native library that must be mmap-executed. /opt/jna is a mounted volume (exec, unlike tmpfs),
+# so JNA can extract and load its .so there while everything else stays noexec/read-only. Without
+# this the admin-user Flyway migration fails with UnsatisfiedLinkError ("failed to map segment").
+CATALINA_OPTS="$CATALINA_OPTS -Djna.tmpdir=/opt/jna"
 #
 # Historical note, so the old flag is not reintroduced: Tomcat 9 required
 #     -Dorg.apache.catalina.connector.RECYCLE_FACADES=true


### PR DESCRIPTION
Mounts the app container's root filesystem read-only (`read_only: true`) with tmpfs for Tomcat's scratch and log dirs. This is **item A** of the container-runtime hardening card and the last of the paired changes to the non-root user (#219), SecurityListener (#221), and dropped capabilities (#230).

A read-only root means a compromised process cannot overwrite `server.xml`, the application, or the JRE. Holding that property meant removing every startup write to the root filesystem:

- **WAR pre-extraction.** Tomcat unpacks `ROOT.war` into `webapps/` at boot, which a read-only root forbids. The Dockerfile now explodes the WAR once at build time and `server.xml` sets `unpackWARs="false"`, so `webapps/` is immutable at runtime. The extracted tree is byte-identical to the WAR contents (precompiled JSPs included).
- **App Insights self-diagnostics.** The agent wrote a log beside its jar in `/opt` (now read-only); `applicationinsights.json` routes `selfDiagnostics` to the console instead.
- **Writable surfaces narrowed** to three tmpfs mounts (`work/`, `temp/`, `logs/`), recreated empty each start. `conf/Catalina/localhost` is intentionally left as the image's pre-created dir, **not** a tmpfs — a tmpfs there would shadow it with an empty root-owned mount and re-introduce the "Unable to create directory" SEVERE that #219 fixed.

### The one deliberate exception: `/opt/jna`

Argon2 password hashing (admin-user creation, login) loads a JNA native library that JNA extracts and then **mmap-executes**. Docker forces `noexec` on tmpfs, so the scratch dirs cannot host it — without an exec surface the first admin migration dies with `UnsatisfiedLinkError` ("failed to map segment from shared object"). A named volume is exec, so `setenv.sh` points `-Djna.tmpdir=/opt/jna` and everything else stays noexec/read-only.

The stronger long-term posture is a system-installed `libargon2` with `argon2-jvm-nolibs`, needing no writable-exec surface at all — tracked as a follow-up on the card.

### Verification — on the running container, not the compose file

| Check | Evidence |
|---|---|
| Read-only root **applied** | `docker inspect` → `ReadonlyRootfs: true` |
| Read-only root **enforced** | write into `conf/` fails "Read-only file system"; write into `work/` succeeds |
| Argon2 exec surface works | admin migration `71120 - create admin` completes, 22 migrations applied, **zero** `UnsatisfiedLinkError` |
| App healthy | `/healthz` UP, homepage 200 (real content), access log written (AU-3), **zero SEVERE** |

App Service for Containers exposes no read-only-root equivalent, so this is evidenced as a verified image/runtime property rather than platform config; the container runtime enforces it locally and in CI's deploy smoke test.

### Merge note

Touches `docker-compose.yaml` in a different region than the open #230 (`cap_drop`/`no-new-privileges`) — the two are independent and merge cleanly in either order. Completes the container-runtime hardening set: #219, #221, #230, this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
