### PR TITLE
Prevent stored DOM XSS in calendar and photo-gallery feeds

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEvents.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEvents.java
@@ -103,13 +103,16 @@ public class CalendarAjaxEvents {
         if (color != null) {
           sb.append("\"color\":\"").append(JsonCommand.toJson(color)).append("\",");
         }
+        // description, location, and title are concatenated into the tooltip/detail markup on the
+        // client (innerHTML via .html()), so HTML-encode before JSON-encoding -- JsonCommand.toJson
+        // is JSON-safe but not HTML-safe (stored DOM XSS).
         if (StringUtils.isNotEmpty(calendarEvent.getSummary())) {
-          sb.append("\"description\":\"").append(JsonCommand.toJson(calendarEvent.getSummary())).append("\",");
+          sb.append("\"description\":\"").append(JsonCommand.toJson(escapeHtml(calendarEvent.getSummary()))).append("\",");
         }
         if (StringUtils.isNotEmpty(calendarEvent.getLocation())) {
-          sb.append("\"location\":\"").append(JsonCommand.toJson(calendarEvent.getLocation())).append("\",");
+          sb.append("\"location\":\"").append(JsonCommand.toJson(escapeHtml(calendarEvent.getLocation()))).append("\",");
         }
-        sb.append("\"title\":\"").append(JsonCommand.toJson(calendarEvent.getTitle())).append("\"");
+        sb.append("\"title\":\"").append(JsonCommand.toJson(escapeHtml(calendarEvent.getTitle()))).append("\"");
         sb.append("}");
       }
     }
@@ -122,5 +125,20 @@ public class CalendarAjaxEvents {
       }
     }
     return null;
+  }
+
+  /**
+   * Minimal HTML entity-encoding for values the client concatenates into markup (tooltip/detail).
+   * Ampersand first so the entities it introduces are not themselves double-encoded.
+   */
+  private static String escapeHtml(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;");
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjax.java
@@ -80,10 +80,12 @@ public class PhotoListAjax extends GenericWidget {
       sb.append("\"id\":").append(fileItem.getId()).append(",");
       sb.append("\"folderId\":").append(fileItem.getFolderId()).append(",");
       sb.append("\"subFolderId\":").append(fileItem.getSubFolderId()).append(",");
+      // title and summary are rendered into the slider markup on the client (innerHTML), so HTML-encode
+      // before JSON-encoding -- JsonCommand.toJson is JSON-safe but not HTML-safe (stored DOM XSS).
       if (StringUtils.isNotEmpty(fileItem.getSummary())) {
-        sb.append("\"summary\":\"").append(JsonCommand.toJson(fileItem.getSummary())).append("\",");
+        sb.append("\"summary\":\"").append(JsonCommand.toJson(escapeHtml(fileItem.getSummary()))).append("\",");
       }
-      sb.append("\"title\":\"").append(JsonCommand.toJson(fileItem.getTitle())).append("\",");
+      sb.append("\"title\":\"").append(JsonCommand.toJson(escapeHtml(fileItem.getTitle()))).append("\",");
       sb.append("\"filename\":\"").append(JsonCommand.toJson(fileItem.getFilename())).append("\",");
       sb.append("\"url\":\"").append(JsonCommand.toJson(url)).append("\"");
       sb.append("}");
@@ -92,10 +94,25 @@ public class PhotoListAjax extends GenericWidget {
     String photoArray = "[" + sb.toString() + "]";
 
     context.setJson("{" +
-        "\"title\": \"" + JsonCommand.toJson(subFolder.getName()) + "\"," +
+        "\"title\": \"" + JsonCommand.toJson(escapeHtml(subFolder.getName())) + "\"," +
         "\"photoList\": " + photoArray +
         "}");
 
     return context;
+  }
+
+  /**
+   * Minimal HTML entity-encoding for values the client concatenates into slider markup (innerHTML).
+   * Ampersand first so the entities it introduces are not themselves double-encoded.
+   */
+  private static String escapeHtml(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;");
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEventsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEventsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.calendar;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+
+/**
+ * The calendar events feed (/json/calendar) returns event title/location/description as JSON that the
+ * FullCalendar tooltip renders straight into markup via jQuery .html(). JSON-encoding is not HTML-safe,
+ * so a crafted event title or location could inject markup (stored DOM XSS). This verifies the feed
+ * HTML-encodes those fields so the payload is inert in the DOM.
+ *
+ * @author Elizabeth Houser
+ */
+class CalendarAjaxEventsTest {
+
+  @Test
+  void eventTitleAndLocationAreHtmlEncoded() {
+    CalendarEvent event = new CalendarEvent();
+    event.setId(1L);
+    event.setUniqueId("event-1");
+    event.setStartDate(new Timestamp(0L));
+    event.setEndDate(new Timestamp(86400000L));
+    event.setAllDay(true);
+    event.setTitle("Party \"><img src=x onerror=alert(1)>");
+    event.setLocation("<script>alert(1)</script>");
+
+    StringBuilder sb = new StringBuilder();
+    try (MockedStatic<CalendarRepository> calendars = mockStatic(CalendarRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      calendars.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+      events.when(() -> CalendarEventRepository.findAll(any(), any())).thenReturn(List.of(event));
+
+      CalendarAjaxEvents.addCalendarEvents(1L, null, new Date(0L), new Date(86400000L), sb);
+
+      String json = sb.toString();
+      Assertions.assertFalse(json.contains("<img"), "raw markup must not appear: " + json);
+      Assertions.assertFalse(json.contains("<script"), "raw markup must not appear: " + json);
+      Assertions.assertTrue(json.contains("&lt;img"), "title must be HTML-encoded: " + json);
+      Assertions.assertTrue(json.contains("&lt;script"), "location must be HTML-encoded: " + json);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjaxTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.LoadSubFolderCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.SubFolder;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+
+/**
+ * The photo-gallery slider loads folder title and photo titles from /json/photoList and writes them
+ * into the slider via innerHTML. JSON-encoding is not HTML-safe, so a crafted subfolder name or file
+ * title could inject markup (stored DOM XSS). This verifies the endpoint HTML-encodes those fields.
+ *
+ * @author Elizabeth Houser
+ */
+class PhotoListAjaxTest extends WidgetBase {
+
+  @Test
+  void folderAndPhotoTitlesAreHtmlEncoded() {
+    addQueryParameter(widgetContext, "subFolderId", "5");
+
+    SubFolder folder = new SubFolder();
+    folder.setId(5L);
+    folder.setName("Trip \"><img src=x onerror=alert(1)>");
+
+    FileItem file = new FileItem();
+    file.setId(9L);
+    file.setFolderId(1L);
+    file.setSubFolderId(5L);
+    file.setTitle("Photo <script>alert(1)</script>");
+    file.setFilename("photo.jpg");
+    file.setCreated(new Timestamp(0L));
+
+    try (MockedStatic<LoadSubFolderCommand> subFolders = mockStatic(LoadSubFolderCommand.class);
+        MockedStatic<FileItemRepository> files = mockStatic(FileItemRepository.class)) {
+      subFolders.when(() -> LoadSubFolderCommand.loadSubFolderByIdForAuthorizedUser(anyLong(), anyLong())).thenReturn(folder);
+      files.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(List.of(file));
+
+      new PhotoListAjax().execute(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertNotNull(json);
+      Assertions.assertFalse(json.contains("<img"), "raw markup must not appear: " + json);
+      Assertions.assertFalse(json.contains("<script"), "raw markup must not appear: " + json);
+      Assertions.assertTrue(json.contains("&lt;img"), "folder name must be HTML-encoded: " + json);
+      Assertions.assertTrue(json.contains("&lt;script"), "photo title must be HTML-encoded: " + json);
+    }
+  }
+}


### PR DESCRIPTION
From the 2026-07-24 security audit. HTML-encodes event title/location/description in the calendar feed and folder/photo titles in the photo-gallery feed, which the clients render via innerHTML. Adds 2 unit tests.