### PR TITLE
Add on-box audit high-water floor to detect oldest-prefix deletion (AU-9)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/audit/AuditLogIntegrityCommand.java
+++ b/src/main/java/com/simisinc/platform/application/audit/AuditLogIntegrityCommand.java
@@ -119,8 +119,20 @@ public class AuditLogIntegrityCommand {
    * verification, or that the chain is intact. Reads in bounded pages so a large trail does not have to be
    * held in memory. Records written before Phase 4 (no hash) are treated as the pre-chain prefix and skipped
    * until the first hashed record, which becomes the chain's anchor.
+   *
+   * <p>Also performs the high-water floor check: if the minimum hashed audit_id in the table is higher than
+   * the stored floor, records were deleted from the oldest prefix outside the retention job (AU-9).
    */
   public static AuditIntegrityResult verify() {
+    long storedFloor = AuditLogRepository.loadHighwaterFloorId();
+    long currentMin = AuditLogRepository.selectMinHashedAuditId();
+
+    AuditIntegrityResult floorBroken = checkHighwaterFloor(storedFloor, currentMin);
+    if (floorBroken != null) {
+      LOG.warn("Audit high-water floor FAILED: " + floorBroken.getReason());
+      return floorBroken;
+    }
+
     ChainVerifier verifier = new ChainVerifier();
     long afterAuditId = 0L;
     while (true) {
@@ -141,7 +153,27 @@ public class AuditLogIntegrityCommand {
         break;
       }
     }
-    return verifier.result();
+    AuditIntegrityResult result = verifier.result();
+    if (result.isIntact() && currentMin > 0) {
+      // Advance the floor to the current minimum, establishing it for the first time if storedFloor==0.
+      AuditLogRepository.saveHighwaterFloorId(currentMin);
+    }
+    return result;
+  }
+
+  /**
+   * Pure floor-check logic: returns a broken result if {@code currentMin > storedFloor} (oldest-prefix
+   * deletion), or null if the floor is not violated. Package-private for unit testing.
+   *
+   * <p>The check is skipped (returns null) when storedFloor==0 (not yet initialized — the first
+   * verify walk will establish the floor) or when currentMin==0 (no hashed records present).
+   */
+  static AuditIntegrityResult checkHighwaterFloor(long storedFloor, long currentMin) {
+    if (storedFloor > 0 && currentMin > 0 && currentMin > storedFloor) {
+      return AuditIntegrityResult.broken(-1L, 0L,
+          "oldest-prefix deletion detected: floor_id=" + storedFloor + " but MIN(audit_id)=" + currentMin);
+    }
+    return null;
   }
 
   private static final int PAGE_SIZE = 1000;

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogRepository.java
@@ -228,6 +228,79 @@ public class AuditLogRepository {
     }
   }
 
+  /**
+   * Returns the minimum audit_id among records that carry a hash, or 0 if there are none.
+   * Used by the high-water floor check in {@link AuditLogIntegrityCommand#verify()}.
+   */
+  public static long selectMinHashedAuditId() {
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(
+             "SELECT MIN(audit_id) FROM " + TABLE_NAME + " WHERE record_hash IS NOT NULL");
+         ResultSet rs = pst.executeQuery()) {
+      if (rs.next()) {
+        long val = rs.getLong(1);
+        return rs.wasNull() ? 0L : val;
+      }
+      return 0L;
+    } catch (SQLException e) {
+      LOG.error("selectMinHashedAuditId: " + e.getMessage(), e);
+      return 0L;
+    }
+  }
+
+  /**
+   * Loads the stored audit high-water floor ID from site_properties. Returns 0 if not yet set or
+   * unreadable, which causes the floor check in verify() to be skipped (safe default: no false positive).
+   */
+  public static long loadHighwaterFloorId() {
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(
+             "SELECT property_value FROM site_properties WHERE property_name = 'audit.highwater.floor_id'");
+         ResultSet rs = pst.executeQuery()) {
+      if (rs.next()) {
+        String val = rs.getString(1);
+        if (val != null && !val.isBlank()) {
+          try {
+            return Long.parseLong(val.trim());
+          } catch (NumberFormatException e) {
+            return 0L;
+          }
+        }
+      }
+      return 0L;
+    } catch (SQLException e) {
+      LOG.error("loadHighwaterFloorId: " + e.getMessage(), e);
+      return 0L;
+    }
+  }
+
+  /**
+   * Monotonically advances the stored audit high-water floor ID. A value <= 0 is a no-op. The floor
+   * never decreases — if the stored value is already >= floorId the upsert is skipped in Java before
+   * hitting the database, so concurrent callers both writing the same value are harmless.
+   * <p>Called by {@link AuditLogIntegrityCommand#verify()} after a verified-intact chain walk and by
+   * {@link com.simisinc.platform.infrastructure.scheduler.audit.AuditLogRetentionJob} after a purge.
+   */
+  public static void saveHighwaterFloorId(long floorId) {
+    if (floorId <= 0) {
+      return;
+    }
+    long current = loadHighwaterFloorId();
+    if (floorId <= current) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(
+             "INSERT INTO site_properties (property_order, property_label, property_name, property_value) "
+             + "VALUES (0, 'Audit log high-water floor ID', 'audit.highwater.floor_id', ?) "
+             + "ON CONFLICT (property_name) DO UPDATE SET property_value = EXCLUDED.property_value")) {
+      pst.setString(1, Long.toString(floorId));
+      pst.executeUpdate();
+    } catch (SQLException e) {
+      LOG.error("saveHighwaterFloorId: " + e.getMessage(), e);
+    }
+  }
+
   public static List<AuditLog> findAll(DataConstraints constraints) {
     if (constraints == null) {
       constraints = new DataConstraints();

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/audit/AuditLogRetentionJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/audit/AuditLogRetentionJob.java
@@ -52,6 +52,14 @@ public class AuditLogRetentionJob {
     int deleted = AuditLogRepository.deleteOlderThan(days);
     if (deleted > 0) {
       LOG.info("Audit retention: deleted " + deleted + " record(s) older than " + days + " days");
+      // Advance the high-water floor to the new minimum so the next verify() does not flag the
+      // reduced minimum as a deletion (AU-9). Done after the delete so the floor only moves to
+      // an ID that actually exists; a concurrent verify() between the delete and this update is
+      // benign — the false-positive window is tiny and the next retention run will clear it.
+      long newMin = AuditLogRepository.selectMinHashedAuditId();
+      if (newMin > 0) {
+        AuditLogRepository.saveHighwaterFloorId(newMin);
+      }
       SaveAuditEventCommand.recordAdminEvent("configuration", "audit.retention.purge", "success",
           -1L, "system", null, null, "audit_log", null, null,
           "deleted=" + deleted + ";olderThanDays=" + days);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1001__audit_highwater.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1001__audit_highwater.sql
@@ -1,0 +1,15 @@
+-- Audit high-water floor for on-box oldest-prefix deletion detection (POA&M #9 / NIST AU-9).
+-- Stored in site_properties so it persists across restarts and is accessible to the same
+-- property-loading path as audit.retentionDays.
+--
+-- The floor ID is the minimum audit_id that is expected to exist in audit_log among records
+-- that carry a hash. It advances monotonically:
+--   - AuditLogIntegrityCommand.verify() sets it when it walks an intact chain (first-time
+--     initialization and after each clean check).
+--   - AuditLogRetentionJob advances it after a legitimate retention purge.
+-- If verify() observes MIN(audit_id) > floor, it reports broken (oldest-prefix deletion
+-- outside the retention path). A value of '0' means not yet established; the check is skipped
+-- until the first intact verify walk sets a real floor.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (0, 'Audit log high-water floor ID', 'audit.highwater.floor_id', '0')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/audit/AuditLogIntegrityCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/audit/AuditLogIntegrityCommandTest.java
@@ -19,6 +19,8 @@ package com.simisinc.platform.application.audit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
@@ -162,6 +164,45 @@ class AuditLogIntegrityCommandTest {
     AuditIntegrityResult result = AuditLogIntegrityCommand.verifyChain(all);
     assertTrue(result.isIntact());
     assertEquals(2, result.getCheckedCount());
+  }
+
+  // --- High-water floor tests ---
+
+  @Test
+  void floorCheckPassesWhenStoredFloorIsZeroUninitialized() {
+    // storedFloor==0 means not yet set; skip the check regardless of currentMin.
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(0L, 5L));
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(0L, 1L));
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(0L, 0L));
+  }
+
+  @Test
+  void floorCheckPassesWhenCurrentMinIsZeroNoHashedRecords() {
+    // currentMin==0 means no hashed records in the table; skip the check.
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(5L, 0L));
+  }
+
+  @Test
+  void floorCheckPassesWhenCurrentMinEqualsFloor() {
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(5L, 5L));
+  }
+
+  @Test
+  void floorCheckPassesWhenCurrentMinBelowFloor() {
+    // currentMin < storedFloor is an impossible normal state (means new records arrived below the floor)
+    // but it must never falsely trigger -- the check is for deletion (currentMin > floor), not insertion.
+    assertNull(AuditLogIntegrityCommand.checkHighwaterFloor(10L, 5L));
+  }
+
+  @Test
+  void floorCheckDetectsOldestPrefixDeletion() {
+    AuditLogIntegrityCommand.AuditIntegrityResult result =
+        AuditLogIntegrityCommand.checkHighwaterFloor(5L, 10L);
+    assertNotNull(result);
+    assertFalse(result.isIntact());
+    assertTrue(result.getReason().contains("oldest-prefix deletion"));
+    assertTrue(result.getReason().contains("floor_id=5"));
+    assertTrue(result.getReason().contains("MIN(audit_id)=10"));
   }
 
   @Test


### PR DESCRIPTION
Closes #296. Closes POA&M item 9 (AU-9, oldest-prefix audit deletion not detectable on-box).

## What this does

The existing hash chain detects deletion-in-place, reordering, and mid-chain removal. What it **cannot** detect is deletion of the oldest contiguous prefix — that leaves a shorter but self-consistent chain indistinguishable from a legitimate retention purge.

This PR adds an on-box monotonic floor: `audit.highwater.floor_id` stored in `site_properties`. On every intact `verify()` walk, the floor is set to `MIN(audit_id WHERE record_hash IS NOT NULL)`. If a subsequent walk finds that minimum is now higher than the stored floor — and no retention purge advanced it — `verify()` reports broken.

## Changes

- **Migration** `UPGRADE_20260725.1001__audit_highwater.sql` — seeds `audit.highwater.floor_id = 0` (0 = not yet initialized; the tamper check is skipped on the first run so a fresh install doesn't false-positive).
- **`AuditLogRepository`** — three new methods: `selectMinHashedAuditId()`, `loadHighwaterFloorId()`, `saveHighwaterFloorId(long)`. The floor is monotonic: `save` is a no-op if the new value is ≤ the current stored value.
- **`AuditLogIntegrityCommand.verify()`** — reads floor + current min before the chain walk; returns `broken` if `currentMin > storedFloor > 0`. Advances floor after an intact walk. New pure helper `checkHighwaterFloor(storedFloor, currentMin)` is package-private and unit-testable without a DB.
- **`AuditLogRetentionJob`** — after a successful prefix purge, advances the floor to the new `MIN(audit_id)` so the next `verify()` accepts the reduced table rather than flagging it as tamper.

## Verification

- `ant -lib lib/war compile-test` — clean (0 errors)
- `AuditLogIntegrityCommandTest` — 14 tests, 0 failures (5 new floor-check tests + existing 9 chain tests)
- `ant -lib lib/war compile-jsp` — 288 JSPs, 0 errors