### PR TITLE
Skip a widget include when its JSP is missing instead of recursing to a stack overflow

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -31,11 +31,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.text.StringEscapeUtils;
 
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -431,11 +433,20 @@ public class WebContainerCommand implements Serializable {
           String widgetContent = null;
           if (result != null) {
             if (widgetContext.hasJsp()) {
-              // @todo if the JSP does not exist, a recursive loop occurs
-              LOG.debug("Including JSP: /WEB-INF/jsp" + widgetContext.getJsp());
-              WidgetResponseWrapper responseWrapper = new WidgetResponseWrapper(response);
-              request.getRequestDispatcher("/WEB-INF/jsp" + widgetContext.getJsp()).include(request, responseWrapper);
-              widgetContent = responseWrapper.getOutputAndClose();
+              String jspPath = "/WEB-INF/jsp" + widgetContext.getJsp();
+              // Guard against including a JSP that does not exist. An include of a missing
+              // resource re-enters the controller servlet and recurses until the stack
+              // overflows (or the request hangs) -- previously an acknowledged @todo. Skip
+              // the include and log instead, so one misconfigured widget cannot take down
+              // the whole page render.
+              if (widgetJspExists(request.getServletContext(), jspPath)) {
+                LOG.debug("Including JSP: " + jspPath);
+                WidgetResponseWrapper responseWrapper = new WidgetResponseWrapper(response);
+                request.getRequestDispatcher(jspPath).include(request, responseWrapper);
+                widgetContent = responseWrapper.getOutputAndClose();
+              } else {
+                LOG.error("Widget JSP not found, skipping include to avoid a render loop: " + jspPath);
+              }
             } else if (widgetContext.hasHtml()) {
               widgetContent = widgetContext.getHtml();
             }
@@ -555,5 +566,26 @@ public class WebContainerCommand implements Serializable {
       replacementValue = StringUtils.replace(replacementValue, "'", "''");
     }
     return StringUtils.replace(content, searchString, replacementValue);
+  }
+
+  /**
+   * Returns true when a widget's JSP actually exists in the web application, so the caller
+   * can skip the include when it does not. Including a missing JSP via RequestDispatcher
+   * re-enters the controller servlet and recurses until the stack overflows -- the failure
+   * this guards against (previously an acknowledged {@code @todo} at the include site). A
+   * malformed path is treated as "does not exist" so a bad widget definition is skipped
+   * rather than thrown out of the entire page render.
+   *
+   * @param servletContext the web application context
+   * @param jspPath        the full context-relative JSP path (e.g. /WEB-INF/jsp/foo.jsp)
+   * @return true if the resource exists and may be included
+   */
+  protected static boolean widgetJspExists(ServletContext servletContext, String jspPath) {
+    try {
+      return servletContext.getResource(jspPath) != null;
+    } catch (MalformedURLException e) {
+      LOG.error("Malformed widget JSP path, skipping include: " + jspPath);
+      return false;
+    }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
@@ -20,7 +20,12 @@ import com.simisinc.platform.domain.model.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -175,6 +180,39 @@ class WebContainerCommandTest {
       content = WebContainerCommand.replaceVariableWithParameterValue(request, content);
     }
     Assertions.assertEquals("Hi ", content);
+  }
+
+  // Guard against including a widget JSP that does not exist -- such an include re-enters
+  // the controller servlet and recurses until the stack overflows.
+
+  private static final String JSP_PATH = "/WEB-INF/jsp/example-widget.jsp";
+
+  @Test
+  void existingWidgetJspMayBeIncluded() throws Exception {
+    ServletContext servletContext = mock(ServletContext.class);
+    URL resource = URI.create("file:/app/WEB-INF/jsp/example-widget.jsp").toURL();
+    when(servletContext.getResource(JSP_PATH)).thenReturn(resource);
+
+    Assertions.assertTrue(WebContainerCommand.widgetJspExists(servletContext, JSP_PATH));
+  }
+
+  @Test
+  void missingWidgetJspIsNotIncluded() throws Exception {
+    ServletContext servletContext = mock(ServletContext.class);
+    // getResource returns null when the resource does not exist
+    when(servletContext.getResource(JSP_PATH)).thenReturn(null);
+
+    Assertions.assertFalse(WebContainerCommand.widgetJspExists(servletContext, JSP_PATH),
+        "a missing JSP must not be included -- that is the recursion trigger");
+  }
+
+  @Test
+  void malformedWidgetJspPathIsTreatedAsMissingNotThrown() throws Exception {
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getResource(JSP_PATH)).thenThrow(new MalformedURLException("bad path"));
+
+    // Must be swallowed and reported as "does not exist", never propagated out of the render
+    Assertions.assertFalse(WebContainerCommand.widgetJspExists(servletContext, JSP_PATH));
   }
 
 }


### PR DESCRIPTION
## The defect

`WebContainerCommand.processWidgets` includes a widget's JSP with no check that the file exists — carrying its own standing admission:

```java
if (widgetContext.hasJsp()) {
  // @todo if the JSP does not exist, a recursive loop occurs
  LOG.debug("Including JSP: /WEB-INF/jsp" + widgetContext.getJsp());
  WidgetResponseWrapper responseWrapper = new WidgetResponseWrapper(response);
  request.getRequestDispatcher("/WEB-INF/jsp" + widgetContext.getJsp()).include(request, responseWrapper);
  ...
}
```

A `RequestDispatcher.include()` of a missing `/WEB-INF/jsp/...` resource re-enters the controller servlet and recurses until the stack overflows (or the request hangs). A single widget pointing at a renamed or absent JSP could take down the whole page render — an availability bug.

## The fix

Guard the include with `widgetJspExists()`: if `ServletContext.getResource` returns `null`, log an error and **skip** the include rather than dispatching into it. A malformed path is treated as "does not exist" (logged, skipped) so a bad widget definition can never throw out of the entire render. JSPs that exist are included exactly as before.

The check is a package-visible helper so it's unit-testable without a servlet container.

## Tests

Added to `WebContainerCommandTest` (3 cases, mocked `ServletContext`) — the class's full 13 pass:

| Case | Expected |
|---|---|
| resource exists (`getResource` → URL) | may be included (`true`) |
| resource missing (`getResource` → `null`) | not included (`false`) — the recursion trigger |
| `getResource` throws `MalformedURLException` | swallowed, treated as missing (`false`), never propagated |

```
[ 13 tests found ] [ 13 tests successful ] [ 0 tests failed ]
```

## Notes

This guards the *missing-file* case (the documented `@todo`). A JSP that exists but recursively includes *itself* is a separate, JSP-level concern and is out of scope here.

Independent branch off `main`; does not touch the open PRs (#230–#233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
