### PR TITLE
Invalidate the cached credentials on password change so the old password stops working

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.application.SecretCryptoCommand;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.database.*;
 import com.simisinc.platform.infrastructure.persistence.ecommerce.OrderRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserGroupRepository;
@@ -371,6 +372,13 @@ public class UserRepository {
     if (DB.update(TABLE_NAME, updateValues, where)) {
       // Invalidate user_tokens since there is a new password
       UserTokenRepository.removeAll(record.getId());
+      // Invalidate the cached plaintext credentials keyed by user id. AuthenticateLoginCommand
+      // caches "username:password" on a successful login and returns on a cache hit WITHOUT
+      // re-verifying the stored hash; without this eviction the OLD password keeps authenticating
+      // after a change/reset (the cache is expireAfterAccess, so use keeps it alive) until the
+      // user next logs in with the new one. Mirrors the token invalidation above. invalidateKey
+      // is null-safe if the cache manager has not been started.
+      CacheManager.invalidateKey(CacheManager.USER_CREDENTIALS_CACHE, record.getId());
       return record;
     }
     LOG.error("updatePassword failed!");

--- a/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.application.login;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -35,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.UserPasswordCommand;
@@ -44,6 +46,8 @@ import com.simisinc.platform.infrastructure.persistence.UserRepository;
 
 import de.mkammerer.argon2.Argon2;
 import de.mkammerer.argon2.Argon2Factory;
+
+import javax.security.auth.login.LoginException;
 
 /**
  * Verifies upgrade-on-login: a user whose password predates the argon2id switch (PR #117) has their stored hash
@@ -142,6 +146,123 @@ class AuthenticateLoginCommandTest {
 
       // No migration is needed, so the password-update path is never touched
       userRepo.verify(() -> UserRepository.updatePassword(any(User.class)), never());
+    }
+  }
+
+  // --- Failure branches of the password login gate (previously untested) ---
+
+  @Test
+  void blankCredentialsAreRejected() {
+    assertThrows(DataException.class,
+        () -> AuthenticateLoginCommand.getAuthenticatedUser("", "pw", IP_ADDRESS));
+    assertThrows(DataException.class,
+        () -> AuthenticateLoginCommand.getAuthenticatedUser("user@example.com", "", IP_ADDRESS));
+    assertThrows(DataException.class,
+        () -> AuthenticateLoginCommand.getAuthenticatedUser("user@example.com", "pw", ""));
+  }
+
+  @Test
+  void aRateLimitedUsernameIsRejected() {
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow("user@example.com", false)).thenReturn(false);
+      assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("user@example.com", "pw", IP_ADDRESS));
+    }
+  }
+
+  @Test
+  void anUnknownUserIsRejectedWithTheGenericMessage() {
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser("ghost@example.com")).thenReturn(null);
+
+      LoginException ex = assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("ghost@example.com", "pw", IP_ADDRESS));
+      assertTrue(ex.getMessage().contains("did not match"), ex.getMessage());
+    }
+  }
+
+  @Test
+  void anUnvalidatedAccountIsRejected() {
+    User user = new User();
+    user.setId(3L);
+    user.setEnabled(true); // validated left null -> isNotValidated() is true
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser("unvalidated@example.com")).thenReturn(user);
+
+      LoginException ex = assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("unvalidated@example.com", "pw", IP_ADDRESS));
+      assertTrue(ex.getMessage().toLowerCase().contains("validated"), ex.getMessage());
+    }
+  }
+
+  @Test
+  void aSuspendedAccountIsRejected() {
+    User user = new User();
+    user.setId(4L);
+    user.setValidated(new Timestamp(System.currentTimeMillis()));
+    user.setEnabled(false); // suspended
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser("suspended@example.com")).thenReturn(user);
+
+      LoginException ex = assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("suspended@example.com", "pw", IP_ADDRESS));
+      assertTrue(ex.getMessage().toLowerCase().contains("suspended"), ex.getMessage());
+    }
+  }
+
+  @Test
+  void aWrongPasswordIsRejected() {
+    User user = enabledUser(5L, UserPasswordCommand.hash("the real password"));
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(any())).thenReturn(null); // cache miss -> real verify runs
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser("user@example.com")).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
+
+      LoginException ex = assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("user@example.com", "the WRONG password", IP_ADDRESS));
+      assertTrue(ex.getMessage().contains("did not match"), ex.getMessage());
+    }
+  }
+
+  @Test
+  void aCachedCredentialAuthenticatesWithoutReverifyingTheStoredHash() throws Exception {
+    // The stored hash is for a DIFFERENT (new) password, so a real hash verify would FAIL. But
+    // the credentials cache holds the submitted username:password, so the login short-circuits
+    // and returns the user. This is the mechanism that makes evicting the cache on a password
+    // change essential (see UserRepository.updatePassword) -- otherwise the old password would
+    // keep authenticating after a change.
+    String username = "cached@example.com";
+    String oldPassword = "the old password";
+    User user = enabledUser(6L, UserPasswordCommand.hash("a different, newer password"));
+    assertFalse(UserPasswordCommand.verify(oldPassword, user.getPassword()),
+        "Sanity: the stored hash must NOT verify the old password");
+
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(6L)).thenReturn(username + ":" + oldPassword);
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+      loadUser.when(() -> LoadUserCommand.loadUser(username)).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
+
+      User result = AuthenticateLoginCommand.getAuthenticatedUser(username, oldPassword, IP_ADDRESS);
+      assertNotNull(result, "a cache hit authenticates without re-verifying the stored hash");
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
+
+/**
+ * Covers the security-relevant cleanup that runs when a user's password changes: alongside
+ * revoking user tokens, the cached plaintext credentials must be invalidated, or the old
+ * password keeps authenticating via AuthenticateLoginCommand's credentials cache.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class UserRepositoryTest {
+
+  @Test
+  void updatePasswordInvalidatesTheCachedCredentials() {
+    User user = new User();
+    user.setId(42L);
+    user.setPassword("$argon2id$v=19$m=65536,t=3,p=1$newhash");
+
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<UserTokenRepository> tokens = mockStatic(UserTokenRepository.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      db.when(() -> DB.update(anyString(), any(SqlUtils.class), any(SqlUtils.class))).thenReturn(true);
+
+      UserRepository.updatePassword(user);
+
+      // The old cached "username:password" for this user must be dropped so it cannot authenticate
+      cacheManager.verify(() -> CacheManager.invalidateKey(CacheManager.USER_CREDENTIALS_CACHE, 42L));
+      // ... and the existing token revocation must still happen
+      tokens.verify(() -> UserTokenRepository.removeAll(42L));
+    }
+  }
+
+  @Test
+  void updatePasswordDoesNotTouchTheCacheWhenTheWriteFails() {
+    User user = new User();
+    user.setId(7L);
+    user.setPassword("$argon2id$hash");
+
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<UserTokenRepository> tokens = mockStatic(UserTokenRepository.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      db.when(() -> DB.update(anyString(), any(SqlUtils.class), any(SqlUtils.class))).thenReturn(false);
+
+      UserRepository.updatePassword(user);
+
+      // No successful write -> no revocation and no cache eviction
+      cacheManager.verify(() -> CacheManager.invalidateKey(anyString(), any()), never());
+      tokens.verify(() -> UserTokenRepository.removeAll(anyLong()), never());
+    }
+  }
+}


### PR DESCRIPTION
## The vulnerability

`AuthenticateLoginCommand` caches `"username:password"` keyed by user id in `USER_CREDENTIALS_CACHE` on a successful login, and on a **cache hit returns the user without re-verifying the stored hash** (an intentional optimization to avoid running Argon2 every request):

```java
String comparison = (String) cache.getIfPresent(user.getId());
if (comparison != null && comparison.equals(username + ":" + password)) {
  return user;   // no hash verification
}
```

`UserRepository.updatePassword` — the choke point for every password change/reset — already revokes user tokens on a new password, but it **never invalidated this credentials cache**. So after a password change:

- the **old** password keeps authenticating (its cached `username:password` still matches, and the new stored hash is never consulted)
- the cache is `expireAfterAccess(20h)`, so an attacker who keeps using the old password **resets the timer** and retains access indefinitely
- it only stops when the legitimate user next logs in with the *new* password (which overwrites the cache entry)

That defeats the point of a password reset — including the "reset a suspected-compromised account" case, where the attacker who knows the old password keeps getting in.

## The fix

Evict the credentials cache for the user id in `updatePassword`, right beside the existing token revocation, using the null-safe `CacheManager.invalidateKey`:

```java
UserTokenRepository.removeAll(record.getId());
CacheManager.invalidateKey(CacheManager.USER_CREDENTIALS_CACHE, record.getId());
```

One line, at the single place every password change flows through (account-validation reset, admin reset, hash-upgrade).

## Tests

**`UserRepositoryTest`** (new) — proves the fix:
- `updatePassword` invalidates the credentials cache (and still revokes tokens)
- a failed DB write touches neither

**`AuthenticateLoginCommandTest`** — expanded 2 → 9, covering the previously-untested login-gate branches:
- **cache hit authenticates without re-verifying the stored hash** — documents the exact mechanism that makes the eviction necessary (stored hash is for a *different* password, yet the cached credential still logs in)
- blank input, rate-limited username, unknown user, unvalidated account, suspended account, wrong password

Full `ci-test` suite green.

## Note

Deliberately **not** adding a coverage-gate entry in this PR — `check-security-coverage.sh` is already touched by the open #235 and #236, and a third concurrent edit would compound the sequential-merge. `AuthenticateLoginCommand` / `UserRepository.updatePassword` are good gate candidates once the queue drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
