### PR TITLE
Visual Editor P0: make the remaining content render-sites format-aware

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentTabsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentTabsWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.application.cms.LoadContentCommand;
+import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.domain.model.cms.ContentTab;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -63,7 +64,7 @@ public class ContentTabsWidget extends GenericWidget {
       String html = null;
       Content content = LoadContentCommand.loadContentByUniqueId(contentTab.getContentUniqueId());
       if (content != null) {
-        html = content.getContent();
+        html = ContentHtmlCommand.toHtml(content.getContent(), content.getContentFormat());
       }
 
       if (StringUtils.isBlank(html)) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/CartWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/CartWidget.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.ecommerce;
 import com.simisinc.platform.application.cms.FontCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
 import com.simisinc.platform.application.ecommerce.*;
+import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.domain.model.ecommerce.*;
 import com.simisinc.platform.infrastructure.persistence.ecommerce.CartItemRepository;
@@ -185,7 +186,7 @@ public class CartWidget extends GenericWidget {
         Content content = LoadContentCommand.loadContentByUniqueId(contentUniqueId);
         String html = null;
         if (content != null) {
-          html = content.getContent();
+          html = ContentHtmlCommand.toHtml(content.getContent(), content.getContentFormat());
         }
         if (StringUtils.isBlank(html)) {
           if (context.hasRole("admin") || context.hasRole("content-manager")) {

--- a/src/main/java/com/simisinc/platform/rest/services/cms/ContentResponse.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/ContentResponse.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.rest.services.cms;
 
+import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 
 /**
@@ -31,7 +32,9 @@ public class ContentResponse {
 
   public ContentResponse(Content thisContent) {
     uniqueId = thisContent.getUniqueId();
-    content = thisContent.getContent();
+    // Return displayable HTML: legacy content passes through, Delta is rendered server-side so API
+    // consumers never receive raw editor JSON.
+    content = ContentHtmlCommand.toHtml(thisContent.getContent(), thisContent.getContentFormat());
   }
 
   public String getUniqueId() {


### PR DESCRIPTION
Completes the render-dispatch coverage from #279/#281. Clean on current `main` — no stack.

## The gap

Three sites still read `content.getContent()` **directly**, bypassing `ContentHtmlCommand.toHtml`, so once Delta content exists they'd render it as **raw JSON**:

| Site | Renders |
|---|---|
| `ContentTabsWidget` | tab content |
| `CartWidget` | ecommerce content block |
| `ContentResponse` | the content REST API |

Each now routes through `toHtml(value, format)`.

## Safety

Every current content row is **format 0 → passthrough**, so no site changes behavior today; Delta content (once the editor writes it) renders server-side everywhere it's displayed — including the API, which now returns displayable HTML rather than raw editor JSON.

## Deliberately not touched

`ContentEditorWidget` — the *edit surface*. Loading content **into** an editor is the editor UI's job (Phase 2 loads raw Delta into Quill, not rendered HTML), not a display render.

## Tests

No new tests: `toHtml` is already covered (`ContentHtmlCommandTest`), and these are format-0-passthrough wirings verified by clean `ant compile`. The **permission** wiring sweep — the delicate part — is a separate follow-up once #282 lands: it must not blindly swap the ~40 `admin || content-manager` checks, most of which aren't content-editing.