### PR TITLE
Visual Editor P1: close the direct-publish bypass [stacked on #289]

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -152,6 +152,16 @@ public class ContentReviewCommand {
     return OFFER_DECIDE;
   }
 
+  /**
+   * Whether a save may publish straight to the live page, skipping review. When governed publishing is
+   * on the answer is always no: the only route to live is submit → approve, so an editor's Save /
+   * Publish Immediately button degrades to a draft save rather than becoming a bypass. Hot-editing a
+   * live page is exactly the hole that would otherwise defeat the whole control.
+   */
+  public static boolean mayPublishDirectly(boolean reviewRequired) {
+    return !reviewRequired;
+  }
+
   /** No draft, so nothing to offer. */
   public static final String OFFER_NONE = "none";
   /** Governed publishing is off: offer the direct publish button. */

--- a/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.application.cms;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
 import org.apache.commons.logging.Log;
@@ -37,6 +38,15 @@ public class SaveContentCommand {
 
     if (contentHtml == null) {
       throw new DataException("Content is required");
+    }
+
+    // Governed publishing: a direct save can never write straight to the live page. This is enforced
+    // here, at the single save chokepoint, so no caller -- editor form, API, or a future one -- can
+    // bypass review by asking to publish. The request degrades to a draft save.
+    if (publish && !ContentReviewCommand
+        .mayPublishDirectly(LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required"))) {
+      LOG.debug("Governed publishing is enabled; saving as a draft for review instead of publishing");
+      publish = false;
     }
 
     // Clean the content

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
@@ -19,6 +19,8 @@ package com.simisinc.platform.presentation.widgets.cms;
 import org.apache.commons.lang3.StringUtils;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.DateCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
@@ -134,8 +136,23 @@ public class ContentEditorWidget extends GenericWidget {
       publish = false;
       LOG.debug("Saving as draft...");
     }
+    // With governed publishing on there is no direct-publish path: the save becomes a draft awaiting
+    // review. SaveContentCommand enforces this regardless; mirroring the decision here keeps the audit
+    // event and the message the author sees truthful about what actually happened.
+    boolean publishWasGated = false;
+    if (publish && !ContentReviewCommand
+        .mayPublishDirectly(LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required"))) {
+      publish = false;
+      publishWasGated = true;
+    }
     try {
       Content content = SaveContentCommand.saveSafeContent(uniqueId, contentHtml, context.getUserId(), publish);
+      if (publishWasGated && content != null) {
+        // A publish was requested and refused: record the gated attempt and tell the author what to do.
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+            "content", String.valueOf(content.getId()), uniqueId, "gated: saved as a draft for review");
+        context.setSuccessMessage("Saved as a draft. This site requires review approval before publishing.");
+      }
       if (content == null) {
         LOG.warn("Content record was not saved!");
         if (publish) {

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -126,6 +126,14 @@ class ContentReviewCommandTest {
   }
 
   @Test
+  void directPublishIsUnavailableWhenReviewIsRequired() {
+    // The bypass that would otherwise defeat the whole control: an editor's Save / Publish Immediately
+    // must not write straight to the live page when governed publishing is on.
+    assertTrue(ContentReviewCommand.mayPublishDirectly(false), "ungoverned sites publish directly as before");
+    assertFalse(ContentReviewCommand.mayPublishDirectly(true), "governed sites have no direct-publish path");
+  }
+
+  @Test
   void offerIsNoneWithoutADraft() {
     Content published = new Content();
     published.setContent("<p>live</p>");


### PR DESCRIPTION
🔒 **Closes a control bypass in the governed publish path** — found while building the review UI, before any of this shipped enabled.

> **Stacked on #289 → #287.** Review those first. **These should land together**: #287 introduces the gate, and this closes the hole in it.

## The bypass

`ContentEditorWidget.post()` publishes by default (`publish = true` unless "Save as Draft") straight through `SaveContentCommand.saveSafeContent`, which **never consulted `content.review.required`**. So with governed publishing ON, anyone who could edit content could still hit **Save** or **Publish Immediately** in the editor and write directly to the live page — skipping submit → approve entirely.

That is precisely the failure mode the scoping study names: *"hot-editing a live page silently defeats the entire control."* The gate in #287 covered the publish **action**; it did not cover the editor's **save** path.

## The fix — enforced at the chokepoint, mirrored for honesty

- **`ContentReviewCommand.mayPublishDirectly(reviewRequired)`** — names the rule: when governed publishing is on there is **no** direct-publish route; the only path to live is submit → approve.
- **`SaveContentCommand.saveSafeContent`** enforces it at the **single save chokepoint**, so no caller — editor form, REST, or any future one — can bypass review by asking to publish. The request **degrades to a draft save**.
- **`ContentEditorWidget`** mirrors the decision so the author is told the truth (*"Saved as a draft. This site requires review approval before publishing."*) and the **gated attempt is audited** (`content.publish` / FAILURE / `gated: saved as a draft for review`) rather than silently recorded as a publish.

## Coverage — all three publish paths now gated

| Path | Gate |
|---|---|
| publish **action** (content page) | `mayPublish` (#287) |
| **save** (editor form: Save / Publish Immediately) | `mayPublishDirectly` — **this PR** |
| approve → publish | goes through the workflow by construction |

## Safety

With the setting **off (the default)** `mayPublishDirectly` returns true and every path behaves exactly as it does today. No deployment is affected; the hole existed only for sites that would have turned governed publishing on.

## Tests — 16 (1 new), all green

the direct-publish rule both ways · plus the full workflow, SoD, gate and offer coverage. Clean `ant compile`.
