### PR TITLE
Add a pytest harness for the tools/*.py check scripts [stacked on #274]

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,30 @@
+# Tests for the tools/*.py check scripts -- the scripts the other gates run.
+# A gate whose own logic is untested can rot silently (the completeness gate
+# was a placebo for weeks before PR #243); this suite pins each tool's CLI
+# contract: discovery rules, findings, and exit codes, strict and non-strict.
+#
+# Coverage note (deliberate): check-war-completeness.py needs a built WAR and
+# generate-db-vex.py needs the GitHub API -- both are exercised for real by
+# their own workflows (war-completeness.yml on every PR; VEX regeneration at
+# triage time), so synthetic tests here would duplicate weaker versions of
+# what already runs. The five filesystem-pure tools are covered here.
+name: Tools tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install pytest
+        run: python3 -m pip install --quiet pytest
+      - name: Run the tools test suite
+        run: python3 -m pytest tools/tests -q

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,72 @@
+"""Shared fixtures for the tools/*.py test suite.
+
+Each check tool is exercised through its real CLI (subprocess against a
+synthetic repository tree in tmp_path), so the tests cover argument parsing and
+exit codes -- the contract CI actually depends on -- not just internals.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+
+POM_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.simisinc</groupId>
+  <artifactId>simis-cms</artifactId>
+  <version>{version}</version>
+  <dependencies>
+{dependencies}
+  </dependencies>
+</project>
+"""
+
+DEP_TEMPLATE = """    <dependency>
+      <groupId>{group}</groupId>
+      <artifactId>{artifact}</artifactId>
+      <version>{version}</version>
+    </dependency>
+"""
+
+
+def run_tool(name: str, root: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run tools/<name>.py against a repo root; returns the completed process."""
+    return subprocess.run(
+        [sys.executable, str(TOOLS_DIR / name), str(root), *args],
+        capture_output=True, text=True,
+    )
+
+
+def write(root: Path, rel: str, content: str) -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return p
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal synthetic repository tree the tools can run against."""
+    return tmp_path
+
+
+def make_pom(root: Path, version: str = "1.0.0-SNAPSHOT", deps=None) -> None:
+    dep_xml = "".join(
+        DEP_TEMPLATE.format(group=g, artifact=a, version=v) for g, a, v in (deps or [])
+    )
+    write(root, "pom.xml", POM_TEMPLATE.format(version=version, dependencies=dep_xml))
+
+
+def make_application_info(root: Path, version: str = "1.0.0") -> None:
+    write(
+        root,
+        "src/main/java/com/simisinc/platform/ApplicationInfo.java",
+        'package com.simisinc.platform;\n\n'
+        'public class ApplicationInfo {\n'
+        f'  public static final String VERSION = "{version}";\n'
+        '}\n',
+    )

--- a/tools/tests/test_check_dependency_drift.py
+++ b/tools/tests/test_check_dependency_drift.py
@@ -1,0 +1,28 @@
+"""check-dependency-drift.py: pom versions vs vendored lib/build jar filenames."""
+
+from conftest import make_pom, run_tool, write
+
+TOOL = "check-dependency-drift.py"
+
+
+def test_matching_versions_pass_strict(repo):
+    make_pom(repo, deps=[("org.example", "widget", "1.2.3")])
+    write(repo, "lib/build/widget-1.2.3.jar", "jar bytes")
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_version_drift_fails_strict(repo):
+    make_pom(repo, deps=[("org.example", "widget", "2.0.0")])
+    write(repo, "lib/build/widget-1.2.3.jar", "jar bytes")
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 1
+    assert "DRIFT" in r.stdout
+
+
+def test_drift_reported_but_exit_zero_without_strict(repo):
+    make_pom(repo, deps=[("org.example", "widget", "2.0.0")])
+    write(repo, "lib/build/widget-1.2.3.jar", "jar bytes")
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 0
+    assert "DRIFT" in r.stdout

--- a/tools/tests/test_check_unescaped_el.py
+++ b/tools/tests/test_check_unescaped_el.py
@@ -1,0 +1,27 @@
+"""check-unescaped-el.py: bare JSP EL vs escaped output."""
+
+from conftest import run_tool, write
+
+TOOL = "check-unescaped-el.py"
+
+ESCAPED = '<%@ taglib prefix="c" uri="jakarta.tags.core" %>\n<c:out value="${user.name}"/>\n'
+BARE = '<%@ taglib prefix="c" uri="jakarta.tags.core" %>\n<p>${user.name}</p>\n'
+
+
+def test_escaped_el_passes_strict(repo):
+    write(repo, "src/main/webapp/WEB-INF/jsp/ok.jsp", ESCAPED)
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_bare_el_fails_strict(repo):
+    write(repo, "src/main/webapp/WEB-INF/jsp/bad.jsp", BARE)
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 1
+    assert "bad.jsp" in (r.stdout + r.stderr)
+
+
+def test_bare_el_reported_but_exit_zero_without_strict(repo):
+    write(repo, "src/main/webapp/WEB-INF/jsp/bad.jsp", BARE)
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 0

--- a/tools/tests/test_check_vendored_provenance.py
+++ b/tools/tests/test_check_vendored_provenance.py
@@ -1,0 +1,52 @@
+"""check-vendored-provenance.py: manifest verification in both directions."""
+
+from conftest import run_tool, write
+
+TOOL = "check-vendored-provenance.py"
+
+
+def seed(repo):
+    write(repo, "lib/build/alpha-1.0.jar", "alpha bytes")
+    write(repo, "lib/war/beta-2.0.jar", "beta bytes")
+
+
+def test_write_then_clean_verify(repo):
+    seed(repo)
+    assert run_tool(TOOL, repo, "--write").returncode == 0
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 0
+    assert "OK: 2 vendored jars" in r.stdout
+
+
+def test_missing_manifest_fails_with_hint(repo):
+    seed(repo)
+    r = run_tool(TOOL, repo)
+    assert r.returncode != 0
+    assert "--write" in (r.stdout + r.stderr)
+
+
+def test_tampered_jar_is_mismatch(repo):
+    seed(repo)
+    run_tool(TOOL, repo, "--write")
+    (repo / "lib/build/alpha-1.0.jar").write_text("alpha bytes TAMPERED")
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 1
+    assert "MISMATCH" in r.stdout and "alpha-1.0.jar" in r.stdout
+
+
+def test_new_jar_is_unlisted(repo):
+    seed(repo)
+    run_tool(TOOL, repo, "--write")
+    write(repo, "lib/build/gamma-3.0.jar", "gamma bytes")
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 1
+    assert "UNLISTED" in r.stdout and "gamma-3.0.jar" in r.stdout
+
+
+def test_deleted_jar_is_missing(repo):
+    seed(repo)
+    run_tool(TOOL, repo, "--write")
+    (repo / "lib/war/beta-2.0.jar").unlink()
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 1
+    assert "MISSING" in r.stdout and "beta-2.0.jar" in r.stdout

--- a/tools/tests/test_check_version_consistency.py
+++ b/tools/tests/test_check_version_consistency.py
@@ -1,0 +1,26 @@
+"""check-version-consistency.py: pom <version> vs ApplicationInfo.VERSION."""
+
+from conftest import make_application_info, make_pom, run_tool
+
+TOOL = "check-version-consistency.py"
+
+
+def test_matching_versions_pass_strict(repo):
+    make_pom(repo, version="20260724.1-SNAPSHOT")
+    make_application_info(repo, version="20260724.1")
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_drifted_versions_fail_strict(repo):
+    make_pom(repo, version="20240101.1-SNAPSHOT")
+    make_application_info(repo, version="20260724.1")
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 1
+
+
+def test_drift_reported_but_exit_zero_without_strict(repo):
+    make_pom(repo, version="20240101.1-SNAPSHOT")
+    make_application_info(repo, version="20260724.1")
+    r = run_tool(TOOL, repo)
+    assert r.returncode == 0

--- a/tools/tests/test_check_xml_well_formed.py
+++ b/tools/tests/test_check_xml_well_formed.py
@@ -1,0 +1,31 @@
+"""check-xml-well-formed.py: the fixed list of build-critical XML files."""
+
+from conftest import run_tool, write
+
+TOOL = "check-xml-well-formed.py"
+
+GOOD = '<?xml version="1.0" encoding="UTF-8"?>\n<root><child/></root>\n'
+BAD = '<?xml version="1.0" encoding="UTF-8"?>\n<root><child></root>\n'  # mismatched tag
+
+
+def seed_all_good(repo):
+    for rel in (
+        "docker/app/conf/server.xml",
+        "src/main/webapp/META-INF/context.xml",
+        "src/main/webapp/WEB-INF/web.xml",
+    ):
+        write(repo, rel, GOOD)
+
+
+def test_well_formed_files_pass_strict(repo):
+    seed_all_good(repo)
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_malformed_file_fails_strict(repo):
+    seed_all_good(repo)
+    write(repo, "src/main/webapp/META-INF/context.xml", BAD)
+    r = run_tool(TOOL, repo, "--strict")
+    assert r.returncode == 1
+    assert "context.xml" in (r.stdout + r.stderr)


### PR DESCRIPTION
Part of #252 (the pytest-harness item — the last code-side checkbox).

> **Stacked on #274** — the suite covers `check-vendored-provenance.py`, which #274 introduces. Review #274 first; the harness is the last commit. Rebases clean once #274 merges.

## Why

The check scripts **are** the gates — and a gate whose own logic is untested can rot silently: the completeness gate was a placebo for weeks before #243 caught it. This suite pins each tool's CLI contract the way CI actually invokes it: **subprocess against synthetic repo trees**, asserting discovery rules, findings, and exit codes in both strict and non-strict modes.

## Coverage — 16 tests, five tools

| Tool | Cases |
|---|---|
| `check-vendored-provenance.py` | clean verify, missing-manifest hint, MISMATCH, UNLISTED, MISSING, `--write` |
| `check-dependency-drift.py` | version match (strict pass), DRIFT (strict fail), DRIFT report-only |
| `check-version-consistency.py` | pom↔ApplicationInfo match, drift strict fail, drift report-only |
| `check-xml-well-formed.py` | all well-formed, malformed file named in output |
| `check-unescaped-el.py` | `<c:out>` passes, bare `${}` strict fail, report-only |

**Deliberately uncovered, reason in the workflow header:** `check-war-completeness.py` (needs a built WAR — exercised for real by its own gate on every PR) and `generate-db-vex.py` (needs the GitHub API — exercised at triage time). Synthetic versions here would be weaker duplicates of what already runs.

## Verification

`16 passed` locally (python 3.9 + pytest 8.4.2); new `tools-tests.yml` runs the suite on every PR/push (checkout SHA-pinned, matching #269's convention).