### PR TITLE
Visual Editor P3: authoring-time accessibility checks

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentAccessibilityCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentAccessibilityCommand.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+/**
+ * Authoring-time accessibility checks over a fragment of content HTML (Project #6, Phase 3).
+ *
+ * <p>Scope is deliberately small. Accessibility here is a <b>nice-to-have pursued where it is cheap
+ * and right</b> — it is not the product's differentiation thesis and this never gates a release. What
+ * it does buy is the one thing Section 508 provision 504 actually asks of an <i>authoring tool</i>:
+ * that it prompt the author toward accessible content while they are writing it. These four checks
+ * are the cheap, high-signal ones — the WCAG 2.1/2.2 AA failures that ADA Title III complaints
+ * overwhelmingly cite — and each maps to a named success criterion so a finding can be explained
+ * rather than merely asserted.
+ *
+ * <p>This reports; it never rewrites. Auto-generating alt text would produce confident-sounding
+ * nonsense for a screen-reader user, which is worse than a visible gap the author can fix.
+ *
+ * @author elizabeth houser
+ */
+public class ContentAccessibilityCommand {
+
+  /** An image carries no alternative text (WCAG 1.1.1 Non-text Content). */
+  public static final String RULE_IMAGE_MISSING_ALT = "image-missing-alt";
+  /** Heading levels skip a rank, e.g. h2 followed by h4 (WCAG 1.3.1 Info and Relationships). */
+  public static final String RULE_HEADING_SKIPPED = "heading-order-skipped";
+  /** Link text conveys nothing out of context (WCAG 2.4.4 Link Purpose). */
+  public static final String RULE_LINK_TEXT_UNCLEAR = "link-text-unclear";
+  /** A link has no discernible text at all (WCAG 2.4.4 / 4.1.2 Name, Role, Value). */
+  public static final String RULE_LINK_NO_TEXT = "link-without-text";
+
+  /**
+   * Link phrases that carry no meaning when a screen-reader user lists the links on a page. Kept
+   * short and unambiguous on purpose: a noisy authoring check gets ignored, and an ignored check
+   * helps nobody.
+   */
+  private static final Set<String> UNCLEAR_LINK_PHRASES = Set.of(
+      "click here", "here", "read more", "more", "link", "this", "this link", "learn more", "details");
+
+  private ContentAccessibilityCommand() {
+    // Static command
+  }
+
+  /**
+   * @return the accessibility findings in the given content HTML, in document order; never null.
+   */
+  public static List<Finding> check(String html) {
+    List<Finding> findings = new ArrayList<>();
+    if (StringUtils.isBlank(html)) {
+      return findings;
+    }
+    Document document = Jsoup.parseBodyFragment(html);
+
+    for (Element image : document.select("img")) {
+      // An explicitly empty alt is correct for a decorative image, so only a MISSING attribute is a
+      // finding. Punishing alt="" would push authors into writing noise for spacer images.
+      if (!image.hasAttr("alt")) {
+        findings.add(new Finding(RULE_IMAGE_MISSING_ALT, "WCAG 1.1.1",
+            "This image has no alt text. Describe it, or mark it decorative with alt=\"\".",
+            describe(image, image.attr("src"))));
+      }
+    }
+
+    int previousLevel = 0;
+    for (Element heading : document.select("h1, h2, h3, h4, h5, h6")) {
+      int level = Integer.parseInt(heading.tagName().substring(1));
+      if (previousLevel > 0 && level > previousLevel + 1) {
+        findings.add(new Finding(RULE_HEADING_SKIPPED, "WCAG 1.3.1",
+            "Heading level jumps from h" + previousLevel + " to h" + level
+                + ". Screen-reader users navigate by heading order, so do not skip a level.",
+            describe(heading, heading.text())));
+      }
+      previousLevel = level;
+    }
+
+    for (Element link : document.select("a")) {
+      String text = link.text().trim();
+      if (text.isEmpty()) {
+        // An image-only link is described by the image's alt text, which the img check covers.
+        if (link.select("img").isEmpty()) {
+          findings.add(new Finding(RULE_LINK_NO_TEXT, "WCAG 2.4.4",
+              "This link has no text, so it cannot be announced.", describe(link, link.attr("href"))));
+        }
+        continue;
+      }
+      String normalized = text.toLowerCase(Locale.ROOT).replaceAll("[\\p{Punct}\\s]+$", "").trim();
+      if (UNCLEAR_LINK_PHRASES.contains(normalized)) {
+        findings.add(new Finding(RULE_LINK_TEXT_UNCLEAR, "WCAG 2.4.4",
+            "Link text \"" + text + "\" does not say where it goes. Screen-reader users often browse a "
+                + "list of links with no surrounding sentence.",
+            describe(link, text)));
+      }
+    }
+
+    return findings;
+  }
+
+  /** @return true if the content has no accessibility findings. */
+  public static boolean isClean(String html) {
+    return check(html).isEmpty();
+  }
+
+  private static String describe(Element element, String detail) {
+    String trimmed = StringUtils.abbreviate(StringUtils.trimToEmpty(detail), 60);
+    return trimmed.isEmpty() ? "<" + element.tagName() + ">" : "<" + element.tagName() + "> " + trimmed;
+  }
+
+  /** One accessibility finding: which rule, which success criterion, and what the author should do. */
+  public static class Finding {
+
+    private final String rule;
+    private final String criterion;
+    private final String message;
+    private final String context;
+
+    Finding(String rule, String criterion, String message, String context) {
+      this.rule = rule;
+      this.criterion = criterion;
+      this.message = message;
+      this.context = context;
+    }
+
+    public String getRule() {
+      return rule;
+    }
+
+    /** The WCAG success criterion, so a finding can be explained rather than merely asserted. */
+    public String getCriterion() {
+      return criterion;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    /** Where in the content it was found, abbreviated for display. */
+    public String getContext() {
+      return context;
+    }
+
+    @Override
+    public String toString() {
+      return rule + " (" + criterion + "): " + message + " [" + context + "]";
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/ContentAccessibilityCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentAccessibilityCommandTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.application.cms.ContentAccessibilityCommand.Finding;
+
+/**
+ * Tests the authoring-time accessibility checks, including the cases that must NOT be reported --
+ * a noisy authoring check gets ignored, and an ignored check helps nobody.
+ *
+ * @author elizabeth houser
+ */
+class ContentAccessibilityCommandTest {
+
+  private static List<String> rules(String html) {
+    return ContentAccessibilityCommand.check(html).stream().map(Finding::getRule).toList();
+  }
+
+  @Test
+  void cleanContentHasNoFindings() {
+    String html = "<h2>About us</h2><p>Some text with a "
+        + "<a href=\"/capabilities\">description of our capabilities</a>.</p>"
+        + "<img src=\"/team.jpg\" alt=\"The engineering team at work\">";
+    assertTrue(ContentAccessibilityCommand.isClean(html), rules(html).toString());
+  }
+
+  @Test
+  void emptyOrBlankContentIsClean() {
+    assertTrue(ContentAccessibilityCommand.isClean(null));
+    assertTrue(ContentAccessibilityCommand.isClean(""));
+    assertTrue(ContentAccessibilityCommand.isClean("   "));
+  }
+
+  @Test
+  void imageWithoutAltIsReported() {
+    List<Finding> findings = ContentAccessibilityCommand.check("<img src=\"/chart.png\">");
+    assertEquals(1, findings.size());
+    assertEquals(ContentAccessibilityCommand.RULE_IMAGE_MISSING_ALT, findings.get(0).getRule());
+    assertEquals("WCAG 1.1.1", findings.get(0).getCriterion());
+    // The context names the offending element so the author can find it.
+    assertTrue(findings.get(0).getContext().contains("chart.png"), findings.get(0).getContext());
+  }
+
+  @Test
+  void decorativeImageWithExplicitEmptyAltIsAccepted() {
+    // alt="" is the CORRECT markup for a decorative image. Reporting it would push authors into
+    // writing noise for spacer images, which actively harms screen-reader users.
+    assertTrue(ContentAccessibilityCommand.isClean("<img src=\"/spacer.gif\" alt=\"\">"));
+  }
+
+  @Test
+  void skippedHeadingLevelIsReported() {
+    List<Finding> findings = ContentAccessibilityCommand.check("<h2>Section</h2><h4>Detail</h4>");
+    assertEquals(1, findings.size());
+    assertEquals(ContentAccessibilityCommand.RULE_HEADING_SKIPPED, findings.get(0).getRule());
+    assertTrue(findings.get(0).getMessage().contains("h2 to h4"), findings.get(0).getMessage());
+  }
+
+  @Test
+  void sequentialAndReturningHeadingLevelsAreAccepted() {
+    // h2 -> h3 -> h2 is a normal document shape: going back UP a level is not a skip.
+    assertTrue(ContentAccessibilityCommand.isClean(
+        "<h2>One</h2><h3>One point one</h3><h2>Two</h2><h3>Two point one</h3>"));
+    // Content that starts at h3 is fine -- the fragment may sit under a page heading.
+    assertTrue(ContentAccessibilityCommand.isClean("<h3>Starts deeper</h3><h4>Then deeper</h4>"));
+  }
+
+  @Test
+  void unclearLinkTextIsReported() {
+    for (String phrase : List.of("click here", "Click Here", "read more", "here.", "Learn more!")) {
+      String html = "<p>For details <a href=\"/x\">" + phrase + "</a></p>";
+      assertEquals(List.of(ContentAccessibilityCommand.RULE_LINK_TEXT_UNCLEAR), rules(html),
+          "expected '" + phrase + "' to be reported");
+    }
+  }
+
+  @Test
+  void descriptiveLinkTextIsAccepted() {
+    assertTrue(ContentAccessibilityCommand.isClean(
+        "<a href=\"/quality\">our AS9100 quality certifications</a>"));
+    // A phrase that merely CONTAINS an unclear word is fine -- only the whole text matters.
+    assertTrue(ContentAccessibilityCommand.isClean("<a href=\"/x\">here is our capability statement</a>"));
+  }
+
+  @Test
+  void linkWithNoTextIsReported() {
+    List<Finding> findings = ContentAccessibilityCommand.check("<a href=\"/empty\"></a>");
+    assertEquals(1, findings.size());
+    assertEquals(ContentAccessibilityCommand.RULE_LINK_NO_TEXT, findings.get(0).getRule());
+  }
+
+  @Test
+  void imageOnlyLinkIsNotDoubleReported() {
+    // An image-only link is named by its alt text, so it is the img rule's business, not the link's.
+    assertEquals(List.of(),
+        rules("<a href=\"/home\"><img src=\"/logo.png\" alt=\"SimIS home\"></a>"));
+    // Without alt, exactly one finding -- the missing alt -- not also "link without text".
+    assertEquals(List.of(ContentAccessibilityCommand.RULE_IMAGE_MISSING_ALT),
+        rules("<a href=\"/home\"><img src=\"/logo.png\"></a>"));
+  }
+
+  @Test
+  void multipleFindingsAreAllReported() {
+    String html = "<h2>Title</h2><h5>Skipped</h5>"
+        + "<img src=\"/a.png\">"
+        + "<a href=\"/b\">click here</a>";
+    List<String> found = rules(html);
+    assertEquals(3, found.size(), found.toString());
+    assertTrue(found.contains(ContentAccessibilityCommand.RULE_HEADING_SKIPPED));
+    assertTrue(found.contains(ContentAccessibilityCommand.RULE_IMAGE_MISSING_ALT));
+    assertTrue(found.contains(ContentAccessibilityCommand.RULE_LINK_TEXT_UNCLEAR));
+    assertFalse(ContentAccessibilityCommand.isClean(html));
+  }
+}


### PR DESCRIPTION
First slice of **Visual Editor P3** (#258) — the authoring-time accessibility check. Clean on `main`, no stack.

## Scope, deliberately small

P3 says *"ship the cheap wins; do not let a11y block the phase"* — and accessibility here is a **nice-to-have pursued where cheap and right**, not the differentiation thesis. This is the cheapest win with real value: the one thing **Section 508 provision 504** actually asks of an *authoring tool*, that it prompt the author toward accessible content while they write.

Four checks — the WCAG 2.1/2.2 AA failures ADA Title III complaints overwhelmingly cite:

| Rule | Criterion | Catches |
|---|---|---|
| `image-missing-alt` | WCAG 1.1.1 | an image with no `alt` attribute |
| `heading-order-skipped` | WCAG 1.3.1 | `h2` → `h4`, which breaks heading navigation |
| `link-text-unclear` | WCAG 2.4.4 | "click here", "read more" — meaningless in a link list |
| `link-without-text` | WCAG 2.4.4 / 4.1.2 | a link that cannot be announced at all |

Each finding carries its **success criterion**, so it can be explained rather than merely asserted.

## Two deliberate design choices

- **It reports; it never rewrites.** Auto-generating alt text produces confident-sounding nonsense for a screen-reader user — worse than a visible gap the author can fix.
- **Not being noisy is a feature.** A noisy authoring check gets ignored, and an ignored check helps nobody. So: `alt=""` is *accepted* (correct markup for a decorative image — punishing it pushes authors into writing noise for spacer images); heading levels returning **up** (`h2→h3→h2`) are fine; content starting at `h3` is fine (the fragment may sit under a page heading); a phrase merely *containing* "here" is fine — only the whole link text counts; and an image-only link is the img rule's business, not double-reported.

## Tests — 11, all green

Both directions, because the negatives are where a lint earns trust: clean content · missing alt · **decorative `alt=""` accepted** · skipped heading · **sequential and returning levels accepted** · five unclear phrases (case/punctuation-insensitive) · **descriptive text accepted** · empty link · **image-only link not double-reported** · multiple findings together.

## Where it goes next

The editor surfaces these at edit time (P3 proper), and they can back a per-page a11y report. Landing the pure logic first, tested, in the same shape as the P0/P1 foundations.
