### PR TITLE
Visual Editor P1: review affordances on the content page [stacked on #287]

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -89,6 +89,9 @@ public class ContentHtmlCommand {
             html = toHtml(content.getDraftContent(), content.getDraftContentFormat());
             context.getRequest().setAttribute("isDraft", "true");
           }
+          // Which review affordance to render, decided here rather than in a JSP expression
+          context.getRequest().setAttribute("reviewOffer", ContentReviewCommand.offerFor(content,
+              context.getUserId(), LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required")));
         }
       }
     }

--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -124,6 +124,45 @@ public class ContentReviewCommand {
     return isApproved(content);
   }
 
+  /**
+   * Which review action the given viewer should be offered for this content, so the decision lives here
+   * rather than in a JSP expression. Returns one of the {@code OFFER_*} constants.
+   *
+   * <p>The separation-of-duties rule is reflected in the UI as well as enforced on the action: a
+   * submitter looking at their own pending draft is told it is awaiting someone else, never offered the
+   * approve button. Offering a button the action would reject is a worse experience and a worse control
+   * story than not offering it.
+   */
+  public static String offerFor(Content content, long viewerId, boolean reviewRequired) {
+    if (content == null || StringUtils.isBlank(content.getDraftContent())) {
+      return OFFER_NONE;
+    }
+    if (!reviewRequired) {
+      // Ungoverned: the classic direct-publish affordance.
+      return OFFER_PUBLISH;
+    }
+    if (!isPendingReview(content)) {
+      // A draft that has not been submitted yet -- its author sends it for review.
+      return OFFER_SUBMIT;
+    }
+    if (viewerId > 0 && viewerId == content.getSubmittedBy()) {
+      // Pending, but this viewer submitted it: they cannot decide their own submission.
+      return OFFER_AWAITING_OTHER;
+    }
+    return OFFER_DECIDE;
+  }
+
+  /** No draft, so nothing to offer. */
+  public static final String OFFER_NONE = "none";
+  /** Governed publishing is off: offer the direct publish button. */
+  public static final String OFFER_PUBLISH = "publish";
+  /** A draft not yet submitted: offer "submit for review". */
+  public static final String OFFER_SUBMIT = "submit";
+  /** Pending review, viewed by its submitter: show status only (separation of duties). */
+  public static final String OFFER_AWAITING_OTHER = "awaiting";
+  /** Pending review, viewed by someone else: offer approve / reject. */
+  public static final String OFFER_DECIDE = "decide";
+
   private static void requireSubmitted(Content content) throws DataException {
     if (!isPendingReview(content)) {
       throw new DataException("Only a draft submitted for review can be approved or rejected");

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -27,9 +27,25 @@
 <div class="platform-content-container">
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
-      <c:if test="${isDraft eq 'true'}">
-        <a class="hollow button small warning" href="${widgetContext.uri}?action=publish&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Publish this content?');">DRAFT</a>
-      </c:if>
+      <%-- The review affordance is chosen by ContentReviewCommand.offerFor(), so separation of duties
+           is reflected here as well as enforced on the action: a submitter is never shown Approve. --%>
+      <c:choose>
+        <c:when test="${reviewOffer eq 'publish'}">
+          <c:if test="${isDraft eq 'true'}">
+            <a class="hollow button small warning" href="${widgetContext.uri}?action=publish&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Publish this content?');">DRAFT</a>
+          </c:if>
+        </c:when>
+        <c:when test="${reviewOffer eq 'submit'}">
+          <a class="hollow button small warning" href="${widgetContext.uri}?action=submitForReview&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Submit this content for review?');">SUBMIT FOR REVIEW</a>
+        </c:when>
+        <c:when test="${reviewOffer eq 'awaiting'}">
+          <span class="label warning" title="Another reviewer must approve this change">AWAITING REVIEW</span>
+        </c:when>
+        <c:when test="${reviewOffer eq 'decide'}">
+          <a class="hollow button small success" href="${widgetContext.uri}?action=approve&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Approve and publish this content?');">APPROVE</a>
+          <a class="hollow button small alert" href="${widgetContext.uri}?action=reject&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Return this content to the author?');">REJECT</a>
+        </c:when>
+      </c:choose>
       <a class="hollow button small secondary" href="${ctx}/content-editor?uniqueId=${uniqueId}&returnPage=${returnPage}"><i class="${font:fas()} fa-edit"></i></a>
     </div>
   </c:if>

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -126,6 +126,40 @@ class ContentReviewCommandTest {
   }
 
   @Test
+  void offerIsNoneWithoutADraft() {
+    Content published = new Content();
+    published.setContent("<p>live</p>");
+    assertEquals(ContentReviewCommand.OFFER_NONE, ContentReviewCommand.offerFor(published, AUTHOR, true));
+    assertEquals(ContentReviewCommand.OFFER_NONE, ContentReviewCommand.offerFor(null, AUTHOR, true));
+  }
+
+  @Test
+  void offerIsDirectPublishWhenReviewIsNotRequired() {
+    assertEquals(ContentReviewCommand.OFFER_PUBLISH, ContentReviewCommand.offerFor(draft(), AUTHOR, false));
+  }
+
+  @Test
+  void offerIsSubmitForAnUnsubmittedDraftUnderReview() {
+    assertEquals(ContentReviewCommand.OFFER_SUBMIT, ContentReviewCommand.offerFor(draft(), AUTHOR, true));
+  }
+
+  @Test
+  void theSubmitterIsNotOfferedTheApproveButtonForTheirOwnDraft() throws DataException {
+    // Separation of duties reflected in the UI: the author sees "awaiting review", not approve/reject.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.OFFER_AWAITING_OTHER,
+        ContentReviewCommand.offerFor(content, AUTHOR, true));
+  }
+
+  @Test
+  void anotherReviewerIsOfferedTheDecision() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.OFFER_DECIDE, ContentReviewCommand.offerFor(content, APPROVER, true));
+  }
+
+  @Test
   void publishGateRequiresApprovalWhenReviewIsRequired() throws DataException {
     Content content = draft();
     // A brand-new draft that was never submitted cannot publish under review.


### PR DESCRIPTION
Fourth slice of **Visual Editor P1** (#256) — the review affordances on the page, so the governed publish path is *usable*. This is the piece that makes it safe to actually turn `content.review.required` on.

> **Stacked on #287** (the workflow + gate). Review that first; this is the last commit.

## The design decision: the state machine picks the button, not the JSP

`ContentReviewCommand.offerFor(content, viewerId, reviewRequired)` returns which affordance to show, so the workflow logic stays in tested Java instead of an untestable `<c:when>` expression chain:

| Offer | Shown when | UI |
|---|---|---|
| `publish` | governed publishing **off** | the classic DRAFT/publish button (unchanged) |
| `submit` | draft not yet submitted | **SUBMIT FOR REVIEW** |
| `awaiting` | pending, **viewed by its submitter** | *AWAITING REVIEW* label — no buttons |
| `decide` | pending, viewed by anyone else | **APPROVE** / **REJECT** |
| `none` | no draft | nothing |

**Separation of duties is reflected in the UI, not just enforced on the action.** An author never sees Approve on their own submission — offering a button the action would reject is both a worse experience and a worse control story.

## Safety

With the setting **off (the default)**, `offerFor` returns `publish` and the page renders exactly as it does today.

## Tests — 15 (5 new), all green

the five offer states, including **the submitter is not offered approve** and **another reviewer is** · plus the existing workflow + gate coverage. Clean `ant compile`; the `unescaped-el` gate passes (0 unallowlisted — the new EL is framework-controlled values only).

## Still to come in P1

The release-authority input (belongs on the editor form, so an approver can type "cleared per case…" — the backend already accepts and audits it), a review queue for approvers, and scheduled publish/unpublish.
