### PR TITLE
Durable account lockout: threshold lock, auto-expiry, admin unlock, audit (#295)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
@@ -21,6 +21,8 @@ import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.login.UserToken;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
@@ -31,6 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import javax.security.auth.login.LoginException;
+import java.sql.Timestamp;
 import java.util.Date;
 
 /**
@@ -83,6 +86,14 @@ public class AuthenticateLoginCommand {
       throw new LoginException("The account has been suspended. Please contact an administrator.");
     }
 
+    // Account lockout (#295): a locked account cannot log in even with the correct password, until the
+    // lock expires or an administrator clears it. Checked before the credentials cache so a lock always wins.
+    if (user.isLocked()) {
+      LOG.debug("Account locked until " + user.getLockedUntil());
+      throw new LoginException("This account is temporarily locked due to failed login attempts. "
+          + "Please try again later or contact an administrator.");
+    }
+
     // Check the credentials cache
     Cache cache = CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE);
     String comparison = (String) cache.getIfPresent(user.getId());
@@ -95,6 +106,10 @@ public class AuthenticateLoginCommand {
     if (verified) {
       // Hash matches password
       LOG.debug("User validated");
+      // Clear any prior failed-attempt / lockout state on a successful login (#295)
+      if (user.getFailedAttemptCount() > 0 || user.getLockedUntil() != null) {
+        UserRepository.resetLockout(user.getId());
+      }
       // Upgrade-on-login: now that the plaintext is confirmed, migrate an older hash to argon2id
       if (!user.getPassword().startsWith("$argon2id$")) {
         upgradeLegacyPasswordHash(user, password);
@@ -102,6 +117,17 @@ public class AuthenticateLoginCommand {
       cache.put(user.getId(), username + ":" + password);
       return user;
     }
+
+    // Record the failed attempt and lock the account once the threshold is crossed (#295, AC-7)
+    int newCount = user.getFailedAttemptCount() + 1;
+    Timestamp lockedUntil = null;
+    if (newCount >= lockoutThreshold()) {
+      lockedUntil = new Timestamp(System.currentTimeMillis() + lockoutDurationMinutes() * 60_000L);
+      SaveAuditEventCommand.recordAuthentication("account.lockout", "failure", user.getId(), username,
+          ipAddress, null, "Account locked after " + newCount + " consecutive failed attempts until " + lockedUntil);
+      LOG.warn("Account locked (user id " + user.getId() + ") after " + newCount + " failed login attempts");
+    }
+    UserRepository.updateLockoutState(user.getId(), newCount, lockedUntil);
 
     // Record rate limiting
     // Limit the number of attempts per username (system(s) attempting the same username)
@@ -130,6 +156,28 @@ public class AuthenticateLoginCommand {
       LOG.info("Upgraded password hash to argon2id for user id: " + user.getId());
     } catch (Exception e) {
       LOG.error("Unable to upgrade password hash to argon2id for user id: " + user.getId(), e);
+    }
+  }
+
+  /** @return the consecutive-failed-attempt threshold before lockout (site property, default 5). */
+  private static int lockoutThreshold() {
+    return parsePositiveInt(LoadSitePropertyCommand.loadByName("account.lockout.threshold"), 5);
+  }
+
+  /** @return how long a locked account stays locked, in minutes (site property, default 15). */
+  private static int lockoutDurationMinutes() {
+    return parsePositiveInt(LoadSitePropertyCommand.loadByName("account.lockout.durationMinutes"), 15);
+  }
+
+  private static int parsePositiveInt(String value, int defaultValue) {
+    if (StringUtils.isBlank(value)) {
+      return defaultValue;
+    }
+    try {
+      int parsed = Integer.parseInt(value.trim());
+      return parsed > 0 ? parsed : defaultValue;
+    } catch (NumberFormatException e) {
+      return defaultValue;
     }
   }
 

--- a/src/main/java/com/simisinc/platform/domain/model/User.java
+++ b/src/main/java/com/simisinc/platform/domain/model/User.java
@@ -56,6 +56,8 @@ public class User extends Entity {
   private boolean mfaEnabled = false;
   private String accountToken = null;
   private Timestamp validated = null;
+  private int failedAttemptCount = 0;
+  private Timestamp lockedUntil = null;
   private long createdBy = -1;
   private long modifiedBy = -1;
   private Timestamp created = null;
@@ -271,6 +273,27 @@ public class User extends Entity {
 
   public void setValidated(Timestamp validated) {
     this.validated = validated;
+  }
+
+  public int getFailedAttemptCount() {
+    return failedAttemptCount;
+  }
+
+  public void setFailedAttemptCount(int failedAttemptCount) {
+    this.failedAttemptCount = failedAttemptCount;
+  }
+
+  public Timestamp getLockedUntil() {
+    return lockedUntil;
+  }
+
+  public void setLockedUntil(Timestamp lockedUntil) {
+    this.lockedUntil = lockedUntil;
+  }
+
+  /** @return true when the account is currently locked -- locked_until is set and still in the future. */
+  public boolean isLocked() {
+    return lockedUntil != null && lockedUntil.after(new Timestamp(System.currentTimeMillis()));
   }
 
   public boolean isNotValidated() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -385,6 +385,29 @@ public class UserRepository {
     return null;
   }
 
+  /**
+   * Persists the account-lockout state after a login attempt (#295): the consecutive failed-attempt
+   * counter and the lockout expiry (null = not locked). The login flow decides the values.
+   */
+  public static void updateLockoutState(long userId, int failedAttemptCount, Timestamp lockedUntil) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("failed_attempt_count", failedAttemptCount)
+        .add("locked_until", lockedUntil);
+    SqlUtils where = new SqlUtils()
+        .add("user_id = ?", userId);
+    if (!DB.update(TABLE_NAME, updateValues, where)) {
+      LOG.error("updateLockoutState failed for user id: " + userId);
+    }
+  }
+
+  /**
+   * Clears the lockout -- resets the failed-attempt count to 0 and removes any lock. Used on a
+   * successful login and when an administrator unlocks the account (#295).
+   */
+  public static void resetLockout(long userId) {
+    updateLockoutState(userId, 0, null);
+  }
+
   public static User createAccountToken(User record) {
     String newToken = UUID.randomUUID().toString();
     SqlUtils updateValues = new SqlUtils()
@@ -531,6 +554,8 @@ public class UserRepository {
       // Decrypt the at-rest TOTP seed so callers always see plaintext (legacy plaintext passes through unchanged)
       record.setMfaSecret(SecretCryptoCommand.decrypt(rs.getString("mfa_secret")));
       record.setMfaEnabled(rs.getBoolean("mfa_enabled"));
+      record.setFailedAttemptCount(rs.getInt("failed_attempt_count"));
+      record.setLockedUntil(rs.getTimestamp("locked_until"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -94,6 +94,8 @@ public class UserDetailsWidget extends GenericWidget {
       return restoreAccount(context, user);
     } else if ("deleteAccount".equals(action)) {
       return deleteAccount(context, user);
+    } else if ("unlockAccount".equals(action)) {
+      return unlockAccount(context, user);
     }
     return context;
   }
@@ -165,6 +167,16 @@ public class UserDetailsWidget extends GenericWidget {
           AuditEventCommand.FAILURE, "user", targetId, targetLabel, e.getMessage());
       context.setErrorMessage("The account could not be deleted: " + e.getMessage());
     }
+    return context;
+  }
+
+  private WidgetContext unlockAccount(WidgetContext context, User user) {
+    // Clear the failed-attempt counter and lockout timestamp so the user can sign in again (#295, AC-7).
+    // The clear is idempotent, so the outcome is recorded as a success even if the lock had just expired.
+    UserRepository.resetLockout(user.getId());
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.unlock",
+        AuditEventCommand.SUCCESS, "user", String.valueOf(user.getId()), user.getEmail(), null);
+    context.setSuccessMessage("Account unlocked");
     return context;
   }
 

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -316,7 +316,9 @@ CREATE TABLE users (
   video_url VARCHAR(255),
   field_values JSONB,
   mfa_secret VARCHAR(64),
-  mfa_enabled BOOLEAN DEFAULT false
+  mfa_enabled BOOLEAN DEFAULT false,
+  failed_attempt_count INTEGER DEFAULT 0,
+  locked_until TIMESTAMP(3)
 );
 CREATE UNIQUE INDEX users_lc_email ON users (LOWER(email));
 CREATE UNIQUE INDEX users_lc_username ON users (LOWER(username));

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1000__account_lockout.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1000__account_lockout.sql
@@ -1,0 +1,6 @@
+-- Durable, auditable account lockout (#295, AC-7 / 800-171 3.1.8). Additive columns on users:
+--   failed_attempt_count : consecutive failed login attempts since the last successful login
+--   locked_until         : when set and in the future, the account is locked from logging in
+-- Both are nullable/defaulted so existing rows migrate cleanly; the login flow maintains them.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_attempt_count INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP(3);

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -51,6 +51,12 @@
     }
     window.location.href = '${widgetContext.uri}?action=deleteAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
   }
+  function unlockAccount() {
+    if (!confirm("Are you sure you want to UNLOCK this user account? This clears the failed login attempts and lockout.")) {
+      return;
+    }
+    window.location.href = '${widgetContext.uri}?action=unlockAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+  }
 </script>
 <div style="margin-top: 6px;background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;">
   <div class="button-container float-right">
@@ -66,6 +72,9 @@
           <c:if test="${!user.enabled}">
             <li><a href="javascript:restoreAccount()">Restore Account</a></li>
           </c:if>
+          <c:if test="${user.locked}">
+            <li><a href="javascript:unlockAccount()">Unlock Account</a></li>
+          </c:if>
           <li><a href="javascript:deleteAccount()">Delete Account</a></li>
         </ul>
       </li>
@@ -75,6 +84,9 @@
     <c:out value="${user.fullName}" />
     <c:if test="${!user.enabled}">
       <span class="label alert">Suspended</span>
+    </c:if>
+    <c:if test="${user.locked}">
+      <span class="label warning">Locked</span>
     </c:if>
   </h3>
   <c:if test="${!empty user.title || !empty user.city || !empty user.state}">
@@ -261,6 +273,16 @@
         </c:choose>
       </div>
     </div>
+    <c:if test="${user.locked}">
+      <div class="grid-x grid-padding-x">
+        <div class="small-4 text-right cell">
+          <small>Locked Until</small>
+        </div>
+        <div class="small-8 align-self-middle cell">
+          <fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${user.lockedUntil}" />
+        </div>
+      </div>
+    </c:if>
     <div class="grid-x grid-padding-x">
       <div class="small-4 text-right cell">
         <small>Created</small>

--- a/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
@@ -16,11 +16,17 @@
 
 package com.simisinc.platform.application.login;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -40,6 +46,8 @@ import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.RateLimitCommand;
 import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
@@ -226,11 +234,14 @@ class AuthenticateLoginCommandTest {
     when(credentialsCache.getIfPresent(any())).thenReturn(null); // cache miss -> real verify runs
     try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
         MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
-        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       loadUser.when(() -> LoadUserCommand.loadUser("user@example.com")).thenReturn(user);
       cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn("");
 
       LoginException ex = assertThrows(LoginException.class,
           () -> AuthenticateLoginCommand.getAuthenticatedUser("user@example.com", "the WRONG password", IP_ADDRESS));
@@ -263,6 +274,113 @@ class AuthenticateLoginCommandTest {
 
       User result = AuthenticateLoginCommand.getAuthenticatedUser(username, oldPassword, IP_ADDRESS);
       assertNotNull(result, "a cache hit authenticates without re-verifying the stored hash");
+    }
+  }
+
+  // --- Durable account lockout (#295, AC-7) ---
+
+  private static User lockoutUser(int failedAttemptCount, Timestamp lockedUntil) {
+    User user = enabledUser(42L, UserPasswordCommand.hash("correct"));
+    user.setFailedAttemptCount(failedAttemptCount);
+    user.setLockedUntil(lockedUntil);
+    return user;
+  }
+
+  private static void stubForLogin(MockedStatic<RateLimitCommand> rl, MockedStatic<CacheManager> cm,
+      MockedStatic<LoadSitePropertyCommand> sp) {
+    rl.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+    rl.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
+    sp.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(""); // -> default threshold 5 / 15m
+    Cache cache = mock(Cache.class);
+    when(cache.getIfPresent(any())).thenReturn(null); // cache miss -> real verify path
+    cm.when(() -> CacheManager.getCache(anyString())).thenReturn(cache);
+  }
+
+  @Test
+  void locksTheAccountOnceTheThresholdIsCrossed() {
+    try (MockedStatic<RateLimitCommand> rl = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> lu = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cm = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> ur = mockStatic(UserRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class);
+        MockedStatic<LoadSitePropertyCommand> sp = mockStatic(LoadSitePropertyCommand.class)) {
+      stubForLogin(rl, cm, sp);
+      lu.when(() -> LoadUserCommand.loadUser("alice")).thenReturn(lockoutUser(4, null)); // one below default 5
+      assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("alice", "wrong", IP_ADDRESS));
+      // Count advances to 5 and a lock (non-null expiry) is set; the lockout is audited.
+      ur.verify(() -> UserRepository.updateLockoutState(eq(42L), eq(5), argThat(t -> t != null)));
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(eq("account.lockout"), any(), eq(42L),
+          any(), any(), any(), any()));
+    }
+  }
+
+  @Test
+  void incrementsButDoesNotLockBelowTheThreshold() {
+    try (MockedStatic<RateLimitCommand> rl = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> lu = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cm = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> ur = mockStatic(UserRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class);
+        MockedStatic<LoadSitePropertyCommand> sp = mockStatic(LoadSitePropertyCommand.class)) {
+      stubForLogin(rl, cm, sp);
+      lu.when(() -> LoadUserCommand.loadUser("alice")).thenReturn(lockoutUser(1, null));
+      assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("alice", "wrong", IP_ADDRESS));
+      ur.verify(() -> UserRepository.updateLockoutState(eq(42L), eq(2), isNull()));
+      audit.verify(() -> SaveAuditEventCommand.recordAuthentication(eq("account.lockout"), any(), anyLong(),
+          any(), any(), any(), any()), never());
+    }
+  }
+
+  @Test
+  void aLockedAccountIsRejectedBeforeThePasswordIsChecked() {
+    try (MockedStatic<RateLimitCommand> rl = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> lu = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cm = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> ur = mockStatic(UserRepository.class);
+        MockedStatic<LoadSitePropertyCommand> sp = mockStatic(LoadSitePropertyCommand.class)) {
+      stubForLogin(rl, cm, sp);
+      Timestamp locked = new Timestamp(System.currentTimeMillis() + 600_000L); // locked 10 minutes out
+      lu.when(() -> LoadUserCommand.loadUser("alice")).thenReturn(lockoutUser(5, locked));
+      // Even the correct password is refused while the account is locked.
+      assertThrows(LoginException.class,
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("alice", "correct", IP_ADDRESS));
+      ur.verify(() -> UserRepository.updateLockoutState(anyLong(), anyInt(), any()), never());
+      ur.verify(() -> UserRepository.resetLockout(anyLong()), never());
+    }
+  }
+
+  @Test
+  void aSuccessfulLoginClearsThePriorFailedAttempts() throws Exception {
+    try (MockedStatic<RateLimitCommand> rl = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> lu = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cm = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> ur = mockStatic(UserRepository.class);
+        MockedStatic<LoadSitePropertyCommand> sp = mockStatic(LoadSitePropertyCommand.class)) {
+      stubForLogin(rl, cm, sp);
+      User u = lockoutUser(3, null); // 3 prior failures, not locked
+      lu.when(() -> LoadUserCommand.loadUser("alice")).thenReturn(u);
+      User result = AuthenticateLoginCommand.getAuthenticatedUser("alice", "correct", IP_ADDRESS);
+      assertEquals(u, result);
+      ur.verify(() -> UserRepository.resetLockout(42L));
+    }
+  }
+
+  @Test
+  void anExpiredLockNoLongerBlocksLogin() throws Exception {
+    try (MockedStatic<RateLimitCommand> rl = mockStatic(RateLimitCommand.class);
+        MockedStatic<LoadUserCommand> lu = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cm = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> ur = mockStatic(UserRepository.class);
+        MockedStatic<LoadSitePropertyCommand> sp = mockStatic(LoadSitePropertyCommand.class)) {
+      stubForLogin(rl, cm, sp);
+      Timestamp expired = new Timestamp(System.currentTimeMillis() - 1000L); // lock already expired
+      User u = lockoutUser(5, expired);
+      lu.when(() -> LoadUserCommand.loadUser("alice")).thenReturn(u);
+      User result = AuthenticateLoginCommand.getAuthenticatedUser("alice", "correct", IP_ADDRESS);
+      assertEquals(u, result);
+      ur.verify(() -> UserRepository.resetLockout(42L));
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.login;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+
+/**
+ * A durable account lockout (#295, AC-7) auto-expires, but an administrator can also clear it early from the
+ * user-details page. These verify that the "Unlock Account" action clears the failed-attempt/lockout state
+ * through the repository and writes an audit record, so the manual recovery path is both effective and traceable,
+ * and that an unrecognized action is a no-op that touches neither.
+ *
+ * @author Elizabeth Houser
+ */
+class UserDetailsWidgetTest extends WidgetBase {
+
+  private static User lockedUser() {
+    User user = new User();
+    user.setId(5L);
+    user.setEmail("locked@example.com");
+    user.setFailedAttemptCount(5);
+    user.setLockedUntil(new Timestamp(System.currentTimeMillis() + 15 * 60_000L));
+    return user;
+  }
+
+  @Test
+  void unlockAccountClearsLockoutAndAudits() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "unlockAccount");
+
+    User target = lockedUser();
+    Assertions.assertTrue(target.isLocked(), "precondition: the target account is locked");
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+
+      new UserDetailsWidget().action(widgetContext);
+
+      // The lockout is cleared through the repository for exactly this user
+      userRepo.verify(() -> UserRepository.resetLockout(5L), times(1));
+      // ...and the administrative unlock is recorded in the audit log as a success
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.USER_MANAGEMENT), eq("user.unlock"),
+          eq(AuditEventCommand.SUCCESS), eq("user"), eq("5"), eq("locked@example.com"), any()), times(1));
+    }
+  }
+
+  @Test
+  void unknownActionDoesNotUnlock() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "somethingElse");
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(lockedUser());
+
+      new UserDetailsWidget().action(widgetContext);
+
+      userRepo.verify(() -> UserRepository.resetLockout(anyLong()), never());
+      audit.verifyNoInteractions();
+    }
+  }
+}


### PR DESCRIPTION
Implements durable account lockout end-to-end (#295, AC-7 / 800-171 3.1.8).

Adds two columns to `users` (`failed_attempt_count`, `locked_until`) via an additive migration + the install DDL, then in `AuthenticateLoginCommand`:
- a **locked account is rejected before the password is even checked** (and before the credentials cache), until the lock expires
- each **failed password increments the counter**; crossing the configurable threshold sets a lock (`locked_until = now + duration`) and records an `account.lockout` authentication audit event
- a **successful login clears** the counter and any lock
- **threshold and duration are site properties** (`account.lockout.threshold` default 5, `account.lockout.durationMinutes` default 15)

**Administrator manual unlock** (user-details page):
- an **"Unlock Account" action, shown only while the account is locked**, clears the failed-attempt counter and lockout via `UserRepository.resetLockout` and records a `user.unlock` audit event
- the page surfaces a **"Locked" status label** and the **"Locked Until"** time so the state is visible before acting
- unlock follows the same page-level gate (`role="admin,community-manager"`) and action-dispatch pattern as the existing suspend / restore / delete controls

**Tests:** 14 command tests (lock-at-threshold, increment-below-threshold, reject-while-locked-before-verify, reset-on-success, allow-after-expiry, plus the pre-existing auth paths) + 2 widget tests (unlock clears state and audits; an unknown action is a no-op). All green on a clean build.

Closes #295.
