### PR TITLE
Prevent privilege escalation in the user-edit form (clamp role assignment)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -18,7 +18,9 @@ package com.simisinc.platform.presentation.widgets.admin.login;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
@@ -30,6 +32,7 @@ import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.UserSession;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -86,15 +89,31 @@ public class UserFormWidget extends GenericWidget {
     BeanUtils.populate(userBean, context.getParameterMap());
     userBean.setModifiedBy(context.getUserId());
 
-    // Populate the roles
+    // Populate the roles -- but an editor may only assign roles at or below their own highest role
+    // level. A role above that level is honored only when the target already holds it (preserve, never
+    // escalate): this stops a lower-privileged editor (e.g. a community-manager, level 90) from
+    // granting admin (level 100) or another higher role through this form, and equally from stripping
+    // one it does not control. Group delegation is unranked and deferred to the deny-by-default work (#299).
     List<Role> roleList = RoleRepository.findAll();
     if (roleList != null) {
+      int actingLevel = highestRoleLevel(context.getUserSession(), roleList);
+      Set<String> retainedHigherRoleCodes = higherRolesTargetAlreadyHolds(userBean.getId(), roleList, actingLevel);
       List<Role> userRoleList = new ArrayList<>();
       for (Role role : roleList) {
         String roleValue = context.getParameter("roleId" + role.getId());
-        if (roleValue != null && roleValue.equals(String.valueOf(role.getId()))) {
-          LOG.debug("Adding user to role: " + role.getCode());
+        boolean requested = roleValue != null && roleValue.equals(String.valueOf(role.getId()));
+        if (role.getLevel() <= actingLevel) {
+          // At or below the editor's level: the editor controls it.
+          if (requested) {
+            LOG.debug("Adding user to role: " + role.getCode());
+            userRoleList.add(role);
+          }
+        } else if (retainedHigherRoleCodes.contains(role.getCode())) {
+          // Above the editor's level but already held by the target: preserve, do not let the editor revoke it.
           userRoleList.add(role);
+        } else if (requested) {
+          LOG.warn("Blocked role escalation: user " + context.getUserId() + " (level " + actingLevel
+              + ") attempted to grant '" + role.getCode() + "' (level " + role.getLevel() + ")");
         }
       }
       userBean.setRoleList(userRoleList);
@@ -144,5 +163,46 @@ public class UserFormWidget extends GenericWidget {
     context.setRedirect("/admin/user-details?userId=" + user.getId());
     return context;
 
+  }
+
+  /**
+   * The highest role level the acting user holds, found by matching their session role codes against
+   * the authoritative role list (which carries the levels). Returns 0 when nothing matches, which
+   * fails closed -- no role above 0 can then be granted.
+   */
+  private static int highestRoleLevel(UserSession userSession, List<Role> allRoles) {
+    int max = 0;
+    if (userSession == null) {
+      return max;
+    }
+    for (Role role : allRoles) {
+      if (userSession.hasRole(role.getCode()) && role.getLevel() > max) {
+        max = role.getLevel();
+      }
+    }
+    return max;
+  }
+
+  /**
+   * The codes of roles the target user already holds whose level is above the editor's -- the roles
+   * the editor may neither grant nor revoke. Empty for a new user.
+   */
+  private static Set<String> higherRolesTargetAlreadyHolds(long userId, List<Role> allRoles, int actingLevel) {
+    Set<String> codes = new HashSet<>();
+    if (userId < 0) {
+      return codes;
+    }
+    User existing = LoadUserCommand.loadUser(userId);
+    if (existing == null || existing.getRoleList() == null) {
+      return codes;
+    }
+    for (Role held : existing.getRoleList()) {
+      for (Role authoritative : allRoles) {
+        if (authoritative.getCode().equals(held.getCode()) && authoritative.getLevel() > actingLevel) {
+          codes.add(authoritative.getCode());
+        }
+      }
+    }
+    return codes;
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.login;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.GroupRepository;
+import com.simisinc.platform.infrastructure.persistence.RoleRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+
+/**
+ * The user-edit form is reachable by both admin and community-manager (admin-layout.xml). Without a
+ * check, the role checkboxes let a lower-privileged editor grant themselves or anyone else a higher
+ * role -- e.g. a community-manager (level 90) granting admin (level 100), a full privilege escalation.
+ * These verify the editor can only set roles at or below their own level, admins are unaffected, and a
+ * higher role the target already holds is neither grantable nor strippable by a lower editor.
+ *
+ * @author Elizabeth Houser
+ */
+class UserFormWidgetTest extends WidgetBase {
+
+  private static Role role(int id, int level, String code, String title) {
+    Role role = new Role(title, code);
+    role.setId(id);
+    role.setLevel(level);
+    return role;
+  }
+
+  private static List<Role> allRoles() {
+    List<Role> roles = new ArrayList<>();
+    roles.add(role(1, 70, "content-editor", "Content Editor"));
+    roles.add(role(2, 80, "content-manager", "Content Manager"));
+    roles.add(role(3, 90, "community-manager", "Community Manager"));
+    roles.add(role(4, 100, "admin", "System Administrator"));
+    return roles;
+  }
+
+  private static User savedUser() {
+    User user = new User();
+    user.setId(5L);
+    user.setEmail("saved@example.com");
+    return user;
+  }
+
+  @Test
+  void communityManagerCannotGrantAdminButKeepsAllowedRoles() throws Exception {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "id", "-1");        // create
+    addQueryParameter(widgetContext, "roleId1", "1");    // content-editor (70) -- allowed
+    addQueryParameter(widgetContext, "roleId4", "4");    // admin (100) -- must be refused
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(savedUser());
+
+      new UserFormWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      List<String> codes = captor.getValue().getRoleList().stream().map(Role::getCode).toList();
+      Assertions.assertTrue(codes.contains("content-editor"), "a role at/below the editor's level must be granted");
+      Assertions.assertFalse(codes.contains("admin"), "a community-manager must NOT be able to grant admin");
+    }
+  }
+
+  @Test
+  void adminCanGrantAdmin() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "roleId4", "4");    // admin
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(savedUser());
+
+      new UserFormWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      List<String> codes = captor.getValue().getRoleList().stream().map(Role::getCode).toList();
+      Assertions.assertTrue(codes.contains("admin"), "an admin must still be able to grant admin");
+    }
+  }
+
+  @Test
+  void communityManagerCannotStripHigherRoleTheTargetAlreadyHolds() throws Exception {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "id", "5");         // editing an existing user
+    addQueryParameter(widgetContext, "roleId1", "1");    // submits content-editor; admin left unchecked
+
+    User target = new User();
+    target.setId(5L);
+    List<Role> held = new ArrayList<>();
+    held.add(role(4, 100, "admin", "System Administrator"));
+    target.setRoleList(held);
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(savedUser());
+
+      new UserFormWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      List<String> codes = captor.getValue().getRoleList().stream().map(Role::getCode).toList();
+      Assertions.assertTrue(codes.contains("admin"), "a higher role the target already holds must be preserved, not stripped");
+      Assertions.assertTrue(codes.contains("content-editor"));
+    }
+  }
+}


### PR DESCRIPTION
From the 2026-07-24 security audit. Clamps role assignment to the acting user's own highest role level; a higher role is honored only when the target already holds it (preserve, never escalate or strip). Stops a community-manager from granting admin. Adds 3 unit tests.