### PR TITLE
Triage the 7 pending DB-image CVEs as not_affected with evidence

### DIFF
--- a/docker/db/.trivyignore
+++ b/docker/db/.trivyignore
@@ -1,17 +1,13 @@
 # Pending-triage CVEs for the database image scan gate.
 #
-# Each CVE here is recorded as `under_investigation` in the OpenVEX document
-# (docker/db/vex/simis-cms-db.openvex.json). Trivy's VEX filtering only
-# suppresses `not_affected`/`fixed` statements, so entries stay here, with an
-# expiry, until triage resolves them. When a CVE is triaged: update its VEX
-# statement (not_affected with justification, or affected with a fix plan) and
-# remove it from this file. If an expiry below lapses first, the publish gate
-# fails on the next run -- that is deliberate: triage cannot be forgotten
-# silently.
-CVE-2023-2953 exp:2026-09-30
-CVE-2023-33204 exp:2026-09-30
-CVE-2025-69720 exp:2026-09-30
-CVE-2026-41992 exp:2026-09-30
-CVE-2026-53615 exp:2026-09-30
-CVE-2026-54369 exp:2026-09-30
-CVE-2026-57433 exp:2026-09-30
+# Entries here are CVEs recorded as `under_investigation` in the OpenVEX
+# document (docker/db/vex/simis-cms-db.openvex.json). Trivy's VEX filtering
+# only suppresses `not_affected`/`fixed` statements, so pending entries live
+# here, each with an expiry (`CVE-XXXX-NNNN exp:YYYY-MM-DD`), until triage
+# resolves them. When a CVE is triaged: update its VEX statement and remove
+# its line here. A lapsed expiry re-fails the publish gate on the next run --
+# deliberately, so triage cannot be forgotten silently.
+#
+# Currently empty: the 7 CVEs pending as of 2026-07-23 were all triaged
+# not_affected (vulnerable_code_not_in_execute_path) with recorded evidence
+# on 2026-07-24 -- see the VEX statements' impact_statement fields.

--- a/docker/db/vex/simis-cms-db.openvex.json
+++ b/docker/db/vex/simis-cms-db.openvex.json
@@ -3,7 +3,7 @@
   "@id": "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db",
   "author": "SimIS Inc. (SimIS CMS maintainers)",
   "timestamp": "2026-07-21T12:51:42+00:00",
-  "version": 2,
+  "version": 3,
   "tooling": "tools/generate-db-vex.py",
   "statements": [
     {
@@ -41,8 +41,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "The server binary links libldap, but the vulnerable code runs only during LDAP client operations, and LDAP authentication is not configured in this image (SCRAM password authentication; no ldap method in the active auth configuration). Configuring LDAP authentication would void this claim.",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -58,8 +59,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "sysstat's collectors (sar/sadc) are launched only by cron, and the image contains no cron daemon, so they never execute; the read-only root filesystem additionally prevents staging the crafted data files the flaw requires.",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -192,8 +194,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "The overflow is in the infocmp diagnostic binary (progs/infocmp.c), which no service in the image ever invokes; database operation processes no terminfo input. Debian rates the issue minor (no-DSA).",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -419,8 +422,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "gzip executes only to decompress *.sql.gz initialization scripts on first boot; this image ships a single plain-text init.sql, and initialization content is operator-baked image content, not adversary-supplied input. Adding compressed init scripts from untrusted sources would void this claim.",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -583,8 +587,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "The flaw is in libblkid's DOS partition-table prober; nothing in the container probes or mounts block devices, and with all Linux capabilities dropped (CapEff 0000000000000000, PR #230) the container cannot perform mount or device-probe operations at all.",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -600,8 +605,9 @@
           ]
         }
       ],
-      "status": "under_investigation",
-      "impact_statement": "General-purpose OS package. Not yet individually analysed for reachability in this image; no exploitability claim is made. Tracked for the next review."
+      "status": "not_affected",
+      "impact_statement": "Exploitation requires a privileged process performing pathname-based ACL operations on attacker-influenced paths; no process in this single-user container manipulates POSIX ACLs, and the root filesystem is read-only.",
+      "justification": "vulnerable_code_not_in_execute_path"
     },
     {
       "vulnerability": {
@@ -1037,8 +1043,10 @@
           ]
         }
       ],
-      "status": "under_investigation"
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Perl is present only as package-management dependency; no runtime component invokes it, the image contains no plperl library (so PL/Perl cannot be enabled), and nothing deserializes Storable blobs. The flaw is a deserialization panic (denial of service) even where reachable. Consistent with the six existing perl statements."
     }
   ],
-  "last_updated": "2026-07-23T00:00:00Z"
+  "last_updated": "2026-07-24T00:00:00Z"
 }


### PR DESCRIPTION
Resolves the open triage action from the scan-gate work (#263/#265): the 7 `under_investigation` CVEs in the DB-image VEX are triaged **`not_affected` / `vulnerable_code_not_in_execute_path`**, each with an evidence-backed `impact_statement` and its configuration caveat. ISSM triage decision recorded 2026-07-24. The `.trivyignore` empties (file retained with its process header — the workflow still passes `--ignorefile`), so the gate now runs on the VEX alone.

## Evidence per CVE (full detail in each statement's `impact_statement`)

| CVE | Component | Why not affected — verified in the image |
|---|---|---|
| CVE-2023-2953 (H) | libldap | Server links libldap, but the flaw is in LDAP *client operations* and LDAP auth is **not configured** (SCRAM). Caveat: enabling LDAP auth voids this |
| CVE-2023-33204 (H) | sysstat | Collectors are launched only by cron and the image **contains no cron daemon** (`/etc/cron.d/sysstat` exists, no cron binary); read-only FS also blocks staging crafted data files |
| CVE-2025-69720 (H) | ncurses | Flaw is in the **`infocmp` diagnostic binary**, which no service invokes; Debian: minor/no-DSA |
| CVE-2026-41992 (H) | gzip | Runs only for `*.sql.gz` init scripts on first boot; image ships **plain `init.sql` only**, and init content is operator-baked, not adversary input |
| CVE-2026-53615 (H) | util-linux/libblkid | Flaw is in the DOS **partition-table prober**; nothing probes/mounts devices, and with **all capabilities dropped** (#230) the container cannot |
| CVE-2026-54369 (H) | libacl1 | Needs a privileged process doing pathname ACL ops on attacker paths; **no in-container process touches POSIX ACLs**; read-only rootfs |
| CVE-2026-57433 (C) | perl Storable | **Perl is never invoked** (the entrypoint's only "perl" match is the substring in "properly"), **`plperl.so` is absent** so PL/Perl cannot be enabled, nothing deserializes Storable blobs; DoS-only even where reachable. Consistent with the six existing perl statements |

Sources: Debian security tracker per CVE (fix statuses: minor/no-DSA/postponed across the set) + direct image inspection (`ldd`, entrypoint, cron, extension library dir) on an image built from this tree.

## Verification

Gate command with the updated VEX and **no ignore entries**, on CI's exact trivy version (0.70.0), against the locally built image:

```
Report Summary: 0 vulnerabilities · exit 0
```

VEX document `version` bumped to 3, `last_updated` 2026-07-24. All 50 statements are now `not_affected`; any new CVE the monthly rebuild surfaces fails the publish until triaged — the designed steady state.
