### PR TITLE
Fix release SBOM signing for cosign 3.x (bundle format)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -60,12 +60,16 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # cosign 3.x writes verification material as a single Sigstore bundle
+      # (--bundle); the separate --output-signature/--output-certificate flags
+      # were removed (they errored under cosign 3.0.6, installed via the
+      # cosign-installer v4 bump). The bundle carries the signature,
+      # certificate, and Rekor entry together -- verify with
+      # `cosign verify-blob --bundle` (see VERIFYING.md).
       - name: Sign the SBOM (keyless)
         run: |
           for f in target/bom.json target/bom.xml; do
-            cosign sign-blob --yes "$f" \
-              --output-signature "$f.sig" \
-              --output-certificate "$f.pem"
+            cosign sign-blob --yes "$f" --bundle "$f.sigstore.json"
           done
 
       - name: Upload the SBOM as a build artifact
@@ -75,10 +79,8 @@ jobs:
           path: |
             target/bom.json
             target/bom.xml
-            target/bom.json.sig
-            target/bom.json.pem
-            target/bom.xml.sig
-            target/bom.xml.pem
+            target/bom.json.sigstore.json
+            target/bom.xml.sigstore.json
 
       - name: Attach the signed SBOM to the release
         if: github.event_name == 'release'
@@ -87,6 +89,6 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             target/simis-cms.war \
-            target/bom.json target/bom.json.sig target/bom.json.pem \
-            target/bom.xml target/bom.xml.sig target/bom.xml.pem \
+            target/bom.json target/bom.json.sigstore.json \
+            target/bom.xml target/bom.xml.sigstore.json \
             --clobber

--- a/VERIFYING.md
+++ b/VERIFYING.md
@@ -45,11 +45,13 @@ rebuilt WAR, which is not byte-identical — fails verification. That is the poi
 ## The release SBOM (signed blobs)
 
 Releases also attach a CycloneDX SBOM generated from the shipped WAR, signed
-keylessly with cosign (`bom.json` / `bom.xml` + `.sig` and `.pem` each):
+keylessly with cosign. Each SBOM (`bom.json` / `bom.xml`) travels with a
+Sigstore bundle (`bom.json.sigstore.json` / `bom.xml.sigstore.json`) that
+carries the signature, certificate, and transparency-log entry together:
 
 ```
 cosign verify-blob bom.json \
-  --signature bom.json.sig --certificate bom.json.pem \
+  --bundle bom.json.sigstore.json \
   --certificate-identity-regexp '^https://github.com/SimisRnD/simis-cms/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```


### PR DESCRIPTION
Fixes a **latent break introduced by #272** (cosign-installer v4 → cosign 3.0.6). Found by dispatching `sbom.yml` after that merge — the verification I flagged as necessary on #272, precisely because `sbom.yml` runs only on release/dispatch so its PR checks proved nothing.

## What broke

cosign 3.x removed `sign-blob`'s `--output-signature` / `--output-certificate` in favor of a single `--bundle`. The old invocation errored:

```
Error: signing target/bom.json: create bundle file: open : no such file or directory
```

So the **release SBOM signing step failed** — every future release would ship an unsigned SBOM. (The same dispatch confirmed **#270's WAR-provenance step succeeds** on its first real run.)

## Fix

- Sign to a **Sigstore bundle** `bom.{json,xml}.sigstore.json` — one file carrying signature + certificate + Rekor entry.
- Attach the bundles to the release instead of the separate `.sig`/`.pem`.
- `VERIFYING.md`: the release-SBOM verify command becomes `cosign verify-blob bom.json --bundle bom.json.sigstore.json …` (identity/issuer constraints unchanged).

## Verification

- Flag interface confirmed against **cosign 3.1.2** locally (`sign-blob --bundle`, `verify-blob --bundle`).
- Keyless signing itself can only be exercised in CI (needs the Actions OIDC identity) — verified by re-dispatching `sbom.yml`; result linked in a follow-up comment here.

No new tools, no permission change. Unblocks clean releases.