### PR TITLE
Re-derive sales tax at checkout instead of charging the cart's stale amount

### DIFF
--- a/src/main/java/com/simisinc/platform/application/ecommerce/OrderCommand.java
+++ b/src/main/java/com/simisinc/platform/application/ecommerce/OrderCommand.java
@@ -34,6 +34,7 @@ import com.sanctionco.jmail.JMail;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
+import com.simisinc.platform.domain.model.ecommerce.Address;
 import com.simisinc.platform.domain.model.ecommerce.Cart;
 import com.simisinc.platform.domain.model.ecommerce.CartItem;
 import com.simisinc.platform.domain.model.ecommerce.Customer;
@@ -171,11 +172,15 @@ public class OrderCommand {
       grandTotal = grandTotal.add(cart.getShippingAndHandlingFee());
     }
 
-    // Finally, determine the taxes
-    if (cart.getTaxAmount() != null) {
-      // @todo Use the Tax service to get the final actual amount
-      grandTotal = grandTotal.add(cart.getTaxAmount());
-    }
+    // Look up the selected shipping rate up front: it is needed both to re-derive
+    // the sales tax below (shipping and handling can themselves be taxable) and to
+    // record the shipping method on the order further down.
+    ShippingRate shippingRate = ShippingRateRepository.findById(cart.getShippingRateId());
+
+    // Finally, determine the taxes -- re-derived from the Tax service and validated
+    // against the amount the customer reviewed, rather than trusted from the cart
+    // (see determineTaxToCharge for why the stored amount can be stale).
+    grandTotal = grandTotal.add(determineTaxToCharge(cart, customer, shippingRate));
 
     // Include Gift Cards (set amount going to gift card, reduce amount CC)
 
@@ -197,8 +202,7 @@ public class OrderCommand {
     order.setBillingAddress(customer.getBillingAddress());
     order.setShippingAddress(customer.getShippingAddress());
 
-    // Shipping information
-    ShippingRate shippingRate = ShippingRateRepository.findById(cart.getShippingRateId());
+    // Shipping information (shippingRate looked up above)
     if (shippingRate != null) {
       order.setShippingRateId(shippingRate.getId());
       order.setShippingMethodId(shippingRate.getShippingMethodId());
@@ -225,8 +229,7 @@ public class OrderCommand {
     order.setShippingFee(cart.getShippingFee());
     order.setHandlingFee(cart.getHandlingFee());
 
-    // Taxes
-    // @todo consider regenerating
+    // Taxes (validated against the Tax service during grand-total computation above)
     order.setTaxAmount(cart.getTaxAmount());
     order.setTaxRate(cart.getTaxRate());
 //    order.setTaxId();
@@ -254,5 +257,47 @@ public class OrderCommand {
       return validOrder;
     }
     return null;
+  }
+
+  /**
+   * Re-derives the sales tax for a cart at checkout and returns the amount to charge.
+   * <p>
+   * The tax stored on the cart was calculated earlier, when the customer chose a
+   * shipping method ({@code ShippingMethodFormWidget}). By the time the order is
+   * placed the tax-rate table, the nexus configuration, or the shipping selection
+   * may have changed, leaving that stored amount stale. This method asks the Tax
+   * service for the current amount and, if it no longer matches what the customer
+   * reviewed ({@code cart.getTaxAmount()}), throws so the caller can send them back
+   * to review -- mirroring how a changed product price or subtotal is handled --
+   * rather than silently charging a total different from the one they saw.
+   * <p>
+   * Note: the re-derivation uses the cart's current subtotal and discount, so it
+   * catches tax-rate/nexus/shipping changes. Regenerating the discount itself at
+   * checkout remains a separate concern (see the discount handling in generateOrder).
+   *
+   * @param cart         the cart being converted to an order
+   * @param customer     the customer, for the destination (shipping) address
+   * @param shippingRate the selected shipping rate (shipping/handling can be taxable)
+   * @return the sales tax to charge (never null; zero when no tax applies)
+   * @throws DataException if the re-derived tax no longer matches the reviewed amount
+   */
+  protected static BigDecimal determineTaxToCharge(Cart cart, Customer customer, ShippingRate shippingRate)
+      throws DataException {
+    BigDecimal reviewedTax = (cart.getTaxAmount() != null ? cart.getTaxAmount() : BigDecimal.ZERO);
+    BigDecimal actualTax = BigDecimal.ZERO;
+    Address shippingAddress = customer.getShippingAddress();
+    if (shippingAddress != null
+        && StringUtils.isNotBlank(shippingAddress.getCountry())
+        && StringUtils.isNotBlank(shippingAddress.getState())
+        && StringUtils.isNotBlank(shippingAddress.getPostalCode())) {
+      BigDecimal taxRate = SalesTaxCommand.estimatedTaxRateForAddress(shippingAddress);
+      if (taxRate != null && shippingRate != null) {
+        actualTax = SalesTaxCommand.estimateTax(cart, shippingAddress, taxRate, shippingRate);
+      }
+    }
+    if (actualTax.compareTo(reviewedTax) != 0) {
+      throw new DataException("The sales tax has been recalculated, please review the cart");
+    }
+    return actualTax;
   }
 }

--- a/src/test/java/com/simisinc/platform/application/ecommerce/OrderCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/ecommerce/OrderCommandTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.ecommerce;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.ecommerce.Address;
+import com.simisinc.platform.domain.model.ecommerce.Cart;
+import com.simisinc.platform.domain.model.ecommerce.Customer;
+import com.simisinc.platform.domain.model.ecommerce.ShippingRate;
+
+/**
+ * Verifies the checkout-time sales-tax re-derivation guard in OrderCommand: the grand
+ * total must charge tax re-derived from the Tax service, never a stale amount stored
+ * on the cart, and a mismatch must bounce the customer back to review the cart.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class OrderCommandTest {
+
+  private static Customer customerShippingTo(String country, String state, String postalCode) {
+    Address address = new Address();
+    address.setCountry(country);
+    address.setState(state);
+    address.setPostalCode(postalCode);
+    Customer customer = new Customer();
+    customer.setShippingAddress(address);
+    return customer;
+  }
+
+  private static Cart cartWithReviewedTax(BigDecimal taxAmount) {
+    Cart cart = new Cart();
+    cart.setTaxAmount(taxAmount);
+    return cart;
+  }
+
+  @Test
+  void taxUnchangedChargesTheReviewedAmount() throws DataException {
+    Cart cart = cartWithReviewedTax(new BigDecimal("8.25"));
+    Customer customer = customerShippingTo("UNITED STATES", "VA", "22182");
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      tax.when(() -> SalesTaxCommand.estimatedTaxRateForAddress(any())).thenReturn(new BigDecimal("0.06"));
+      tax.when(() -> SalesTaxCommand.estimateTax(any(), any(), any(), any())).thenReturn(new BigDecimal("8.25"));
+
+      BigDecimal charged = OrderCommand.determineTaxToCharge(cart, customer, shippingRate);
+
+      Assertions.assertEquals(0, charged.compareTo(new BigDecimal("8.25")));
+    }
+  }
+
+  @Test
+  void taxIncreasedSinceReviewBouncesToReview() {
+    Cart cart = cartWithReviewedTax(new BigDecimal("8.25"));
+    Customer customer = customerShippingTo("UNITED STATES", "VA", "22182");
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      tax.when(() -> SalesTaxCommand.estimatedTaxRateForAddress(any())).thenReturn(new BigDecimal("0.06"));
+      // The tax-rate table was updated after the customer chose a shipping method
+      tax.when(() -> SalesTaxCommand.estimateTax(any(), any(), any(), any())).thenReturn(new BigDecimal("9.00"));
+
+      DataException ex = Assertions.assertThrows(DataException.class,
+          () -> OrderCommand.determineTaxToCharge(cart, customer, shippingRate));
+      Assertions.assertTrue(ex.getMessage().toLowerCase().contains("review the cart"));
+    }
+  }
+
+  @Test
+  void nexusRemovedButCartStillHasTaxBouncesToReview() {
+    // The reviewed cart carries tax, but there is no longer a taxable nexus for the address
+    Cart cart = cartWithReviewedTax(new BigDecimal("8.25"));
+    Customer customer = customerShippingTo("UNITED STATES", "VA", "22182");
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      tax.when(() -> SalesTaxCommand.estimatedTaxRateForAddress(any())).thenReturn(null);
+
+      DataException ex = Assertions.assertThrows(DataException.class,
+          () -> OrderCommand.determineTaxToCharge(cart, customer, shippingRate));
+      Assertions.assertTrue(ex.getMessage().toLowerCase().contains("review the cart"));
+      // With no rate, the amount calculation must not be attempted
+      tax.verify(() -> SalesTaxCommand.estimateTax(any(), any(), any(), any()), never());
+    }
+  }
+
+  @Test
+  void newlyTaxableButCartHasNoTaxBouncesToReview() {
+    // The cart was never taxed, but a nexus now makes the destination taxable.
+    // Charging the order as-is would silently under-collect tax; bounce instead.
+    Cart cart = cartWithReviewedTax(null);
+    Customer customer = customerShippingTo("UNITED STATES", "VA", "22182");
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      tax.when(() -> SalesTaxCommand.estimatedTaxRateForAddress(any())).thenReturn(new BigDecimal("0.06"));
+      tax.when(() -> SalesTaxCommand.estimateTax(any(), any(), any(), any())).thenReturn(new BigDecimal("7.50"));
+
+      DataException ex = Assertions.assertThrows(DataException.class,
+          () -> OrderCommand.determineTaxToCharge(cart, customer, shippingRate));
+      Assertions.assertTrue(ex.getMessage().toLowerCase().contains("review the cart"));
+    }
+  }
+
+  @Test
+  void noTaxApplicableAndNoneReviewedChargesZero() throws DataException {
+    Cart cart = cartWithReviewedTax(null);
+    Customer customer = customerShippingTo("UNITED STATES", "VA", "22182");
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      tax.when(() -> SalesTaxCommand.estimatedTaxRateForAddress(any())).thenReturn(null);
+
+      BigDecimal charged = OrderCommand.determineTaxToCharge(cart, customer, shippingRate);
+
+      Assertions.assertEquals(0, charged.compareTo(BigDecimal.ZERO));
+    }
+  }
+
+  @Test
+  void incompleteAddressWithReviewedTaxBouncesWithoutCallingTheService() {
+    // Address is missing a postal code, so tax cannot be re-derived; a cart that
+    // nonetheless carries a tax amount is stale and must bounce, not charge blindly.
+    Cart cart = cartWithReviewedTax(new BigDecimal("5.00"));
+    Customer customer = customerShippingTo("UNITED STATES", "VA", null);
+    ShippingRate shippingRate = new ShippingRate();
+
+    try (MockedStatic<SalesTaxCommand> tax = mockStatic(SalesTaxCommand.class)) {
+      DataException ex = Assertions.assertThrows(DataException.class,
+          () -> OrderCommand.determineTaxToCharge(cart, customer, shippingRate));
+      Assertions.assertTrue(ex.getMessage().toLowerCase().contains("review the cart"));
+      tax.verify(() -> SalesTaxCommand.estimatedTaxRateForAddress(any()), never());
+      tax.verify(() -> SalesTaxCommand.estimateTax(any(), any(), any(), any()), never());
+    }
+  }
+}


### PR DESCRIPTION
## The defect

`OrderCommand.generateOrder` re-validates the subtotal against live SKU prices and re-derives the discount at checkout, but takes sales tax **straight from the cart**:

```java
if (cart.getTaxAmount() != null) {
  // @todo Use the Tax service to get the final actual amount
  grandTotal = grandTotal.add(cart.getTaxAmount());
}
```

That `cart.getTaxAmount()` was calculated earlier, when the customer chose a shipping method (`ShippingMethodFormWidget`). If the US sales-tax-rate table, the nexus configuration, or the shipping selection changed between then and order placement, the customer is charged a **stale tax** — silently — and the stale figure is persisted onto the order (`order.setTaxAmount(cart.getTaxAmount())`).

The codebase already has the right pattern for this class of staleness: a changed product price or subtotal throws *"please review the cart"* rather than charging a stale number (lines 147-155). Tax was the one total that skipped that guard.

## The fix

Re-derive tax from the Tax service (`SalesTaxCommand`) at checkout and compare it to the amount the customer reviewed. If it no longer matches, throw *"the sales tax has been recalculated, please review the cart"* — consistent with the existing price/subtotal guards — instead of charging a total different from the one they saw. This also closes the reverse, more insidious case: a cart that was never taxed but is now taxable no longer places an order that **silently under-collects** tax (a compliance problem).

**Behavioral choice** (confirmed deliberately): *bounce-to-re-review*, not *silently charge the corrected amount* — so the charged total always equals the displayed total.

The tax logic is extracted into `determineTaxToCharge(cart, customer, shippingRate)` so it's unit-testable without standing up the whole order pipeline.

## Tests

`OrderCommandTest` — 6 cases, single `mockStatic(SalesTaxCommand)`, all green:

| Case | Expected |
|---|---|
| tax unchanged | charges the reviewed amount |
| tax increased since review | bounce |
| nexus removed, cart still has tax | bounce (amount calc not attempted) |
| newly taxable, cart has no tax | bounce (no silent under-collection) |
| incomplete address, cart has tax | bounce (service not called) |
| no tax anywhere | charges zero |

```
[ 6 tests found ] [ 6 tests successful ] [ 0 tests failed ]
```

## Scope boundary

Documented on the method: the re-derivation uses the cart's current subtotal and discount, so it catches **tax-rate / nexus / shipping** changes. Regenerating the *discount* itself at checkout is a separate pre-existing concern (there's an adjacent `@todo consider re-generating`) and is left untouched here — one clean concern per PR.

Independent branch off `main`; does not touch the open hardening PRs (#230, #231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
