### PR TITLE
Refresh the johnzon and Dockerfile STIG rationales left stale by #216

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,12 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # Held deliberately: entangled with the javax-to-jakarta migration
+      # Held at 1.x. johnzon 2.x moves its JSON-P / JSON-B implementation from the
+      # javax.json.* namespace to jakarta.json.*, a migration this app has NOT done -- the
+      # JSON-B code still imports javax.json.bind.Jsonb / JsonbBuilder (johnzon pinned 1.3.0).
+      # This is a SEPARATE migration from the jakarta.servlet one that shipped in PR #216;
+      # that one does not clear this hold. Bumping to 2.x would break those imports.
+      # Revisit: migrate the app's JSON-B usage to jakarta.json.bind, then take johnzon 2.x.
       - dependency-name: "org.apache.johnzon:*"
         update-types: ["version-update:semver-major"]
       # Held at 3.2.x: 3.3+ throws on undefined properties (breaks WorkflowTaskTest)
@@ -43,8 +48,8 @@ updates:
       # while the image is still Tomcat 11 would compile against APIs the running server lacks,
       # and check-dependency-drift.py skips provided scope, so nothing would catch the mismatch.
       # Minor/patch bumps are NOT ignored, so Tomcat 11 security fixes still flow.
-      # Revisit: move the Docker base image to Tomcat 12 in the same change (and re-map the
-      # server.xml / setenv.sh STIG overlay, per the Dockerfile TODOs).
+      # Revisit: move the Docker base image to Tomcat 12 in the same change, and re-verify
+      # the server.xml / setenv.sh STIG overlay against the new base.
       - dependency-name: "org.apache.tomcat:tomcat-servlet-api"
         update-types: ["version-update:semver-major"]
       # Held at 12.x: Flyway is the schema-migration engine and there is currently NO

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -18,13 +18,13 @@ FROM tomcat:11.0-jdk21@sha256:543dd74d992458d558875de8493399a718270b361b16e4ea67
 # docker-tomcat9-stig-hardening.md (private).
 #
 # Carried onto Tomcat 11 during the jakarta.servlet migration. Every server.xml edit was
-# re-verified against stock Tomcat 11 and remains valid. TWO items still need a decision
-# before this counts as compliance evidence, both flagged in the files themselves:
-#   - setenv.sh: RECYCLE_FACADES does not exist in Tomcat 11, so that control is currently
-#     unenforced (the flag is commented out rather than left silently ineffective).
-#   - server.xml: Tomcat 11 adds maxPartCount / maxPartHeaderSize, which the Tomcat 9-era
-#     profile does not cover.
-# The STIG rule-ID mapping itself has NOT been re-done for a Tomcat 11 baseline.
+# re-verified against stock Tomcat 11 and remains valid. The two items the migration left
+# open were resolved on the <Connector> in server.xml (see that file for the reasoning):
+#   - discardFacades="true": the Tomcat 11 replacement for the RECYCLE_FACADES system
+#     property (since removed from setenv.sh); on by default in 11, set explicitly to assert it.
+#   - maxPartCount / maxPartHeaderSize: new Tomcat 11 multipart limits with no Tomcat 9
+#     equivalent, pinned to the documented Tomcat 11 defaults (50 / 512).
+# Still open: the STIG rule-ID mapping has NOT been re-done for a Tomcat 11 baseline.
 COPY ./docker/app/conf/server.xml /usr/local/tomcat/conf/server.xml
 COPY ./docker/app/conf/setenv.sh /usr/local/tomcat/bin/setenv.sh
 RUN chmod 0750 /usr/local/tomcat/bin/setenv.sh && rm -rf /usr/local/tomcat/webapps.dist


### PR DESCRIPTION
## What

Follow-up to #276, which refreshed the `tomcat-servlet-api` hold. Two more notes still cited the jakarta migration as an open/blocking reason and are now stale or misleading. Comment/note-only — no behaviour change, no build impact.

## 1. `.github/dependabot.yml` — `johnzon` major hold (reworded, still held)

The note said *"entangled with the javax-to-jakarta migration,"* which now reads as cleared by #216. It is **not** — it hinges on a **separate** migration:
- johnzon 2.x moves JSON-P / JSON-B from `javax.json.*` to `jakarta.json.*`.
- The app has **not** done that migration — the JSON-B code still imports `javax.json.bind.Jsonb` / `JsonbBuilder` (johnzon pinned `1.3.0`).
- #216 was servlet-only and does not free this bump.

(Net observation: the "Jakarta EE migration" is only partial — `jakarta.servlet` done, `javax.json` not.)

## 2. `.github/dependabot.yml` — `tomcat-servlet-api` revisit note

Small tidy: drop the *"per the Dockerfile TODOs"* pointer (those TODOs are resolved — see below); it now just says to re-verify the STIG overlay against the new base on a future Tomcat 12 move.

## 3. `docker/app/Dockerfile` — stale STIG comment

The comment still claimed *"TWO items still need a decision"* (RECYCLE_FACADES, `maxPartCount`/`maxPartHeaderSize`). Both were **resolved** on the `<Connector>` in `server.xml` by `664af698` (`discardFacades="true"` and the multipart limits). Updated to reflect that. The one genuinely open item — the STIG **rule-ID re-mapping** for a Tomcat 11 baseline — is preserved.
