### PR TITLE
Visual Editor P1: release-authority input on approval [stacked on #290]

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -80,9 +80,19 @@ public class ContentReviewCommand {
   public static void approve(Content content, long approverId, String releaseReference) throws DataException {
     requireSubmitted(content);
     requireApproverIsNotSubmitter(content, approverId);
+    String reference = StringUtils.trimToNull(releaseReference);
+    // The column is VARCHAR(255); reject an over-long value rather than letting the database throw
+    // mid-approval, which would leave the approver without a clear reason.
+    if (reference != null && reference.length() > MAX_RELEASE_REFERENCE_LENGTH) {
+      throw new DataException(
+          "The release authority reference must be " + MAX_RELEASE_REFERENCE_LENGTH + " characters or fewer");
+    }
     content.setApprovedBy(approverId);
-    content.setReleaseReference(StringUtils.trimToNull(releaseReference));
+    content.setReleaseReference(reference);
   }
+
+  /** Matches the {@code release_reference} column width. */
+  public static final int MAX_RELEASE_REFERENCE_LENGTH = 255;
 
   /**
    * An approver rejects a submitted draft, sending it back to the author to revise and resubmit.

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -42,7 +42,20 @@
           <span class="label warning" title="Another reviewer must approve this change">AWAITING REVIEW</span>
         </c:when>
         <c:when test="${reviewOffer eq 'decide'}">
-          <a class="hollow button small success" href="${widgetContext.uri}?action=approve&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Approve and publish this content?');">APPROVE</a>
+          <%-- The release-authority reference travels with the approval and is recorded in the audit
+               trail ("cleared per PA case ...", "CO email dated ..."), which is what makes the trail
+               exportable assessment evidence rather than just a timestamp. A GET form produces the
+               same request shape as the action links beside it. --%>
+          <form method="get" action="${widgetContext.uri}" class="platform-content-review-form">
+            <input type="hidden" name="action" value="approve"/>
+            <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+            <input type="hidden" name="token" value="${userSession.formToken}"/>
+            <input type="text" name="releaseReference" maxlength="255"
+                   placeholder="Release authority (e.g. cleared per PA case 2026-114)"
+                   title="Optional: the approval authority to record in the audit trail"/>
+            <button type="submit" class="hollow button small success"
+                    onclick="return confirm('Approve and publish this content?');">APPROVE</button>
+          </form>
           <a class="hollow button small alert" href="${widgetContext.uri}?action=reject&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Return this content to the author?');">REJECT</a>
         </c:when>
       </c:choose>

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -126,6 +126,22 @@ class ContentReviewCommandTest {
   }
 
   @Test
+  void anOverlongReleaseReferenceIsRejectedNotTruncated() throws DataException {
+    // The column is VARCHAR(255). Fail with a clear message rather than letting the database throw
+    // mid-approval -- and never silently truncate an authority reference that is audit evidence.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    String tooLong = "x".repeat(ContentReviewCommand.MAX_RELEASE_REFERENCE_LENGTH + 1);
+    assertThrows(DataException.class, () -> ContentReviewCommand.approve(content, APPROVER, tooLong));
+    assertFalse(ContentReviewCommand.isApproved(content), "a rejected approval must not approve");
+
+    // The maximum length itself is accepted.
+    String atLimit = "x".repeat(ContentReviewCommand.MAX_RELEASE_REFERENCE_LENGTH);
+    ContentReviewCommand.approve(content, APPROVER, atLimit);
+    assertEquals(atLimit, content.getReleaseReference());
+  }
+
+  @Test
   void directPublishIsUnavailableWhenReviewIsRequired() {
     // The bypass that would otherwise defeat the whole control: an editor's Save / Publish Immediately
     // must not write straight to the live page when governed publishing is on.


### PR DESCRIPTION
Sixth slice of **Visual Editor P1** (#256) — the **release-authority reference**, a named compliance requirement from the scoping study's §5 that the backend already accepted but nothing could supply.

> **Stacked on #290 → #289 → #287.** Review those first.

## Why this matters

The scoping study calls for *"a release-authority reference field ('cleared per case #…', 'CO email dated…')"* — because under DFARS 252.204-7000 / OPSEC review, **who approved** is only half the evidence; **under what authority** is the other half. #287 already accepted `releaseReference` on approve and wrote it into the audit trail; there was simply no way for an approver to enter one.

## What this lands

- **The input, where the decision is made.** The APPROVE affordance becomes a small GET form carrying a `releaseReference` text field — the same request shape as the action links beside it (the framework routes `action(WidgetContext)` from query params, exactly as the existing publish link does), so no new plumbing and no JS.
- **A server-side length guard.** `release_reference` is `VARCHAR(255)`; `approve()` now rejects an over-long value with a clear message instead of letting the database throw mid-approval — and **never silently truncates**, because a truncated authority reference is corrupted evidence.

## Tests — 17 (1 new), all green

over-long reference rejected *and the content left unapproved* · the exact maximum accepted · plus the full workflow, SoD, gate, bypass and offer coverage. Clean `ant compile`; `unescaped-el` gate clean.

## P1 status after this

Working end to end: submit → approve (by someone else, with recorded authority) → publish, every path gated, every transition audited. **Remaining:** a review queue for approvers (a dedicated screen listing what's pending) and scheduled publish/unpublish.
