### PR TITLE
infra: add the application tier in Bicep (ACR + App Service)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,18 +17,21 @@ design. Treat it as reviewed-but-unapplied.
 
 | File | Purpose |
 |---|---|
-| `main.bicep` | Orchestrator; wires the modules and exposes outputs for the app tier |
+| `main.bicep` | Orchestrator; wires the modules and exposes outputs for the edge tier |
 | `modules/network.bicep` | VNet, App Service integration subnet, private-endpoint subnet, private DNS zones |
 | `modules/loganalytics.bicep` | Log Analytics workspace (container stdout → Sentinel "Path A") |
 | `modules/storage.bicep` | Storage account + file share backing `CMS_PATH` |
 | `modules/keyvault.bicep` | Key Vault (RBAC, private endpoint, purge protection) |
 | `modules/postgres.bicep` | PostgreSQL Flexible Server + database + PostGIS allow-list + private endpoint |
+| `modules/acr.bicep` | Container registry for the signed app image; admin account disabled |
+| `modules/appservice.bicep` | Plan + Linux container app: managed identity, Key Vault references, `CMS_PATH` mount, VNet integration, diagnostics |
+| `modules/rbac.bicep` | The app identity's grants: Key Vault Secrets User + AcrPull |
 
 ## What is not here yet
 
-The **application tier** (Container Registry + App Service with managed identity,
-Key Vault references, the `CMS_PATH` mount, and diagnostic settings) and the **edge**
-(Front Door + WAF). Both consume `main.bicep`'s outputs.
+The **edge** (Front Door + WAF, issue #245), which consumes `main.bicep`'s outputs —
+and until it lands, `CMS_TRUSTED_PROXIES` stays empty. The pipeline that pushes the
+image to the registry is issue #246.
 
 ## Decisions this implements
 
@@ -68,3 +71,20 @@ for f in infra/modules/*.bicep infra/main.bicep; do az bicep build --file "$f" -
 `postgresAdministratorPassword` is a `@secure()` parameter with no default and **must
 not** be committed. Supply it at deploy time from Key Vault or a secure pipeline
 variable.
+
+## Before first boot (application tier)
+
+The app resolves three Key Vault references at startup, and IaC deliberately does
+**not** create the secret values — the ISSM does, once, before the first start:
+
+- `db-password` — the database login's password
+- `cms-secret-key` — the CMS encryption key
+- `cms-admin-password` — the admin bootstrap password
+
+The image must also exist in the registry (issue #246's pipeline, or a one-time
+manual push) — App Service pulls it with its managed identity via AcrPull; there is
+no registry password. Two settings that matter at cutover: `customUrl` (CMS_URL)
+switches to the custom domain, and `trustedProxies` (CMS_TRUSTED_PROXIES) must be
+set to the edge egress ranges when the edge tier fronts the app — otherwise
+`getRemoteAddr()`/`isSecure()` see the proxy, degrading the Secure-cookie flag, the
+IP firewall, rate limiting, and the audit source IP.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,9 +1,10 @@
 // ---------------------------------------------------------------------------
 // simis-cms — Azure infrastructure (Milestone #4 Phase 2)
 //
-// Foundation layer: network, observability, storage, secret custody, database.
-// The application tier (ACR + App Service) and the edge (Front Door + WAF) are
-// authored separately and consume the outputs below.
+// Foundation layer (network, observability, storage, secret custody, database)
+// plus the application tier (container registry, App Service, role grants).
+// The edge (Front Door + WAF) is authored separately and consumes the outputs
+// below.
 //
 // Design inputs, all resolved in Phase 0
 // (governance/decision-milestone-4-phase0-decisions.md):
@@ -40,6 +41,21 @@ param logRetentionInDays int = 90
 
 @description('Quota for the CMS_PATH file share, in GiB.')
 param fileShareQuotaGb int = 100
+
+@description('App Service plan SKU. Scale up only for the pilot (decision #8).')
+param appServicePlanSku string = 'P1v3'
+
+@description('Image repository and tag the app runs, relative to the registry. The publish pipeline (issue #246) pushes it.')
+param containerImage string = 'simis-cms:latest'
+
+@description('Database login the application connects with. Pilot default is the administrator login; a lesser application role is a hardening follow-up.')
+param dbUser string = 'simiscmsadmin'
+
+@description('CMS_TRUSTED_PROXIES value. Set to the edge egress ranges when the edge tier (#245) fronts the app.')
+param trustedProxies string = ''
+
+@description('Public URL of the site (CMS_URL). Empty means the App Service default hostname; the custom domain replaces it at cutover.')
+param customUrl string = ''
 
 var namePrefix = '${workloadName}-${environmentName}'
 
@@ -103,7 +119,49 @@ module postgres 'modules/postgres.bicep' = {
   }
 }
 
-// Consumed by the application tier when it is authored.
+module acr 'modules/acr.bicep' = {
+  name: 'acr'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+  }
+}
+
+module appService 'modules/appservice.bicep' = {
+  name: 'appservice'
+  params: {
+    location: location
+    namePrefix: namePrefix
+    tags: tags
+    appSubnetId: network.outputs.appSubnetId
+    keyVaultUri: keyVault.outputs.keyVaultUri
+    storageAccountName: storage.outputs.storageAccountName
+    cmsPathShareName: storage.outputs.fileShareName
+    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
+    acrLoginServer: acr.outputs.loginServer
+    containerImage: containerImage
+    planSkuName: appServicePlanSku
+    postgresFqdn: postgres.outputs.serverFqdn
+    postgresDatabaseName: postgres.outputs.databaseName
+    dbUser: dbUser
+    trustedProxies: trustedProxies
+    customUrl: customUrl
+  }
+}
+
+// Grants come last: they need the app's principal id, which only exists once
+// the app does.
+module rbac 'modules/rbac.bicep' = {
+  name: 'rbac'
+  params: {
+    principalId: appService.outputs.appServicePrincipalId
+    keyVaultName: keyVault.outputs.keyVaultName
+    acrName: acr.outputs.registryName
+  }
+}
+
+// Consumed by the edge tier when it is authored.
 output vnetId string = network.outputs.vnetId
 output appSubnetId string = network.outputs.appSubnetId
 output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId
@@ -113,3 +171,7 @@ output storageAccountName string = storage.outputs.storageAccountName
 output cmsPathShareName string = storage.outputs.fileShareName
 output postgresFqdn string = postgres.outputs.serverFqdn
 output postgresDatabaseName string = postgres.outputs.databaseName
+output acrLoginServer string = acr.outputs.loginServer
+output acrName string = acr.outputs.registryName
+output appServiceName string = appService.outputs.appServiceName
+output appServiceHostName string = appService.outputs.defaultHostName

--- a/infra/modules/acr.bicep
+++ b/infra/modules/acr.bicep
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------
+// Azure Container Registry for the signed application image.
+//
+// The publish pipeline builds, scans, signs, and attests the image; pushing it
+// here (issue #246) replaces GHCR as the deployment source. The registry
+// admin account stays disabled: App Service pulls with its managed identity
+// via the AcrPull role (rbac.bicep), so no registry password exists at all.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the registry.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Registry SKU. Standard fits the pilot; Premium adds private endpoints and geo-replication if required later.')
+@allowed(['Basic', 'Standard', 'Premium'])
+param skuName string = 'Standard'
+
+// Registry names are globally unique, alphanumeric only, 5-50 chars.
+// 'cr' (2) + prefix with hyphens removed (12 for simiscms-pilot) + 13 from
+// uniqueString() stays comfortably inside the limit.
+var registryName = toLower('cr${replace(namePrefix, '-', '')}${uniqueString(resourceGroup().id)}')
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: registryName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    // Managed identity + RBAC only; a registry password would be a second,
+    // unaudited credential path.
+    adminUserEnabled: false
+  }
+}
+
+output registryName string = registry.name
+output registryId string = registry.id
+output loginServer string = registry.properties.loginServer

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -1,0 +1,187 @@
+// ---------------------------------------------------------------------------
+// App Service plan + Linux container app (Phase 0 decision #2).
+//
+// Single instance, scale UP only for the pilot (decision #8) -- no autoscale
+// and no additional instances. The container runs non-root and listens on
+// 8080 (it cannot bind below 1024), exposing /healthz for the health check.
+//
+// Secret custody (decision #6): the app reads plain env vars; the three
+// sensitive ones (DB_PASSWORD, CMS_SECRET_KEY, CMS_ADMIN_PASSWORD) are Key
+// Vault references resolved at startup by the system-assigned managed
+// identity, so no secret value ever appears in app configuration, template,
+// or output. The secrets themselves are created by the ISSM at deploy time --
+// never by IaC.
+//
+// CMS_PATH is an Azure Files mount: App Service containers are ephemeral, and
+// an in-container file library silently loses every upload on restart.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the plan and app.')
+param location string
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Delegated subnet for regional VNet integration (outbound).')
+param appSubnetId string
+
+@description('Key Vault URI, e.g. https://kv-name.vault.azure.net/. Used to build the Key Vault references.')
+param keyVaultUri string
+
+@description('Storage account holding the CMS_PATH file share.')
+param storageAccountName string
+
+@description('Name of the CMS_PATH file share.')
+param cmsPathShareName string
+
+@description('Log Analytics workspace for diagnostic settings (Sentinel Path A: container stdout).')
+param logAnalyticsWorkspaceId string
+
+@description('Login server of the container registry, e.g. crname.azurecr.io.')
+param acrLoginServer string
+
+@description('Image repository and tag to run, relative to the registry.')
+param containerImage string = 'simis-cms:latest'
+
+@description('App Service plan SKU. Scale up only for the pilot (decision #8).')
+param planSkuName string = 'P1v3'
+
+@description('PostgreSQL server FQDN (DB_SERVER_NAME).')
+param postgresFqdn string
+
+@description('Application database name (DB_NAME).')
+param postgresDatabaseName string
+
+@description('Database login the application connects with (DB_USER).')
+param dbUser string
+
+@description('CMS administrator username created at first boot (CMS_ADMIN_USERNAME).')
+param cmsAdminUsername string = 'admin'
+
+@description('CMS_TRUSTED_PROXIES value. Must be set to the edge egress ranges when the edge tier (#245) fronts the app; otherwise getRemoteAddr()/isSecure() see the proxy, degrading the Secure-cookie flag, IP firewall, rate limiting, and audit source IP.')
+param trustedProxies string = ''
+
+@description('Public URL of the site (CMS_URL). Defaults to the App Service hostname until the custom domain lands at cutover.')
+param customUrl string = ''
+
+@description('Key Vault secret name for the database password.')
+param dbPasswordSecretName string = 'db-password'
+
+@description('Key Vault secret name for the CMS secret key.')
+param cmsSecretKeySecretName string = 'cms-secret-key'
+
+@description('Key Vault secret name for the CMS admin bootstrap password.')
+param cmsAdminPasswordSecretName string = 'cms-admin-password'
+
+var planName = 'plan-${namePrefix}'
+var appName = 'app-${namePrefix}'
+var cmsPathMount = '/cms-data'
+var cmsUrl = empty(customUrl) ? 'https://${appName}.azurewebsites.net' : customUrl
+
+// The share is mounted with the storage account key, fetched at deploy time --
+// the key is never written into source or parameters.
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: planName
+  location: location
+  tags: tags
+  kind: 'linux'
+  sku: {
+    name: planSkuName
+    capacity: 1
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  tags: tags
+  kind: 'app,linux,container'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    virtualNetworkSubnetId: appSubnetId
+    // Key Vault references resolve with the system-assigned identity.
+    keyVaultReferenceIdentity: 'SystemAssigned'
+    siteConfig: {
+      linuxFxVersion: 'DOCKER|${acrLoginServer}/${containerImage}'
+      // Pull with the managed identity (AcrPull, rbac.bicep) -- the registry
+      // admin account is disabled, so there is no password to leak.
+      acrUseManagedIdentityCreds: true
+      alwaysOn: true
+      http20Enabled: true
+      minTlsVersion: '1.2'
+      ftpsState: 'Disabled'
+      healthCheckPath: '/healthz'
+      // Route all outbound through the VNet so the private endpoints for the
+      // database and Key Vault (and their private DNS zones) are what resolve.
+      vnetRouteAllEnabled: true
+      azureStorageAccounts: {
+        cmspath: {
+          type: 'AzureFiles'
+          accountName: storageAccountName
+          shareName: cmsPathShareName
+          mountPath: cmsPathMount
+          accessKey: storageAccount.listKeys().keys[0].value
+        }
+      }
+      appSettings: [
+        // The container listens on 8080 (non-root cannot bind below 1024).
+        { name: 'WEBSITES_PORT', value: '8080' }
+        // --- Application contract (issue #244): plain env vars ---
+        { name: 'CMS_URL', value: cmsUrl }
+        { name: 'CMS_FORCE_SSL', value: 'true' }
+        // Single-node pilot runs everything; 'web' would skip the overhead
+        // tasks that only make sense to skip in a multi-node cluster.
+        { name: 'CMS_NODE_TYPE', value: 'standalone' }
+        { name: 'CMS_PATH', value: cmsPathMount }
+        { name: 'CMS_TRUSTED_PROXIES', value: trustedProxies }
+        { name: 'CMS_ADMIN_USERNAME', value: cmsAdminUsername }
+        { name: 'CMS_ADMIN_PASSWORD', value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/${cmsAdminPasswordSecretName})' }
+        { name: 'CMS_SECRET_KEY', value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/${cmsSecretKeySecretName})' }
+        { name: 'DB_SERVER_NAME', value: postgresFqdn }
+        { name: 'DB_NAME', value: postgresDatabaseName }
+        { name: 'DB_USER', value: dbUser }
+        { name: 'DB_PASSWORD', value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/${dbPasswordSecretName})' }
+        { name: 'DB_SSL', value: 'true' }
+      ]
+    }
+  }
+}
+
+// Container stdout to Log Analytics -- exactly the Sentinel "Path A" ingestion
+// the detection kit was written against. HTTP/audit/platform logs ride along
+// for the workbook and the WAF correlation later.
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${appName}'
+  scope: app
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      { category: 'AppServiceConsoleLogs', enabled: true }
+      { category: 'AppServiceHTTPLogs', enabled: true }
+      { category: 'AppServiceAuditLogs', enabled: true }
+      { category: 'AppServicePlatformLogs', enabled: true }
+    ]
+    metrics: [
+      { category: 'AllMetrics', enabled: true }
+    ]
+  }
+}
+
+output appServiceName string = app.name
+output appServicePrincipalId string = app.identity.principalId
+output defaultHostName string = app.properties.defaultHostName
+output planId string = plan.id

--- a/infra/modules/rbac.bicep
+++ b/infra/modules/rbac.bicep
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------
+// Role assignments for the application's system-assigned managed identity.
+//
+// Lives in its own module because the assignments need the app's principal
+// id, which only exists after the app -- while the vault and registry are
+// created before it. Two grants, both least-privilege data-plane reads:
+//
+//   Key Vault Secrets User -- resolve the DB_PASSWORD / CMS_SECRET_KEY /
+//     CMS_ADMIN_PASSWORD references (decision #6; the vault is RBAC-mode).
+//   AcrPull -- pull the application image; the registry admin account is
+//     disabled, so this is the only pull path.
+// ---------------------------------------------------------------------------
+
+@description('Principal id of the App Service system-assigned managed identity.')
+param principalId string
+
+@description('Name of the Key Vault holding the application secrets.')
+param keyVaultName string
+
+@description('Name of the container registry the app pulls from.')
+param acrName string
+
+// Built-in role definition ids (stable, documented platform GUIDs).
+var keyVaultSecretsUserRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+var acrPullRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: acrName
+}
+
+resource keyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, principalId, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    principalId: principalId
+    roleDefinitionId: keyVaultSecretsUserRoleId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource acrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(registry.id, principalId, acrPullRoleId)
+  scope: registry
+  properties: {
+    principalId: principalId
+    roleDefinitionId: acrPullRoleId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
Closes #244.

> Originally stacked on #242; that merged, and this branch is rebased onto `main` — the diff is the app tier alone.

Continues Milestone #4 Phase 2: the application tier that consumes the foundation's outputs.

## What this lands

| Module | Purpose |
|---|---|
| `acr` | Container registry for the signed app image. **Admin account disabled** — the only pull path is the app's managed identity (AcrPull), so no registry password exists at all |
| `appservice` | Linux plan + container app: single instance, scale-up-only (decision #8). System-assigned identity, Key Vault references, `CMS_PATH` mount, VNet integration with route-all, diagnostics → Log Analytics (Sentinel **Path A**) |
| `rbac` | The identity's two least-privilege data-plane grants: **Key Vault Secrets User** + **AcrPull** — a separate module because the grants need the app's principal id, which only exists once the app does |

## The app contract, implemented from source

Everything in issue #244's env-var contract is wired: `WEBSITES_PORT=8080` (the container runs non-root and can't bind below 1024), `healthCheckPath: /healthz`, `DB_SERVER_NAME`/`DB_NAME` from the postgres module, `CMS_FORCE_SSL`/`DB_SSL` on.

- **The three secrets are Key Vault references** (`@Microsoft.KeyVault(SecretUri=…)`) resolved at startup by the managed identity — no secret value in app configuration, template, parameters, or outputs. The storage key for the share mount is fetched with `listKeys()` at deploy time, same property.
- **`CMS_NODE_TYPE=standalone`** — verified in `InstanceManager.java`: `web` skips the overhead tasks, which is wrong for a single-node pilot that must run them.
- **`CMS_TRUSTED_PROXIES` stays parameterized and empty** until the edge tier (#245) exists; the README documents why it must be set at that point (proxy-IP degradation of Secure-cookie, IP firewall, rate limiting, audit source IP).
- **IaC deliberately does not create secret values.** The README's new "Before first boot" section lists the three secrets the ISSM creates once (`db-password`, `cms-secret-key`, `cms-admin-password`) and notes the image must be pushed (#246) before first start.

## Verification

```
az bicep build --file <each of the 4 touched files> --stdout
→ zero errors, zero warnings (Bicep CLI 0.45.15)
```

⚠️ Authored and type-checked, **not deployed and not `what-if`'d** — the subscription remains the Phase 0 hard dependency. Treat as reviewed-but-unapplied.

## Still to author (Phase 2 remainder)

The **edge** (Front Door + WAF, #245) consuming the new `main.bicep` outputs, and the **push-to-ACR pipeline** (#246).
