### PR TITLE
Visual Editor P1: persist the review-workflow state [stacked on #285]

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.Content;
+
+/**
+ * The governed publish path (Project #6, Phase 1): the state machine that takes a content draft through
+ * <b>draft → submitted → (approved &amp; published | rejected)</b> with a named approver.
+ *
+ * <p>This is the compliance mechanism for CMMC AC.L1-b.1.iv / NIST 800-171 3.1.22 (control of what is
+ * posted to publicly accessible systems). It enforces the rules; the caller persists the result and
+ * writes the append-only audit record that is the exportable assessment evidence. Two rules are
+ * load-bearing and enforced here rather than in the UI, so no screen can bypass them:
+ *
+ * <ul>
+ * <li><b>Separation of duties (AC-5).</b> The approver can never be the person who submitted the
+ * content. This is a data rule, not merely a role rule, so it holds even between two users who both
+ * hold the approver role.</li>
+ * <li><b>Publish is gated on approval.</b> Only a submitted draft can be approved, and only an
+ * approved draft should be published — {@link #isApproved(Content)} is the gate the publish path
+ * checks, so hot-editing a live page cannot skip review.</li>
+ * </ul>
+ *
+ * <p>The transitions mutate the content's workflow fields; timestamps and the immutable record of who
+ * did what and when are captured by the audit trail at the call site.
+ *
+ * @author elizabeth houser
+ */
+public class ContentReviewCommand {
+
+  /** A draft being edited, or one sent back by a rejection: the author's to change. */
+  public static final String STATUS_DRAFT = "draft";
+  /** A draft submitted for review and awaiting an approver's decision. */
+  public static final String STATUS_SUBMITTED = "submitted";
+
+  private ContentReviewCommand() {
+    // Static command
+  }
+
+  /**
+   * The author submits the current draft for review. There must be a draft to submit.
+   */
+  public static void submitForReview(Content content, long submitterId) throws DataException {
+    if (content == null || StringUtils.isBlank(content.getDraftContent())) {
+      throw new DataException("There is no draft to submit for review");
+    }
+    if (submitterId <= 0) {
+      throw new DataException("A valid submitter is required");
+    }
+    content.setDraftStatus(STATUS_SUBMITTED);
+    content.setSubmittedBy(submitterId);
+    // A fresh submission carries no prior approval.
+    content.setApprovedBy(-1);
+    content.setReleaseReference(null);
+  }
+
+  /**
+   * An approver approves a submitted draft, recording the release-authority reference. Enforces
+   * separation of duties. After this returns, {@link #isApproved(Content)} is true and the publish
+   * path may promote the draft to live.
+   */
+  public static void approve(Content content, long approverId, String releaseReference) throws DataException {
+    requireSubmitted(content);
+    requireApproverIsNotSubmitter(content, approverId);
+    content.setApprovedBy(approverId);
+    content.setReleaseReference(StringUtils.trimToNull(releaseReference));
+  }
+
+  /**
+   * An approver rejects a submitted draft, sending it back to the author to revise and resubmit.
+   * Enforces separation of duties.
+   */
+  public static void reject(Content content, long approverId) throws DataException {
+    requireSubmitted(content);
+    requireApproverIsNotSubmitter(content, approverId);
+    content.setDraftStatus(STATUS_DRAFT);
+    content.setApprovedBy(-1);
+  }
+
+  /** @return true if the content has a draft awaiting an approver's decision. */
+  public static boolean isPendingReview(Content content) {
+    return content != null && STATUS_SUBMITTED.equals(content.getDraftStatus());
+  }
+
+  /**
+   * @return true if the submitted draft has been approved and may be published. The publish path must
+   *         check this so an unreviewed change can never reach the live page.
+   */
+  public static boolean isApproved(Content content) {
+    return isPendingReview(content) && content.getApprovedBy() > 0;
+  }
+
+  private static void requireSubmitted(Content content) throws DataException {
+    if (!isPendingReview(content)) {
+      throw new DataException("Only a draft submitted for review can be approved or rejected");
+    }
+  }
+
+  private static void requireApproverIsNotSubmitter(Content content, long approverId) throws DataException {
+    if (approverId <= 0) {
+      throw new DataException("A valid approver is required");
+    }
+    if (approverId == content.getSubmittedBy()) {
+      throw new DataException(
+          "The approver must be different from the person who submitted the content (separation of duties)");
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/Content.java
@@ -38,6 +38,13 @@ public class Content extends Entity {
   // page mid-conversion can have an HTML published version and a Delta draft at the same time.
   private int contentFormat = 0;
   private int draftContentFormat = 0;
+  // Governed publish path (P1): a draft moves draft -> submitted -> (approved+published | rejected).
+  // The named approver and the release-authority reference are recorded here and, immutably, in the
+  // audit trail. Separation of duties (approver != submitter) is enforced in ContentReviewCommand.
+  private String draftStatus = null;
+  private long submittedBy = -1;
+  private long approvedBy = -1;
+  private String releaseReference = null;
   private long createdBy = -1;
   private long modifiedBy = -1;
   private Timestamp created = null;
@@ -93,6 +100,38 @@ public class Content extends Entity {
 
   public void setDraftContentFormat(int draftContentFormat) {
     this.draftContentFormat = draftContentFormat;
+  }
+
+  public String getDraftStatus() {
+    return draftStatus;
+  }
+
+  public void setDraftStatus(String draftStatus) {
+    this.draftStatus = draftStatus;
+  }
+
+  public long getSubmittedBy() {
+    return submittedBy;
+  }
+
+  public void setSubmittedBy(long submittedBy) {
+    this.submittedBy = submittedBy;
+  }
+
+  public long getApprovedBy() {
+    return approvedBy;
+  }
+
+  public void setApprovedBy(long approvedBy) {
+    this.approvedBy = approvedBy;
+  }
+
+  public String getReleaseReference() {
+    return releaseReference;
+  }
+
+  public void setReleaseReference(String releaseReference) {
+    this.releaseReference = releaseReference;
   }
 
   public long getCreatedBy() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -105,6 +105,10 @@ public class ContentRepository {
         .add("draft_content", StringUtils.trimToNull(record.getDraftContent()))
         .add("content_format", record.getContentFormat())
         .add("draft_content_format", record.getDraftContentFormat())
+        .add("draft_status", StringUtils.trimToNull(record.getDraftStatus()))
+        .add("submitted_by", record.getSubmittedBy())
+        .add("approved_by", record.getApprovedBy())
+        .add("release_reference", StringUtils.trimToNull(record.getReleaseReference()))
         .add("created_by", record.getCreatedBy())
         .add("modified_by", record.getModifiedBy());
     record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
@@ -122,6 +126,10 @@ public class ContentRepository {
         .add("draft_content", StringUtils.trimToNull(record.getDraftContent()))
         .add("content_format", record.getContentFormat())
         .add("draft_content_format", record.getDraftContentFormat())
+        .add("draft_status", StringUtils.trimToNull(record.getDraftStatus()))
+        .add("submitted_by", record.getSubmittedBy())
+        .add("approved_by", record.getApprovedBy())
+        .add("release_reference", StringUtils.trimToNull(record.getReleaseReference()))
         .add("modified_by", record.getModifiedBy())
         .add("modified", new Timestamp(System.currentTimeMillis()));
     SqlUtils where = new SqlUtils()
@@ -145,6 +153,12 @@ public class ContentRepository {
     // Promote the draft's format stamp with its content, then clear it alongside the emptied draft.
     updateValues.add("content_format = draft_content_format");
     updateValues.add("draft_content_format = 0");
+    // The draft is consumed, so clear its review workflow. The durable record of who submitted and
+    // approved, and under what release authority, lives in the append-only audit trail, not here.
+    updateValues.add("draft_status = null");
+    updateValues.add("submitted_by = -1");
+    updateValues.add("approved_by = -1");
+    updateValues.add("release_reference = null");
     updateValues.add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())));
     SqlUtils where = new SqlUtils().add("draft_content IS NOT NULL AND content_unique_id = ?", record.getUniqueId());
     if (DB.update(TABLE_NAME, updateValues, where)) {
@@ -156,7 +170,8 @@ public class ContentRepository {
     if (record == null || StringUtils.isBlank(record.getUniqueId())) {
       return;
     }
-    String set = "draft_content = null, draft_content_format = 0";
+    String set = "draft_content = null, draft_content_format = 0, "
+        + "draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null";
     SqlUtils where = new SqlUtils().add("content_unique_id = ?", record.getUniqueId());
     if (DB.update(TABLE_NAME, set, where)) {
       CacheManager.invalidateKey(CacheManager.CONTENT_UNIQUE_ID_CACHE, record.getUniqueId());
@@ -202,6 +217,12 @@ public class ContentRepository {
       }
       if (DB.hasColumn(rs, "draft_content_format")) {
         record.setDraftContentFormat(rs.getInt("draft_content_format"));
+      }
+      if (DB.hasColumn(rs, "draft_status")) {
+        record.setDraftStatus(rs.getString("draft_status"));
+        record.setSubmittedBy(rs.getLong("submitted_by"));
+        record.setApprovedBy(rs.getLong("approved_by"));
+        record.setReleaseReference(rs.getString("release_reference"));
       }
       if (DB.hasColumn(rs, "highlight")) {
         record.setHighlight(rs.getString("highlight"));

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -140,6 +140,10 @@ CREATE TABLE content (
   draft_content TEXT,
   content_format INTEGER NOT NULL DEFAULT 0,
   draft_content_format INTEGER NOT NULL DEFAULT 0,
+  draft_status VARCHAR(20),
+  submitted_by BIGINT DEFAULT -1,
+  approved_by BIGINT DEFAULT -1,
+  release_reference VARCHAR(255),
   content_text TEXT,
   tsv TSVECTOR
 );

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1002__content_review_workflow.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1002__content_review_workflow.sql
@@ -1,0 +1,10 @@
+-- Governed publish path (Project #6, Phase 1): the review-workflow state on a content draft.
+-- draft_status moves draft -> submitted -> (approved & published | rejected); submitted_by and
+-- approved_by name the two people the separation-of-duties control keeps distinct; release_reference
+-- records the release authority ("cleared per case ..."). Defaults leave existing content in the
+-- unsubmitted state, so nothing changes until content is submitted through the workflow. These are the
+-- current-state snapshot; the durable who/when record is the append-only audit trail.
+ALTER TABLE content ADD COLUMN IF NOT EXISTS draft_status VARCHAR(20);
+ALTER TABLE content ADD COLUMN IF NOT EXISTS submitted_by BIGINT DEFAULT -1;
+ALTER TABLE content ADD COLUMN IF NOT EXISTS approved_by BIGINT DEFAULT -1;
+ALTER TABLE content ADD COLUMN IF NOT EXISTS release_reference VARCHAR(255);

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.Content;
+
+/**
+ * Tests the governed publish state machine, with emphasis on the two load-bearing controls:
+ * separation of duties (approver != submitter) and publish-gated-on-approval.
+ *
+ * @author elizabeth houser
+ */
+class ContentReviewCommandTest {
+
+  private static final long AUTHOR = 10L;
+  private static final long APPROVER = 20L;
+
+  private static Content draft() {
+    Content content = new Content();
+    content.setUniqueId("page-block");
+    content.setDraftContent("<p>proposed change</p>");
+    return content;
+  }
+
+  @Test
+  void submitMovesDraftToSubmitted() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.STATUS_SUBMITTED, content.getDraftStatus());
+    assertEquals(AUTHOR, content.getSubmittedBy());
+    assertTrue(ContentReviewCommand.isPendingReview(content));
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void submitRequiresADraft() {
+    Content content = new Content(); // no draft content
+    assertThrows(DataException.class, () -> ContentReviewCommand.submitForReview(content, AUTHOR));
+  }
+
+  @Test
+  void approveBySomeoneElseRecordsApproverAndReference() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.approve(content, APPROVER, "  cleared per PA case 2026-114  ");
+    assertEquals(APPROVER, content.getApprovedBy());
+    assertEquals("cleared per PA case 2026-114", content.getReleaseReference()); // trimmed
+    assertTrue(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void theSubmitterCannotApproveTheirOwnContent() throws DataException {
+    // Separation of duties (AC-5) -- the heart of the control. Enforced on the data, not the role, so
+    // it holds even if the author also holds the approver role.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    DataException e = assertThrows(DataException.class,
+        () -> ContentReviewCommand.approve(content, AUTHOR, "self-approved"));
+    assertTrue(e.getMessage().toLowerCase().contains("separation of duties"), e.getMessage());
+    // The content is not approved by the failed attempt.
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void aDraftThatWasNotSubmittedCannotBeApproved() {
+    // Publish-gated-on-approval: nothing can be approved (and thus published) without first being
+    // submitted for review -- no bypass of the workflow.
+    Content content = draft();
+    assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, APPROVER, null));
+    assertFalse(ContentReviewCommand.isApproved(content));
+  }
+
+  @Test
+  void rejectSendsItBackToTheAuthor() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.reject(content, APPROVER);
+    assertEquals(ContentReviewCommand.STATUS_DRAFT, content.getDraftStatus());
+    assertFalse(ContentReviewCommand.isApproved(content));
+    assertFalse(ContentReviewCommand.isPendingReview(content));
+  }
+
+  @Test
+  void theSubmitterCannotRejectTheirOwnContent() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertThrows(DataException.class, () -> ContentReviewCommand.reject(content, AUTHOR));
+  }
+
+  @Test
+  void approvalRequiresAValidApprover() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, -1L, null));
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -199,6 +199,10 @@ class ContentRepositoryTest {
           + "draft_content TEXT, "
           + "content_format INTEGER NOT NULL DEFAULT 0, "
           + "draft_content_format INTEGER NOT NULL DEFAULT 0, "
+          + "draft_status VARCHAR(20), "
+          + "submitted_by BIGINT DEFAULT -1, "
+          + "approved_by BIGINT DEFAULT -1, "
+          + "release_reference VARCHAR(255), "
           + "created_by BIGINT, "
           + "modified_by BIGINT, "
           + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
@@ -206,6 +210,50 @@ class ContentRepositoryTest {
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the content schema", se);
     }
+  }
+
+  @Test
+  void reviewWorkflowFieldsRoundTrip() {
+    // A submitted-and-approved draft persists its review state (P1). submitted_by != approved_by is
+    // the separation-of-duties data the audit evidence rests on, so prove it survives a save/reload.
+    Content content = new Content();
+    content.setUniqueId("under-review");
+    content.setContent("<p>live</p>");
+    content.setDraftContent("<p>proposed</p>");
+    content.setDraftStatus("submitted");
+    content.setSubmittedBy(10L);
+    content.setApprovedBy(20L);
+    content.setReleaseReference("cleared per PA case 2026-114");
+    ContentRepository.save(content);
+
+    Content reloaded = ContentRepository.findByUniqueId("under-review");
+    assertNotNull(reloaded);
+    assertEquals("submitted", reloaded.getDraftStatus());
+    assertEquals(10L, reloaded.getSubmittedBy());
+    assertEquals(20L, reloaded.getApprovedBy());
+    assertEquals("cleared per PA case 2026-114", reloaded.getReleaseReference());
+  }
+
+  @Test
+  void publishClearsTheReviewWorkflow() {
+    // Publishing consumes the draft, so its workflow state resets; the durable record is the audit trail.
+    Content content = new Content();
+    content.setUniqueId("to-publish");
+    content.setDraftContent("<p>approved draft</p>");
+    content.setDraftStatus("submitted");
+    content.setSubmittedBy(10L);
+    content.setApprovedBy(20L);
+    content.setReleaseReference("cleared per PA case 2026-115");
+    ContentRepository.save(content);
+
+    ContentRepository.publish(content);
+
+    Content published = ContentRepository.findByUniqueId("to-publish");
+    assertEquals("<p>approved draft</p>", published.getContent(), "the draft became the live content");
+    assertNull(published.getDraftStatus());
+    assertEquals(-1L, published.getSubmittedBy());
+    assertEquals(-1L, published.getApprovedBy());
+    assertNull(published.getReleaseReference());
   }
 
   private static Content addContent(String uniqueId, String html) {


### PR DESCRIPTION
Second slice of **Visual Editor P1** (#256) — the persistence behind the governed-publish state machine (#285).

> **Stacked on #285** (the state machine adds the `Content` fields). Review #285 first; this is the last commit. Rebases onto `main` once it merges.

## What this lands

- **Schema** — `draft_status`, `submitted_by`, `approved_by`, `release_reference` on the `content` table, in the fresh-install DDL and an idempotent `ADD COLUMN IF NOT EXISTS` migration. Defaults leave existing content in the unsubmitted state, so **nothing changes until content moves through the workflow**.
- **Repository** — insert/update carry the four fields; `buildRecord` reads them (`DB.hasColumn`-guarded, same idiom as the format columns); **publish and `removeDraft` clear them** — the draft that carried the workflow is consumed, and the durable who/when/authority record is the **append-only audit trail**, not a mutable content column.

## Tests

`ContentRepositoryTest` gains the four columns in its focused schema (so inserts don't hit "column does not exist" — the failure mode #281 caught) plus two round-trip tests, both against **Testcontainers Postgres**:
- a submitted+approved draft persists its state — including `submitted_by != approved_by`, the separation-of-duties data the audit evidence rests on
- **publish resets the workflow** to a clean state

**6/6 green locally.**

## Next in P1

The transition actions (submit/approve/reject) wired to persistence + the audit record at each step, the publish path made to *require* `isApproved()`, and the admin-screen UI. This slice is the substrate.
