### PR TITLE
infra: add the edge tier in Bicep (Front Door Premium + WAF)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -24,14 +24,26 @@ design. Treat it as reviewed-but-unapplied.
 | `modules/keyvault.bicep` | Key Vault (RBAC, private endpoint, purge protection) |
 | `modules/postgres.bicep` | PostgreSQL Flexible Server + database + PostGIS allow-list + private endpoint |
 | `modules/acr.bicep` | Container registry for the signed app image; admin account disabled |
-| `modules/appservice.bicep` | Plan + Linux container app: managed identity, Key Vault references, `CMS_PATH` mount, VNet integration, diagnostics |
+| `modules/appservice.bicep` | Plan + Linux container app: managed identity, Key Vault references, `CMS_PATH` mount, VNet integration, diagnostics; public ingress disabled |
 | `modules/rbac.bicep` | The app identity's grants: Key Vault Secrets User + AcrPull |
+| `modules/frontdoor.bicep` | Front Door Premium + WAF (managed rulesets), Private Link origin, optional custom domain with managed TLS, edge logs to the workspace |
 
 ## What is not here yet
 
-The **edge** (Front Door + WAF, issue #245), which consumes `main.bicep`'s outputs —
-and until it lands, `CMS_TRUSTED_PROXIES` stays empty. The pipeline that pushes the
-image to the registry is issue #246.
+The pipeline that pushes the image to the registry is issue #246.
+
+## The ingress path, end to end
+
+```
+client
+  └─ HTTPS → Front Door (managed TLS; WAF in Prevention: DRS 2.1 + bot rules)
+       └─ Private Link → App Service (publicNetworkAccess: Disabled — no public path)
+            └─ VNet-integrated outbound → private endpoints → PostgreSQL, Key Vault
+```
+
+Nothing between the client and the database is publicly reachable except the edge
+itself. The app's only ingress is Front Door's Private Link origin; the database
+and vault accept only their private endpoints.
 
 ## Decisions this implements
 
@@ -83,8 +95,24 @@ The app resolves three Key Vault references at startup, and IaC deliberately doe
 
 The image must also exist in the registry (issue #246's pipeline, or a one-time
 manual push) — App Service pulls it with its managed identity via AcrPull; there is
-no registry password. Two settings that matter at cutover: `customUrl` (CMS_URL)
-switches to the custom domain, and `trustedProxies` (CMS_TRUSTED_PROXIES) must be
-set to the edge egress ranges when the edge tier fronts the app — otherwise
-`getRemoteAddr()`/`isSecure()` see the proxy, degrading the Secure-cookie flag, the
-IP firewall, rate limiting, and the audit source IP.
+no registry password.
+
+## Edge deploy-time steps (the template cannot do these)
+
+1. **Approve the Private Link connection.** Front Door's origin appears on the App
+   Service as a *pending* private endpoint connection; approve it once
+   (`az network private-endpoint-connection approve`). Until then the edge serves
+   502s — the app has no other ingress by design.
+2. **Set `trustedProxies` (CMS_TRUSTED_PROXIES) to the `AzureFrontDoor.Backend`
+   service-tag ranges.** The proxy-aware handling shipped in #166/#182; this value
+   activates it. Without it, `getRemoteAddr()`/`isSecure()` see the proxy rather
+   than the client, degrading the Secure-cookie flag, the IP firewall, rate
+   limiting, and the audit source IP. The ranges are published in Azure's
+   service-tags feed and change over time — set at deploy, revisit on the monthly
+   cadence rather than hardcoding here.
+3. **At cutover:** set `customDomainName` (Front Door provisions the managed
+   certificate; DNS CNAMEs to the endpoint hostname) and `customUrl` (CMS_URL)
+   to the same domain. Until then the WAF fronts the default endpoint hostname.
+4. **WAF mode:** ships in `Prevention`. If content authoring hits managed-rule
+   false positives, drop to `Detection` *temporarily*, tune exclusions, and return
+   to `Prevention` before cutover — Detection-forever is the failure mode to avoid.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,10 +1,9 @@
 // ---------------------------------------------------------------------------
 // simis-cms — Azure infrastructure (Milestone #4 Phase 2)
 //
-// Foundation layer (network, observability, storage, secret custody, database)
-// plus the application tier (container registry, App Service, role grants).
-// The edge (Front Door + WAF) is authored separately and consumes the outputs
-// below.
+// All three layers: the foundation (network, observability, storage, secret
+// custody, database), the application tier (container registry, App Service,
+// role grants), and the edge (Front Door Premium + WAF, Private Link origin).
 //
 // Design inputs, all resolved in Phase 0
 // (governance/decision-milestone-4-phase0-decisions.md):
@@ -56,6 +55,13 @@ param trustedProxies string = ''
 
 @description('Public URL of the site (CMS_URL). Empty means the App Service default hostname; the custom domain replaces it at cutover.')
 param customUrl string = ''
+
+@description('WAF mode for the edge. Prevention blocks; Detection only logs while tuning.')
+@allowed(['Prevention', 'Detection'])
+param wafMode string = 'Prevention'
+
+@description('Custom domain for the edge, e.g. www.example.org. Empty until the DNS cutover decision.')
+param customDomainName string = ''
 
 var namePrefix = '${workloadName}-${environmentName}'
 
@@ -161,7 +167,22 @@ module rbac 'modules/rbac.bicep' = {
   }
 }
 
-// Consumed by the edge tier when it is authored.
+module frontDoor 'modules/frontdoor.bicep' = {
+  name: 'frontdoor'
+  params: {
+    namePrefix: namePrefix
+    tags: tags
+    appServiceId: appService.outputs.appServiceId
+    appHostName: appService.outputs.defaultHostName
+    privateLinkLocation: location
+    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
+    wafMode: wafMode
+    customDomainName: customDomainName
+  }
+}
+
+// Deploy-time reference: hostnames for DNS and verification, ids for the
+// approval and trusted-proxy steps documented in the README.
 output vnetId string = network.outputs.vnetId
 output appSubnetId string = network.outputs.appSubnetId
 output logAnalyticsWorkspaceId string = logAnalytics.outputs.workspaceId
@@ -175,3 +196,5 @@ output acrLoginServer string = acr.outputs.loginServer
 output acrName string = acr.outputs.registryName
 output appServiceName string = appService.outputs.appServiceName
 output appServiceHostName string = appService.outputs.defaultHostName
+output frontDoorEndpointHostName string = frontDoor.outputs.endpointHostName
+output frontDoorId string = frontDoor.outputs.frontDoorId

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -76,6 +76,10 @@ param cmsSecretKeySecretName string = 'cms-secret-key'
 @description('Key Vault secret name for the CMS admin bootstrap password.')
 param cmsAdminPasswordSecretName string = 'cms-admin-password'
 
+@description('Public ingress to the app. Disabled: the only path in is the edge tier\'s Private Link origin (frontdoor.bicep). Enable temporarily only for pre-edge debugging.')
+@allowed(['Enabled', 'Disabled'])
+param publicNetworkAccess string = 'Disabled'
+
 var planName = 'plan-${namePrefix}'
 var appName = 'app-${namePrefix}'
 var cmsPathMount = '/cms-data'
@@ -113,6 +117,8 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: plan.id
     httpsOnly: true
     virtualNetworkSubnetId: appSubnetId
+    // Ingress only through the edge tier's Private Link origin.
+    publicNetworkAccess: publicNetworkAccess
     // Key Vault references resolve with the system-assigned identity.
     keyVaultReferenceIdentity: 'SystemAssigned'
     siteConfig: {
@@ -182,6 +188,7 @@ resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' 
 }
 
 output appServiceName string = app.name
+output appServiceId string = app.id
 output appServicePrincipalId string = app.identity.principalId
 output defaultHostName string = app.properties.defaultHostName
 output planId string = plan.id

--- a/infra/modules/frontdoor.bicep
+++ b/infra/modules/frontdoor.bicep
@@ -1,0 +1,235 @@
+// ---------------------------------------------------------------------------
+// Edge tier: Front Door Premium + WAF in front of App Service.
+//
+// Premium rather than Standard because the WAF managed rulesets (OWASP-derived
+// DRS + bot rules) only run on Premium -- a WAF with custom rules alone would
+// be an empty shell. Premium also enables the Private Link origin below, which
+// is what makes "reachable only through the edge" literal: the app's public
+// ingress is disabled outright (appservice.bicep), and Front Door reaches it
+// over a private endpoint. There is no public path to the origin at all.
+//
+// Ingress path, end to end:
+//   client -> Front Door (TLS, WAF) -> Private Link -> App Service
+//          -> private endpoints (PostgreSQL, Key Vault)
+//
+// Two deploy-time steps this template cannot do by itself:
+//   1. The Private Link connection from Front Door appears on the App Service
+//      as a pending private endpoint connection and must be APPROVED once
+//      (az network private-endpoint-connection approve). Until approved, the
+//      origin is unreachable and the endpoint serves 502s.
+//   2. CMS_TRUSTED_PROXIES (main.bicep trustedProxies) must be set to the
+//      AzureFrontDoor.Backend service-tag ranges so the app resolves the real
+//      client from X-Forwarded-For (the handling shipped in #166/#182; this
+//      configuration is what activates it).
+// ---------------------------------------------------------------------------
+
+@description('Prefix applied to resource names.')
+param namePrefix string
+
+@description('Tags applied to every resource.')
+param tags object
+
+@description('Resource id of the App Service the edge fronts (Private Link target).')
+param appServiceId string
+
+@description('Default hostname of the App Service (origin host).')
+param appHostName string
+
+@description('Region of the App Service, used for the Private Link connection.')
+param privateLinkLocation string
+
+@description('Log Analytics workspace for access, WAF, and health-probe logs.')
+param logAnalyticsWorkspaceId string
+
+@description('WAF mode. Prevention blocks; Detection only logs. Ship in Prevention; drop to Detection temporarily if content-authoring hits false positives, tune, and return to Prevention before cutover.')
+@allowed(['Prevention', 'Detection'])
+param wafMode string = 'Prevention'
+
+@description('Custom domain, e.g. www.example.org. Empty skips the domain + managed certificate until cutover (DNS is a cutover-day decision).')
+param customDomainName string = ''
+
+// WAF policy names allow letters and digits only.
+var wafPolicyName = 'waf${replace(namePrefix, '-', '')}'
+var profileName = 'afd-${namePrefix}'
+var endpointName = 'fde-${namePrefix}'
+
+resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2024-02-01' = {
+  name: wafPolicyName
+  location: 'Global'
+  tags: tags
+  sku: {
+    name: 'Premium_AzureFrontDoor'
+  }
+  properties: {
+    policySettings: {
+      enabledState: 'Enabled'
+      mode: wafMode
+      requestBodyCheck: 'Enabled'
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          // Microsoft Default Rule Set (OWASP-derived), block on match.
+          ruleSetType: 'Microsoft_DefaultRuleSet'
+          ruleSetVersion: '2.1'
+          ruleSetAction: 'Block'
+        }
+        {
+          ruleSetType: 'Microsoft_BotManagerRuleSet'
+          ruleSetVersion: '1.0'
+        }
+      ]
+    }
+  }
+}
+
+resource profile 'Microsoft.Cdn/profiles@2024-02-01' = {
+  name: profileName
+  location: 'global'
+  tags: tags
+  sku: {
+    name: 'Premium_AzureFrontDoor'
+  }
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdEndpoints@2024-02-01' = {
+  parent: profile
+  name: endpointName
+  location: 'global'
+  tags: tags
+  properties: {
+    enabledState: 'Enabled'
+  }
+}
+
+resource originGroup 'Microsoft.Cdn/profiles/originGroups@2024-02-01' = {
+  parent: profile
+  name: 'og-app'
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    healthProbeSettings: {
+      // The container exposes /healthz (same probe App Service itself uses).
+      probePath: '/healthz'
+      probeRequestType: 'GET'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 30
+    }
+  }
+}
+
+resource origin 'Microsoft.Cdn/profiles/originGroups/origins@2024-02-01' = {
+  parent: originGroup
+  name: 'app-service'
+  properties: {
+    hostName: appHostName
+    httpPort: 80
+    httpsPort: 443
+    // The Host header must match the App Service hostname or its front end
+    // rejects the request.
+    originHostHeader: appHostName
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    // Private Link to the app: with the app's public access disabled, this is
+    // the only ingress path. The connection must be approved once at deploy
+    // time (see header).
+    sharedPrivateLinkResource: {
+      privateLink: {
+        id: appServiceId
+      }
+      groupId: 'sites'
+      privateLinkLocation: privateLinkLocation
+      requestMessage: 'Front Door edge for ${namePrefix}'
+    }
+    enforceCertificateNameCheck: true
+  }
+}
+
+// Custom domain with a managed certificate; skipped until the domain exists.
+resource customDomain 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = if (!empty(customDomainName)) {
+  parent: profile
+  name: replace(customDomainName, '.', '-')
+  properties: {
+    hostName: customDomainName
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+    }
+  }
+}
+
+resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
+  parent: endpoint
+  name: 'route-app'
+  properties: {
+    originGroup: {
+      id: originGroup.id
+    }
+    supportedProtocols: ['Http', 'Https']
+    patternsToMatch: ['/*']
+    forwardingProtocol: 'HttpsOnly'
+    httpsRedirect: 'Enabled'
+    linkToDefaultDomain: 'Enabled'
+    customDomains: empty(customDomainName) ? [] : [
+      {
+        id: customDomain.id
+      }
+    ]
+    // No caching: the CMS is dynamic and sets its own headers. Static-asset
+    // caching is a deliberate later tune, not a default.
+  }
+  dependsOn: [
+    origin
+  ]
+}
+
+// Attach the WAF to everything the endpoint serves.
+resource securityPolicy 'Microsoft.Cdn/profiles/securityPolicies@2024-02-01' = {
+  parent: profile
+  name: 'waf-attach'
+  properties: {
+    parameters: {
+      type: 'WebApplicationFirewall'
+      wafPolicy: {
+        id: wafPolicy.id
+      }
+      associations: [
+        {
+          domains: concat(
+            [{ id: endpoint.id }],
+            empty(customDomainName) ? [] : [{ id: customDomain.id }]
+          )
+          patternsToMatch: ['/*']
+        }
+      ]
+    }
+  }
+}
+
+// Access, WAF, and health-probe logs to the workspace -- the WAF half of the
+// Sentinel correlation the app's console logs already feed.
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${profileName}'
+  scope: profile
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      { category: 'FrontDoorAccessLog', enabled: true }
+      { category: 'FrontDoorWebApplicationFirewallLog', enabled: true }
+      { category: 'FrontDoorHealthProbeLog', enabled: true }
+    ]
+    metrics: [
+      { category: 'AllMetrics', enabled: true }
+    ]
+  }
+}
+
+output endpointHostName string = endpoint.properties.hostName
+// Every request Front Door forwards carries X-Azure-FDID with this id; an
+// origin-side check against it is a later hardening option.
+output frontDoorId string = profile.properties.frontDoorId
+output wafPolicyId string = wafPolicy.id


### PR DESCRIPTION
Closes #245.

> Originally stacked on #264; that merged, and this branch is rebased onto `main` — the diff is the edge tier alone.

Completes the Milestone #4 Phase 2 template set: **foundation → app tier → edge.**

## The ingress path (acceptance criterion)

```
client
  └─ HTTPS → Front Door (managed TLS; WAF Prevention: DRS 2.1 + bot rules)
       └─ Private Link → App Service (publicNetworkAccess: Disabled — no public path)
            └─ VNet-integrated outbound → private endpoints → PostgreSQL, Key Vault
```

Nothing between the client and the database is publicly reachable except the edge itself.

## Design choices

- **Front Door Premium, not Standard.** The managed WAF rulesets (OWASP-derived DRS 2.1 + bot rules) only run on Premium — a custom-rules-only WAF is an empty shell for a CMS. Premium also enables the **Private Link origin**, which makes "reachable only through the edge" literal rather than a header-check convention: the app's public ingress is disabled outright.
- **WAF ships in `Prevention`** (parameterized). The README names Detection-forever as the failure mode to avoid: if content authoring hits false positives, drop to Detection *temporarily*, tune, return to Prevention before cutover.
- **Custom domain is optional and empty** while the DNS decision is open — when set, Front Door provisions the managed certificate (min TLS 1.2) and the WAF association picks the domain up automatically. HTTPS redirect on; forwarding `HttpsOnly`; **no caching** (dynamic CMS; asset caching is a deliberate later tune).
- **Health probe on `/healthz`**, matching the app's own health check.
- **Edge logs → Log Analytics** (access, WAF, health-probe) — the WAF half of the Sentinel correlation the app's console logs already feed.

## The setting that must not be missed (from #245)

`CMS_TRUSTED_PROXIES` must carry the `AzureFrontDoor.Backend` service-tag ranges — that configuration is what activates the proxy-aware handling shipped in #166/#182. The README's new **"Edge deploy-time steps"** section documents it alongside the other step the template cannot do: the **one-time Private Link connection approval** on the App Service (until approved, the edge serves 502s — by design, since the app has no other ingress).

## Verification

```
az bicep build --file infra/{main,modules/frontdoor,modules/appservice}.bicep --stdout
→ zero errors, zero warnings (Bicep CLI 0.45.15)
```

⚠️ Authored and type-checked, **not deployed and not `what-if`'d** — the subscription remains the Phase 0 hard dependency.

With this, Phase 2's remaining item is the **push-to-ACR pipeline (#246)**.
