### PR TITLE
Guard RemoteContentWidget server-side fetch against SSRF

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidget.java
@@ -30,6 +30,7 @@ import org.jsoup.select.Elements;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.application.http.RemoteUrlValidationCommand;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -73,6 +74,13 @@ public class RemoteContentWidget extends GenericWidget {
       content = imageTag;
       cache.put(url, content);
       return useReturnType(context, content);
+    }
+
+    // Reject internal/link-local/metadata targets before any server-side fetch (SSRF).
+    // The url is an operator-set widget preference; mirror the dataset remote-fetch guard (#236).
+    if (!RemoteUrlValidationCommand.isFetchAllowed(url)) {
+      LOG.warn("Blocked an SSRF-unsafe remote content url: " + url);
+      return null;
     }
 
     // Get the remote data, and cache it

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/RemoteContentWidgetTest.java
@@ -16,18 +16,41 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
 
 /**
- * Verifies that the remote-image wrapper sanitizes its url (a widget preference) before placing it
- * into the src attribute, so a value with an embedded quote or an active scheme cannot break out of
- * the attribute and inject markup (stored XSS).
+ * Two properties of the remote-content widget:
+ * <ol>
+ * <li>the remote-image wrapper sanitizes its url (a widget preference) before placing it into the
+ * src attribute, so a value with an embedded quote or an active scheme cannot break out of the
+ * attribute and inject markup (stored XSS);</li>
+ * <li>the server-side fetch is gated by {@link com.simisinc.platform.application.http.RemoteUrlValidationCommand}
+ * so an operator-set url cannot point the server at an internal, link-local, or cloud-metadata
+ * address (SSRF).</li>
+ * </ol>
  *
  * @author Elizabeth Houser
  * @created 2026-07-19
  */
-class RemoteContentWidgetTest {
+class RemoteContentWidgetTest extends WidgetBase {
 
   @Test
   void safeImageUrlProducesImgTag() {
@@ -49,5 +72,46 @@ class RemoteContentWidgetTest {
   @Test
   void nullUrlIsRejected() {
     Assertions.assertNull(RemoteContentWidget.buildImageTag(null));
+  }
+
+  @Test
+  void internalMetadataUrlIsBlockedBeforeAnyServerFetch() {
+    // The cloud instance-metadata endpoint: the canonical SSRF credential-theft target.
+    Map<String, String> preferences = new HashMap<>();
+    preferences.put("url", "http://169.254.169.254/latest/meta-data/iam/");
+    widgetContext.setPreferences(preferences);
+
+    Cache cache = mock(Cache.class);
+    when(cache.getIfPresent(any())).thenReturn(null);
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.CONTENT_REMOTE_URL_CACHE)).thenReturn(cache);
+
+      WidgetContext result = new RemoteContentWidget().execute(widgetContext);
+
+      // Refused, and — the point of the guard — the server never fetched it.
+      Assertions.assertNull(result);
+      httpGet.verify(() -> HttpGetCommand.execute(any()), never());
+    }
+  }
+
+  @Test
+  void publicUrlIsAllowedThroughToTheFetch() {
+    // A public, routable literal address must NOT be blocked — the guard should not over-refuse.
+    Map<String, String> preferences = new HashMap<>();
+    preferences.put("url", "http://93.184.216.34/feed");
+    widgetContext.setPreferences(preferences);
+
+    Cache cache = mock(Cache.class);
+    when(cache.getIfPresent(any())).thenReturn(null);
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.CONTENT_REMOTE_URL_CACHE)).thenReturn(cache);
+      httpGet.when(() -> HttpGetCommand.execute("http://93.184.216.34/feed")).thenReturn("");
+
+      new RemoteContentWidget().execute(widgetContext);
+
+      httpGet.verify(() -> HttpGetCommand.execute("http://93.184.216.34/feed"), times(1));
+    }
   }
 }


### PR DESCRIPTION
From the 2026-07-24 whole-product security audit. Gates the operator-set URL fetch in RemoteContentWidget on RemoteUrlValidationCommand.isFetchAllowed (fail closed), mirroring the dataset fetch guard from PR 236, so it can no longer reach internal, link-local, or cloud-metadata addresses. Adds 6 unit tests (metadata blocked, public allowed).