### PR TITLE
Visual Editor P0: Delta write-path (validate + stamp on save)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
@@ -64,4 +64,51 @@ public class SaveContentCommand {
 
   }
 
+  /**
+   * Saves visual-editor content, which is stored as Quill Delta JSON (format
+   * {@link DeltaContentCommand#DELTA_FORMAT_VERSION}) rather than HTML.
+   *
+   * <p>Unlike {@link #saveSafeContent} this does NOT clean or transform the value: Delta is stored
+   * verbatim and sanitized at render time by {@link DeltaContentCommand#render(String)}, so cleaning
+   * the JSON here would corrupt it. The guarantee on save is only that the value is a well-formed,
+   * current-shape Delta document; anything else is rejected rather than stored for the renderer to
+   * choke on later. A draft save leaves the published version (which may still be legacy HTML)
+   * untouched -- the two format stamps are what make that mixed state representable.
+   */
+  public static Content saveSafeDeltaContent(String contentUniqueId, String deltaJson, long userId, boolean publish)
+      throws DataException {
+
+    if (deltaJson == null) {
+      throw new DataException("Content is required");
+    }
+    if (!DeltaContentCommand.isValidDelta(deltaJson)) {
+      throw new DataException("Content is not a valid editor document");
+    }
+    if (DeltaContentCommand.isLegacyDeltaShape(deltaJson)) {
+      // The removed Quill 1.x shape needs migration, not storage.
+      throw new DataException("Content uses an unsupported legacy editor format");
+    }
+
+    Content content = ContentRepository.findByUniqueId(contentUniqueId);
+    if (content == null) {
+      LOG.debug("Saving new Delta content record...");
+      content = new Content();
+      content.setUniqueId(contentUniqueId);
+    }
+    if (publish) {
+      // Publish: the Delta becomes the live version and the draft is cleared.
+      content.setContent(deltaJson);
+      content.setContentFormat(DeltaContentCommand.DELTA_FORMAT_VERSION);
+      content.setDraftContent(null);
+      content.setDraftContentFormat(DeltaContentCommand.LEGACY_HTML_FORMAT);
+    } else {
+      // Draft only: leave the published version and its stamp untouched.
+      content.setDraftContent(deltaJson);
+      content.setDraftContentFormat(DeltaContentCommand.DELTA_FORMAT_VERSION);
+    }
+    content.setCreatedBy(userId);
+    content.setModifiedBy(userId);
+    return ContentRepository.save(content);
+  }
+
 }

--- a/src/test/java/com/simisinc/platform/application/cms/SaveContentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveContentCommandTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.Content;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+
+/**
+ * Tests the visual editor's Delta write-path: valid, current-shape Delta is stamped and stored;
+ * anything else is rejected before it reaches the repository.
+ *
+ * @author elizabeth houser
+ */
+class SaveContentCommandTest {
+
+  private static final String VALID_DELTA = "{\"ops\":[{\"insert\":\"hello\\n\"}]}";
+
+  @Test
+  void nullContentIsRejected() {
+    assertThrows(DataException.class,
+        () -> SaveContentCommand.saveSafeDeltaContent("uid", null, 1L, false));
+  }
+
+  @Test
+  void malformedDocumentIsRejected() {
+    assertThrows(DataException.class,
+        () -> SaveContentCommand.saveSafeDeltaContent("uid", "not-a-delta", 1L, false));
+    assertThrows(DataException.class,
+        () -> SaveContentCommand.saveSafeDeltaContent("uid", "{\"blocks\":[]}", 1L, false));
+  }
+
+  @Test
+  void legacyDeltaShapeIsRejected() {
+    // The removed Quill 1.x embed shape (integer insert) must be migrated, not stored.
+    assertThrows(DataException.class,
+        () -> SaveContentCommand.saveSafeDeltaContent("uid", "{\"ops\":[{\"insert\":1}]}", 1L, false));
+  }
+
+  @Test
+  void draftSaveStampsDeltaFormatOnTheDraftOnly() throws DataException {
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(null);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+
+      Content saved = SaveContentCommand.saveSafeDeltaContent("uid", VALID_DELTA, 7L, false);
+
+      assertEquals(VALID_DELTA, saved.getDraftContent());
+      assertEquals(DeltaContentCommand.DELTA_FORMAT_VERSION, saved.getDraftContentFormat());
+      // The published side is untouched on a draft save -- the mixed HTML/Delta state the two
+      // columns exist to represent.
+      assertNull(saved.getContent());
+      assertEquals(DeltaContentCommand.LEGACY_HTML_FORMAT, saved.getContentFormat());
+    }
+  }
+
+  @Test
+  void publishStampsDeltaFormatAndClearsTheDraft() throws DataException {
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(null);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+
+      Content saved = SaveContentCommand.saveSafeDeltaContent("uid", VALID_DELTA, 7L, true);
+
+      assertEquals(VALID_DELTA, saved.getContent());
+      assertEquals(DeltaContentCommand.DELTA_FORMAT_VERSION, saved.getContentFormat());
+      assertNull(saved.getDraftContent());
+      assertEquals(DeltaContentCommand.LEGACY_HTML_FORMAT, saved.getDraftContentFormat());
+    }
+  }
+}


### PR DESCRIPTION
The write-side complement to the render dispatch, completing the P0 Delta round-trip: **write Delta → store as format 2 → read → render**.

> #279 and #281 have merged; rebased onto `main` — the diff is the write-path commit alone.

## What this adds

`SaveContentCommand.saveSafeDeltaContent(uniqueId, deltaJson, userId, publish)`:

- **Validates, does not clean.** Delta is stored verbatim and sanitized at *render* time (`DeltaContentCommand.render`); cleaning the JSON at rest would corrupt it. So the save-time guarantee is only that the value is a **well-formed, current-shape** Delta document — `null`, unparseable JSON, and the removed Quill 1.x shape are each rejected with a `DataException` **before anything reaches the repository**.
- **Stamps the format.** A draft save stamps only the draft (leaving a possibly-legacy-HTML published version untouched); a publish makes the Delta the live version and clears the draft. The two format columns (#281) make that mixed state representable.

## Tests — 5, all green locally

null / malformed / legacy-1.x-shape rejection · draft-vs-publish stamping (mocked `ContentRepository`, no DB needed for the stamping assertions).

## Where it sits

No caller yet — the Quill editor UI (P2) and the `/json/*` save endpoint are later slices; this is the application-layer write logic they'll call, landed and tested first (as the renderer was). With it, the Delta pipeline round-trips end to end.
