### PR TITLE
Check delete permission before deleting a CMS folder

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderDetailsWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
+import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
 import com.simisinc.platform.application.cms.DeleteFolderCommand;
 import com.simisinc.platform.domain.model.cms.Folder;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
@@ -60,6 +61,15 @@ public class FolderDetailsWidget extends GenericWidget {
     long folderId = context.getParameterAsLong("folderId");
     if (folderId > -1) {
       Folder folder = FolderRepository.findById(folderId);
+      // Check the user's delete permission on THIS folder before removing it. Deleting a folder
+      // (and everything in it) is more destructive than deleting a file, which is already gated on
+      // CheckFolderPermissionCommand.userHasDeletePermission -- without this, any user who can reach
+      // the action could delete any folder by id.
+      if (folder == null || !CheckFolderPermissionCommand.userHasDeletePermission(folder.getId(), context.getUserId())) {
+        context.setErrorMessage("Error. Folder could not be deleted.");
+        context.setRedirect("/admin/folders");
+        return context;
+      }
       try {
         DeleteFolderCommand.deleteFolder(folder);
         context.setSuccessMessage("Folder deleted");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderDetailsWidgetTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
+import com.simisinc.platform.application.cms.DeleteFolderCommand;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+
+/**
+ * Verifies that deleting a CMS folder is gated on the user's per-folder delete permission, matching
+ * how file and item deletes are gated. Without the check, any user who can reach the action could
+ * delete any folder by id -- broken access control.
+ *
+ * @author Liz Houser
+ * @created 7/23/2026
+ */
+class FolderDetailsWidgetTest extends WidgetBase {
+
+  private static Folder folderWithId(long id) {
+    Folder folder = new Folder();
+    folder.setId(id);
+    return folder;
+  }
+
+  @Test
+  void deleteWithoutPermissionDoesNotRemoveTheFolder() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<DeleteFolderCommand> deleteCmd = mockStatic(DeleteFolderCommand.class)) {
+      folderRepo.when(() -> FolderRepository.findById(5L)).thenReturn(folderWithId(5L));
+      perm.when(() -> CheckFolderPermissionCommand.userHasDeletePermission(anyLong(), anyLong())).thenReturn(false);
+
+      new FolderDetailsWidget().delete(widgetContext);
+
+      // The folder must NOT be deleted when the user lacks delete permission on it
+      deleteCmd.verify(() -> DeleteFolderCommand.deleteFolder(any()), never());
+    }
+  }
+
+  @Test
+  void deleteWithPermissionRemovesTheFolder() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<DeleteFolderCommand> deleteCmd = mockStatic(DeleteFolderCommand.class)) {
+      folderRepo.when(() -> FolderRepository.findById(5L)).thenReturn(folderWithId(5L));
+      perm.when(() -> CheckFolderPermissionCommand.userHasDeletePermission(anyLong(), anyLong())).thenReturn(true);
+
+      new FolderDetailsWidget().delete(widgetContext);
+
+      deleteCmd.verify(() -> DeleteFolderCommand.deleteFolder(any()));
+    }
+  }
+
+  @Test
+  void deleteOfAMissingFolderIsRejected() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<DeleteFolderCommand> deleteCmd = mockStatic(DeleteFolderCommand.class)) {
+      folderRepo.when(() -> FolderRepository.findById(5L)).thenReturn(null);
+      perm.when(() -> CheckFolderPermissionCommand.userHasDeletePermission(anyLong(), anyLong())).thenReturn(true);
+
+      new FolderDetailsWidget().delete(widgetContext);
+
+      // A null folder must not reach the delete (and the permission check must not NPE on it)
+      deleteCmd.verify(() -> DeleteFolderCommand.deleteFolder(any()), never());
+    }
+  }
+}


### PR DESCRIPTION
## The vulnerability (broken access control)

`FolderDetailsWidget.delete()` loaded a folder by id and deleted it with **no permission check**:

```java
long folderId = context.getParameterAsLong("folderId");
if (folderId > -1) {
  Folder folder = FolderRepository.findById(folderId);   // unauthorized load
  DeleteFolderCommand.deleteFolder(folder);              // no permission check
```

Any user who can reach the action could delete **any folder by id** — and a folder delete takes everything in it. It's the odd one out in the permission model:

- deleting a **file** already goes through `CheckFolderPermissionCommand.userHasDeletePermission` (`FolderFilesListWidget`)
- deleting an **item** goes through the collection analog (`DeleteItemButtonWidget`)
- deleting the whole **folder** — the most destructive — was unguarded

## The fix

Gate the delete on `userHasDeletePermission` for that folder (and reject a missing folder), matching the file/item delete paths exactly:

```java
if (folder == null || !CheckFolderPermissionCommand.userHasDeletePermission(folder.getId(), context.getUserId())) {
  context.setErrorMessage("Error. Folder could not be deleted.");
  context.setRedirect("/admin/folders");
  return context;
}
```

## Parity note

`userHasDeletePermission` is a **per-folder group check with no implicit admin bypass** — verified identical to `CheckCollectionPermissionCommand.userHasDeletePermission`, which the shipping item-delete widget already enforces. So a user (admin included) who isn't in a group with delete permission on the folder can no longer delete it. That's the **existing** access-control model applied to the one path that was missing it — not a new restriction.

## Tests — `FolderDetailsWidgetTest` (3, `WidgetBase` + `mockStatic`)

| Case | Result |
|---|---|
| no delete permission | folder is **not** removed |
| has delete permission | folder is removed |
| missing folder | rejected (no delete, no NPE) |

Full `ci-test` suite green.

Independent of the open OAuth PRs (#238, #239) — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
