### PR TITLE
Visual Editor P0: server-side Delta renderer + format-aware render dispatch

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -43,6 +43,31 @@ public class ContentHtmlCommand {
 
   static String HTML_JSP = "/cms/content-html.jsp";
 
+  /**
+   * Renders a stored content string to display HTML according to its format stamp. This is the single
+   * point where the content pipeline decides how a stored value becomes HTML:
+   *
+   * <ul>
+   * <li>{@link DeltaContentCommand#LEGACY_HTML_FORMAT} (and any unrecognized value) is already HTML and
+   * passes through unchanged -- the backward-compatible default, since legacy content is the vast
+   * majority and was cleaned by {@code SaveContentCommand} on the way in.</li>
+   * <li>{@link DeltaContentCommand#DELTA_FORMAT_VERSION} is visual-editor Quill Delta JSON, rendered
+   * server-side through the allowlist in {@link DeltaContentCommand} -- never Quill's HTML-export path.</li>
+   * </ul>
+   *
+   * <p>Null in, null out: callers already treat a null result as "no content" (e.g. the add-content
+   * button), so that contract is preserved.
+   */
+  public static String toHtml(String content, int contentFormat) {
+    if (content == null) {
+      return null;
+    }
+    if (contentFormat == DeltaContentCommand.DELTA_FORMAT_VERSION) {
+      return DeltaContentCommand.render(content);
+    }
+    return content;
+  }
+
   public static String getHtmlFromPreferences(WidgetContext context) {
 
     String html = null;

--- a/src/main/java/com/simisinc/platform/application/cms/DeltaContentCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/DeltaContentCommand.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
+import org.jsoup.safety.Cleaner;
+import org.jsoup.safety.Safelist;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * The server-side boundary for the visual editor's rich-text content.
+ *
+ * <p>The visual editor (Project #6) stores rich text as <b>Quill 2.x Delta JSON</b> and renders it
+ * <b>here, on the server</b>, into a small allowlisted subset of HTML. It deliberately does NOT use
+ * the editor's own {@code getSemanticHTML()} / {@code getHTML()} export path.
+ *
+ * <p><b>Why that matters (security).</b> CVE-2025-15056 is an XSS in Quill's HTML-<i>export</i> blots
+ * (formula/video interpolate unescaped user values in {@code html()}); it is reachable ONLY via the
+ * export API and does not touch Delta storage or server rendering. By storing Delta and rendering it
+ * ourselves through {@link #INLINE_FORMATS} — which does not include formula or video — the vulnerable
+ * code is never in the execute path. This is the same VEX {@code not_affected /
+ * vulnerable_code_not_in_execute_path} pattern used for the database image, and it is a
+ * <b>design constraint, not an assumption</b>: introducing an export-API call, or widening the format
+ * allowlist to a raw-HTML-bearing format, voids it. See the build-vs-adopt runbook, third pass.
+ *
+ * <p><b>Format versioning.</b> Stored content carries a stamped {@link #DELTA_FORMAT_VERSION} so the
+ * renderer can tell Delta from legacy HTML and so a future Quill Delta shape change (1.x embeds/list
+ * keys were removed in 2.0) is a migration rather than silent corruption.
+ *
+ * @author elizabeth houser
+ */
+public class DeltaContentCommand {
+
+  private static final Log LOG = LogFactory.getLog(DeltaContentCommand.class);
+
+  /** Content predating the visual editor: an HTML string, rendered via {@link HtmlCommand}. */
+  public static final int LEGACY_HTML_FORMAT = 0;
+
+  /**
+   * Quill 2.x Delta JSON, rendered by this class. There is no format {@code 1}: Quill's own 1.x Delta
+   * shape (integer embed values, different list attribute keys) was removed in Quill 2.0, so the number
+   * is reserved for that legacy shape should a migration ever need to name what it upgrades <i>from</i>.
+   */
+  public static final int DELTA_FORMAT_VERSION = 2;
+
+  /**
+   * The inline formats the hybrid seam supports. Anything outside this set is ignored on render. This is
+   * the allowlist the CVE-2025-15056 analysis above depends on — notably it excludes {@code formula} and
+   * {@code video}. Do not add a format that carries raw HTML without revisiting that analysis.
+   */
+  public static final List<String> INLINE_FORMATS = List.of("bold", "italic", "code", "link");
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // The safelist enumerates exactly the tags/attributes render() emits, and nothing else. It is
+  // defense-in-depth: even a bug in the block/inline assembly below cannot emit script, an event
+  // handler, or a disallowed URL scheme, because the output is re-cleaned against this before return.
+  private static final Safelist RENDER_SAFELIST = new Safelist()
+      .addTags("p", "br", "strong", "em", "code", "pre", "blockquote",
+          "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "a")
+      .addAttributes("a", "href", "rel", "target")
+      .addProtocols("a", "href", "http", "https", "mailto")
+      .addEnforcedAttribute("a", "rel", "noopener noreferrer");
+
+  private DeltaContentCommand() {
+    // Static command
+  }
+
+  /**
+   * @return true if the value parses as a Quill Delta document ({@code {"ops":[...]}}).
+   */
+  public static boolean isValidDelta(String deltaJson) {
+    return parseOps(deltaJson) != null;
+  }
+
+  /**
+   * Detects the removed Quill 1.x Delta shape (embed inserts with integer values), which needs migration
+   * before it can be rendered. Distinct from an invalid document, so a migration can find these on sight.
+   */
+  public static boolean isLegacyDeltaShape(String deltaJson) {
+    JsonNode ops = parseOps(deltaJson);
+    if (ops == null) {
+      return false;
+    }
+    for (JsonNode op : ops) {
+      JsonNode insert = op.get("insert");
+      if (insert != null && insert.isNumber()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Renders a Quill Delta document to the allowlisted HTML subset. Returns an empty string for null,
+   * blank, or unparseable input rather than throwing — a bad stored value must never break a page render.
+   */
+  public static String render(String deltaJson) {
+    JsonNode ops = parseOps(deltaJson);
+    if (ops == null) {
+      return "";
+    }
+
+    List<String> blocks = new ArrayList<>();
+    StringBuilder line = new StringBuilder();
+    List<String> pendingListItems = new ArrayList<>();
+    String pendingListType = null;
+
+    for (JsonNode op : ops) {
+      JsonNode insert = op.get("insert");
+      if (insert == null || !insert.isTextual()) {
+        // Embeds (image/formula/video) are objects, not text, and are outside the allowlist: skip them.
+        continue;
+      }
+      JsonNode attributes = op.get("attributes");
+      String text = insert.textValue();
+
+      // A text insert may span multiple lines; each '\n' closes the current line as a block.
+      int start = 0;
+      for (int i = 0; i < text.length(); i++) {
+        if (text.charAt(i) != '\n') {
+          continue;
+        }
+        // Inline text before this newline belongs to the current line, formatted by THIS op's attributes.
+        line.append(applyInlineFormats(text.substring(start, i), attributes));
+        // The newline itself carries the block-level attributes for the line it closes.
+        String listType = blockListType(attributes);
+        if (listType != null) {
+          if (pendingListType != null && !pendingListType.equals(listType)) {
+            blocks.add(wrapList(pendingListType, pendingListItems));
+            pendingListItems = new ArrayList<>();
+          }
+          pendingListType = listType;
+          pendingListItems.add("<li>" + line + "</li>");
+        } else {
+          if (pendingListType != null) {
+            blocks.add(wrapList(pendingListType, pendingListItems));
+            pendingListItems = new ArrayList<>();
+            pendingListType = null;
+          }
+          String block = wrapBlock(line.toString(), attributes);
+          if (block != null) {
+            blocks.add(block);
+          }
+        }
+        line.setLength(0);
+        start = i + 1;
+      }
+      // Trailing inline text with no newline yet stays buffered for the next line.
+      if (start < text.length()) {
+        line.append(applyInlineFormats(text.substring(start), attributes));
+      }
+    }
+    if (pendingListType != null) {
+      blocks.add(wrapList(pendingListType, pendingListItems));
+    }
+    // Any dangling inline content with no closing newline becomes a final paragraph.
+    if (line.length() > 0) {
+      blocks.add("<p>" + line + "</p>");
+    }
+
+    return sanitize(String.join("", blocks));
+  }
+
+  // --- internals -----------------------------------------------------------------------------------
+
+  private static JsonNode parseOps(String deltaJson) {
+    if (deltaJson == null || deltaJson.isBlank()) {
+      return null;
+    }
+    try {
+      JsonNode root = MAPPER.readTree(deltaJson);
+      JsonNode ops = root.get("ops");
+      if (ops == null || !ops.isArray()) {
+        return null;
+      }
+      return ops;
+    } catch (Exception e) {
+      LOG.debug("Not a parseable Delta document: " + e.getMessage());
+      return null;
+    }
+  }
+
+  private static String applyInlineFormats(String rawText, JsonNode attributes) {
+    if (rawText.isEmpty()) {
+      return "";
+    }
+    // Escape first: the text is always literal content, never markup, regardless of what it contains.
+    String html = Entities.escape(rawText);
+    if (attributes == null) {
+      return html;
+    }
+    if (attributes.path("code").asBoolean(false)) {
+      html = "<code>" + html + "</code>";
+    }
+    if (attributes.path("bold").asBoolean(false)) {
+      html = "<strong>" + html + "</strong>";
+    }
+    if (attributes.path("italic").asBoolean(false)) {
+      html = "<em>" + html + "</em>";
+    }
+    JsonNode link = attributes.get("link");
+    if (link != null && link.isTextual()) {
+      // The href is passed through as-is here; RENDER_SAFELIST enforces the http/https/mailto scheme
+      // allowlist and drops the anchor entirely if the scheme is not permitted (e.g. javascript:).
+      html = "<a href=\"" + Entities.escape(link.textValue()) + "\">" + html + "</a>";
+    }
+    return html;
+  }
+
+  private static String blockListType(JsonNode attributes) {
+    if (attributes == null) {
+      return null;
+    }
+    JsonNode list = attributes.get("list");
+    if (list == null || !list.isTextual()) {
+      return null;
+    }
+    return "ordered".equals(list.textValue()) ? "ol" : "ul";
+  }
+
+  private static String wrapBlock(String inner, JsonNode attributes) {
+    if (attributes != null) {
+      int header = attributes.path("header").asInt(0);
+      if (header >= 1 && header <= 6) {
+        return "<h" + header + ">" + inner + "</h" + header + ">";
+      }
+      if (attributes.path("blockquote").asBoolean(false)) {
+        return "<blockquote>" + inner + "</blockquote>";
+      }
+      if (attributes.path("code-block").asBoolean(false)) {
+        return "<pre><code>" + inner + "</code></pre>";
+      }
+    }
+    // Skip genuinely empty paragraphs (consecutive newlines) rather than emitting <p></p> noise.
+    if (inner.isEmpty()) {
+      return null;
+    }
+    return "<p>" + inner + "</p>";
+  }
+
+  private static String wrapList(String listTag, List<String> items) {
+    return "<" + listTag + ">" + String.join("", items) + "</" + listTag + ">";
+  }
+
+  private static String sanitize(String html) {
+    Document dirty = Jsoup.parseBodyFragment(html);
+    Document clean = new Cleaner(RENDER_SAFELIST).clean(dirty);
+    clean.outputSettings().prettyPrint(false);
+    return clean.body().html();
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/ContentHtmlCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentHtmlCommandTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the format-aware content render dispatch: legacy HTML passes through, visual-editor Delta is
+ * rendered server-side through {@link DeltaContentCommand}.
+ *
+ * @author elizabeth houser
+ */
+class ContentHtmlCommandTest {
+
+  @Test
+  void legacyFormatPassesHtmlThroughUnchanged() {
+    // Existing content is stored HTML (cleaned on save); rendering must not alter it.
+    String html = "<p>Existing <strong>html</strong> with <a href=\"/x\">a link</a></p>";
+    assertEquals(html, ContentHtmlCommand.toHtml(html, DeltaContentCommand.LEGACY_HTML_FORMAT));
+  }
+
+  @Test
+  void unrecognizedFormatFallsBackToPassthrough() {
+    // A format this build does not know is treated as legacy passthrough -- backward compatible, since
+    // format 0 dominates and a newer format only appears once a newer build wrote it.
+    String html = "<p>content</p>";
+    assertEquals(html, ContentHtmlCommand.toHtml(html, 99));
+  }
+
+  @Test
+  void deltaFormatIsRenderedServerSide() {
+    String delta = "{\"ops\":[{\"insert\":\"hi\",\"attributes\":{\"bold\":true}},{\"insert\":\"\\n\"}]}";
+    assertEquals("<p><strong>hi</strong></p>",
+        ContentHtmlCommand.toHtml(delta, DeltaContentCommand.DELTA_FORMAT_VERSION));
+  }
+
+  @Test
+  void deltaFormatRoutesThroughTheSanitizingRenderer() {
+    // Proves Delta content dispatches to the renderer (which escapes), not to passthrough (which would
+    // emit the raw string). Passthrough of this value would be a stored-XSS; the dispatch prevents it.
+    String delta = "{\"ops\":[{\"insert\":\"<script>alert(1)</script>\\n\"}]}";
+    String html = ContentHtmlCommand.toHtml(delta, DeltaContentCommand.DELTA_FORMAT_VERSION);
+    assertFalse(html.contains("<script"), html);
+  }
+
+  @Test
+  void nullContentStaysNull() {
+    // Callers treat null as "no content" (the add-content button path), so the contract is preserved.
+    assertNull(ContentHtmlCommand.toHtml(null, DeltaContentCommand.DELTA_FORMAT_VERSION));
+    assertNull(ContentHtmlCommand.toHtml(null, DeltaContentCommand.LEGACY_HTML_FORMAT));
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/DeltaContentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/DeltaContentCommandTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the server-side Delta rendering boundary for the visual editor, with emphasis on the security
+ * contract: content is rendered from Delta through an allowlist, never the Quill HTML-export path.
+ *
+ * @author elizabeth houser
+ */
+class DeltaContentCommandTest {
+
+  @Test
+  void formatConstantsAreStable() {
+    // The stored stamp is a contract with persisted content; a silent change would misread stored rows.
+    assertEquals(0, DeltaContentCommand.LEGACY_HTML_FORMAT);
+    assertEquals(2, DeltaContentCommand.DELTA_FORMAT_VERSION);
+  }
+
+  @Test
+  void plainTextBecomesAnEscapedParagraph() {
+    String html = DeltaContentCommand.render("{\"ops\":[{\"insert\":\"Hello & <world>\\n\"}]}");
+    assertEquals("<p>Hello &amp; &lt;world&gt;</p>", html);
+  }
+
+  @Test
+  void inlineAllowlistIsApplied() {
+    assertEquals("<p><strong>b</strong></p>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"b\",\"attributes\":{\"bold\":true}},{\"insert\":\"\\n\"}]}"));
+    assertEquals("<p><em>i</em></p>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"i\",\"attributes\":{\"italic\":true}},{\"insert\":\"\\n\"}]}"));
+    assertEquals("<p><code>c</code></p>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"c\",\"attributes\":{\"code\":true}},{\"insert\":\"\\n\"}]}"));
+  }
+
+  @Test
+  void formatsOutsideTheAllowlistAreIgnored() {
+    // underline and color are real Quill formats but outside the hybrid seam; they must not render.
+    String html = DeltaContentCommand.render(
+        "{\"ops\":[{\"insert\":\"x\",\"attributes\":{\"underline\":true,\"color\":\"#ff0000\"}},{\"insert\":\"\\n\"}]}");
+    assertEquals("<p>x</p>", html);
+  }
+
+  @Test
+  void blockLevelFormatsRender() {
+    assertEquals("<h2>Title</h2>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"Title\"},{\"insert\":\"\\n\",\"attributes\":{\"header\":2}}]}"));
+    assertEquals("<blockquote>quoted</blockquote>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"quoted\"},{\"insert\":\"\\n\",\"attributes\":{\"blockquote\":true}}]}"));
+    assertEquals("<ul><li>one</li><li>two</li></ul>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"one\"},{\"insert\":\"\\n\",\"attributes\":{\"list\":\"bullet\"}}"
+            + ",{\"insert\":\"two\"},{\"insert\":\"\\n\",\"attributes\":{\"list\":\"bullet\"}}]}"));
+    assertEquals("<ol><li>one</li></ol>",
+        DeltaContentCommand.render("{\"ops\":[{\"insert\":\"one\"},{\"insert\":\"\\n\",\"attributes\":{\"list\":\"ordered\"}}]}"));
+  }
+
+  @Test
+  void allowedLinkKeepsHrefAndGainsRel() {
+    String html = DeltaContentCommand.render(
+        "{\"ops\":[{\"insert\":\"site\",\"attributes\":{\"link\":\"https://example.org\"}},{\"insert\":\"\\n\"}]}");
+    assertTrue(html.contains("href=\"https://example.org\""), html);
+    // Enforced by the safelist so an editor cannot opt out of tab-nabbing protection.
+    assertTrue(html.contains("rel=\"noopener noreferrer\""), html);
+    assertTrue(html.contains(">site</a>"), html);
+  }
+
+  @Test
+  void javascriptUrlSchemeIsStripped() {
+    // The javascript: scheme is not in the safelist's protocol allowlist for href.
+    String html = DeltaContentCommand.render(
+        "{\"ops\":[{\"insert\":\"x\",\"attributes\":{\"link\":\"javascript:alert(1)\"}},{\"insert\":\"\\n\"}]}");
+    assertFalse(html.contains("javascript"), html);
+    // The visible text survives even though the dangerous link does not.
+    assertTrue(html.contains("x"), html);
+  }
+
+  @Test
+  void cve2025_15056PayloadIsNeutralised() {
+    // The published PoC for CVE-2025-15056 (Quill HTML-export XSS). We render Delta server-side and never
+    // call the export blots, so the payload is inert content: every angle bracket is escaped, so there is
+    // no live <img>/<span> element and the onerror text a browser sees is plain text it will not execute.
+    // This test enforces the design constraint the not_affected VEX position depends on -- the literal
+    // "onerror" substring surviving as escaped text is exactly the point, not a leak.
+    String payload = "</span><img src=x onerror=alert(1)>";
+    String delta = "{\"ops\":[{\"insert\":" + jsonString(payload) + "},{\"insert\":\"\\n\"}]}";
+    String html = DeltaContentCommand.render(delta);
+    assertEquals("<p>&lt;/span&gt;&lt;img src=x onerror=alert(1)&gt;</p>", html);
+    // No live markup survived: the brackets are all escaped entities, not tags.
+    assertFalse(html.contains("<img"), html);
+    assertFalse(html.contains("<span"), html);
+  }
+
+  @Test
+  void embedInsertsAreDropped() {
+    // Object inserts (image/formula/video) are outside the allowlist and must not reach the output.
+    String html = DeltaContentCommand.render(
+        "{\"ops\":[{\"insert\":{\"image\":\"https://x/y.png\"}},{\"insert\":\"caption\\n\"}]}");
+    assertEquals("<p>caption</p>", html);
+    assertFalse(html.toLowerCase().contains("img"), html);
+  }
+
+  @Test
+  void isValidDeltaDistinguishesShape() {
+    assertTrue(DeltaContentCommand.isValidDelta("{\"ops\":[{\"insert\":\"hi\\n\"}]}"));
+    assertFalse(DeltaContentCommand.isValidDelta("{\"blocks\":[]}"));
+    assertFalse(DeltaContentCommand.isValidDelta("not json"));
+    assertFalse(DeltaContentCommand.isValidDelta(""));
+    assertFalse(DeltaContentCommand.isValidDelta(null));
+  }
+
+  @Test
+  void legacyOneXShapeIsDetectable() {
+    // A 1.x embed carried an integer insert value; that shape needs migration before it can render.
+    assertTrue(DeltaContentCommand.isLegacyDeltaShape("{\"ops\":[{\"insert\":1,\"attributes\":{\"image\":true}}]}"));
+    assertFalse(DeltaContentCommand.isLegacyDeltaShape("{\"ops\":[{\"insert\":\"text\\n\"}]}"));
+  }
+
+  @Test
+  void unparseableInputRendersEmptyNotError() {
+    // A bad stored value must never break a page render.
+    assertEquals("", DeltaContentCommand.render(null));
+    assertEquals("", DeltaContentCommand.render(""));
+    assertEquals("", DeltaContentCommand.render("garbage"));
+    assertEquals("", DeltaContentCommand.render("{\"ops\":\"notarray\"}"));
+  }
+
+  private static String jsonString(String value) {
+    return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
+}


### PR DESCRIPTION
First slice of **Visual Editor P0** (#255) — the content-side foundation the whole editor program inherits: the security-critical **Delta renderer** plus the **format-aware dispatch** that routes stored content to it. Landed and tested first, on purpose.

## What this is

The visual editor stores rich text as **Quill 2.x Delta JSON** and renders it **server-side** into a small allowlisted HTML subset. `DeltaContentCommand` is that boundary:

- **`render(deltaJson)`** — Delta ops → HTML. Inline: **bold / italic / code / link only** (`INLINE_FORMATS`). Block: paragraph, `h1`–`h6`, blockquote, code-block, bullet/ordered lists. All text is escaped; the assembled HTML is then re-cleaned against a jsoup safelist that enumerates *exactly* the tags and attributes the renderer emits — defense-in-depth, so even an assembly bug cannot emit script, an event handler, or a `javascript:` / `data:` URL. Links gain an enforced `rel="noopener noreferrer"`.
- **Stamped format version** (`DELTA_FORMAT_VERSION = 2`, `LEGACY_HTML_FORMAT = 0`) so Delta is distinguishable from the HTML already stored on the `Content` entity, and the removed Quill 1.x Delta shape is detectable (`isLegacyDeltaShape`) for a future migration.
- **Fail-safe**: unparseable / legacy-shape / `null` input renders `""`, never throws — a bad stored value can't break a page render.

## The format dispatch (`ContentHtmlCommand.toHtml`)

`toHtml(content, format)` is the single point where a stored value becomes display HTML: **legacy content (and any unrecognized format) passes through unchanged** — zero behavior change, since no format-2 content exists yet and legacy HTML was cleaned on save — while `DELTA_FORMAT_VERSION` content routes through the renderer above. It's the seam the content widgets will call once the format stamp is persisted (next slice), keeping the render decision in one tested place rather than scattered across the read-sites.

## The security contract — why this is the first slice

`CVE-2025-15056` is an XSS in Quill's **HTML-export** blots (formula/video interpolate unescaped values in `html()`), reachable **only** via `getSemanticHTML()` / `getHTML()`. By storing Delta, rendering it ourselves, and never registering those formats, the vulnerable code is never in the execute path — the same `not_affected / vulnerable_code_not_in_execute_path` pattern this repo already uses for the DB-image VEX.

That's written down as an **enforced constraint, not an assumption**: the test suite renders the published CVE PoC (`</span><img src=x onerror=alert(1)>`) and asserts the exact inert, fully-escaped output:

```
<p>&lt;/span&gt;&lt;img src=x onerror=alert(1)&gt;</p>
```

## Tests — 17, all green locally

_(12 renderer + 5 dispatch)_

inline + block rendering · allowlist ignores out-of-band formats (underline/color) · `javascript:` scheme stripped · enforced link `rel` · embeds dropped · valid vs legacy-1.x shape detection · fail-safe on bad input · **the CVE-2025-15056 PoC → escaped text**.

Verified: clean `ant compile`; `DeltaContentCommandTest` 12/12 via the JUnit console launcher.

## Not in this slice (the rest of P0)

The `/json/*` service endpoints, the closed-by-default PermissionEngine (builder-vs-editor split), the per-block JSP fragments, and the Flyway migration + `Content.contentFormat` persistence that activates the dispatch through the live widget read-sites. Each is a follow-up PR against #255.
