### PR TITLE
ci: add a path-based PR labeler (actions/labeler)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,59 @@
+# Path-based PR labels, applied by .github/workflows/labeler.yml (actions/labeler).
+#
+# Only labels that can be inferred from WHICH FILES a PR touches live here. Topical labels
+# that need judgement -- security, accessibility, performance, privacy, authentication,
+# modernization, bug/enhancement -- are deliberately absent and stay manual (or a future
+# triage step). sync-labels is off in the workflow, so these rules only ADD labels; a label
+# applied by hand is never stripped by the automation.
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/webapp/**'
+
+java:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/**'
+          - 'pom.xml'
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file: 'src/test/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/labeler.yml'
+          - 'tools/**'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file: 'docker/**'
+
+deployment:
+  - changed-files:
+      - any-glob-to-any-file: 'infra/**'
+
+compliance:
+  - changed-files:
+      - any-glob-to-any-file: 'docker/app/conf/**'
+
+supply-chain:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/build/**'
+          - '.github/workflows/sbom.yml'
+          - '.github/workflows/publish-images.yml'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'pom.xml'
+          - 'lib/build/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+# Path-based PR labeler. Applies the file-path rules in .github/labeler.yml (frontend, java,
+# ci, docker, ...) so every PR gets its mechanical labels without anyone remembering to add
+# them -- this closes the "nobody labelled it" gap that let labels lapse, not triage. Topical
+# labels (security, accessibility, performance, ...) are not inferable from paths and stay
+# manual.
+#
+# Uses pull_request_target, NOT pull_request, because this repo's PRs come from forks
+# (e.g. lizhsr/simis-cms), and a fork's pull_request GITHUB_TOKEN is read-only -- it cannot
+# add labels. pull_request_target runs in the BASE repo with a writable token. That is safe
+# here: actions/labeler never checks out or executes the PR's code; it only reads the
+# changed-file list from the API and .github/labeler.yml from the base branch.
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
+        with:
+          sync-labels: false


### PR DESCRIPTION
## Why

Labels here were being applied **by hand via the API** (as `lizhsr`) plus Dependabot for its own PRs. When the manual labelling stopped (last hand-applied label was 2026-07-25 04:39 UTC), every new issue and non-Dependabot PR went unlabelled — there was never an automated labeler to fall back on. This adds one for the labels that can be inferred from **which files a PR touches**.

## What

**`.github/labeler.yml`** — path → label rules, all onto existing repo labels:

| Label | Paths |
|---|---|
| `frontend` | `src/main/webapp/**` |
| `java` | `src/main/java/**`, `pom.xml` |
| `testing` | `src/test/**` |
| `ci` | `.github/workflows/**`, `.github/labeler.yml`, `tools/**` |
| `docker` | `docker/**` |
| `deployment` | `infra/**` |
| `compliance` | `docker/app/conf/**` (STIG overlay) |
| `supply-chain` | `lib/build/**`, `sbom.yml`, `publish-images.yml` |
| `dependencies` | `pom.xml`, `lib/build/**` |
| `documentation` | `**/*.md`, `docs/**` |

**`.github/workflows/labeler.yml`** — runs `actions/labeler` (SHA-pinned `@bf12e9b0…` / v7).

## Design notes

- **`pull_request_target`, not `pull_request`:** this repo's PRs come from forks (e.g. `lizhsr/simis-cms`), and a fork's `pull_request` token is read-only, so it can't add labels. `pull_request_target` runs in the base repo with a writable token. **Safe here** because `actions/labeler` never checks out or executes the PR's code — it only reads the changed-file list and the base branch's `labeler.yml`.
- **`sync-labels: false`** — only ever *adds* labels; never strips a hand-applied one.
- **Scope:** mechanical/path-inferable labels only. Topical labels that need judgement (`security`, `accessibility`, `performance`, `privacy`, `authentication`, `bug`/`enhancement`, …) stay manual. **Dependabot** keeps labelling its own PRs independently.

## Note

Because `pull_request_target` runs the workflow version on the **base** branch, this won't label its own PR — it starts working on PRs opened after merge. (I've labelled this PR `ci` by hand to match.)
