### PR TITLE
Only match an OAuth login to a local account by a verified email

### DIFF
--- a/src/main/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommand.java
+++ b/src/main/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommand.java
@@ -65,21 +65,13 @@ public class OAuthUserInfoCommand {
 
     LOG.debug("Determining user information...");
 
-    // Find the user or create a new one
-    User user = null;
+    // Determine the identity from the token's userinfo
     String username = json.get("preferred_username").asText();
-    String email = null;
-    if (json.has("email")) {
-      email = json.get("email").asText();
-    }
-    // Search by optional email address first since that is a key
-    if (StringUtils.isNotBlank(email)) {
-      user = UserRepository.findByEmailAddress(email);
-    }
-    // Then try username
-    if (user == null) {
-      user = UserRepository.findByUsername(username);
-    }
+    String email = json.has("email") ? json.get("email").asText() : null;
+    boolean emailVerified = json.has("email_verified") && json.get("email_verified").asBoolean(false);
+
+    // Find the existing local user, or create a new one
+    User user = resolveExistingUser(username, email, emailVerified);
     if (user == null) {
       user = new User();
     }
@@ -95,11 +87,8 @@ public class OAuthUserInfoCommand {
       JsonNode node = json.get("family_name");
       user.setLastName(node.asText());
     }
-    if (json.has("email_verified")) {
-      JsonNode node = json.get("email_verified");
-      if (node.asBoolean(false)) {
-        user.setValidated(new Timestamp(System.currentTimeMillis()));
-      }
+    if (emailVerified) {
+      user.setValidated(new Timestamp(System.currentTimeMillis()));
     }
 
     // Check for CMS Roles
@@ -147,5 +136,31 @@ public class OAuthUserInfoCommand {
       LOG.error("User could not be saved: " + de.getMessage(), de);
       return null;
     }
+  }
+
+  /**
+   * Finds the existing local user an OAuth identity maps to.
+   * <p>
+   * The email is used to match an existing account ONLY when the identity provider asserts it is
+   * verified (the {@code email_verified} claim). Otherwise an OAuth identity that merely claims
+   * someone else's email -- unverified -- would match and log in as that person's local account, a
+   * classic "sign in with ..." account-takeover. An unverified or absent email falls back to the
+   * IdP's {@code preferred_username}, which is that provider's stable identifier for the account.
+   *
+   * @param username      the IdP preferred_username (required)
+   * @param email         the claimed email, or null
+   * @param emailVerified whether the IdP asserts the email is verified
+   * @return the matched user, or null if none matches (the caller then creates a new account)
+   */
+  protected static User resolveExistingUser(String username, String email, boolean emailVerified) {
+    User user = null;
+    // Match by email only when the provider has verified it
+    if (emailVerified && StringUtils.isNotBlank(email)) {
+      user = UserRepository.findByEmailAddress(email);
+    }
+    if (user == null) {
+      user = UserRepository.findByUsername(username);
+    }
+    return user;
   }
 }

--- a/src/test/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommandTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * Verifies how an OAuth identity is matched to an existing local account. The email is trusted for
+ * matching only when the identity provider asserts it is verified; otherwise an OAuth identity that
+ * merely claims someone else's email must not be able to log in as that person (account takeover).
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class OAuthUserInfoCommandTest {
+
+  private static User userWithId(long id) {
+    User user = new User();
+    user.setId(id);
+    return user;
+  }
+
+  @Test
+  void aVerifiedEmailMatchesAnExistingAccountByEmail() {
+    User existing = userWithId(10L);
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByEmailAddress("known@example.com")).thenReturn(existing);
+
+      User result = OAuthUserInfoCommand.resolveExistingUser("someusername", "known@example.com", true);
+
+      assertSame(existing, result);
+      // A verified email match short-circuits; the username lookup is not needed
+      userRepo.verify(() -> UserRepository.findByUsername(anyString()), never());
+    }
+  }
+
+  @Test
+  void anUnverifiedEmailIsNeverMatchedByEmail() {
+    // The takeover guard: an OAuth identity claiming an unverified victim email must NOT match the
+    // victim's account by email; only the IdP's preferred_username is consulted.
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUsername("attacker")).thenReturn(null);
+
+      User result = OAuthUserInfoCommand.resolveExistingUser("attacker", "victim@example.com", false);
+
+      assertNull(result, "an unverified email must not match an existing account");
+      userRepo.verify(() -> UserRepository.findByEmailAddress(anyString()), never());
+      userRepo.verify(() -> UserRepository.findByUsername("attacker"));
+    }
+  }
+
+  @Test
+  void anUnverifiedEmailFallsBackToTheUsername() {
+    User existing = userWithId(11L);
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUsername("realuser")).thenReturn(existing);
+
+      User result = OAuthUserInfoCommand.resolveExistingUser("realuser", "unverified@example.com", false);
+
+      assertSame(existing, result);
+      userRepo.verify(() -> UserRepository.findByEmailAddress(anyString()), never());
+    }
+  }
+
+  @Test
+  void aVerifiedEmailWithNoEmailMatchFallsBackToTheUsername() {
+    User existing = userWithId(12L);
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByEmailAddress("new@example.com")).thenReturn(null);
+      userRepo.when(() -> UserRepository.findByUsername("existinguser")).thenReturn(existing);
+
+      User result = OAuthUserInfoCommand.resolveExistingUser("existinguser", "new@example.com", true);
+
+      assertSame(existing, result);
+    }
+  }
+
+  @Test
+  void noExistingAccountReturnsNullSoTheCallerCreatesOne() {
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByEmailAddress(anyString())).thenReturn(null);
+      userRepo.when(() -> UserRepository.findByUsername(anyString())).thenReturn(null);
+
+      assertNull(OAuthUserInfoCommand.resolveExistingUser("nobody", "nobody@example.com", true));
+    }
+  }
+}


### PR DESCRIPTION
## The vulnerability (OAuth account takeover)

When a user signs in via OAuth, `OAuthUserInfoCommand.createUser` maps the IdP identity to a local account — matching **by email first**:

```java
if (StringUtils.isNotBlank(email)) {
  user = UserRepository.findByEmailAddress(email);   // no email_verified check
}
if (user == null) {
  user = UserRepository.findByUsername(username);
}
```

The `email_verified` claim **is** read from the userinfo response — but only to set the local `validated` flag, **not** to gate this match. So an OAuth identity that merely *claims* an unverified `victim@example.com` matches the victim's existing local account and **logs in as the victim** — the classic "Sign in with …" account-takeover.

## The fix

Match by email **only when the IdP asserts `email_verified: true`**; otherwise fall back to the IdP's `preferred_username` (that provider's stable identifier for the account). Extracted into a testable `resolveExistingUser(username, email, emailVerified)`.

```java
if (emailVerified && StringUtils.isNotBlank(email)) {
  user = UserRepository.findByEmailAddress(email);
}
if (user == null) {
  user = UserRepository.findByUsername(username);
}
```

## Behavior impact — please read

- **Verified-email logins: unchanged.** For an IdP that verifies emails (e.g. Keycloak with *Verify Email* on — which is what this deployment's userinfo already returns `email_verified` for), legitimate users match by email exactly as before.
- **Changed (and intended):** an identity whose email is **unverified** no longer matches an existing account by that email — it falls back to username matching. That is precisely the takeover case being closed.
- **Edge:** an IdP that returns `email` but never `email_verified` would stop matching by email (treated as unverified). Flagging for the reviewer; the safe default is not to trust an unasserted verification.

The unconditional `updateValidated` ("skip email validation" — trust the IdP as the auth authority) is **left as-is** deliberately; the `validated`-flag logic is otherwise unchanged.

## Tests — `OAuthUserInfoCommandTest` (5, `mockStatic(UserRepository)`)

| Case | Result |
|---|---|
| verified email | matches existing account by email |
| **unverified email** | **never matched by email** — only username is consulted (the takeover guard) |
| unverified email | falls back to username match |
| verified email, no email match | falls back to username |
| no match | returns null → caller creates a new account |

Full `ci-test` suite green. Not added to the security-coverage gate: the tests cover the extracted guard (`resolveExistingUser`) completely, but the surrounding `createUser` orchestration (userinfo fetch, role/group mapping, save) is still untested, so class-level coverage is low — gating it would demand testing that plumbing, which is out of scope for this fix. It's a good gate candidate once `createUser` is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
