### PR TITLE
Add the Azure infrastructure foundation in Bicep (Milestone #4 Phase 2)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,70 @@
+# Azure infrastructure (Bicep)
+
+Infrastructure-as-code for deploying simis-cms to Azure — Milestone #4 Phase 2.
+
+Every resource here is reproducible and reviewable, which is the point: the templates
+are themselves a CM-2 configuration-management evidence artifact, not just a
+convenience.
+
+## Status
+
+**Authored and type-checked. Not deployed.** Everything compiles clean with
+`az bicep build`, but nothing here has been applied or run through `what-if` — that
+needs an Azure subscription, which is the hard dependency called out in the Phase 0
+design. Treat it as reviewed-but-unapplied.
+
+## What is here
+
+| File | Purpose |
+|---|---|
+| `main.bicep` | Orchestrator; wires the modules and exposes outputs for the app tier |
+| `modules/network.bicep` | VNet, App Service integration subnet, private-endpoint subnet, private DNS zones |
+| `modules/loganalytics.bicep` | Log Analytics workspace (container stdout → Sentinel "Path A") |
+| `modules/storage.bicep` | Storage account + file share backing `CMS_PATH` |
+| `modules/keyvault.bicep` | Key Vault (RBAC, private endpoint, purge protection) |
+| `modules/postgres.bicep` | PostgreSQL Flexible Server + database + PostGIS allow-list + private endpoint |
+
+## What is not here yet
+
+The **application tier** (Container Registry + App Service with managed identity,
+Key Vault references, the `CMS_PATH` mount, and diagnostic settings) and the **edge**
+(Front Door + WAF). Both consume `main.bicep`'s outputs.
+
+## Decisions this implements
+
+Resolved in Phase 0 — see `decision-milestone-4-phase0-decisions.md` in the runbooks:
+
+- **#1** Azure Commercial · **#2** App Service for Containers · **#3** Bicep
+- **#4** private endpoints for the database and Key Vault, with VNet integration
+- **#5** hardened official base images · **#6** Key Vault + managed identity
+- **#7** platform FIPS modules · **#8** scale up only for the pilot
+
+## Two things that are load-bearing
+
+- **`CMS_PATH` must be external storage.** App Service containers are ephemeral, so the
+  uploaded file library lives on the Azure Files share and is mounted in. If it stays
+  inside the container, every restart silently loses uploads.
+- **PostGIS must be allow-listed before it can be created.** On Flexible Server an
+  extension has to appear in the `azure.extensions` server parameter before
+  `CREATE EXTENSION` succeeds. `postgres.bicep` sets it, which is what lets the Flyway
+  install run unattended on first boot.
+
+## Validate locally
+
+No subscription or login required:
+
+```
+az bicep build --file infra/main.bicep --stdout > /dev/null
+```
+
+Silence means success. To check every file:
+
+```
+for f in infra/modules/*.bicep infra/main.bicep; do az bicep build --file "$f" --stdout > /dev/null || echo "FAILED: $f"; done
+```
+
+## Deploy-time inputs
+
+`postgresAdministratorPassword` is a `@secure()` parameter with no default and **must
+not** be committed. Supply it at deploy time from Key Vault or a secure pipeline
+variable.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// simis-cms — Azure infrastructure (Milestone #4 Phase 2)
+//
+// Foundation layer: network, observability, storage, secret custody, database.
+// The application tier (ACR + App Service) and the edge (Front Door + WAF) are
+// authored separately and consume the outputs below.
+//
+// Design inputs, all resolved in Phase 0
+// (governance/decision-milestone-4-phase0-decisions.md):
+//   #1 Azure Commercial            #2 App Service for Containers
+//   #3 Bicep                       #4 private endpoints for DB + Key Vault
+//   #5 hardened official images    #6 Key Vault + managed identity
+//   #7 platform FIPS modules       #8 scale UP only for the pilot
+//
+// Authored and type-checked with `az bicep build`. It has NOT been deployed or
+// run through `what-if` -- that needs a subscription (Phase 0 §7 hard
+// dependency). Treat it as reviewed-but-unapplied until then.
+// ---------------------------------------------------------------------------
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for all resources. Azure Commercial (decision #1).')
+param location string = resourceGroup().location
+
+@description('Environment name, used in resource naming and tags, e.g. pilot.')
+param environmentName string = 'pilot'
+
+@description('Workload name, used in resource naming.')
+param workloadName string = 'simiscms'
+
+@description('PostgreSQL administrator login.')
+param postgresAdministratorLogin string = 'simiscmsadmin'
+
+@description('PostgreSQL administrator password. Supply at deploy time from Key Vault or a secure pipeline variable; never commit a value.')
+@secure()
+param postgresAdministratorPassword string
+
+@description('Log retention in days. Sentinel ingestion is usage-priced.')
+param logRetentionInDays int = 90
+
+@description('Quota for the CMS_PATH file share, in GiB.')
+param fileShareQuotaGb int = 100
+
+var namePrefix = '${workloadName}-${environmentName}'
+
+var tags = {
+  workload: workloadName
+  environment: environmentName
+  managedBy: 'bicep'
+  milestone: 'milestone-4'
+}
+
+module network 'modules/network.bicep' = {
+  name: 'network'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+  }
+}
+
+module logAnalytics 'modules/loganalytics.bicep' = {
+  name: 'loganalytics'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+    retentionInDays: logRetentionInDays
+  }
+}
+
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+    fileShareQuotaGb: fileShareQuotaGb
+  }
+}
+
+module keyVault 'modules/keyvault.bicep' = {
+  name: 'keyvault'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+    privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
+    privateDnsZoneId: network.outputs.keyVaultDnsZoneId
+  }
+}
+
+module postgres 'modules/postgres.bicep' = {
+  name: 'postgres'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+    privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
+    privateDnsZoneId: network.outputs.postgresDnsZoneId
+    administratorLogin: postgresAdministratorLogin
+    administratorLoginPassword: postgresAdministratorPassword
+  }
+}
+
+// Consumed by the application tier when it is authored.
+output vnetId string = network.outputs.vnetId
+output appSubnetId string = network.outputs.appSubnetId
+output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId
+output keyVaultName string = keyVault.outputs.keyVaultName
+output keyVaultUri string = keyVault.outputs.keyVaultUri
+output storageAccountName string = storage.outputs.storageAccountName
+output cmsPathShareName string = storage.outputs.fileShareName
+output postgresFqdn string = postgres.outputs.serverFqdn
+output postgresDatabaseName string = postgres.outputs.databaseName

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------
+// Key Vault + private endpoint.
+//
+// Phase 0 decision #6: Key Vault + managed identity is the secret custody
+// mechanism for the database credential and the inventoried integration
+// secrets. Nothing sensitive is baked into the image or app configuration.
+//
+// The app itself has no Azure-AD awareness -- it reads plain env vars
+// (DB_PASSWORD, CMS_SECRET_KEY, CMS_ADMIN_PASSWORD). App Service resolves
+// those from Key Vault using its managed identity, so the secret never
+// appears in template output or app configuration.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the vault.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Subnet that will hold the private endpoint.')
+param privateEndpointSubnetId string
+
+@description('Private DNS zone for privatelink.vaultcore.azure.net.')
+param privateDnsZoneId string
+
+// Vault names are globally unique, 3-24 chars, alphanumeric and hyphens.
+var keyVaultName = take('kv-${namePrefix}-${uniqueString(resourceGroup().id)}', 24)
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    // RBAC rather than access policies: role assignments are auditable and
+    // manageable as IaC, which access policies are not.
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
+    // Reachable only through the private endpoint below.
+    publicNetworkAccess: 'Disabled'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+    }
+  }
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: 'pep-${keyVaultName}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'plsc-keyvault'
+        properties: {
+          privateLinkServiceId: keyVault.id
+          groupIds: ['vault']
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'vaultcore'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+output keyVaultName string = keyVault.name
+output keyVaultId string = keyVault.id
+output keyVaultUri string = keyVault.properties.vaultUri

--- a/infra/modules/loganalytics.bicep
+++ b/infra/modules/loganalytics.bicep
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// Log Analytics workspace.
+//
+// The app writes to container stdout, which App Service ships here. That is
+// exactly the Sentinel "Path A" ingestion the detection kit was written
+// against, so no agent or custom collector is required.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the workspace.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Log retention in days. Ingestion is usage-priced, so this is a cost lever.')
+@minValue(30)
+@maxValue(730)
+param retentionInDays int = 90
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'log-${namePrefix}'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: retentionInDays
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+output workspaceId string = workspace.id
+output workspaceCustomerId string = workspace.properties.customerId

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------
+// Network foundation: VNet, delegated app-integration subnet, private-endpoint
+// subnet, and the private DNS zones the private endpoints resolve through.
+//
+// Phase 0 decision #4: private endpoints for the database and Key Vault, with
+// VNet integration for the app. Nothing in the data path is publicly reachable.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for all networking resources.')
+param location string
+
+@description('Prefix applied to resource names, e.g. simiscms-pilot.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Address space for the virtual network.')
+param vnetAddressPrefix string = '10.20.0.0/16'
+
+@description('Subnet delegated to App Service for VNet integration (outbound).')
+param appSubnetPrefix string = '10.20.1.0/24'
+
+@description('Subnet holding the private endpoints for PostgreSQL and Key Vault.')
+param privateEndpointSubnetPrefix string = '10.20.2.0/24'
+
+var appSubnetName = 'snet-app'
+var privateEndpointSubnetName = 'snet-private-endpoints'
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: 'vnet-${namePrefix}'
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [vnetAddressPrefix]
+    }
+    subnets: [
+      {
+        // App Service regional VNet integration requires a delegated, dedicated subnet.
+        name: appSubnetName
+        properties: {
+          addressPrefix: appSubnetPrefix
+          delegations: [
+            {
+              name: 'appservice-delegation'
+              properties: {
+                serviceName: 'Microsoft.Web/serverFarms'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: privateEndpointSubnetName
+        properties: {
+          addressPrefix: privateEndpointSubnetPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+        }
+      }
+    ]
+  }
+}
+
+// Private DNS zones. Without these the app resolves the public FQDN of each
+// service instead of its private endpoint address, and the connection fails.
+resource postgresDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.postgres.database.azure.com'
+  location: 'global'
+  tags: tags
+}
+
+resource keyVaultDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.vaultcore.azure.net'
+  location: 'global'
+  tags: tags
+}
+
+resource postgresDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: postgresDnsZone
+  name: 'link-${namePrefix}'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource keyVaultDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: keyVaultDnsZone
+  name: 'link-${namePrefix}'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+output vnetId string = vnet.id
+output appSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, appSubnetName)
+output privateEndpointSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, privateEndpointSubnetName)
+output postgresDnsZoneId string = postgresDnsZone.id
+output keyVaultDnsZoneId string = keyVaultDnsZone.id

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------
+// Azure Database for PostgreSQL Flexible Server + database + private endpoint.
+//
+// PostGIS is required: the install migrations and the application's geo
+// features depend on it. On Flexible Server an extension must first be
+// allow-listed via the azure.extensions server parameter before CREATE
+// EXTENSION will succeed -- allow-listing it here is what lets the Flyway
+// install run unattended on first boot.
+//
+// Phase 0 §7 flags verifying PostGIS availability for the chosen region/tier
+// early; that check belongs at deploy time, not here.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the database.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Subnet that will hold the private endpoint.')
+param privateEndpointSubnetId string
+
+@description('Private DNS zone for privatelink.postgres.database.azure.com.')
+param privateDnsZoneId string
+
+@description('Administrator login for the server.')
+param administratorLogin string
+
+@description('Administrator password. Supply from Key Vault at deploy time; never commit a value.')
+@secure()
+param administratorLoginPassword string
+
+@description('PostgreSQL major version.')
+@allowed(['14', '15', '16', '17'])
+param postgresVersion string = '16'
+
+@description('Compute SKU. Pilot is scale-up-only (Phase 0 decision #8), so a single server is sufficient.')
+param skuName string = 'Standard_D2ds_v5'
+
+@description('SKU tier.')
+@allowed(['Burstable', 'GeneralPurpose', 'MemoryOptimized'])
+param skuTier string = 'GeneralPurpose'
+
+@description('Allocated storage in GiB.')
+param storageSizeGb int = 128
+
+@description('Name of the application database.')
+param databaseName string = 'simiscms'
+
+@description('Backup retention in days.')
+@minValue(7)
+@maxValue(35)
+param backupRetentionDays int = 14
+
+var serverName = 'psql-${namePrefix}'
+
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+  name: serverName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  properties: {
+    version: postgresVersion
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    storage: {
+      storageSizeGB: storageSizeGb
+      autoGrow: 'Enabled'
+    }
+    backup: {
+      backupRetentionDays: backupRetentionDays
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      // Scale-up-only pilot; revisit with the scale-out topology decision.
+      mode: 'Disabled'
+    }
+    network: {
+      // Reachable only through the private endpoint below.
+      publicNetworkAccess: 'Disabled'
+    }
+  }
+}
+
+// Allow-list PostGIS so the install migrations can CREATE EXTENSION.
+resource extensionsAllowList 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
+  parent: postgresServer
+  name: 'azure.extensions'
+  properties: {
+    value: 'POSTGIS'
+    source: 'user-override'
+  }
+}
+
+resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
+  parent: postgresServer
+  name: databaseName
+  properties: {
+    charset: 'UTF8'
+    collation: 'en_US.utf8'
+  }
+  dependsOn: [
+    extensionsAllowList
+  ]
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: 'pep-${serverName}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'plsc-postgres'
+        properties: {
+          privateLinkServiceId: postgresServer.id
+          groupIds: ['postgresqlServer']
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'postgres'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+output serverName string = postgresServer.name
+output serverFqdn string = postgresServer.properties.fullyQualifiedDomainName
+output databaseName string = database.name

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------
+// Storage account + file share backing CMS_PATH.
+//
+// This is load-bearing: App Service containers are ephemeral, so the uploaded
+// file library MUST live on an external share mounted into the app at
+// CMS_PATH. If it stays inside the container, every restart silently loses
+// uploads. See digitalocean-recovery-and-cutover.md §3 (runbooks).
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the storage account.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Quota for the CMS_PATH file share, in GiB.')
+@minValue(1)
+@maxValue(102400)
+param fileShareQuotaGb int = 100
+
+// Storage account names are globally unique, lowercase, alphanumeric, 3-24 chars.
+// uniqueString() always returns 13 characters, so this is 15-24 by construction:
+// 'st' (2) + up to 9 of the prefix + 13. Truncating the prefix rather than the
+// whole string keeps the unique suffix intact.
+var storageAccountName = toLower('st${take(replace(namePrefix, '-', ''), 9)}${uniqueString(resourceGroup().id)}')
+var fileShareName = 'cms-path'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    // TLS 1.2 minimum and no anonymous blob access; the share is reached with
+    // the account key held in Key Vault, never public.
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource fileServices 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource cmsPathShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+  parent: fileServices
+  name: fileShareName
+  properties: {
+    shareQuota: fileShareQuotaGb
+    enabledProtocols: 'SMB'
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output storageAccountId string = storageAccount.id
+output fileShareName string = cmsPathShare.name


### PR DESCRIPTION
Starts **Milestone #4 Phase 2** — the largest unbuilt chunk of the milestone, and one that is *not* gated on an Azure subscription. The templates are authorable and verifiable now, and are themselves a **CM-2 configuration-management evidence artifact**, not just a deployment convenience.

## What this lands — the foundation layer

| Module | Purpose |
|---|---|
| `network` | VNet, delegated App Service integration subnet, private-endpoint subnet, and the private DNS zones the endpoints resolve through |
| `loganalytics` | Workspace for container stdout — exactly the Sentinel **Path A** ingestion the detection kit was written against |
| `storage` | Storage account + file share backing `CMS_PATH` |
| `keyvault` | RBAC-authorised vault; public access disabled, purge protection on, private endpoint only |
| `postgres` | Flexible Server + database + private endpoint, with **PostGIS allow-listed** |

`main.bicep` wires them and exposes outputs for the application tier.

## Two constraints that are load-bearing

Both are commented at their definitions, because both are silent failures rather than loud ones:

- **`CMS_PATH` must be external storage.** App Service containers are ephemeral — an in-container file library loses every upload on restart.
- **PostGIS must be allow-listed before it can be created.** On Flexible Server an extension must appear in the `azure.extensions` server parameter before `CREATE EXTENSION` succeeds. Setting it here is what lets the Flyway install run unattended on first boot.

## Decisions implemented

All resolved in Phase 0: Azure Commercial · App Service for Containers · Bicep · private endpoints for DB + Key Vault · hardened official base images · Key Vault + managed identity · platform FIPS modules · scale-up-only for the pilot (hence no autoscale and no HA replica).

## Verification

```
az bicep build --file infra/main.bicep --stdout   # and each module
→ 5 modules + main: zero errors, zero warnings
```

The compiler earned its place twice while writing this — it caught a stray property on the subnet definition, and a storage-account name expression whose minimum length couldn't be proven. Both are exactly the class of error that otherwise surfaces at `apply` time against a live subscription.

⚠️ **Authored and type-checked, but NOT deployed and NOT run through `what-if`** — that needs a subscription, the hard dependency recorded in the Phase 0 design. Treat as reviewed-but-unapplied.

🔐 `postgresAdministratorPassword` is a `@secure()` parameter with **no default** and must be supplied at deploy time from Key Vault or a secure pipeline variable.

## Still to author

The **application tier** (Container Registry + App Service with managed identity, Key Vault references, the `CMS_PATH` mount, diagnostics) and the **edge** (Front Door + WAF). Both consume `main.bicep`'s outputs.

Two notes already captured for that work: the app reads plain `DB_PASSWORD` / `CMS_SECRET_KEY` / `CMS_ADMIN_PASSWORD` env vars (no Azure-AD DB auth), so those become Key Vault references resolved by the App Service managed identity; and `CMS_TRUSTED_PROXIES` must be set to the edge egress ranges, or `getRemoteAddr()`/`isSecure()` return the proxy's values and the Secure-cookie flag, IP firewall, rate limiting, and audit source IP all degrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
