### PR TITLE
Bind the OAuth state to the session to stop login CSRF

### DIFF
--- a/src/main/java/com/simisinc/platform/application/oauth/OAuthAuthorizationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/oauth/OAuthAuthorizationCommand.java
@@ -20,11 +20,14 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.presentation.controller.SessionConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.text.RandomStringGenerator;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -45,7 +48,7 @@ public class OAuthAuthorizationCommand {
   private static RandomStringGenerator generator = new RandomStringGenerator.Builder()
       .selectFrom("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789".toCharArray()).build();
 
-  public static String getAuthorizationUrl(String resource) {
+  public static String getAuthorizationUrl(HttpServletRequest request, String resource) {
     String serviceUrl = LoadSitePropertyCommand.loadByName("oauth.serviceUrl");
     String clientId = LoadSitePropertyCommand.loadByName("oauth.clientId");
     if (StringUtils.isAnyBlank(serviceUrl, clientId)) {
@@ -60,6 +63,11 @@ public class OAuthAuthorizationCommand {
       resource ="/";
     }
     stateCache.put(state, resource);
+    // [CSRF] Bind the state to THIS user's session. The callback is only accepted if it returns
+    // the state this session generated -- otherwise an attacker who obtains a valid state+code for
+    // their own account could trick a victim into the callback and log the victim into the
+    // attacker's account (login CSRF / session fixation).
+    request.getSession(true).setAttribute(SessionConstants.OAUTH_STATE, state);
 
     String authorizationUrl =
         serviceUrl + (serviceUrl.endsWith("/") ? "" : "/") + "protocol/openid-connect/auth" +
@@ -75,5 +83,26 @@ public class OAuthAuthorizationCommand {
 
   public static String resourceIfStateIsValid(String state) {
     return (stateCache.getIfPresent(state));
+  }
+
+  /**
+   * Confirms that an OAuth callback's {@code state} is the one this session generated, and consumes
+   * it so it cannot be replayed. This is the CSRF protection for the login flow: the state stored in
+   * {@code getAuthorizationUrl} is bound to the session that started the flow, so a callback carrying
+   * a state that some other session obtained is rejected. Returns false for a null session, a blank
+   * state, or a mismatch; the stored state is always cleared (single use).
+   *
+   * @param session the current session ({@code request.getSession(false)}), may be null
+   * @param state   the state parameter returned on the callback
+   * @return true only if the state matches the one bound to this session
+   */
+  public static boolean consumeValidState(HttpSession session, String state) {
+    if (session == null || StringUtils.isBlank(state)) {
+      return false;
+    }
+    Object expected = session.getAttribute(SessionConstants.OAUTH_STATE);
+    // Single use: clear it whether or not it matches, so a state cannot be replayed
+    session.removeAttribute(SessionConstants.OAUTH_STATE);
+    return state.equals(expected);
   }
 }

--- a/src/main/java/com/simisinc/platform/application/oauth/OAuthRequestCommand.java
+++ b/src/main/java/com/simisinc/platform/application/oauth/OAuthRequestCommand.java
@@ -69,6 +69,12 @@ public class OAuthRequestCommand {
       LOG.debug("Checking callback, retrieving access token...");
       String state = request.getParameter("state");
       String code = request.getParameter("code");
+      // [CSRF] The callback's state must be the one THIS session generated at the start of the
+      // flow; otherwise reject it (login CSRF / session fixation). Consumes the state (single use).
+      if (!OAuthAuthorizationCommand.consumeValidState(request.getSession(false), state)) {
+        LOG.warn("OAuth callback state did not match the session; rejecting a possible login CSRF");
+        return "/";
+      }
       OAuthToken oAuthToken = OAuthAccessTokenCommand.retrieveAccessToken(state, code);
       if (oAuthToken == null) {
         // Failed, return user back to login
@@ -190,6 +196,6 @@ public class OAuthRequestCommand {
     }
 
     // Otherwise, the user must log in
-    return OAuthAuthorizationCommand.getAuthorizationUrl(resource);
+    return OAuthAuthorizationCommand.getAuthorizationUrl(request, resource);
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
@@ -29,6 +29,7 @@ public class SessionConstants {
   public static final String CAPTCHA_TEXT = "captchaText";
   public static final String OAUTH_USER_TOKEN = "oauthUserToken";
   public static final String OAUTH_USER_EXPIRATION_TIME = "oauthUserExpiration";
+  public static final String OAUTH_STATE = "oauthState";
   public static final String MFA_PENDING_USER_ID = "mfaPendingUserId";
   public static final String MFA_PENDING_SINCE = "mfaPendingSince";
 }

--- a/src/test/java/com/simisinc/platform/application/oauth/OAuthAuthorizationCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/oauth/OAuthAuthorizationCommandTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.presentation.controller.SessionConstants;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Verifies the OAuth login-CSRF guard: a callback's {@code state} is accepted only when it matches
+ * the value bound to the session that started the flow, and the state is single-use. Without this,
+ * an attacker could present a state+code for their own account and log a victim into it.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class OAuthAuthorizationCommandTest {
+
+  @Test
+  void aMatchingSessionStateIsAcceptedAndConsumed() {
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.OAUTH_STATE)).thenReturn("ABC123");
+
+    assertTrue(OAuthAuthorizationCommand.consumeValidState(session, "ABC123"));
+    // Single use: the state is cleared so it cannot be replayed
+    verify(session).removeAttribute(SessionConstants.OAUTH_STATE);
+  }
+
+  @Test
+  void aStateNotBoundToThisSessionIsRejected() {
+    // Login-CSRF case: the victim's session never generated a state, but the attacker supplies one
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.OAUTH_STATE)).thenReturn(null);
+
+    assertFalse(OAuthAuthorizationCommand.consumeValidState(session, "attacker-supplied-state"));
+  }
+
+  @Test
+  void aMismatchedStateIsRejectedAndStillCleared() {
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.OAUTH_STATE)).thenReturn("expected-state");
+
+    assertFalse(OAuthAuthorizationCommand.consumeValidState(session, "some-other-state"));
+    verify(session).removeAttribute(SessionConstants.OAUTH_STATE);
+  }
+
+  @Test
+  void aNullSessionIsRejected() {
+    assertFalse(OAuthAuthorizationCommand.consumeValidState(null, "anything"));
+  }
+
+  @Test
+  void aBlankStateIsRejected() {
+    HttpSession session = mock(HttpSession.class);
+    assertFalse(OAuthAuthorizationCommand.consumeValidState(session, ""));
+    assertFalse(OAuthAuthorizationCommand.consumeValidState(session, null));
+  }
+}


### PR DESCRIPTION
## The vulnerability (OAuth login CSRF / session fixation)

The OAuth `state` parameter exists to bind a callback to the browser that started the flow. Here it was stored in a **global, static cache** (`state → resource`), not in the user's session:

```java
private static Cache<String, String> stateCache = Caffeine.newBuilder()...build();
...
stateCache.put(state, resource);                 // authorization request
...
public static String resourceIfStateIsValid(String state) {
  return stateCache.getIfPresent(state);         // callback — any session passes
}
```

Because validation is global, **any** browser presenting a state that exists in the cache is accepted. So an attacker can:

1. start an OAuth login, obtaining a valid `state`+`code` for **their own** account;
2. trick a victim into loading `/oauth/callback?state=…&code=…` (a plain top-level GET);
3. the global cache accepts the state → the attacker's `code` is exchanged → **the victim is silently logged into the attacker's account**.

That's login CSRF / session fixation: anything the victim then does (enters personal data, links a card, uploads files) lands in the attacker's account. The state was also never consumed, so it could be replayed within its 5-minute window.

## The fix

Bind the state to the session that started the flow — the standard OWASP pattern:

- `getAuthorizationUrl(request, resource)` stores the generated state in `session[OAUTH_STATE]`.
- The callback calls `consumeValidState(session, state)` **before** exchanging the code: it returns true only if the state matches the one this session generated, and it **clears the state (single use)** so it cannot be replayed. A null session, blank state, or mismatch is rejected.

A victim who never started the flow has no `OAUTH_STATE` in their session, so the forged callback is rejected.

## Tests — `OAuthAuthorizationCommandTest` (5, mock `HttpSession`)

| Case | Result |
|---|---|
| state matches the session | accepted, and **consumed** (single-use verified) |
| **state not bound to this session** (no session state) | **rejected** — the login-CSRF case |
| state mismatch | rejected, state still cleared |
| null session | rejected |
| blank/null state | rejected |

Full `ci-test` suite green.

## Notes

- Relies on the session cookie being sent on the callback redirect (SameSite=Lax/None) — the universal requirement for OAuth-with-session-state, and already true here since the post-callback code reads/writes the session.
- Independent of the open [#238](https://github.com/SimisRnD/simis-cms/pull/238) (that fixes OAuth account-linking in `OAuthUserInfoCommand`; this fixes the callback CSRF in `OAuthAuthorizationCommand`/`OAuthRequestCommand` — different files).
- Not added to the coverage gate: the CSRF guard (`consumeValidState`) is fully tested, but `getAuthorizationUrl`/`resourceIfStateIsValid` remain untested, so class-level coverage is below the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
