### PR TITLE
Enforce the WAR completeness check with --strict

### DIFF
--- a/.github/workflows/war-completeness.yml
+++ b/.github/workflows/war-completeness.yml
@@ -7,10 +7,17 @@
 # nobody declared. That gap is what let the WAR ship okhttp -- a Kotlin library --
 # with no kotlin-stdlib anywhere in it, which broke the Square payment path.
 #
-# REPORT-ONLY for now: it prints findings and exits 0. `main` currently fails this
-# check for exactly the okhttp/kotlin reason above; PR #207 fixes it. Once that has
-# merged and this reports zero unexpected, flip enforcement on by adding --strict
-# to the run line below, the same way the drift check was flipped.
+# ENFORCING: --strict makes an unexpected class fail the job. Until 2026-07-23 this
+# ran report-only, which was a trap -- `completeness` was already a required status
+# check, so the gate looked enforcing on the branch rules while the script could only
+# ever exit 0. The only thing it actually proved was that `ant package` succeeded,
+# which the `build` check already proves.
+#
+# The precondition the earlier comment set -- PR #207 merged and the report clean --
+# was met on 2026-07-21. Verified before enabling: a locally built WAR reports
+# "0 unexpected, 46 allowlisted" and exits 0 under --strict, and the same WAR with
+# kotlin-stdlib deleted exits 1 with 73 unexpected classes (okhttp needs kotlin.*),
+# reproducing the original Square failure. The gate discriminates.
 name: WAR completeness
 
 on:
@@ -38,5 +45,5 @@ jobs:
       - name: Build the WAR
         run: ant -noinput -buildfile build.xml -lib lib/war package
 
-      - name: Report classes referenced but missing from the WAR
-        run: python3 tools/check-war-completeness.py --war target/simis-cms.war
+      - name: Fail if a class is referenced but missing from the WAR
+        run: python3 tools/check-war-completeness.py --war target/simis-cms.war --strict


### PR DESCRIPTION
## The problem: a required check that could never fail

`completeness` **is** in `required_status_checks` on `main`, so the job blocks a merge. But the job ran:

```yaml
run: python3 tools/check-war-completeness.py --war target/simis-cms.war   # no --strict
```

and the script is report-only by default:

```
# tools/check-war-completeness.py:47
Report-only by default: prints findings, always exits 0.
```

So the gate **could not fail on a completeness finding.** The only thing it proved was that `ant package` succeeded — which the `build` check already proves.

That is worse than having no check at all, because both the branch rules and the PR checks list present it as enforcement.

The workflow's own header set the precondition: flip `--strict` once #207 merged and the report was clean. **#207 merged 2026-07-21.** The flag was never added.

## Verified before enabling

Against a WAR built locally from this branch:

| WAR | `--strict` exit | report |
|---|---|---|
| as built | **0** | `0 unexpected, 46 allowlisted packages` |
| same WAR, `kotlin-stdlib-*.jar` deleted | **1** | `73 unexpected` — `okhttp-4.12.0.jar needs kotlin.Deprecated`, `kotlin.Lazy`, … |

The second case is not hypothetical: it reproduces the exact failure this check exists for. okhttp is written in Kotlin, `kotlin-stdlib` was excluded from the vendored set, and the Square payment path threw `NoClassDefFoundError: kotlin/jvm/internal/Intrinsics` on the first call — in a WAR that passed every check that was green at the time.

So the gate discriminates: it passes what should pass and fails the bug it was built to catch.

## Risk

Low. The report is clean today, and the `completeness` check on this PR is itself the proof — it now runs with `--strict`, so if the assessment above were wrong, this PR would go red rather than merge quietly.

The residual risk is that the 62-entry allowlist is too permissive, in which case `--strict` is stricter than before but still not as strict as it looks. That is being audited separately and is not a reason to hold this change — a gate that can fail is strictly better than one that cannot.