### PR TITLE
Attest WAR build provenance; add VERIFYING.md

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,8 +21,9 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # attach the SBOM to the release
+      contents: write      # attach the SBOM + WAR to the release
       id-token: write      # keyless signing via Sigstore OIDC
+      attestations: write  # record the WAR build-provenance attestation
     steps:
       - uses: actions/checkout@v7
 
@@ -35,6 +36,16 @@ jobs:
       # Build the same artifact that ships, so the SBOM describes exactly it
       - name: Package the web application
         run: ant -noinput -buildfile build.xml -lib lib/war package
+
+      # Build provenance for the WAR itself (SLSA provenance): proves this
+      # exact artifact came from this workflow and commit -- the same story the
+      # container images already have, extended to the artifact inside them.
+      # The WAR is attached to the release below so the attested subject is
+      # retrievable; an attestation for an unfetchable artifact proves nothing.
+      - name: Attest WAR build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: target/simis-cms.war
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
@@ -75,6 +86,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
+            target/simis-cms.war \
             target/bom.json target/bom.json.sig target/bom.json.pem \
             target/bom.xml target/bom.xml.sig target/bom.xml.pem \
             --clobber

--- a/VERIFYING.md
+++ b/VERIFYING.md
@@ -1,0 +1,80 @@
+# Verifying SimIS CMS artifacts
+
+Every published artifact carries verifiable, keyless (Sigstore) evidence of where
+it came from and what is inside it. This page lists the exact commands. All of
+them work with only the `gh` CLI (and `cosign` for the release SBOM blobs) — no
+keys to distribute, nothing to trust but the transparency log.
+
+## Container images (GHCR)
+
+Both images publish **build provenance** (who built it, from which commit) and a
+**CycloneDX SBOM attestation** (what is inside it), bound to the image digest:
+
+```
+gh attestation verify oci://ghcr.io/simisrnd/simis-cms:latest --owner SimisRnD
+gh attestation verify oci://ghcr.io/simisrnd/simis-cms-db:latest --owner SimisRnD
+```
+
+That verifies every attestation on the digest. To select one kind:
+
+```
+# provenance only
+gh attestation verify oci://ghcr.io/simisrnd/simis-cms:latest --owner SimisRnD \
+  --predicate-type https://slsa.dev/provenance/v1
+# SBOM only
+gh attestation verify oci://ghcr.io/simisrnd/simis-cms:latest --owner SimisRnD \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+Pin to a digest rather than a tag when verifying what you actually deployed:
+`oci://ghcr.io/simisrnd/simis-cms@sha256:<digest>`.
+
+## The WAR (release asset)
+
+Each release attaches the built `simis-cms.war` with its own build-provenance
+attestation. Download the asset, then:
+
+```
+gh release download <tag> --repo SimisRnD/simis-cms --pattern 'simis-cms.war'
+gh attestation verify simis-cms.war --owner SimisRnD
+```
+
+The attestation binds the file's SHA-256, so any modification — or a locally
+rebuilt WAR, which is not byte-identical — fails verification. That is the point.
+
+## The release SBOM (signed blobs)
+
+Releases also attach a CycloneDX SBOM generated from the shipped WAR, signed
+keylessly with cosign (`bom.json` / `bom.xml` + `.sig` and `.pem` each):
+
+```
+cosign verify-blob bom.json \
+  --signature bom.json.sig --certificate bom.json.pem \
+  --certificate-identity-regexp '^https://github.com/SimisRnD/simis-cms/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+## Air-gapped verification
+
+Fetch the attestation bundle online, verify offline:
+
+```
+# online side
+gh attestation download oci://ghcr.io/simisrnd/simis-cms:latest --owner SimisRnD
+gh attestation trusted-root > trusted_root.jsonl
+# offline side (bundle + trusted root + artifact travel together)
+gh attestation verify oci://... --owner SimisRnD \
+  --bundle <digest>.jsonl --custom-trusted-root trusted_root.jsonl
+```
+
+## What else is pinned or published
+
+- **Base images** are digest-pinned in the Dockerfiles (`FROM name:tag@sha256:…`),
+  and every workflow action is pinned to a commit SHA; Dependabot maintains both.
+- **Vulnerability posture** for the DB image is published as OpenVEX at
+  `docker/db/vex/simis-cms-db.openvex.json` — machine-enforced by the publish
+  gate, so a new CRITICAL/HIGH cannot reach `:latest` without a recorded triage
+  decision. Statements carry per-CVE justifications and the configuration
+  caveats under which they hold.
+- Published images are scanned on a monthly schedule as well as on every publish;
+  results land in the repository's Security tab.


### PR DESCRIPTION
Part of #252 (WAR build-provenance attestation + VERIFYING.md items).

## WAR provenance (SLSA story, artifact-level)

The container images already publish provenance + SBOM attestations; the artifact *inside* them didn't. The release workflow now:

- records **build provenance for `target/simis-cms.war`** (`actions/attest-build-provenance`, subject-path), and
- **attaches the WAR to the release** — an attestation whose subject can't be fetched proves nothing, so the artifact and its evidence ship together. Verification binds the file's SHA-256; a modified or locally rebuilt WAR fails, which is the point.

`attestations: write` added to the job's permission block; everything else unchanged.

## VERIFYING.md

One page, exact commands, no keys to distribute: image provenance + SBOM verification (by tag, by digest, filtered by predicate type), the WAR release asset, the cosign-signed release SBOM blobs (with `--certificate-identity-regexp` + OIDC issuer constraints so it can't be satisfied by someone else's cert), and the **air-gapped flow** (`gh attestation download` + `trusted-root` + offline `--bundle` verify). Closes with what's pinned (action SHAs, base-image digests, Dependabot-maintained) and where the machine-enforced VEX lives.

## Verification

- `sbom.yml` parses clean; the new step needs no new tooling (the action is already used in `publish-images.yml`).
- The WAR attestation itself first exercises on the next release — same deferred-execution shape as every release-triggered step in this workflow.
- Merge-order note: touches `sbom.yml` in different hunks than #269's pin lines; merges cleanly either order.