### PR TITLE
Hold base-image majors in Dependabot (postgres, tomcat, golang)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,11 +61,36 @@ updates:
   # Maintains the base-image digest pins in the Dockerfiles (FROM name:tag@sha256:...):
   # Dependabot proposes the new digest when the tag moves, so pinning stays current
   # instead of freezing the images in time.
+  #
+  # Base-image MAJORS are held (same philosophy as the maven section): a runtime
+  # major is a migration event, not a dependency bump. The first weekly run proved
+  # the point by proposing postgres 17->18 (PR #271) -- a bump that changes the
+  # initdb on-disk format (existing volumes will not boot), invalidates the
+  # package baseline the published VEX was triaged against, and moves the
+  # PostGIS/Flyway compatibility surface. Majors happen as deliberate upgrade
+  # PRs with their own checklist; minor/patch/digest updates keep flowing here.
   - package-ecosystem: "docker"
     directory: "/docker/app"
     schedule:
       interval: "weekly"
+    ignore:
+      # Held: Tomcat majors move the servlet-API surface the app compiles
+      # against (9->11 was its own migration, PR #216). Revisit deliberately.
+      - dependency-name: "tomcat"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/docker/db"
     schedule:
       interval: "weekly"
+    ignore:
+      # Held: PostgreSQL majors change the data-directory format (pg_upgrade or
+      # dump/restore required), the Debian package set behind the published VEX,
+      # and the PostGIS compatibility matrix -- and the container major should
+      # move together with the Azure Flexible Server version in infra/, not
+      # ahead of it. See PR #271 for the held example.
+      - dependency-name: "postgres"
+        update-types: ["version-update:semver-major"]
+      # Held for the same reason majors are held generally; the gosu build
+      # stage tracks the golang minor line via digest updates.
+      - dependency-name: "golang"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Follow-up to the #269 docker-ecosystem addition, prompted by its very first weekly run proposing **postgres 17→18 (#271)** as a routine bump.

A runtime major is a **migration event**, not a dependency update — the maven section already encodes exactly this philosophy (majors individually, each with a documented reason). This extends it to the base images, with per-image reasons in the config:

- **postgres**: initdb on-disk format changes (existing volumes won't boot), the Debian package baseline behind the published VEX changes, PostGIS/Flyway compatibility moves — and the container major should move **together with** the Azure Flexible Server version in `infra/`, not ahead of it.
- **tomcat**: majors move the servlet-API surface the app compiles against (9→11 was its own migration, #216).
- **golang** (gosu build stage): same general principle; the minor line keeps flowing via digest updates.

Minor/patch/**digest** updates — the reason the ecosystem exists — keep flowing untouched.

Suggested handling of the open bot PRs: close **#271** (held per the above; the 17→18 upgrade deserves its own tracked issue with a checklist), and see the advisory comment on **#272** (cosign 3.x is only exercised on release/dispatch, so its green PR checks prove nothing — verify via a manual `sbom.yml` dispatch after merge).