### PR TITLE
Keep the real Admin role when a non-admin edits an admin user, and cover the guard

### DIFF
--- a/.github/scripts/check-security-coverage.sh
+++ b/.github/scripts/check-security-coverage.sh
@@ -68,6 +68,12 @@ set -euo pipefail
 # role/group primitive) -- is covered by ValidateUserAccessToWebPageCommandTest
 # at ~88% and shares the 0.50 floor. The floor exists to fail the gate if those
 # tests are removed, since this is an access-control decision.
+#
+# SaveUserCommand.saveUser() -- the user create/update path, including the
+# privilege-assignment guard that decides who may grant or remove the Admin role
+# -- is covered by SaveUserCommandTest at ~72% and shares the 0.50 floor. A
+# non-admin must be able to neither grant Admin nor strip it from another user;
+# the floor exists to fail the gate if that authorization coverage is removed.
 TARGETS='
 com.simisinc.platform.application.IpAddressCommand,0.50
 com.simisinc.platform.application.SecretCryptoCommand,0.50
@@ -77,6 +83,7 @@ com.simisinc.platform.application.cms.UrlCommand,0.50
 com.simisinc.platform.application.cms.NumberCommand,0.30
 com.simisinc.platform.application.DoNotTrackCommand,0.50
 com.simisinc.platform.application.cms.ValidateUserAccessToWebPageCommand,0.50
+com.simisinc.platform.application.register.SaveUserCommand,0.50
 '
 
 CSV="${1:-${JACOCO_CSV:-target/coverage-reports/jacoco.csv}}"

--- a/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
+++ b/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
@@ -103,9 +103,12 @@ public class SaveUserCommand {
     // Verify the allowed roles
     LOG.debug("Verifying the allowed roles...");
     if (userMakingChange != null && !userMakingChange.hasRole("admin")) {
-      // Maintain the admin permission because the record already has it
+      // Maintain the admin permission because the record already has it. Take the role from
+      // the stored user (which has it) -- userBean does not (the condition above requires
+      // !userBean.hasRole("admin")), so userBean.getRole("admin") would be null and would add
+      // a null into the role list, dropping the very permission this branch means to keep.
       if (user.hasRole("admin") && !userBean.hasRole("admin")) {
-        userBean.getRoleList().add(userBean.getRole("admin"));
+        userBean.getRoleList().add(user.getRole("admin"));
       } else if (!user.hasRole("admin") && userBean.hasRole("admin")) {
         // Don't allow it to be added if it wasn't there
         userBean.removeRole("admin");

--- a/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.register;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * Exercises the privilege-assignment guard in SaveUserCommand.saveUser: who may grant or
+ * remove the Admin role. This is a security-critical authorization path that had no test
+ * coverage. The cases below pin down that a non-admin editor can neither grant nor strip
+ * Admin, that an admin can do both (except removing it from their own account), and that
+ * the "maintain Admin" path keeps the real role rather than corrupting the role list.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class SaveUserCommandTest {
+
+  private static final long EDITOR_ID = 2L;
+  private static final long TARGET_ID = 5L;
+
+  private static List<Role> roles(String... codes) {
+    List<Role> list = new ArrayList<>();
+    for (String code : codes) {
+      list.add(new Role(code, code)); // Role(title, code)
+    }
+    return list;
+  }
+
+  private static User userWithRoles(long id, String... roleCodes) {
+    User user = new User();
+    user.setId(id);
+    user.setRoleList(roles(roleCodes));
+    return user;
+  }
+
+  /** A well-formed edit of an existing user (id > -1) requesting the given roles. */
+  private static User editBeanRequesting(long targetId, long editorId, String... requestedRoleCodes) {
+    User bean = new User();
+    bean.setId(targetId);
+    bean.setModifiedBy(editorId);
+    bean.setFirstName("Test");
+    bean.setLastName("User");
+    bean.setEmail("test@example.com");
+    bean.setUsername("test@example.com");
+    bean.setRoleList(roles(requestedRoleCodes));
+    bean.setGroupList(new ArrayList<>());
+    return bean;
+  }
+
+  /** Runs saveUser with the collaborators stubbed; UserRepository.save echoes its argument. */
+  private static User runSaveUser(User editor, User existing, User bean) throws Exception {
+    try (MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+         MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+         MockedStatic<GenerateUserUniqueIdCommand> genId = mockStatic(GenerateUserUniqueIdCommand.class)) {
+      loadUser.when(() -> LoadUserCommand.loadUser(bean.getModifiedBy())).thenReturn(editor);
+      loadUser.when(() -> LoadUserCommand.loadUser(bean.getId())).thenReturn(existing);
+      genId.when(() -> GenerateUserUniqueIdCommand.generateUniqueId(any(), any())).thenReturn("uniqueid");
+      userRepo.when(() -> UserRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+      return SaveUserCommand.saveUser(bean);
+    }
+  }
+
+  @Test
+  void nonAdminCannotGrantAdminRole() throws Exception {
+    User editor = userWithRoles(EDITOR_ID, "users");
+    User existing = userWithRoles(TARGET_ID, "users");
+    User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users", "admin"); // trying to escalate
+
+    User saved = runSaveUser(editor, existing, bean);
+
+    Assertions.assertFalse(saved.hasRole("admin"), "a non-admin must not be able to grant Admin");
+    Assertions.assertTrue(saved.hasRole("users"));
+  }
+
+  @Test
+  void nonAdminCannotRemoveAdminFromAnotherUser() throws Exception {
+    User editor = userWithRoles(EDITOR_ID, "users");
+    User existing = userWithRoles(TARGET_ID, "admin", "users"); // target currently has Admin
+    User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users"); // omits admin -> would remove it
+
+    User saved = runSaveUser(editor, existing, bean);
+
+    // The guard must MAINTAIN the existing Admin role -- with the real role object, not a
+    // null placeholder (a null in the list corrupts every later hasRole/role iteration).
+    Assertions.assertTrue(saved.hasRole("admin"), "a non-admin must not be able to remove Admin");
+    Assertions.assertFalse(saved.getRoleList().contains(null), "the role list must not contain a null role");
+  }
+
+  @Test
+  void adminCanGrantAdminRole() throws Exception {
+    User editor = userWithRoles(EDITOR_ID, "admin");
+    User existing = userWithRoles(TARGET_ID, "users");
+    User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users", "admin");
+
+    User saved = runSaveUser(editor, existing, bean);
+
+    Assertions.assertTrue(saved.hasRole("admin"), "an admin may grant Admin");
+  }
+
+  @Test
+  void adminCanRemoveAdminFromAnotherUser() throws Exception {
+    User editor = userWithRoles(EDITOR_ID, "admin");
+    User existing = userWithRoles(TARGET_ID, "admin", "users");
+    User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users"); // admin de-escalates another user
+
+    User saved = runSaveUser(editor, existing, bean);
+
+    Assertions.assertFalse(saved.hasRole("admin"), "an admin may remove Admin from another user");
+  }
+
+  @Test
+  void userCannotRemoveAdminFromOwnAccount() {
+    // Self-edit: the editor and the target are the same admin account.
+    User self = userWithRoles(EDITOR_ID, "admin");
+    User bean = editBeanRequesting(EDITOR_ID, EDITOR_ID, "users"); // removing own Admin
+
+    DataException ex = Assertions.assertThrows(DataException.class,
+        () -> runSaveUser(self, self, bean));
+    Assertions.assertTrue(ex.getMessage().toLowerCase().contains("admin role from your own account"));
+  }
+}


### PR DESCRIPTION
## What this started as, and what it found

The maintenance triage flagged `SaveUserCommand`'s privilege-assignment guard as the highest-value **untested** security path. Writing the missing tests surfaced a real authorization bug in it.

## The bug

When the editor is **not** an admin, the guard must neither let Admin be granted nor let it be stripped from a user who already has it. The "maintain Admin" branch was broken:

```java
if (user.hasRole("admin") && !userBean.hasRole("admin")) {
  userBean.getRoleList().add(userBean.getRole("admin"));   // <-- always null here
}
```

The branch condition requires `!userBean.hasRole("admin")`, and `getRole`/`hasRole` share the same lookup — so `userBean.getRole("admin")` is **always null** in this branch. It adds `null` to the role list, so instead of *preserving* Admin it **drops** it, and the null then **NPEs** on the next role iteration (e.g. `hasRole`).

**Net effect:** a non-admin editing an admin user and submitting without the Admin box could strip that user's Admin — and crash the save. The fix takes the role from the stored user, which actually has it:

```java
userBean.getRoleList().add(user.getRole("admin"));
```

## Found test-first

The "non-admin cannot remove Admin from another user" test **fails against the original code** (the null → NPE) and **passes after the one-line fix** — so the test demonstrably catches the regression, not just documents current behavior.

## Tests — `SaveUserCommandTest` (5 cases)

| Case | Guarantee |
|---|---|
| non-admin requests Admin on a user | not granted |
| non-admin omits Admin on an admin user | **maintained — with the real role, never a null** (the bug) |
| admin requests Admin | granted |
| admin removes Admin from another user | allowed |
| user removes Admin from their **own** account | blocked (`DataException`) |

## Durability

Added `SaveUserCommand` to `.github/scripts/check-security-coverage.sh` at the **0.50** floor (measured **72.4%** instruction coverage) so this authorization coverage cannot silently regress — the same pattern as `ValidateUserAccessToWebPageCommand` (#228).

## Verification

Full `ci-test` suite green (BUILD SUCCESSFUL, zero failures); the coverage gate passes with 9 classes checked. Independent branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
