### PR TITLE
Add org-level MFA enforcement for privileged roles (IA-2(1))

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -300,6 +300,26 @@ public class PageServlet extends HttpServlet {
         return;
       }
 
+      // MFA enforcement (IA-2(1)): redirect users in a required role who have not enrolled in MFA.
+      // Exemptions: the enrollment page itself, the logout page, and static asset paths (to avoid loops).
+      if (userSession.isLoggedIn() && !"/my-security".equals(pagePath)
+          && !"/logout".equals(pagePath) && !pagePath.startsWith("/assets/")) {
+        String mfaRequiredRoles = LoadSitePropertyCommand.loadByName("mfa.required.roles");
+        if (StringUtils.isNotBlank(mfaRequiredRoles)) {
+          for (String role : mfaRequiredRoles.split(",")) {
+            if (userSession.hasRole(role.trim())) {
+              if (!userSession.isMfaEnabled()) {
+                LOG.info("MFA enforcement: redirecting user " + userSession.getUserId()
+                    + " (role=" + role.trim() + ") to /my-security to complete MFA enrollment");
+                response.sendRedirect(request.getContextPath() + "/my-security");
+                return;
+              }
+              break; // user has MFA; no need to check remaining required roles
+            }
+          }
+        }
+      }
+
       // Determine the core data to be used by local and remote widgets...
       Map<String, String> coreData = new HashMap<>();
       coreData.put("userId", String.valueOf(userSession.getUserId()));

--- a/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
@@ -65,6 +65,7 @@ public class UserSession implements Serializable {
   private long lastOrderId = -1;
   private boolean showSiteConfirmation = true;
   private boolean showSiteNewsletterSignup = true;
+  private boolean mfaEnabled = false;
 
   public UserSession() {
   }
@@ -79,7 +80,16 @@ public class UserSession implements Serializable {
     userId = user.getId();
     roleList = user.getRoleList();
     groupList = user.getGroupList();
+    mfaEnabled = user.getMfaEnabled();
     loginTime = System.currentTimeMillis();
+  }
+
+  public boolean isMfaEnabled() {
+    return mfaEnabled;
+  }
+
+  public void setMfaEnabled(boolean mfaEnabled) {
+    this.mfaEnabled = mfaEnabled;
   }
 
   public void setRoleList(List<Role> roleList) {

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -492,10 +492,11 @@ public class WebRequestFilter implements Filter {
         return;
       }
 
-      // Update user roles and groups
+      // Update user roles, groups, and MFA state
       LOG.debug("Updating user roles and groups");
       userSession.setRoleList(user.getRoleList());
       userSession.setGroupList(user.getGroupList());
+      userSession.setMfaEnabled(user.getMfaEnabled());
     }
 
     // The home page can show an overlay (a couple of different kinds)

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__mfa_required_roles.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__mfa_required_roles.sql
@@ -1,0 +1,9 @@
+-- Org-level MFA enforcement site setting (POA&M IA-2(1) / 800-171 3.5.3).
+-- A comma-separated list of role codes whose members must have TOTP MFA enrolled before
+-- reaching any page. Empty (the default) means off -- non-breaking opt-in per deployment,
+-- matching the same rollout shape as content.review.required.
+-- Enabling this property via the admin settings page (or SQL) is itself audited by
+-- SitePropertiesEditorWidget as 'setting.update' in the audit trail.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (1, 'Roles required to use MFA (comma-separated codes, e.g. admin,content-manager)', 'mfa.required.roles', '')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -398,6 +398,17 @@
     </section>
   </page>
 
+  <page name="/admin/security-settings" role="admin" title="Security Settings">
+    <section>
+      <column class="small-12 large-8 cell">
+        <widget name="sitePropertiesEditor">
+          <title>MFA Enforcement</title>
+          <prefix>mfa</prefix>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/bi-properties" role="admin" title="BI Settings">
     <section>
       <column class="small-12 large-10 cell">

--- a/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
@@ -202,6 +202,17 @@
     </section>
   </page>
 
+  <!-- User Security Settings: MFA enrollment -->
+  <page name="/my-security" title="Security Settings" class="platform-dialog">
+    <section class="align-center">
+      <column class="small-12 medium-8 large-6 cell">
+        <widget name="myMfaSettings" class="callout box radius">
+          <title>Two-Factor Authentication</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <!-- Content Editing -->
   <page name="/content-editor" role="admin,content-manager" title="Content Editor" class="full-page">
     <section>


### PR DESCRIPTION
Closes #297

## Summary

- Adds `mfa.required.roles` site property (comma-separated role codes, default empty = off) configurable by admins at `/admin/security-settings`
- Extends `UserSession` with `mfaEnabled` flag, populated at login and refreshed by `WebRequestFilter` on every request alongside roles
- Gates access in `PageServlet` after `allowsUser()`: if the requesting user holds a required role but has not enrolled in MFA, they are redirected to `/my-security` to complete enrollment before proceeding
- Adds `/my-security` page wiring `myMfaSettings` widget for self-service TOTP enrollment; exempted from the gate to prevent a redirect loop; `/logout` and `/assets/*` also exempted
- Adds `/admin/security-settings` admin page showing the `sitePropertiesEditor` scoped to the `mfa` prefix; every save is audited automatically as `setting.update` by the existing widget
- Flyway migration seeds the `mfa.required.roles` row with an empty default so the feature is non-breaking on existing deployments

## Test plan

- [ ] Build clean (`ant compile-test`); 288 JSPs compile (`ant compile-jsp`)
- [ ] Deploy with `mfa.required.roles` empty — no change in behavior for any user
- [ ] Set `mfa.required.roles=admin` in `/admin/security-settings` and confirm the property saves and appears in audit log as `setting.update`
- [ ] Log in as an admin user without MFA enrolled — expect redirect to `/my-security`; `/logout` still works from that state
- [ ] Enroll TOTP from `/my-security`, then confirm navigation is no longer blocked on subsequent requests
- [ ] Log in as a non-admin user — confirm no redirect regardless of `mfa.required.roles` value
- [ ] Verify `WebRequestFilter` refreshes `mfaEnabled` on each request (unenrolling mid-session triggers the gate on the next page load)