### PR TITLE
ci: enforce the image scan gate using the published VEX

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -73,9 +73,9 @@ jobs:
           output: trivy-simis-cms.sarif
           severity: CRITICAL,HIGH
           limit-severities-for-sarif: true
-          # Report only for now: the Tomcat base image carries OS CVEs we do
-          # not control, and failing here would block every release. Raise to
-          # '1' once the baseline is triaged, to fail on new CRITICAL/HIGH.
+          # Report scan: always exit 0 so the SARIF below reaches the Security
+          # tab on every run. Enforcement is the separate gate step after the
+          # upload -- splitting them means a failing gate never costs visibility.
           exit-code: '0'
 
       - name: Publish the application scan results
@@ -83,6 +83,13 @@ jobs:
         with:
           sarif_file: trivy-simis-cms.sarif
           category: image-simis-cms
+
+      # Blocking gate: the application image's CRITICAL/HIGH baseline is zero,
+      # so any finding is new -- fail before the image is pushed, so a
+      # vulnerable image is never published. Runs after the SARIF upload and
+      # reuses the trivy binary the report scan's action installed on PATH.
+      - name: Enforce the application image scan gate
+        run: trivy image --scanners vuln --severity CRITICAL,HIGH --exit-code 1 "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA"
 
       - name: Push the application image
         run: |
@@ -121,6 +128,7 @@ jobs:
           output: trivy-simis-cms-db.sarif
           severity: CRITICAL,HIGH
           limit-severities-for-sarif: true
+          # Report scan, exit 0 -- same split as the application image above.
           exit-code: '0'
 
       - name: Publish the database scan results
@@ -128,6 +136,21 @@ jobs:
         with:
           sarif_file: trivy-simis-cms-db.sarif
           category: image-simis-cms-db
+
+      # Blocking gate for the database image: the published OpenVEX suppresses
+      # the triaged Debian will-not-fix set (not_affected), and .trivyignore
+      # carries the under_investigation set with expiry dates -- so pending
+      # triage cannot be forgotten silently. Anything else (a new/unexpected
+      # CRITICAL/HIGH) fails the publish before the push. Raw CLI because
+      # trivy-action v0.36.0 exposes no vex input. The VEX claims hold for the
+      # image as configured: enabling PL/Perl, postgis_raster, or xml-handling
+      # voids them (see the VEX impact statements).
+      - name: Enforce the database image scan gate
+        run: >-
+          trivy image --scanners vuln --severity CRITICAL,HIGH --exit-code 1
+          --vex docker/db/vex/simis-cms-db.openvex.json
+          --ignorefile docker/db/.trivyignore
+          "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA"
 
       - name: Push the database image
         run: |

--- a/docker/db/.trivyignore
+++ b/docker/db/.trivyignore
@@ -1,0 +1,17 @@
+# Pending-triage CVEs for the database image scan gate.
+#
+# Each CVE here is recorded as `under_investigation` in the OpenVEX document
+# (docker/db/vex/simis-cms-db.openvex.json). Trivy's VEX filtering only
+# suppresses `not_affected`/`fixed` statements, so entries stay here, with an
+# expiry, until triage resolves them. When a CVE is triaged: update its VEX
+# statement (not_affected with justification, or affected with a fix plan) and
+# remove it from this file. If an expiry below lapses first, the publish gate
+# fails on the next run -- that is deliberate: triage cannot be forgotten
+# silently.
+CVE-2023-2953 exp:2026-09-30
+CVE-2023-33204 exp:2026-09-30
+CVE-2025-69720 exp:2026-09-30
+CVE-2026-41992 exp:2026-09-30
+CVE-2026-53615 exp:2026-09-30
+CVE-2026-54369 exp:2026-09-30
+CVE-2026-57433 exp:2026-09-30

--- a/docker/db/vex/simis-cms-db.openvex.json
+++ b/docker/db/vex/simis-cms-db.openvex.json
@@ -3,7 +3,7 @@
   "@id": "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db",
   "author": "SimIS Inc. (SimIS CMS maintainers)",
   "timestamp": "2026-07-21T12:51:42+00:00",
-  "version": 1,
+  "version": 2,
   "tooling": "tools/generate-db-vex.py",
   "statements": [
     {
@@ -12,13 +12,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libhdf5-103-1@1.10.8+repack1-1?distro=debian-12"
+              "@id": "pkg:deb/debian/libhdf5-103-1"
             },
             {
-              "@id": "pkg:deb/debian/libhdf5-hl-100@1.10.8+repack1-1?distro=debian-12"
+              "@id": "pkg:deb/debian/libhdf5-hl-100"
             }
           ]
         }
@@ -33,10 +33,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libldap-2.5-0@2.5.13+dfsg-5?distro=debian-12"
+              "@id": "pkg:deb/debian/libldap-2.5-0"
             }
           ]
         }
@@ -50,10 +50,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/sysstat@12.6.1-1?distro=debian-12"
+              "@id": "pkg:deb/debian/sysstat"
             }
           ]
         }
@@ -67,10 +67,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -85,10 +85,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/zlib1g@1:1.2.13.dfsg-1?distro=debian-12"
+              "@id": "pkg:deb/debian/zlib1g"
             }
           ]
         }
@@ -103,10 +103,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+              "@id": "pkg:deb/debian/libtiff6"
             }
           ]
         }
@@ -121,10 +121,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -139,10 +139,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -157,10 +157,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+              "@id": "pkg:deb/debian/libheif1"
             }
           ]
         }
@@ -175,19 +175,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libncursesw6@6.4-4?distro=debian-12"
+              "@id": "pkg:deb/debian/libncursesw6"
             },
             {
-              "@id": "pkg:deb/debian/libtinfo6@6.4-4?distro=debian-12"
+              "@id": "pkg:deb/debian/libtinfo6"
             },
             {
-              "@id": "pkg:deb/debian/ncurses-base@6.4-4?distro=debian-12"
+              "@id": "pkg:deb/debian/ncurses-base"
             },
             {
-              "@id": "pkg:deb/debian/ncurses-bin@6.4-4?distro=debian-12"
+              "@id": "pkg:deb/debian/ncurses-bin"
             }
           ]
         }
@@ -201,10 +201,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libsqlite3-0@3.40.1-2+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libsqlite3-0"
             }
           ]
         }
@@ -219,13 +219,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl3-gnutls"
             },
             {
-              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl4"
             }
           ]
         }
@@ -240,10 +240,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+              "@id": "pkg:deb/debian/libtiff6"
             }
           ]
         }
@@ -258,19 +258,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -285,10 +285,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -303,10 +303,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+              "@id": "pkg:deb/debian/libheif1"
             }
           ]
         }
@@ -321,10 +321,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+              "@id": "pkg:deb/debian/libheif1"
             }
           ]
         }
@@ -339,10 +339,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+              "@id": "pkg:deb/debian/libheif1"
             }
           ]
         }
@@ -357,10 +357,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libde265-0@1.0.11-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libde265-0"
             }
           ]
         }
@@ -375,10 +375,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libtiff6@4.5.0-6+deb12u4?distro=debian-12"
+              "@id": "pkg:deb/debian/libtiff6"
             }
           ]
         }
@@ -393,10 +393,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libheif1@1.15.1-1+deb12u1?distro=debian-12"
+              "@id": "pkg:deb/debian/libheif1"
             }
           ]
         }
@@ -411,10 +411,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/gzip@1.12-1?distro=debian-12"
+              "@id": "pkg:deb/debian/gzip"
             }
           ]
         }
@@ -428,19 +428,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -455,19 +455,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -482,10 +482,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -500,19 +500,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -527,16 +527,16 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-data"
             },
             {
-              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-plugins"
             },
             {
-              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/libgdal32"
             }
           ]
         }
@@ -551,34 +551,34 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/bsdutils@1:2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/bsdutils"
             },
             {
-              "@id": "pkg:deb/debian/libblkid1@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libblkid1"
             },
             {
-              "@id": "pkg:deb/debian/libfdisk1@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libfdisk1"
             },
             {
-              "@id": "pkg:deb/debian/libmount1@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libmount1"
             },
             {
-              "@id": "pkg:deb/debian/libsmartcols1@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libsmartcols1"
             },
             {
-              "@id": "pkg:deb/debian/libuuid1@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libuuid1"
             },
             {
-              "@id": "pkg:deb/debian/mount@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/mount"
             },
             {
-              "@id": "pkg:deb/debian/util-linux@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/util-linux"
             },
             {
-              "@id": "pkg:deb/debian/util-linux-extra@2.38.1-5+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/util-linux-extra"
             }
           ]
         }
@@ -592,10 +592,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libacl1@2.3.1-3?distro=debian-12"
+              "@id": "pkg:deb/debian/libacl1"
             }
           ]
         }
@@ -609,10 +609,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+              "@id": "pkg:deb/debian/libssh2-1"
             }
           ]
         }
@@ -627,10 +627,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+              "@id": "pkg:deb/debian/libssh2-1"
             }
           ]
         }
@@ -645,10 +645,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -663,10 +663,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -681,10 +681,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -699,10 +699,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -717,10 +717,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libaom3@3.6.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libaom3"
             }
           ]
         }
@@ -735,10 +735,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -753,10 +753,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libexpat1@2.5.0-1+deb12u2?distro=debian-12"
+              "@id": "pkg:deb/debian/libexpat1"
             }
           ]
         }
@@ -771,19 +771,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -798,13 +798,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl3-gnutls"
             },
             {
-              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl4"
             }
           ]
         }
@@ -819,10 +819,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u6?distro=debian-12"
+              "@id": "pkg:deb/debian/libxml2"
             }
           ]
         }
@@ -837,10 +837,10 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libssh2-1@1.10.0-3+b1?distro=debian-12"
+              "@id": "pkg:deb/debian/libssh2-1"
             }
           ]
         }
@@ -855,16 +855,16 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-data"
             },
             {
-              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-plugins"
             },
             {
-              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/libgdal32"
             }
           ]
         }
@@ -879,16 +879,16 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/gdal-data@3.6.2+dfsg-1?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-data"
             },
             {
-              "@id": "pkg:deb/debian/gdal-plugins@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/gdal-plugins"
             },
             {
-              "@id": "pkg:deb/debian/libgdal32@3.6.2+dfsg-1+b2?distro=debian-12"
+              "@id": "pkg:deb/debian/libgdal32"
             }
           ]
         }
@@ -903,13 +903,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl3-gnutls"
             },
             {
-              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl4"
             }
           ]
         }
@@ -924,19 +924,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -951,13 +951,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl3-gnutls"
             },
             {
-              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl4"
             }
           ]
         }
@@ -972,13 +972,13 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libcurl3-gnutls@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl3-gnutls"
             },
             {
-              "@id": "pkg:deb/debian/libcurl4@7.88.1-10+deb12u15?distro=debian-12"
+              "@id": "pkg:deb/debian/libcurl4"
             }
           ]
         }
@@ -993,19 +993,19 @@
       },
       "products": [
         {
-          "@id": "pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd",
+          "@id": "pkg:oci/simis-cms-db",
           "subcomponents": [
             {
-              "@id": "pkg:deb/debian/libperl5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/libperl5.36"
             },
             {
-              "@id": "pkg:deb/debian/perl@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl"
             },
             {
-              "@id": "pkg:deb/debian/perl-base@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-base"
             },
             {
-              "@id": "pkg:deb/debian/perl-modules-5.36@5.36.0-7+deb12u3?distro=debian-12"
+              "@id": "pkg:deb/debian/perl-modules-5.36"
             }
           ]
         }
@@ -1013,6 +1013,32 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Perl is present as a Debian base/tooling dependency but is never executed at runtime: the image does not install postgresql-17-plperl, so the database engine cannot invoke Perl, and the container entrypoint is the stock postgres shell entrypoint, not a Perl script. No process in the running container executes these modules."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-57433"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libperl5.36"
+            },
+            {
+              "@id": "pkg:deb/debian/perl"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-base"
+            },
+            {
+              "@id": "pkg:deb/debian/perl-modules-5.36"
+            }
+          ]
+        }
+      ],
+      "status": "under_investigation"
     }
-  ]
+  ],
+  "last_updated": "2026-07-23T00:00:00Z"
 }


### PR DESCRIPTION
Closes #253.

## The headline finding

The published VEX (`docker/db/vex/simis-cms-db.openvex.json`, PR #192) **had never actually filtered a Trivy scan.** Verified locally before touching CI: scanning a locally built DB image gave **97 CRITICAL/HIGH rows with the VEX and 97 without it** — zero suppression. Two independent purl defects, isolated by controlled single-statement experiments:

| Defect | In the VEX | What Trivy derives | Effect |
|---|---|---|---|
| Product purl | `pkg:oci/simis-cms-db?repository_url=ghcr.io/simisrnd` (namespace only) | full-repo `repository_url`, and none at all pre-push | never matches |
| Subcomponent purls | `pkg:deb/debian/zlib1g@1:1.2.13.dfsg-1?distro=debian-12` | `…@1.2.13.dfsg-1?arch=…&distro=debian-12.15&epoch=1` | version pin + point-release qualifier + epoch encoding all mismatch |

So the "accepted-risk baseline" was documentation, not enforcement — exactly what this issue exists to fix.

## Changes

**1. VEX purls made match-robust.** Products → bare `pkg:oci/simis-cms-db`; subcomponents → name-level `pkg:deb/debian/<pkg>`. Absent purl qualifiers are wildcards, so matching survives the registry move to ACR (Milestone #4), scan-before-push (no registry digest yet), Debian point releases, and epoch encoding — while staying precise to CVE + package. Justifications and impact statements untouched; doc `version` bumped to 2. **Verified: 97 rows → 21, and the 43 `not_affected` statements all suppress.**

**2. CVE-2026-57433 (perl, CRITICAL) added as `under_investigation`.** Published after the VEX was authored (2026-07-21); the fixed VEX surfaced it immediately — the gate working on its first run. Its sibling CVE-2026-57432 was triaged `not_affected` (code not in execute path), which suggests a likely resolution, but that's a triage decision — so it enters as `under_investigation`, not a rubber-stamped `not_affected`.

**3. `docker/db/.trivyignore` — the pending-triage list, with teeth.** Trivy's VEX filtering only suppresses `not_affected`/`fixed`, so the 7 `under_investigation` CVEs would fail the gate today. They live in an ignore file with `exp:2026-09-30`: **when a date lapses, the gate fails again** — pending triage cannot be forgotten silently. Verified by back-dating an entry: the scan re-fails. Resolving a CVE means updating its VEX statement and deleting its line here. (Expiry date is the ISSM's to tune.)

**4. The gates in `publish-images.yml`.** Report scans stay `exit-code: '0'` — the SARIF upload to the Security tab must never be lost to a gate failure. Each image then gets a blocking gate step **after the SARIF upload and before the push**, so a vulnerable image is never published:

- **App image:** plain `--scanners vuln --severity CRITICAL,HIGH --exit-code 1` — baseline is zero, so any finding is new.
- **DB image:** same, plus `--vex` + `--ignorefile`.

Raw `trivy` CLI because `trivy-action` has no `vex` input even at latest (v0.36.0); the binary comes from the report-scan action's setup. The stale "raise to '1' once the baseline is triaged" comment is replaced by the real thing.

## Verification (all local, against images built from this tree)

| Check | Result |
|---|---|
| DB scan, no VEX | 97 rows |
| DB scan, published VEX (pre-fix) | 97 rows — **zero suppression** |
| DB scan, fixed VEX | 21 rows, exactly the `under_investigation` set + CVE-2026-57433 |
| DB gate without ignore file | exit 1 (bites) |
| DB gate with ignore file | exit 0 (green today) |
| Ignore entry back-dated | exit 1 (expiry has teeth) |
| App image scan | clean at CRITICAL/HIGH; gate exit 0 |
| Workflow YAML | parses; step order scan → SARIF → gate → push for both images |

## Operational notes

- The **monthly rebuild becomes a real canary**: a new Debian CVE fails the publish and demands triage (new VEX statement) instead of scrolling past in a report.
- Scope caveat carried into the workflow comment: the VEX claims hold **for the image as configured** — enabling PL/Perl, `postgis_raster`, or xml-handling voids them.
- This branch is independent of #262 (SBOM attestation); both touch `publish-images.yml` in different hunks and merge cleanly in either order.
