### PR TITLE
Refresh three rationales left stale by the jakarta.servlet migration (#216)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,17 @@ updates:
       # Revisit on: a CVE, Square EOL'ing the legacy SDK, or needing new features.
       - dependency-name: "com.squareup:square"
         update-types: ["version-update:semver-major"]
-      # Held: Tomcat 10+ moves the servlet API from javax.* to jakarta.*, which
-      # this app is not migrated for. Revisit with the Jakarta EE migration.
+      # Held at 11.x. The original reason -- the javax->jakarta break at Tomcat 10 -- is
+      # retired: that migration shipped in PR #216 and the app now runs Tomcat 11 /
+      # jakarta.servlet / Servlet 6.1. The major stays held for a different, current reason:
+      # tomcat-servlet-api is `provided` (compile-only, and deliberately NOT vendored into the
+      # WAR), so its version must match the Servlet spec the *runtime* container supplies --
+      # pinned by docker/app/Dockerfile `FROM tomcat:11.0-jdk21`. A major to 12.x in the pom
+      # while the image is still Tomcat 11 would compile against APIs the running server lacks,
+      # and check-dependency-drift.py skips provided scope, so nothing would catch the mismatch.
+      # Minor/patch bumps are NOT ignored, so Tomcat 11 security fixes still flow.
+      # Revisit: move the Docker base image to Tomcat 12 in the same change (and re-map the
+      # server.xml / setenv.sh STIG overlay, per the Dockerfile TODOs).
       - dependency-name: "org.apache.tomcat:tomcat-servlet-api"
         update-types: ["version-update:semver-major"]
       # Held at 12.x: Flyway is the schema-migration engine and there is currently NO


### PR DESCRIPTION
## What

PR #216 (jakarta.servlet / Tomcat 11) left several explanatory notes citing the "javax→jakarta migration" as an open or blocking reason. **Three of them are now stale or misleading.** This corrects the reasoning — comment/note-only, no behaviour change, no build impact.

## 1. `.github/dependabot.yml` — `tomcat-servlet-api` major hold

The old note's reason (the javax→jakarta break at Tomcat 10) is **retired**: #216 shipped it, and the app now runs Tomcat 11 / `jakarta.servlet` / Servlet 6.1.

The hold **stays**, for the real current reason:
- `tomcat-servlet-api` is **`provided`** (compile-only) and **not vendored** into the WAR — the runtime container supplies the API.
- Its version must track the Servlet spec the runtime Tomcat provides — pinned by `docker/app/Dockerfile` (`FROM tomcat:11.0-jdk21`).
- A major to 12.x while the image is Tomcat 11 would compile against APIs the running server lacks, and `tools/check-dependency-drift.py` **skips `provided` scope**, so nothing would catch the mismatch.
- Only majors are ignored, so minor/patch (Tomcat 11 security fixes) still flow.

## 2. `.github/dependabot.yml` — `johnzon` major hold (reworded, still held)

The note said "entangled with the javax-to-jakarta migration," which now reads as cleared-by-#216. It is **not** — it hinges on a **separate** migration:
- johnzon 2.x moves JSON-P / JSON-B from `javax.json.*` to `jakarta.json.*`.
- The app has **not** done that migration — the JSON-B code still imports `javax.json.bind.Jsonb` / `JsonbBuilder` (johnzon pinned `1.3.0`).
- #216 was servlet-only and does not free this bump. Reworded to say so.

(Net observation: the "Jakarta EE migration" is only partial — `jakarta.servlet` done, `javax.json` not.)

## 3. `docker/app/Dockerfile` — stale STIG comment

The comment still claimed *"TWO items still need a decision"* (RECYCLE_FACADES, `maxPartCount`/`maxPartHeaderSize`). Both were **resolved** on the `<Connector>` in `server.xml` by `664af698` (`discardFacades="true"` and the multipart limits). Updated to reflect that. The one genuinely open item — the STIG **rule-ID re-mapping** for a Tomcat 11 baseline — is preserved.
