### PR TITLE
Visual Editor P0: persist the content format stamp (2 columns) + activate render dispatch [stacked on #279]

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -80,11 +80,11 @@ public class ContentHtmlCommand {
       // Check for the content
       Content content = LoadContentCommand.loadContentByUniqueId(uniqueId);
       if (content != null) {
-        html = content.getContent();
+        html = toHtml(content.getContent(), content.getContentFormat());
         // Look for draft content
         if (context.hasRole("admin") || context.hasRole("content-manager")) {
           if (content.getDraftContent() != null) {
-            html = content.getDraftContent();
+            html = toHtml(content.getDraftContent(), content.getDraftContentFormat());
             context.getRequest().setAttribute("isDraft", "true");
           }
         }
@@ -166,11 +166,11 @@ public class ContentHtmlCommand {
       String embeddedHtml = "";
       Content content = LoadContentCommand.loadContentByUniqueId(embeddedUniqueId);
       if (content != null) {
-        embeddedHtml = content.getContent();
+        embeddedHtml = toHtml(content.getContent(), content.getContentFormat());
         // Look for draft content
         if (hasEditorPermission) {
           if (content.getDraftContent() != null) {
-            embeddedHtml = content.getDraftContent();
+            embeddedHtml = toHtml(content.getDraftContent(), content.getDraftContentFormat());
             hasDraftContent = true;
           }
         }
@@ -380,7 +380,7 @@ public class ContentHtmlCommand {
           //          "data-multiple-opened=\"true\"\n" +
           (StringUtils.isNotBlank(revealClass) ? "data-additional-overlay-classes=\"" + revealClass + "\"\n" : "") +
           "data-close-on-click=\"true\">\n" +
-          content.getContent() + "\n" +
+          toHtml(content.getContent(), content.getContentFormat()) + "\n" +
           "<button class=\"close-button\" data-close aria-label=\"Close reveal\" type=\"button\">\n" +
           "<span aria-hidden=\"true\"><i class=\"" + FontCommand.fal() + " fa-circle-xmark\"></i></span>\n" +
           "</button>\n" +

--- a/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
@@ -33,6 +33,11 @@ public class Content extends Entity {
   private String uniqueId = null;
   private String content = null;
   private String draftContent = null;
+  // Format stamp for content/draftContent: 0 = legacy HTML, 2 = visual-editor Quill Delta JSON
+  // (DeltaContentCommand.DELTA_FORMAT_VERSION). Draft and published carry their own stamp because a
+  // page mid-conversion can have an HTML published version and a Delta draft at the same time.
+  private int contentFormat = 0;
+  private int draftContentFormat = 0;
   private long createdBy = -1;
   private long modifiedBy = -1;
   private Timestamp created = null;
@@ -72,6 +77,22 @@ public class Content extends Entity {
 
   public void setDraftContent(String draftContent) {
     this.draftContent = draftContent;
+  }
+
+  public int getContentFormat() {
+    return contentFormat;
+  }
+
+  public void setContentFormat(int contentFormat) {
+    this.contentFormat = contentFormat;
+  }
+
+  public int getDraftContentFormat() {
+    return draftContentFormat;
+  }
+
+  public void setDraftContentFormat(int draftContentFormat) {
+    this.draftContentFormat = draftContentFormat;
   }
 
   public long getCreatedBy() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -103,6 +103,8 @@ public class ContentRepository {
         .add("content", StringUtils.trimToNull(record.getContent()))
         .add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())))
         .add("draft_content", StringUtils.trimToNull(record.getDraftContent()))
+        .add("content_format", record.getContentFormat())
+        .add("draft_content_format", record.getDraftContentFormat())
         .add("created_by", record.getCreatedBy())
         .add("modified_by", record.getModifiedBy());
     record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
@@ -118,6 +120,8 @@ public class ContentRepository {
         .add("content", StringUtils.trimToNull(record.getContent()))
         .add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())))
         .add("draft_content", StringUtils.trimToNull(record.getDraftContent()))
+        .add("content_format", record.getContentFormat())
+        .add("draft_content_format", record.getDraftContentFormat())
         .add("modified_by", record.getModifiedBy())
         .add("modified", new Timestamp(System.currentTimeMillis()));
     SqlUtils where = new SqlUtils()
@@ -138,6 +142,9 @@ public class ContentRepository {
     SqlUtils updateValues = new SqlUtils();
     updateValues.add("content = draft_content");
     updateValues.add("draft_content = null");
+    // Promote the draft's format stamp with its content, then clear it alongside the emptied draft.
+    updateValues.add("content_format = draft_content_format");
+    updateValues.add("draft_content_format = 0");
     updateValues.add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())));
     SqlUtils where = new SqlUtils().add("draft_content IS NOT NULL AND content_unique_id = ?", record.getUniqueId());
     if (DB.update(TABLE_NAME, updateValues, where)) {
@@ -149,7 +156,7 @@ public class ContentRepository {
     if (record == null || StringUtils.isBlank(record.getUniqueId())) {
       return;
     }
-    String set = "draft_content = null";
+    String set = "draft_content = null, draft_content_format = 0";
     SqlUtils where = new SqlUtils().add("content_unique_id = ?", record.getUniqueId());
     if (DB.update(TABLE_NAME, set, where)) {
       CacheManager.invalidateKey(CacheManager.CONTENT_UNIQUE_ID_CACHE, record.getUniqueId());
@@ -189,6 +196,13 @@ public class ContentRepository {
       record.setDraftContent(rs.getString("draft_content"));
       record.setCreated(rs.getTimestamp("created"));
       record.setModified(rs.getTimestamp("modified"));
+      // Guarded like highlight: a query or a not-yet-migrated database may not carry these columns.
+      if (DB.hasColumn(rs, "content_format")) {
+        record.setContentFormat(rs.getInt("content_format"));
+      }
+      if (DB.hasColumn(rs, "draft_content_format")) {
+        record.setDraftContentFormat(rs.getInt("draft_content_format"));
+      }
       if (DB.hasColumn(rs, "highlight")) {
         record.setHighlight(rs.getString("highlight"));
       }

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -138,6 +138,8 @@ CREATE TABLE content (
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
   modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
   draft_content TEXT,
+  content_format INTEGER NOT NULL DEFAULT 0,
+  draft_content_format INTEGER NOT NULL DEFAULT 0,
   content_text TEXT,
   tsv TSVECTOR
 );

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1000__content_format.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1000__content_format.sql
@@ -1,0 +1,8 @@
+-- Stamps stored content with a format version so the visual editor's Quill Delta content is
+-- distinguishable from legacy HTML on render (see DeltaContentCommand / ContentHtmlCommand.toHtml).
+-- Two columns because a page mid-conversion has an HTML published version and a Delta draft at the
+-- same time -- the governed publish path keeps the draft off the live version until it is approved.
+-- Both default to 0 (legacy HTML), so an existing site renders exactly as it did; a row becomes
+-- format 2 only when content is saved through the visual editor.
+ALTER TABLE content ADD COLUMN IF NOT EXISTS content_format INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE content ADD COLUMN IF NOT EXISTS draft_content_format INTEGER NOT NULL DEFAULT 0;

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -197,6 +197,8 @@ class ContentRepositoryTest {
           + "content TEXT, "
           + "content_text TEXT, "
           + "draft_content TEXT, "
+          + "content_format INTEGER NOT NULL DEFAULT 0, "
+          + "draft_content_format INTEGER NOT NULL DEFAULT 0, "
           + "created_by BIGINT, "
           + "modified_by BIGINT, "
           + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "


### PR DESCRIPTION
Decision 1 for **Visual Editor P0** (#255), implementing the two-format-columns call.

> **Stacked on #279** (the renderer + dispatch). Review #279 first; this is the last commit. Rebases onto `main` once #279 merges.

## Why two columns

A page being converted to the editor has an **HTML published version and a Delta draft at the same time** — the governed publish path (P1) keeps the draft off the live version until it's approved. One column can't describe that; two can.

## What changed

- **Schema** — `content_format` + `draft_content_format` on `content`, both `INTEGER NOT NULL DEFAULT 0`. In the fresh-install DDL *and* an idempotent `ADD COLUMN IF NOT EXISTS` upgrade migration.
- **Entity** — `Content.contentFormat` / `draftContentFormat`.
- **Repository** — insert/update carry both stamps; **publish** promotes `draft_content_format → content_format` with the content and clears the draft's stamp; `removeDraft` resets it; `buildRecord` reads both, guarded by `DB.hasColumn` (same idiom as `highlight`, so a not-yet-migrated DB is safe).
- **Render dispatch activated** — the three content read-sites (`getHtmlFromPreferences`, `embedInlineContent`, the reveal card) now render through `ContentHtmlCommand.toHtml(value, format)`.

## Safety: zero behavior change for existing sites

Every current row is format 0, so every read is **passthrough** — legacy HTML renders byte-for-byte as before (the passthrough branch is unit-tested). A row becomes format 2 only once the editor write-path (a later slice) saves Delta. `deploy-smoke-test` boots the real WAR against real Postgres with the new DDL.

## Known follow-up (noted, not a gap)

`content_text` (the search column) is derived from the stored value as HTML. For Delta it should be derived from the *rendered* text — but that belongs with the write-path slice, in the application layer, so it doesn't invert the persistence→application dependency. No Delta content exists until then, so it's correct for every current row.

## Tests

The 17 renderer/dispatch tests still pass; clean `ant compile`. Repository round-trip and the DDL ride on CI (`build` + `deploy-smoke-test`).
