### PR TITLE
Apply dataset date and assignedTo field mappings instead of silently dropping them

### DIFF
--- a/src/main/java/com/simisinc/platform/application/datasets/SaveDatasetRowCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/SaveDatasetRowCommand.java
@@ -22,17 +22,22 @@ import com.simisinc.platform.application.items.ItemPhoneNumberCommand;
 import com.simisinc.platform.application.items.SaveItemCommand;
 import com.simisinc.platform.application.maps.CheckGeoPointCommand;
 import com.simisinc.platform.domain.model.CustomField;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.datasets.Dataset;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -252,13 +257,25 @@ public class SaveDatasetRowCommand {
       } else if ("cost".equals(mapping)) {
         item.setCost(new BigDecimal(value));
       } else if ("startDate".equals(mapping)) {
-        // @todo
+        Timestamp startDate = parseTimestamp(value);
+        if (startDate != null) {
+          item.setStartDate(startDate);
+        }
       } else if ("endDate".equals(mapping)) {
-        // @todo
+        Timestamp endDate = parseTimestamp(value);
+        if (endDate != null) {
+          item.setEndDate(endDate);
+        }
       } else if ("expectedDate".equals(mapping)) {
-        // @todo
+        Timestamp expectedDate = parseTimestamp(value);
+        if (expectedDate != null) {
+          item.setExpectedDate(expectedDate);
+        }
       } else if ("expirationDate".equals(mapping)) {
-        // @todo
+        Timestamp expirationDate = parseTimestamp(value);
+        if (expirationDate != null) {
+          item.setExpirationDate(expirationDate);
+        }
       } else if ("url".equals(mapping)) {
         item.setUrl(value);
       } else if ("imageUrl".equals(mapping)) {
@@ -266,7 +283,10 @@ public class SaveDatasetRowCommand {
       } else if ("barcode".equals(mapping)) {
         item.setBarcode(value);
       } else if ("assignedTo".equals(mapping)) {
-        // @todo
+        long assignedToUserId = resolveAssignedToUserId(value);
+        if (assignedToUserId > -1) {
+          item.setAssignedTo(assignedToUserId);
+        }
       } else if ("custom".equals(mapping)) {
         String columnName = columnNames.get(i);
         String title = fieldTitles.get(i);
@@ -283,6 +303,56 @@ public class SaveDatasetRowCommand {
       item.setName(item.getName().substring(0, 250));
     }
     return item;
+  }
+
+  /**
+   * Parses a dataset cell into a Timestamp, trying the date/time formats that dataset
+   * exports commonly use. Datasets carry no declared source format, so a set of patterns
+   * is attempted strictly (to avoid silently accepting a nonsense date). A value matching
+   * none is logged and skipped rather than stored wrong -- importing a wrong date is worse
+   * than importing none, which is the silent data loss this replaces. Parsing is naive
+   * (any zone designator is treated as a literal); fidelity beyond the stored value is out
+   * of scope here.
+   *
+   * @param value the trimmed cell value (never blank here -- blanks are skipped earlier)
+   * @return the parsed Timestamp, or null if the value could not be parsed
+   */
+  protected static Timestamp parseTimestamp(String value) {
+    try {
+      java.util.Date date = DateUtils.parseDateStrictly(value,
+          "yyyy-MM-dd'T'HH:mm:ss'Z'",
+          "yyyy-MM-dd'T'HH:mm:ssXXX",
+          "yyyy-MM-dd'T'HH:mm:ss",
+          "yyyy-MM-dd HH:mm:ss",
+          "yyyy-MM-dd",
+          "MM/dd/yyyy HH:mm:ss",
+          "MM/dd/yyyy",
+          "yyyy/MM/dd");
+      return new Timestamp(date.getTime());
+    } catch (ParseException e) {
+      LOG.warn("Dataset date value could not be parsed, skipping: '" + value + "'");
+      return null;
+    }
+  }
+
+  /**
+   * Resolves a dataset cell to a user id for an "assignedTo" mapping. The item form labels
+   * this field a user name, so the value is looked up as a username. An unrecognized user
+   * is logged and skipped (returns -1) rather than guessed at or stored as a bogus id --
+   * assigning an item to the wrong user is worse than leaving it unassigned. (Resolving by
+   * email or numeric id could be added if a dataset needs it; username is the existing
+   * convention.)
+   *
+   * @param value the trimmed cell value (never blank here -- blanks are skipped earlier)
+   * @return the matching user id, or -1 if no user matches
+   */
+  protected static long resolveAssignedToUserId(String value) {
+    User user = UserRepository.findByUsername(value);
+    if (user == null) {
+      LOG.warn("Dataset assignedTo value did not match a username, skipping: '" + value + "'");
+      return -1;
+    }
+    return user.getId();
   }
 
   private static void updateGeoPoint(Item item) {

--- a/src/test/java/com/simisinc/platform/application/datasets/SaveDatasetRowCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/datasets/SaveDatasetRowCommandTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.datasets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * Verifies that dataset-import field mappings for the date fields and assignedTo are
+ * actually applied -- previously these were empty branches that silently dropped the
+ * value. The guarantees under test: recognizable dates parse, an unrecognizable or
+ * invalid date is skipped (never stored wrong), and assignedTo resolves a username to a
+ * user id or is skipped rather than assigned to a bogus/wrong user.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class SaveDatasetRowCommandTest {
+
+  private static void assertYmd(Timestamp ts, int year, int month0Based, int day) {
+    Assertions.assertNotNull(ts, "expected a parsed timestamp, not null");
+    Calendar c = Calendar.getInstance();
+    c.setTime(ts);
+    Assertions.assertEquals(year, c.get(Calendar.YEAR));
+    Assertions.assertEquals(month0Based, c.get(Calendar.MONTH));
+    Assertions.assertEquals(day, c.get(Calendar.DAY_OF_MONTH));
+  }
+
+  @Test
+  void parsesIsoDate() {
+    assertYmd(SaveDatasetRowCommand.parseTimestamp("2026-01-15"), 2026, Calendar.JANUARY, 15);
+  }
+
+  @Test
+  void parsesSpaceSeparatedDateTime() {
+    Timestamp ts = SaveDatasetRowCommand.parseTimestamp("2026-01-15 14:30:00");
+    assertYmd(ts, 2026, Calendar.JANUARY, 15);
+    Calendar c = Calendar.getInstance();
+    c.setTime(ts);
+    Assertions.assertEquals(14, c.get(Calendar.HOUR_OF_DAY));
+    Assertions.assertEquals(30, c.get(Calendar.MINUTE));
+  }
+
+  @Test
+  void parsesUsSlashDate() {
+    assertYmd(SaveDatasetRowCommand.parseTimestamp("01/15/2026"), 2026, Calendar.JANUARY, 15);
+  }
+
+  @Test
+  void parsesIsoUtcInstant() {
+    assertYmd(SaveDatasetRowCommand.parseTimestamp("2026-01-15T14:30:00Z"), 2026, Calendar.JANUARY, 15);
+  }
+
+  @Test
+  void unparseableDateReturnsNullRatherThanWrongData() {
+    Assertions.assertNull(SaveDatasetRowCommand.parseTimestamp("not a date"));
+  }
+
+  @Test
+  void invalidCalendarDateRejectedByStrictParsing() {
+    // Lenient parsing would roll "month 13, day 45" over into a real (wrong) date;
+    // strict parsing must reject it so no nonsense date is imported.
+    Assertions.assertNull(SaveDatasetRowCommand.parseTimestamp("2026-13-45"));
+  }
+
+  @Test
+  void assignedToResolvesUsernameToUserId() {
+    User user = new User();
+    user.setId(42L);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUsername(eq("jsmith"))).thenReturn(user);
+
+      Assertions.assertEquals(42L, SaveDatasetRowCommand.resolveAssignedToUserId("jsmith"));
+    }
+  }
+
+  @Test
+  void assignedToUnknownUserReturnsMinusOneRatherThanBogusId() {
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUsername(any())).thenReturn(null);
+
+      Assertions.assertEquals(-1L, SaveDatasetRowCommand.resolveAssignedToUserId("ghost"));
+    }
+  }
+}


### PR DESCRIPTION
## The defect

`SaveDatasetRowCommand.constructItem` dispatches each dataset column to an item field by its mapping name. **Five of those branches were empty `// @todo` stubs** — `startDate`, `endDate`, `expectedDate`, `expirationDate`, and `assignedTo`:

```java
} else if ("startDate".equals(mapping)) {
  // @todo
} else if ("endDate".equals(mapping)) {
  // @todo
...
} else if ("assignedTo".equals(mapping)) {
  // @todo
}
```

Because the branch *matched*, the value was neither applied nor treated as custom/unmapped — it was **silently discarded**. A dataset that mapped a column to any of these imported nothing for that field, and the loss was invisible until someone noticed the data was blank.

## The fix

Fill the branches, with data-safety as the priority — **never store wrong data**:

- **The four date fields** parse the cell into a `Timestamp` (`parseTimestamp`) via the formats dataset exports commonly use (ISO date/datetime, ISO UTC instant, US `MM/dd/yyyy`, …). Datasets carry no declared source format, so parsing is **strict**: a value matching no pattern is logged and skipped. Importing a *wrong* date (e.g. lenient parsing rolling "month 13" into next year) is worse than importing none.
- **assignedTo** resolves the cell to a user id (`resolveAssignedToUserId`). The item form labels this field a *user name*, so the value is looked up as a username; an unrecognized user is logged and skipped (`-1`), never assigned to a bogus or wrong user.

Both paths turn silent data loss into **either a correct value or a logged skip**.

## Tests

Logic extracted into two package-visible helpers so they're unit-testable without the whole import pipeline. `SaveDatasetRowCommandTest` — 8 cases, all green:

| Case | Expected |
|---|---|
| ISO date `2026-01-15` | parsed |
| space datetime `2026-01-15 14:30:00` | parsed (incl. time) |
| US slash `01/15/2026` | parsed |
| ISO UTC `2026-01-15T14:30:00Z` | parsed |
| `not a date` | null (skipped, not stored) |
| `2026-13-45` | null (strict rejects the rollover) |
| assignedTo known username | resolves to user id |
| assignedTo unknown user | `-1` (skipped, not a bogus id) |

```
[ 8 tests found ] [ 8 tests successful ] [ 0 tests failed ]
```

## Scope boundary

Documented on the methods: date parsing is naive (a zone designator is treated as a literal), and assignedTo resolves **by username only**. Resolving by email or numeric id, or richer timezone handling, can be added if a dataset needs it — username matches the existing form convention. One clean concern per PR.

Independent branch off `main`; does not touch the open PRs (#230, #231, #232).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
