### PR TITLE
ci: attest a CycloneDX SBOM for each published container image

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,7 +23,7 @@ permissions:
   packages: write         # publish to the SimIS container registry
   security-events: write  # send image scan results to the Security tab
   id-token: write         # keyless OIDC identity for build provenance
-  attestations: write     # record the signed provenance attestation
+  attestations: write     # record the signed provenance + SBOM attestations
 
 # Serialize publishes: without this, two overlapping runs can race and an older
 # commit's build could finish last and win the :latest tag. Queue instead of
@@ -57,6 +57,11 @@ jobs:
 
       - name: Sign in to the registry
         run: echo '${{ secrets.GITHUB_TOKEN }}' | docker login "$REGISTRY" -u '${{ github.actor }}' --password-stdin
+
+      # Syft generates the per-image SBOMs below (the same tool sbom.yml uses for
+      # the WAR). Installed once here, before the images are built and scanned.
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
 
       # --- Application image (docker/app/Dockerfile, built from repo root) ---
       - name: Build the application image
@@ -104,6 +109,22 @@ jobs:
           subject-digest: ${{ steps.app_digest.outputs.digest }}
           push-to-registry: true
 
+      # Software Bill of Materials: enumerate what is actually inside the image
+      # -- base OS, JRE, and app layers. Provenance proves who built it; an SBOM
+      # says what is in it. Scans the just-built image, so the SBOM describes the
+      # same digest the attestation above is bound to. Purely additive -- the
+      # provenance step above is unchanged.
+      - name: Generate the CycloneDX SBOM for the application image
+        run: syft "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA" -o cyclonedx-json=sbom-simis-cms.cdx.json
+
+      - name: Attest the application image SBOM
+        uses: actions/attest-sbom@v4
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms
+          subject-digest: ${{ steps.app_digest.outputs.digest }}
+          sbom-path: sbom-simis-cms.cdx.json
+          push-to-registry: true
+
       # --- Database image ---------------------------------------------------
       # docker/db/Dockerfile references ./docker/db/init.sql, so it builds from
       # the repository root (not the docker/db directory).
@@ -145,4 +166,18 @@ jobs:
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms-db
           subject-digest: ${{ steps.db_digest.outputs.digest }}
+          push-to-registry: true
+
+      # SBOM for the database image -- the image whose base-OS layers carry the
+      # findings the application image does not, so enumerating its contents
+      # matters most here. Same additive pattern as the application image above.
+      - name: Generate the CycloneDX SBOM for the database image
+        run: syft "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA" -o cyclonedx-json=sbom-simis-cms-db.cdx.json
+
+      - name: Attest the database image SBOM
+        uses: actions/attest-sbom@v4
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms-db
+          subject-digest: ${{ steps.db_digest.outputs.digest }}
+          sbom-path: sbom-simis-cms-db.cdx.json
           push-to-registry: true


### PR DESCRIPTION
Closes #223.

## Gap

`publish-images.yml` signs **build provenance** for both images (`actions/attest-build-provenance`) but attaches **no SBOM**. The two answer different questions:

| | Question answered |
|---|---|
| Build provenance | *Was this image built by our pipeline, from our source?* |
| SBOM | *What is actually inside it?* |

So a consumer who verifies provenance still can't enumerate an image's contents without pulling and scanning it. `sbom.yml` already produces a CycloneDX SBOM, but from the **WAR** — it covers the app's Java dependencies, not the base OS layers or the JRE, and the **database image has no SBOM at all**.

## Change

Install syft once (the same tool `sbom.yml` uses), then per image:

1. **Generate** a CycloneDX SBOM by scanning the just-built image — so it captures the base OS + JRE layers, not just Java deps.
2. **Attest** it with `actions/attest-sbom@v4` (`push-to-registry: true`), bound to the same digest as the existing provenance attestation.

Mirrors the provenance step exactly, for both `simis-cms` and `simis-cms-db`.

## Why this shape

- **`actions/attest-sbom@v4`**, not `cosign attach sbom` — it is the sibling of the `attest-build-provenance@v4` already in this file, stores the SBOM as an OCI referrer of the image digest, and verifies with the same `gh attestation verify` the acceptance criteria name. Inputs were confirmed against the action's `action.yml`.
- **Purely additive** — the provenance steps are untouched; `permissions` already grants `id-token: write` + `attestations: write`, so no permission change was needed (only its comment updated).

## Verification

- Workflow YAML parses clean; step order verified — each `generate → attest SBOM` pair sits right after that image's provenance step.
- `actions/attest-sbom@v4` is the current major (latest v4.1.0), matching the repo's `@v4` provenance pin; `anchore/sbom-action/download-syft@v0` is current.
- Full SBOM push + `gh attestation verify` exercises only when the workflow runs on `main` (it publishes to GHCR), the same way provenance is exercised today.

## Acceptance (from #223)

- [x] Each published image carries a retrievable SBOM — attested per image, `push-to-registry`.
- [x] Fetchable and verifiable from the registry without rebuilding — stored as an OCI referrer of the digest.
- [x] Existing provenance attestation still verifies with `gh attestation verify` — provenance steps unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
