### PR TITLE
Recognize HTML end tags with trailing junk in the unescaped-EL script mask

### DIFF
--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -182,10 +182,13 @@ CONTEXT_JS = "JS"
 
 TAG = re.compile(r"<[^>]*>", re.S)
 COMMENT = re.compile(r"<%--.*?--%>", re.S)
-# The end tag allows whitespace before ">" per the HTML spec (</script >, </script\n>),
-# so match \s* -- otherwise a script block closed that way is not recognised, and an
-# unescaped EL expression in its JS context could slip past this gate (CodeQL py/bad-tag-filter).
-SCRIPT = re.compile(r"<script\b[^>]*>(.*?)</script\s*>", re.S | re.I)
+# An HTML end tag closes the element even when it carries trailing junk: the parser accepts
+# </script >, </script\n>, and </script foo="bar"> alike, discarding whatever follows the name.
+# Matching only \s* before ">" therefore misses a real end tag, leaving the rest of the file
+# masked as script and letting an unescaped EL expression slip past this gate unreported --
+# a false negative in an XSS lint. [^>]* accepts the junk; \b still rejects </scriptfoo>.
+# (CodeQL py/bad-tag-filter flagged the \s* form.)
+SCRIPT = re.compile(r"<script\b[^>]*>(.*?)</script\b[^>]*>", re.S | re.I)
 EL = re.compile(r"\$\{[^}]+\}")
 # A backtick-delimited JS template literal, including newlines.
 TEMPLATE_LITERAL = re.compile(r"`[^`]*`", re.S)


### PR DESCRIPTION
## What

`tools/check-unescaped-el.py` masks `<script>` blocks so it can tell a JavaScript context from an HTML one. The end-tag pattern only allowed whitespace before `>`:

```
</script\s*>
```

An HTML end tag is still an end tag when it carries trailing junk — the parser discards everything after the tag name — so `</script foo>` and `</script bar="x">` close the element but were not recognized here. The mask then ran past the real end of the block and swallowed the markup that followed.

## Why it matters

The failure mode is a **misclassified context**, not a dropped finding. Expressions inside the over-wide span get reported as JS when they are really HTML (or the reverse). That matters because the two take different fixes — `<c:out>` does **not** protect a value interpolated into a JavaScript string — so a misclassified site can be "fixed" without actually being fixed.

## The fix

```
</script\b[^>]*>
```

`[^>]*` accepts the trailing junk; `\b` still rejects `</scriptfoo>`, which is not an end tag.

| case | before | after | expected |
|---|---|---|---|
| `</script>` | ✅ | ✅ | match |
| `</script >` | ✅ | ✅ | match |
| `</script\n>` | ✅ | ✅ | match |
| `</script foo>` | ❌ | ✅ | match |
| `</script bar="x">` | ❌ | ✅ | match |
| `</scriptfoo>` | ❌ | ❌ | no match |

## Impact on current results: none

No JSP in the tree uses the affected form (`grep -rniE "</script[^>]+>"` over `src/` returns nothing), so this is a robustness fix rather than a live vulnerability. The gate reports identically before and after:

```
Summary: 0 unallowlisted, 106 allowlisted sites.
```

`--strict` exits 0 both ways; the full output is byte-identical.

## Also

Closes the open CodeQL `py/bad-tag-filter` alert (high) on this file, raised when #213 merged. Worth noting the alert came from CodeQL's **default setup** — the repo's `.github/workflows/codeql.yml`, which applies the vendored-JS `paths-ignore` config, is still `workflow_dispatch`-only and has not been adopted.

There is no test harness for `tools/*.py` and CI does not run Python tests, so this carries no unit test. That gap is worth its own issue rather than inventing a harness here.