### PR TITLE
Visual Editor P0: wire the content-edit gates to the editor permission check

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -82,7 +82,7 @@ public class ContentHtmlCommand {
       if (content != null) {
         html = toHtml(content.getContent(), content.getContentFormat());
         // Look for draft content
-        if (context.hasRole("admin") || context.hasRole("content-manager")) {
+        if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
           if (content.getDraftContent() != null) {
             html = toHtml(content.getDraftContent(), content.getDraftContentFormat());
             context.getRequest().setAttribute("isDraft", "true");
@@ -105,7 +105,7 @@ public class ContentHtmlCommand {
     html = embedInlineContent(context, html);
 
     // Display a button for admins to add content
-    boolean hasEditorPermission = (context.hasRole("admin") || context.hasRole("content-manager"));
+    boolean hasEditorPermission = EditorPermissionCommand.canEditContent(context.getUserSession());
     if (uniqueId != null && html == null) {
       if (hasEditorPermission) {
         html = "<a class=\"button tiny radius primary\" href=\"" + context.getContextPath()
@@ -156,7 +156,7 @@ public class ContentHtmlCommand {
       return html;
     }
 
-    boolean hasEditorPermission = (context.hasRole("admin") || context.hasRole("content-manager"));
+    boolean hasEditorPermission = EditorPermissionCommand.canEditContent(context.getUserSession());
     boolean hasDraftContent = false;
     int endUniqueIdx;
 
@@ -336,7 +336,7 @@ public class ContentHtmlCommand {
     }
 
     // Determine editing, links, settings
-    boolean hasEditorPermission = (context.hasRole("admin") || context.hasRole("content-manager"));
+    boolean hasEditorPermission = EditorPermissionCommand.canEditContent(context.getUserSession());
     String returnPage = context.getUri();
     String contentEditorLink = "";
     if (hasEditorPermission) {
@@ -392,7 +392,7 @@ public class ContentHtmlCommand {
 
   public static WidgetContext performWebAction(WidgetContext context) {
     // Permission is required
-    if (!(context.hasRole("admin") || context.hasRole("content-manager"))) {
+    if (!EditorPermissionCommand.canEditContent(context.getUserSession())) {
       LOG.warn("No permission found");
       return context;
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentAccordionWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentAccordionWidget.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.domain.model.cms.AccordionSection;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -44,7 +45,7 @@ public class ContentAccordionWidget extends GenericWidget {
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentCardsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentCardsWidget.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -43,7 +44,7 @@ public class ContentCardsWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentCarouselWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentCarouselWidget.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -44,7 +45,7 @@ public class ContentCarouselWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentGalleryWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentGalleryWidget.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -43,7 +44,7 @@ public class ContentGalleryWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentRevealWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentRevealWidget.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -43,7 +44,7 @@ public class ContentRevealWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentSliderWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentSliderWidget.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -43,7 +44,7 @@ public class ContentSliderWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentTabsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentTabsWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
@@ -68,7 +69,7 @@ public class ContentTabsWidget extends GenericWidget {
       }
 
       if (StringUtils.isBlank(html)) {
-        if (context.hasRole("admin") || context.hasRole("content-manager")) {
+        if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
           html = "<a class=\"button tiny radius primary\" href=\"" + context.getContextPath() + "/content-editor?uniqueId=" + contentTab.getContentUniqueId() + "&returnPage=" + context.getUri() + "\"><i class=\"fa fa-edit\"></i> Add Content Here</a>";
         }
       }
@@ -83,7 +84,7 @@ public class ContentTabsWidget extends GenericWidget {
       return null;
     }
 
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -64,7 +65,7 @@ public class ContentWidget extends GenericWidget {
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
     // Determine if the editor button is shown
-    if (context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (EditorPermissionCommand.canEditContent(context.getUserSession())) {
       context.getRequest().setAttribute("showEditor", "true");
       context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
     }


### PR DESCRIPTION
Completes **Visual Editor P0** (#255) — the permission wiring sweep, now unblocked by #282 landing `EditorPermissionCommand` on `main`. Clean on current `main`, no stack.

## What changed — 13 content-edit gates

The scattered `hasRole("admin") || hasRole("content-manager")` checks that guard **content editing** now call `EditorPermissionCommand.canEditContent(...)`, so the builder-vs-editor split has one enforcement point instead of thirteen copies:

- `ContentHtmlCommand` ×5 — draft-content visibility, the "Add Content Here" button, the inline editor, the reveal-card editor link, and the **action handler** (which now also guards P1's submit/approve/reject — correct: approving is content-tier, and separation of duties is enforced independently inside `ContentReviewCommand`)
- The eight content widgets ×1 each — `Content`, `ContentAccordion`, `ContentCards`, `ContentCarousel`, `ContentGallery`, `ContentReveal`, `ContentSlider`, `ContentTabs` — all "show the edit button" affordances

## Why this is non-breaking

`canEditContent` grants `admin`, `content-manager`, **and** `content-editor` — a strict **superset** of the old check (covered by `EditorPermissionCommandTest`, 6/6). Every user who could edit content before still can; the only change is that the new `content-editor` tier — which **nobody holds yet** — would also pass. Behavior on every existing deployment is identical.

## Deliberately NOT swept (the surgical part)

These matched the same text pattern but guard **different resources**, so a blind rename would have handed content-editors doors the tier was never meant to open:

| Left alone | Why |
|---|---|
| `BlogPostWidget`, `BlogPostListWidget` | unpublished blog-post visibility — a different resource |
| `WikiWidget` | has its own three-role model (adds `community-manager`) |
| `MenuWidget`, `TableOfContentsWidget` | site structure/navigation, not content blocks |
| `SearchInfoWidget` | search diagnostics |
| calendar / cart / folder / admin widgets | unrelated domains entirely |

Extending the editor tier to any of those is a **product decision**, not a mechanical substitution — deliberately out of scope here.

## Verification

Clean `ant compile`; `EditorPermissionCommandTest` 6/6 (the superset property that makes this safe). With this, **P0 is complete**: content model, render dispatch, persistence, write-path, permission split — and now the wiring.
