### PR TITLE
ci: SHA-pin every action and base image; job-level token permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,3 +58,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # Maintains the base-image digest pins in the Dockerfiles (FROM name:tag@sha256:...):
+  # Dependabot proposes the new digest when the tag moves, so pinning stays current
+  # instead of freezing the images in time.
+  - package-ecosystem: "docker"
+    directory: "/docker/app"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/docker/db"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,9 +15,9 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
       with:
         # setup-java v2+ requires an explicit distribution (v1 did not)
         distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
       run: ant -noinput -buildfile build.xml -lib lib/tests ci-test
     - name: Upload code coverage report
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: jacoco-coverage-report
         path: target/coverage-reports/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,17 +41,17 @@ jobs:
           - language: actions
             build-mode: none
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: 21
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -63,6 +63,6 @@ jobs:
         run: ant -noinput -buildfile build.xml clean compile
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -25,7 +25,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # ubuntu-latest ships python3; no extra setup or network needed.
       - name: Fail on un-allowlisted pom vs vendored-jar drift
         run: python3 tools/check-dependency-drift.py . --strict

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -18,12 +18,10 @@ on:
     # fixes as they ship, without waiting for a code push (06:00 UTC on the 1st).
     - cron: '0 6 1 * *'
 
+# Default token: read-only. The write grants live at the job level below, so
+# any job added later starts from least privilege instead of inheriting writes.
 permissions:
-  contents: read          # read the source to build from
-  packages: write         # publish to the SimIS container registry
-  security-events: write  # send image scan results to the Security tab
-  id-token: write         # keyless OIDC identity for build provenance
-  attestations: write     # record the signed provenance + SBOM attestations
+  contents: read
 
 # Serialize publishes: without this, two overlapping runs can race and an older
 # commit's build could finish last and win the :latest tag. Queue instead of
@@ -38,11 +36,17 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # read the source to build from
+      packages: write         # publish to the SimIS container registry
+      security-events: write  # send image scan results to the Security tab
+      id-token: write         # keyless OIDC identity for build provenance
+      attestations: write     # record the signed provenance + SBOM attestations
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: '21'
@@ -61,7 +65,7 @@ jobs:
       # Syft generates the per-image SBOMs below (the same tool sbom.yml uses for
       # the WAR). Installed once here, before the images are built and scanned.
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       # --- Application image (docker/app/Dockerfile, built from repo root) ---
       - name: Build the application image
@@ -71,7 +75,7 @@ jobs:
           -t "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA" .
 
       - name: Scan the application image
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE_PREFIX }}/simis-cms:${{ github.sha }}
           format: sarif
@@ -84,7 +88,7 @@ jobs:
           exit-code: '0'
 
       - name: Publish the application scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: trivy-simis-cms.sarif
           category: image-simis-cms
@@ -110,7 +114,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest the application image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms
           subject-digest: ${{ steps.app_digest.outputs.digest }}
@@ -125,7 +129,7 @@ jobs:
         run: syft "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA" -o cyclonedx-json=sbom-simis-cms.cdx.json
 
       - name: Attest the application image SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms
           subject-digest: ${{ steps.app_digest.outputs.digest }}
@@ -142,7 +146,7 @@ jobs:
           -t "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA" .
 
       - name: Scan the database image
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE_PREFIX }}/simis-cms-db:${{ github.sha }}
           format: sarif
@@ -153,7 +157,7 @@ jobs:
           exit-code: '0'
 
       - name: Publish the database scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: trivy-simis-cms-db.sarif
           category: image-simis-cms-db
@@ -196,7 +200,7 @@ jobs:
         run: docker push "$IMAGE_PREFIX/simis-cms-db:latest"
 
       - name: Attest the database image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms-db
           subject-digest: ${{ steps.db_digest.outputs.digest }}
@@ -209,7 +213,7 @@ jobs:
         run: syft "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA" -o cyclonedx-json=sbom-simis-cms-db.cdx.json
 
       - name: Attest the database image SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/simis-cms-db
           subject-digest: ${{ steps.db_digest.outputs.digest }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -24,10 +24,10 @@ jobs:
       contents: write      # attach the SBOM to the release
       id-token: write      # keyless signing via Sigstore OIDC
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: 21
@@ -37,7 +37,7 @@ jobs:
         run: ant -noinput -buildfile build.xml -lib lib/war package
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       # Scan the built WAR (its WEB-INF/lib/*.jar) and emit CycloneDX json + xml
       - name: Generate the CycloneDX SBOM from the built WAR
@@ -47,7 +47,7 @@ jobs:
             -o cyclonedx-xml=target/bom.xml
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign the SBOM (keyless)
         run: |
@@ -58,7 +58,7 @@ jobs:
           done
 
       - name: Upload the SBOM as a build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: |

--- a/.github/workflows/unescaped-el.yml
+++ b/.github/workflows/unescaped-el.yml
@@ -30,7 +30,7 @@ jobs:
   unescaped-el:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # ubuntu-latest ships python3; no extra setup or network needed.
       - name: Fail on malformed XML config (server.xml, context.xml, web.xml, TLDs)
         run: python3 tools/check-xml-well-formed.py . --strict

--- a/.github/workflows/war-completeness.yml
+++ b/.github/workflows/war-completeness.yml
@@ -33,10 +33,10 @@ jobs:
   completeness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: 21

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -7,7 +7,7 @@
 
 # Tomcat 11 (Jakarta EE / jakarta.servlet). The application targets Servlet 6.1; it will not
 # run on the Tomcat 9 base this image used previously, which serves the javax.* namespace.
-FROM tomcat:11.0-jdk21
+FROM tomcat:11.0-jdk21@sha256:543dd74d992458d558875de8493399a718270b361b16e4ea6750371a13dda077
 
 # STIG hardening. Overlay the hardened server.xml (shutdown port disabled, HTTP TRACE off,
 # server banner suppressed, no error-page disclosure, autoDeploy off, access logging), add


### PR DESCRIPTION
Part of #252 (afternoon cluster, items 2–3).

## What changed

- **Every action SHA-pinned** — 11 distinct refs across all 8 workflows, tag kept as a trailing comment (`@<sha> # v7`). A tag can be repointed by a compromised upstream; a commit SHA cannot. SHAs resolved from each repo's tag at pin time.
- **App base image digest-pinned** to the multi-arch index (`tomcat:11.0-jdk21@sha256:543d…`) — the DB Dockerfile was already fully pinned (#220); this closes the one remaining mutable FROM. Digest verified resolvable on the registry.
- **Token permissions to job level** in `publish-images.yml`: workflow default is now `contents: read`; the five write grants live on the `publish` job — any future job starts from least privilege. (This is also exactly what Scorecard's Token-Permissions probe measures.)
- **Dependabot maintains the pins**: `docker` ecosystem added for both Dockerfile directories; the existing `github-actions` entry maintains the action SHAs. Pinned-but-maintained, not frozen.

## Verification

- All 9 YAML files parse clean.
- `docker buildx imagetools inspect tomcat:11.0-jdk21@sha256:543d…` resolves (multi-arch OCI index — both amd64 CI and arm64 local builds resolve their platform).
- Permissions structure confirmed: workflow `{contents: read}`, job carries the writes.

Merge note: touches `codeql.yml` in a different hunk than #268 — the two merge cleanly in either order.