### PR TITLE
Block SSRF in the dataset remote-file fetch (source and paging URLs)

### DIFF
--- a/.github/scripts/check-security-coverage.sh
+++ b/.github/scripts/check-security-coverage.sh
@@ -68,6 +68,12 @@ set -euo pipefail
 # role/group primitive) -- is covered by ValidateUserAccessToWebPageCommandTest
 # at ~88% and shares the 0.50 floor. The floor exists to fail the gate if those
 # tests are removed, since this is an access-control decision.
+#
+# RemoteUrlValidationCommand.isFetchAllowed() -- the SSRF guard for server-side fetches
+# of an untrusted (dataset source / response-derived paging) URL: it blocks loopback,
+# link-local (the cloud-metadata endpoint), and private targets. Covered by
+# RemoteUrlValidationCommandTest at ~86% and shares the 0.50 floor, since this is the
+# control that stops SSRF to internal services and instance-metadata credentials.
 TARGETS='
 com.simisinc.platform.application.IpAddressCommand,0.50
 com.simisinc.platform.application.SecretCryptoCommand,0.50
@@ -77,6 +83,7 @@ com.simisinc.platform.application.cms.UrlCommand,0.50
 com.simisinc.platform.application.cms.NumberCommand,0.30
 com.simisinc.platform.application.DoNotTrackCommand,0.50
 com.simisinc.platform.application.cms.ValidateUserAccessToWebPageCommand,0.50
+com.simisinc.platform.application.http.RemoteUrlValidationCommand,0.50
 '
 
 CSV="${1:-${JACOCO_CSV:-target/coverage-reports/jacoco.csv}}"

--- a/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
@@ -35,6 +35,7 @@ import com.simisinc.platform.application.elearning.PERLSCourseListCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.application.http.HttpDownloadFileCommand;
 import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.application.http.RemoteUrlValidationCommand;
 import com.simisinc.platform.domain.model.datasets.Dataset;
 import com.simisinc.platform.infrastructure.persistence.datasets.DatasetRepository;
 
@@ -51,6 +52,11 @@ public class DatasetDownloadRemoteFileCommand {
   public static boolean handleRemoteFileDownload(Dataset dataset, long userId) throws DataException {
     if (StringUtils.isBlank(dataset.getSourceUrl())) {
       throw new DataException("A source url is required");
+    }
+    // [SSRF] The source url is arbitrary admin input; refuse to fetch anything that
+    // resolves to an internal/loopback/link-local (cloud metadata) or private address.
+    if (!RemoteUrlValidationCommand.isFetchAllowed(dataset.getSourceUrl())) {
+      throw new DataException("The source url is not permitted");
     }
 
     String fileType = dataset.getFileType();
@@ -230,6 +236,12 @@ public class DatasetDownloadRemoteFileCommand {
       return;
     }
     LOG.debug("Next url: " + nextUrl);
+
+    // [SSRF] nextUrl comes from the fetched response, so it is fully controlled by whoever
+    // runs the source server -- validate it before following, exactly like the source url.
+    if (!RemoteUrlValidationCommand.isFetchAllowed(nextUrl)) {
+      throw new IOException("Blocked a paging url that is not permitted: " + nextUrl);
+    }
 
     // Use the url to get the next page content
     String content = HttpGetCommand.execute(nextUrl);

--- a/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import java.net.InetAddress;
+import java.net.URI;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.validator.routines.UrlValidator;
+
+/**
+ * SSRF guard for server-side fetches of a caller-supplied (untrusted) URL. Applied where the
+ * URL is arbitrary user/admin input or is derived from a fetched response -- NOT on the
+ * fixed third-party API clients (OAuth, Stripe, MapBox, ...), which legitimately target
+ * configured endpoints that may be internal in some deployments.
+ * <p>
+ * A URL is allowed only when it is http/https and its host resolves exclusively to public,
+ * routable addresses. Loopback, any-local, link-local (which includes the 169.254.169.254
+ * cloud-metadata endpoint on Azure/AWS/GCP), private/site-local, IPv6 unique-local, and
+ * multicast addresses are blocked -- the ranges an SSRF payload uses to reach internal
+ * services or steal instance-metadata credentials. Because the check resolves the host and
+ * inspects the resulting address, numeric-encoding tricks (e.g. http://2130706433/) are
+ * caught too: they resolve to a loopback/private address and are rejected.
+ * <p>
+ * Residual: this does not by itself defeat DNS rebinding (the JDK HttpClient re-resolves the
+ * host when it connects, so a hostname that returns a public address here could return an
+ * internal one at fetch time). Blocking literal-IP and stable-DNS targets covers the common
+ * metadata-endpoint attack; pinning the validated address at connect time is the stronger
+ * follow-up.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+public class RemoteUrlValidationCommand {
+
+  private static final Log LOG = LogFactory.getLog(RemoteUrlValidationCommand.class);
+
+  private static final String[] ALLOWED_SCHEMES = { "http", "https" };
+
+  /**
+   * Determines whether a server-side fetch of the given URL is permitted. Fails closed:
+   * a blank, malformed, non-http(s), unresolvable, or internally-routed URL returns false.
+   *
+   * @param url the caller-supplied URL to be fetched
+   * @return true only if the URL is safe to fetch
+   */
+  public static boolean isFetchAllowed(String url) {
+    if (StringUtils.isBlank(url)) {
+      return false;
+    }
+    if (!new UrlValidator(ALLOWED_SCHEMES).isValid(url)) {
+      LOG.debug("Blocked a non-http(s) or malformed url: " + url);
+      return false;
+    }
+    try {
+      String host = URI.create(url).getHost();
+      if (StringUtils.isBlank(host)) {
+        LOG.debug("Blocked a url with no resolvable host: " + url);
+        return false;
+      }
+      InetAddress[] addresses = InetAddress.getAllByName(host);
+      if (addresses == null || addresses.length == 0) {
+        return false;
+      }
+      // Every address the host resolves to must be public/routable; if any is internal,
+      // reject -- a host that resolves to both a public and a private address is not safe.
+      for (InetAddress address : addresses) {
+        if (isBlockedAddress(address)) {
+          LOG.warn("Blocked an SSRF-unsafe address for host " + host + ": " + address.getHostAddress());
+          return false;
+        }
+      }
+      return true;
+    } catch (Exception e) {
+      // Unresolvable host, malformed authority, etc. -- fail closed.
+      LOG.warn("Blocked a url that could not be validated: " + url);
+      return false;
+    }
+  }
+
+  /**
+   * True when the address is one an SSRF payload uses to reach the host or internal network:
+   * loopback, any-local, link-local (incl. the cloud metadata endpoint), private/site-local,
+   * IPv6 unique-local, or multicast.
+   */
+  static boolean isBlockedAddress(InetAddress address) {
+    if (address.isLoopbackAddress()      // 127.0.0.0/8, ::1
+        || address.isAnyLocalAddress()   // 0.0.0.0, ::
+        || address.isLinkLocalAddress()  // 169.254.0.0/16 (cloud metadata), fe80::/10
+        || address.isSiteLocalAddress()  // 10/8, 172.16/12, 192.168/16
+        || address.isMulticastAddress()) {
+      return true;
+    }
+    // InetAddress.isSiteLocalAddress() does not recognize IPv6 unique-local (fc00::/7);
+    // block it explicitly.
+    byte[] bytes = address.getAddress();
+    if (bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/RemoteUrlValidationCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/RemoteUrlValidationCommandTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the SSRF guard for server-side fetches: internal, loopback, link-local (cloud
+ * metadata), private, IPv6 unique-local, and multicast targets are blocked, while ordinary
+ * public URLs are allowed. Tests use IP literals only, so they resolve without DNS/network.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class RemoteUrlValidationCommandTest {
+
+  // --- isFetchAllowed: the URL gate callers use ---
+
+  @Test
+  void allowsAnOrdinaryPublicUrl() {
+    assertTrue(RemoteUrlValidationCommand.isFetchAllowed("https://8.8.8.8/dataset.json"));
+    assertTrue(RemoteUrlValidationCommand.isFetchAllowed("http://1.1.1.1/feed.xml"));
+  }
+
+  @Test
+  void blocksTheCloudMetadataEndpoint() {
+    // 169.254.169.254 = the Azure/AWS/GCP instance-metadata service (credential theft)
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://169.254.169.254/latest/meta-data/iam/"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://169.254.169.254/metadata/instance?api-version=2021-02-01"));
+  }
+
+  @Test
+  void blocksLoopbackAndPrivateRanges() {
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://127.0.0.1:8080/admin"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://10.0.0.5/internal"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://172.16.4.4/"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://192.168.1.1/"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://0.0.0.0/"));
+  }
+
+  @Test
+  void blocksNumericEncodedLoopback() {
+    // http://2130706433/ is 127.0.0.1 in decimal; inspecting the resolved address catches it
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("http://2130706433/"));
+  }
+
+  @Test
+  void blocksNonHttpSchemesAndGarbage() {
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("ftp://8.8.8.8/file"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("file:///etc/passwd"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed("not-a-url"));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed(""));
+    assertFalse(RemoteUrlValidationCommand.isFetchAllowed(null));
+  }
+
+  // --- isBlockedAddress: the address classifier, exercised directly on IP literals ---
+
+  @Test
+  void classifierBlocksEveryInternalRange() throws Exception {
+    String[] internal = {
+        "127.0.0.1", "0.0.0.0", "169.254.169.254", "10.0.0.1", "172.16.0.1",
+        "192.168.1.1", "::1", "fe80::1", "fc00::1"
+    };
+    for (String ip : internal) {
+      assertTrue(RemoteUrlValidationCommand.isBlockedAddress(InetAddress.getByName(ip)),
+          "expected blocked: " + ip);
+    }
+  }
+
+  @Test
+  void classifierAllowsPublicAddresses() throws Exception {
+    for (String ip : new String[] { "8.8.8.8", "1.1.1.1", "93.184.216.34" }) {
+      assertFalse(RemoteUrlValidationCommand.isBlockedAddress(InetAddress.getByName(ip)),
+          "expected allowed: " + ip);
+    }
+  }
+}


### PR DESCRIPTION
## The vulnerability (SSRF)

`DatasetDownloadRemoteFileCommand` fetches an admin-configured dataset **source URL** server-side. The HTTP helpers it uses (`HttpGetCommand`, `HttpDownloadFileCommand`) validate only the **scheme** — nothing checks where the URL points. So a source URL like:

- `http://169.254.169.254/metadata/instance?...` — the Azure/AWS/GCP **instance-metadata endpoint** (→ managed-identity credential theft on the Azure target)
- `http://127.0.0.1:8080/…`, `http://10.x/…`, `http://192.168.x/…` — internal services

is fetched with no restriction. That's server-side request forgery.

**Worse — the paging path follows a response-controlled URL.** `appendNextUrls` reads the "next page" URL out of the *fetched response itself* (`thisNode.asText()`) and fetches it. So even a vetted source server can redirect the fetch to an internal address on the next page — a fully attacker-controlled URL that was **completely unvalidated**.

## The fix

New `RemoteUrlValidationCommand.isFetchAllowed(url)`:
- http/https only
- resolve the host and **reject if any resolved address** is loopback, any-local, link-local (incl. the metadata endpoint), private/site-local, IPv6 unique-local, or multicast
- inspects the *resolved* address, so numeric-encoding tricks (`http://2130706433/` == `127.0.0.1`) are caught
- **fails closed** on blank/malformed/unresolvable/non-http(s) input

Applied at the two untrusted entry points — the **dataset source URL** and the **response-derived paging URL** — and **deliberately not** inside the shared HTTP helpers, so the fixed third-party API clients (OAuth, Stripe, PERLS…) that may legitimately target an internal configured endpoint are unaffected.

## Tests — `RemoteUrlValidationCommandTest` (7 cases, hermetic — IP literals, no DNS)

| Case | Result |
|---|---|
| `169.254.169.254` metadata endpoint | blocked |
| loopback / `10.x` / `172.16.x` / `192.168.x` / `0.0.0.0` | blocked |
| numeric-encoded loopback (`http://2130706433/`) | blocked |
| `ftp://`, `file://`, garbage, null/empty | blocked |
| ordinary public URL (`https://8.8.8.8/…`) | allowed |
| address classifier over IPv4 + IPv6 literals | internal blocked, public allowed |

Added to the security-coverage gate at **0.50** (measured **86.2%**). Full `ci-test` suite green; gate passes (9 classes).

## Residual (documented on the class)

This does not by itself defeat **DNS rebinding** — the JDK `HttpClient` re-resolves the host at connect time. It blocks the literal-IP and stable-DNS metadata attacks (the common case); pinning the validated address at connect time is the stronger follow-up.

## Merge note

Touches `.github/scripts/check-security-coverage.sh` (adds one gate entry), as does the open [#235](https://github.com/SimisRnD/simis-cms/pull/235). They append different classes; if #235 merges first this rebases to a trivial one-line add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
