### PR TITLE
Secrets-at-rest: fail closed when CMS_SECRET_KEY is unset (POA&M #16)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
+++ b/src/main/java/com/simisinc/platform/application/SecretCryptoCommand.java
@@ -100,11 +100,13 @@ public class SecretCryptoCommand {
   }
 
   /**
-   * Encrypts a secret for storage. Blank input is returned unchanged, and when no key is configured the value is
-   * returned as-is (legacy plaintext) so an unconfigured deployment keeps working.
+   * Encrypts a secret for storage. Blank or already-encrypted input is returned unchanged. When no key is
+   * configured this fails closed (throws) rather than silently storing plaintext (#16); callers that store
+   * secrets must configure {@code CMS_SECRET_KEY}.
    *
    * @param plaintext the secret to protect
-   * @return an {@code enc:}-prefixed ciphertext, or the input unchanged when blank / no key
+   * @return an {@code enc:}-prefixed ciphertext, or the input unchanged when blank / already encrypted
+   * @throws IllegalStateException when a non-blank secret is supplied but no key is configured
    */
   public static String encrypt(String plaintext) {
     // Idempotent: a blank value or one that is already encrypted is returned unchanged, so re-encrypting
@@ -114,7 +116,13 @@ public class SecretCryptoCommand {
     }
     SecretKeySpec k = key();
     if (k == null) {
-      return plaintext;
+      // Fail closed (#16): never store a recoverable secret in plaintext. A deployment that stores secrets
+      // (TOTP seeds, integration/payment credentials) must configure CMS_SECRET_KEY; one that never uses those
+      // features never reaches here (blank/already-encrypted values return above). The re-encryption upgrade
+      // and the startup path both check isEnabled() and skip/warn rather than reach this throw.
+      throw new IllegalStateException(
+          "CMS_SECRET_KEY is not configured; refusing to store a secret in plaintext. "
+              + "Set CMS_SECRET_KEY (a base64-encoded 256-bit key) to enable secret storage.");
     }
     try {
       byte[] iv = new byte[IV_BYTES];

--- a/src/main/java/com/simisinc/platform/infrastructure/database/upgrade/V20260719_1004__reencrypt_secret_properties.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/database/upgrade/V20260719_1004__reencrypt_secret_properties.java
@@ -71,8 +71,11 @@ public class V20260719_1004__reencrypt_secret_properties extends BaseJavaMigrati
   public void migrate(Context context) throws Exception {
 
     if (!SecretCryptoCommand.isEnabled()) {
-      LOG.warn("CMS_SECRET_KEY is not configured; secret site properties will be re-saved unchanged and remain "
-          + "plaintext at rest. Configure the key and re-run this upgrade to encrypt them.");
+      // encrypt() now fails closed without a key (#16), so skip the re-save entirely rather than throw during
+      // startup. Existing values remain plaintext; configure the key and re-run this upgrade to encrypt them.
+      LOG.warn("CMS_SECRET_KEY is not configured; skipping secret site-property re-encryption. Existing values "
+          + "remain plaintext at rest. Configure the key and re-run this upgrade to encrypt them.");
+      return;
     }
 
     // Track the root prefix of every value we re-save so the property cache can be expired afterward, mirroring

--- a/src/main/java/com/simisinc/platform/presentation/controller/ContextListener.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/ContextListener.java
@@ -37,6 +37,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.simisinc.platform.ApplicationInfo;
+import com.simisinc.platform.application.SecretCryptoCommand;
 import com.simisinc.platform.application.admin.DatabaseCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
@@ -68,6 +69,14 @@ public class ContextListener implements ServletContextListener {
 
     // System properties
     System.setProperty("java.awt.headless", "true");
+
+    // At-rest secret encryption (#16): warn loudly when the key is absent. Secret storage fails closed, so
+    // storing TOTP seeds or integration/payment credentials will be refused until the key is set.
+    if (!SecretCryptoCommand.isEnabled()) {
+      LOG.warn("CMS_SECRET_KEY is not configured -- at-rest secret encryption is DISABLED. Storing TOTP seeds or "
+          + "integration/payment credentials will be refused (fail-closed). Set CMS_SECRET_KEY (a base64-encoded "
+          + "256-bit key) to enable those features.");
+    }
 
     // Monitor the success
     boolean isSuccessful = true;

--- a/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/SecretCryptoCommandTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Base64;
@@ -82,10 +83,15 @@ class SecretCryptoCommandTest {
   }
 
   @Test
-  void withoutAKeyEncryptionIsANoOpAndDecryptFailsSafe() {
+  void withoutAKeyEncryptRefusesAndDecryptFailsSafe() {
     System.clearProperty(PROP);
     assertFalse(SecretCryptoCommand.isEnabled());
-    assertEquals("secret", SecretCryptoCommand.encrypt("secret"), "no key -> stored as-is (backward compatible)");
+    // Fail closed (#16): a secret must never be stored in plaintext when no key is configured.
+    assertThrows(IllegalStateException.class, () -> SecretCryptoCommand.encrypt("secret"),
+        "no key -> must refuse to store a secret, not return plaintext");
+    // Blank/null still pass through without a key (nothing secret to protect) -- these must not throw.
+    assertNull(SecretCryptoCommand.encrypt(null));
+    assertEquals("", SecretCryptoCommand.encrypt(""));
     // An encrypted value cannot be read without the key: fail safe to null, never expose a broken value.
     assertNull(SecretCryptoCommand.decrypt("enc:AAAAAAAAAAAAAAAA"));
   }


### PR DESCRIPTION
Implements the fail-closed policy for at-rest secret encryption (POA&M #16).

**Before:** `SecretCryptoCommand.encrypt()` silently returned plaintext when `CMS_SECRET_KEY` was unset, so TOTP seeds and integration/payment credentials could be stored unencrypted with no signal.

**Now:**
- `encrypt()` **fails closed** -- it throws when a non-blank secret is supplied and no key is configured, so a secret is never stored in plaintext. Blank / already-encrypted values still pass through (no key needed).
- Only secret values reach `encrypt()` (`SitePropertyRepository` gates on `isSecret()`; `UserRepository` for the TOTP seed), so non-secret config saves are unaffected, and a deployment that never stores secrets never reaches the throw.
- The re-encryption upgrade (`V20260719_1004`) now **skips** when no key is configured, so a keyless deployment still boots (it no longer calls the now-throwing `encrypt()`).
- `ContextListener` logs a startup **WARNING** when the key is absent.

Production (Azure) always sets `CMS_SECRET_KEY` via Key Vault, so it is unaffected. The unit test is updated to assert the refusal.

Chosen posture: **fail-closed + startup warning** (not a hard boot-fail), per the ISSM decision.
