### PR TITLE
Visual Editor P1: governed publish state machine (draft→review→approve, separation of duties)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.Content;
+
+/**
+ * The governed publish path (Project #6, Phase 1): the state machine that takes a content draft through
+ * <b>draft → submitted → (approved &amp; published | rejected)</b> with a named approver.
+ *
+ * <p>This is the compliance mechanism for CMMC AC.L1-b.1.iv / NIST 800-171 3.1.22 (control of what is
+ * posted to publicly accessible systems). It enforces the rules; the caller persists the result and
+ * writes the append-only audit record that is the exportable assessment evidence. Two rules are
+ * load-bearing and enforced here rather than in the UI, so no screen can bypass them:
+ *
+ * <ul>
+ * <li><b>Separation of duties (AC-5).</b> The approver can never be the person who submitted the
+ * content. This is a data rule, not merely a role rule, so it holds even between two users who both
+ * hold the approver role.</li>
+ * <li><b>Publish is gated on approval.</b> Only a submitted draft can be approved, and only an
+ * approved draft should be published — {@link #isApproved(Content)} is the gate the publish path
+ * checks, so hot-editing a live page cannot skip review.</li>
+ * </ul>
+ *
+ * <p>The transitions mutate the content's workflow fields; timestamps and the immutable record of who
+ * did what and when are captured by the audit trail at the call site.
+ *
+ * @author elizabeth houser
+ */
+public class ContentReviewCommand {
+
+  /** A draft being edited, or one sent back by a rejection: the author's to change. */
+  public static final String STATUS_DRAFT = "draft";
+  /** A draft submitted for review and awaiting an approver's decision. */
+  public static final String STATUS_SUBMITTED = "submitted";
+
+  private ContentReviewCommand() {
+    // Static command
+  }
+
+  /**
+   * The author submits the current draft for review. There must be a draft to submit.
+   */
+  public static void submitForReview(Content content, long submitterId) throws DataException {
+    if (content == null || StringUtils.isBlank(content.getDraftContent())) {
+      throw new DataException("There is no draft to submit for review");
+    }
+    if (submitterId <= 0) {
+      throw new DataException("A valid submitter is required");
+    }
+    content.setDraftStatus(STATUS_SUBMITTED);
+    content.setSubmittedBy(submitterId);
+    // A fresh submission carries no prior approval.
+    content.setApprovedBy(-1);
+    content.setReleaseReference(null);
+  }
+
+  /**
+   * An approver approves a submitted draft, recording the release-authority reference. Enforces
+   * separation of duties. After this returns, {@link #isApproved(Content)} is true and the publish
+   * path may promote the draft to live.
+   */
+  public static void approve(Content content, long approverId, String releaseReference) throws DataException {
+    requireSubmitted(content);
+    requireApproverIsNotSubmitter(content, approverId);
+    content.setApprovedBy(approverId);
+    content.setReleaseReference(StringUtils.trimToNull(releaseReference));
+  }
+
+  /**
+   * An approver rejects a submitted draft, sending it back to the author to revise and resubmit.
+   * Enforces separation of duties.
+   */
+  public static void reject(Content content, long approverId) throws DataException {
+    requireSubmitted(content);
+    requireApproverIsNotSubmitter(content, approverId);
+    content.setDraftStatus(STATUS_DRAFT);
+    content.setApprovedBy(-1);
+  }
+
+  /** @return true if the content has a draft awaiting an approver's decision. */
+  public static boolean isPendingReview(Content content) {
+    return content != null && STATUS_SUBMITTED.equals(content.getDraftStatus());
+  }
+
+  /**
+   * @return true if the submitted draft has been approved and may be published. The publish path must
+   *         check this so an unreviewed change can never reach the live page.
+   */
+  public static boolean isApproved(Content content) {
+    return isPendingReview(content) && content.getApprovedBy() > 0;
+  }
+
+  private static void requireSubmitted(Content content) throws DataException {
+    if (!isPendingReview(content)) {
+      throw new DataException("Only a draft submitted for review can be approved or rejected");
+    }
+  }
+
+  private static void requireApproverIsNotSubmitter(Content content, long approverId) throws DataException {
+    if (approverId <= 0) {
+      throw new DataException("A valid approver is required");
+    }
+    if (approverId == content.getSubmittedBy()) {
+      throw new DataException(
+          "The approver must be different from the person who submitted the content (separation of duties)");
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
@@ -38,6 +38,13 @@ public class Content extends Entity {
   // page mid-conversion can have an HTML published version and a Delta draft at the same time.
   private int contentFormat = 0;
   private int draftContentFormat = 0;
+  // Governed publish path (P1): a draft moves draft -> submitted -> (approved+published | rejected).
+  // The named approver and the release-authority reference are recorded here and, immutably, in the
+  // audit trail. Separation of duties (approver != submitter) is enforced in ContentReviewCommand.
+  private String draftStatus = null;
+  private long submittedBy = -1;
+  private long approvedBy = -1;
+  private String releaseReference = null;
   private long createdBy = -1;
   private long modifiedBy = -1;
   private Timestamp created = null;
@@ -93,6 +100,38 @@ public class Content extends Entity {
 
   public void setDraftContentFormat(int draftContentFormat) {
     this.draftContentFormat = draftContentFormat;
+  }
+
+  public String getDraftStatus() {
+    return draftStatus;
+  }
+
+  public void setDraftStatus(String draftStatus) {
+    this.draftStatus = draftStatus;
+  }
+
+  public long getSubmittedBy() {
+    return submittedBy;
+  }
+
+  public void setSubmittedBy(long submittedBy) {
+    this.submittedBy = submittedBy;
+  }
+
+  public long getApprovedBy() {
+    return approvedBy;
+  }
+
+  public void setApprovedBy(long approvedBy) {
+    this.approvedBy = approvedBy;
+  }
+
+  public String getReleaseReference() {
+    return releaseReference;
+  }
+
+  public void setReleaseReference(String releaseReference) {
+    this.releaseReference = releaseReference;
   }
 
   public long getCreatedBy() {

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.Content;
+
+/**
+ * Tests the governed publish state machine, with emphasis on the two load-bearing controls:
+ * separation of duties (approver != submitter) and publish-gated-on-approval.
+ *
+ * @author elizabeth houser
+ */
+class ContentReviewCommandTest {
+
+  private static final long AUTHOR = 10L;
+  private static final long APPROVER = 20L;
+
+  private static Content draft() {
+    Content content = new Content();
+    content.setUniqueId("page-block");
+    content.setDraftContent("<p>proposed change</p>");
+    return content;
+  }
+
+  @Test
+  void submitMovesDraftToSubmitted() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.STATUS_SUBMITTED, content.getDraftStatus());
+    assertEquals(AUTHOR, content.getSubmittedBy());
+    assertTrue(ContentReviewCommand.isPendingReview(content));
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void submitRequiresADraft() {
+    Content content = new Content(); // no draft content
+    assertThrows(DataException.class, () -> ContentReviewCommand.submitForReview(content, AUTHOR));
+  }
+
+  @Test
+  void approveBySomeoneElseRecordsApproverAndReference() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.approve(content, APPROVER, "  cleared per PA case 2026-114  ");
+    assertEquals(APPROVER, content.getApprovedBy());
+    assertEquals("cleared per PA case 2026-114", content.getReleaseReference()); // trimmed
+    assertTrue(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void theSubmitterCannotApproveTheirOwnContent() throws DataException {
+    // Separation of duties (AC-5) -- the heart of the control. Enforced on the data, not the role, so
+    // it holds even if the author also holds the approver role.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    DataException e = assertThrows(DataException.class,
+        () -> ContentReviewCommand.approve(content, AUTHOR, "self-approved"));
+    assertTrue(e.getMessage().toLowerCase().contains("separation of duties"), e.getMessage());
+    // The content is not approved by the failed attempt.
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void aDraftThatWasNotSubmittedCannotBeApproved() {
+    // Publish-gated-on-approval: nothing can be approved (and thus published) without first being
+    // submitted for review -- no bypass of the workflow.
+    Content content = draft();
+    assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, APPROVER, null));
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void rejectSendsItBackToTheAuthor() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.reject(content, APPROVER);
+    assertEquals(ContentReviewCommand.STATUS_DRAFT, content.getDraftStatus());
+    assertFalse(ContentReviewCommand.isApproved(content));
+    assertFalse(ContentReviewCommand.isPendingReview(content));
+  }
+
+  @Test
+  void theSubmitterCannotRejectTheirOwnContent() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertThrows(DataException.class, () -> ContentReviewCommand.reject(content, AUTHOR));
+  }
+
+  @Test
+  void approvalRequiresAValidApprover() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, -1L, null));
+  }
+}


### PR DESCRIPTION
First slice of **Visual Editor P1** (#256) — the compliance keystone. The state machine that governs how a change reaches a live page: **draft → submitted → (approved & published | rejected)** with a named approver.

This is the mechanism for **CMMC AC.L1-b.1.iv / NIST 800-171 3.1.22** (control of what is posted to publicly accessible systems), and its audit trail is exportable assessment evidence. Clean on current `main` — no stack.

## What this lands

`ContentReviewCommand` enforces the two load-bearing controls **in domain code**, so no screen can bypass them:

- **Separation of duties (AC-5)** — the approver can *never* be the submitter. Enforced on the **data** (`approverId != submittedBy`), not merely the role, so it holds even between two users who both hold the approver role. This is the heart of the control.
- **Publish gated on approval** — only a *submitted* draft can be approved; `isApproved()` is the gate the publish path will check, so hot-editing a live page can't skip review (the "no visual-editor bypass" the scoping study calls for).

`Content` gains the workflow fields (`draftStatus`, `submittedBy`, `approvedBy`, `releaseReference`). The immutable *who/when* record is the append-only audit trail's job at the call site.

## Tests — 8, all green locally

submit → submitted · approve-by-another records approver + release reference (trimmed) · reject sends it back to the author · **the submitter can't approve or reject their own content** (SoD, both paths) · an unsubmitted draft can't be approved (the gate) · approval needs a valid approver.

## Not in this slice (rest of P1)

Persistence (the workflow columns + migration + repository), the audit records at each transition, wiring the publish path to *require* `isApproved()`, the submit/approve/reject actions on the existing admin content screens, the release-authority field in the UI, and scheduled publish/unpublish. This slice is the compliance core they all sit on — landed and tested first, same as the P0 foundation.
