### PR TITLE
Visual Editor P1: governed-publish workflow + gate (opt-in, strict when on)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.cms.Content;
@@ -414,10 +416,18 @@ public class ContentHtmlCommand {
       return context;
     }
 
-    // Determine the action
+    // Determine the action. Governed publishing (Project #6, Phase 1) adds the review workflow; the
+    // gate is enforced only when the site has opted in via content.review.required.
     String action = context.getParameter("action");
+    boolean reviewRequired = LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required");
     if ("publish".equals(action)) {
-      return publishContent(context, content);
+      return publishContent(context, content, reviewRequired);
+    } else if ("submitForReview".equals(action)) {
+      return submitForReview(context, content);
+    } else if ("approve".equals(action)) {
+      return approveContent(context, content);
+    } else if ("reject".equals(action)) {
+      return rejectContent(context, content);
     } else if ("deleteContent".equals(action)) {
       return deleteContent(context, content);
     }
@@ -425,11 +435,65 @@ public class ContentHtmlCommand {
     return context;
   }
 
-  private static WidgetContext publishContent(WidgetContext context, Content content) {
-    if (StringUtils.isNotBlank(content.getDraftContent())) {
-      ContentRepository.publish(content);
-      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.SUCCESS,
+  private static WidgetContext publishContent(WidgetContext context, Content content, boolean reviewRequired) {
+    if (StringUtils.isBlank(content.getDraftContent())) {
+      return context;
+    }
+    // The gate: with governed publishing on, an unapproved draft cannot be published directly -- the
+    // only path to live is submit -> approve. With it off, this is the direct publish it always was.
+    if (!ContentReviewCommand.mayPublish(content, reviewRequired)) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+          "content", String.valueOf(content.getId()), content.getUniqueId(), "blocked: draft not approved for release");
+      context.setErrorMessage("This content must be submitted for review and approved before it can be published");
+      return context;
+    }
+    ContentRepository.publish(content);
+    AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.SUCCESS,
+        "content", String.valueOf(content.getId()), content.getUniqueId(), null);
+    return context;
+  }
+
+  private static WidgetContext submitForReview(WidgetContext context, Content content) {
+    try {
+      ContentReviewCommand.submitForReview(content, context.getUserId());
+      ContentRepository.save(content);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.submit", AuditEventCommand.SUCCESS,
           "content", String.valueOf(content.getId()), content.getUniqueId(), null);
+      context.setSuccessMessage("The content was submitted for review");
+    } catch (DataException e) {
+      context.setErrorMessage(e.getMessage());
+    }
+    return context;
+  }
+
+  private static WidgetContext approveContent(WidgetContext context, Content content) {
+    String releaseReference = context.getParameter("releaseReference");
+    try {
+      // approve() enforces separation of duties (the approver cannot be the submitter); approval then
+      // promotes the draft to live and records the named approver + release authority in the audit trail.
+      ContentReviewCommand.approve(content, context.getUserId(), releaseReference);
+      ContentRepository.publish(content);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.approve", AuditEventCommand.SUCCESS,
+          "content", String.valueOf(content.getId()), content.getUniqueId(),
+          StringUtils.isNotBlank(releaseReference) ? "release authority: " + releaseReference : null);
+      context.setSuccessMessage("The content was approved and published");
+    } catch (DataException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.approve", AuditEventCommand.FAILURE,
+          "content", String.valueOf(content.getId()), content.getUniqueId(), e.getMessage());
+      context.setErrorMessage(e.getMessage());
+    }
+    return context;
+  }
+
+  private static WidgetContext rejectContent(WidgetContext context, Content content) {
+    try {
+      ContentReviewCommand.reject(content, context.getUserId());
+      ContentRepository.save(content);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.reject", AuditEventCommand.SUCCESS,
+          "content", String.valueOf(content.getId()), content.getUniqueId(), null);
+      context.setSuccessMessage("The content was returned to the author");
+    } catch (DataException e) {
+      context.setErrorMessage(e.getMessage());
     }
     return context;
   }

--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -108,6 +108,22 @@ public class ContentReviewCommand {
     return isPendingReview(content) && content.getApprovedBy() > 0;
   }
 
+  /**
+   * The publish gate. When governed publishing is not enabled ({@code reviewRequired} false) a draft may
+   * be published directly, as it always could -- backward compatible. When it is enabled, only an
+   * approved draft may go live, and there is no other path: this is the enforcement of the "no
+   * visual-editor bypass" rule, so hot-editing a live page cannot skip review.
+   *
+   * @param reviewRequired the {@code content.review.required} site setting
+   * @return whether this content may be published now
+   */
+  public static boolean mayPublish(Content content, boolean reviewRequired) {
+    if (!reviewRequired) {
+      return true;
+    }
+    return isApproved(content);
+  }
+
   private static void requireSubmitted(Content content) throws DataException {
     if (!isPendingReview(content)) {
       throw new DataException("Only a draft submitted for review can be approved or rejected");

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -41,6 +41,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (23, 'Show cart?', 'site.cart', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (24, 'Allow registrations?', 'site.registrations', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (26, 'Show login?', 'site.login', 'false', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (27, 'Require review approval before publishing content', 'content.review.required', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (30, 'Header line 1', 'site.header.line1', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (31, 'Header link name', 'site.header.link', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (32, 'Header details page', 'site.header.page', '', 'web-page');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1003__content_review_required.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260724.1003__content_review_required.sql
@@ -1,0 +1,7 @@
+-- Governed publish path (Project #6, Phase 1): the site-wide switch for mandatory review approval.
+-- Default 'false' -- existing sites keep publishing directly, so this changes nothing on upgrade. An
+-- ISSM turns it on as a conscious, auditable governance decision; when on, only an approved draft may
+-- be published and there is no bypass (enforced in ContentReviewCommand.mayPublish / ContentHtmlCommand).
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (27, 'Require review approval before publishing content', 'content.review.required', 'false', 'boolean')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -115,4 +115,26 @@ class ContentReviewCommandTest {
     ContentReviewCommand.submitForReview(content, AUTHOR);
     assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, -1L, null));
   }
+
+  @Test
+  void publishGateIsOpenWhenReviewIsNotRequired() throws DataException {
+    // Backward compatible: with governed publishing off, any draft state may publish directly.
+    Content content = draft();
+    assertTrue(ContentReviewCommand.mayPublish(content, false));
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertTrue(ContentReviewCommand.mayPublish(content, false));
+  }
+
+  @Test
+  void publishGateRequiresApprovalWhenReviewIsRequired() throws DataException {
+    Content content = draft();
+    // A brand-new draft that was never submitted cannot publish under review.
+    assertFalse(ContentReviewCommand.mayPublish(content, true));
+    // Submitted but not yet approved: still blocked -- no bypass.
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertFalse(ContentReviewCommand.mayPublish(content, true));
+    // Approved by a different person: the gate opens.
+    ContentReviewCommand.approve(content, APPROVER, null);
+    assertTrue(ContentReviewCommand.mayPublish(content, true));
+  }
 }


### PR DESCRIPTION
Third slice of **Visual Editor P1** (#256) — the review workflow wired into the content actions, and the publish gate. Implements the rollout we agreed: **opt-in (default off), strict when on, switch-audited, site-wide.**

> #285 and #286 have merged; rebased onto `main` — the diff is the governed-publish commit alone.

## What this lands

- **The gate logic** — `ContentReviewCommand.mayPublish(content, reviewRequired)`. Off → publish directly, as always (backward compatible). On → **only an approved draft may go live, no bypass**. Pure and unit-tested.
- **The switch** — a `content.review.required` site property (default `false`), seeded + migrated. Existing deployments are **unchanged** until an ISSM enables it — a conscious, auditable governance decision, which is the stronger AC.L1-b.1.iv evidence (the org chose to govern, on a date, in the record).
- **The actions** — `performWebAction` gains **submit / approve / reject**, each recording an append-only audit event (`content.submit` / `.approve` / `.reject`). Publish now honors the gate. **`approve` enforces separation of duties** (the approver can't be the submitter) and, on success, promotes the draft to live with the **named approver + release authority** captured in the tamper-evident audit trail. A blocked publish records a `FAILURE` event.

## Safety

With the setting **off (the default), behavior is identical to today** — a content-manager publishes directly. Nothing changes on any existing deployment until governed publishing is deliberately turned on.

## ⚠️ Sequencing note

The actions are URL-triggered today (`?action=submitForReview|approve|reject`), like the existing publish/delete. The **admin-screen buttons + the release-authority field are the immediate next slice** — so the setting should stay off in production until that UI lands, or an operator would have the gate on with no button to submit/approve through.

## Tests

`ContentReviewCommandTest` is now 10 (adds the gate open-when-off / closed-until-approved-when-on cases); `ContentRepositoryTest` round-trips the workflow state. Clean `ant compile`. The action handlers are presentation glue in the established `publishContent`/`deleteContent` style; the compliance logic they call (SoD, the gate) is the tested part.

## Rest of P1

The admin-screen UI (submit/approve/reject buttons + release-authority field + a review queue), and scheduled publish/unpublish.

