### PR TITLE
Add step-up re-authentication for sensitive actions (IA-2 / AC-6)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -470,6 +470,12 @@ public class ContentHtmlCommand {
   }
 
   private static WidgetContext approveContent(WidgetContext context, Content content) {
+    // Content approval is a high-value action (AC-L1-b.1.iv); the approver must have re-verified
+    // their identity within the last 5 minutes (IA-2 / AC-6).
+    if (!context.getUserSession().isStepUpValid()) {
+      context.setRedirect("/step-up-auth?return=" + context.getUri());
+      return context;
+    }
     String releaseReference = context.getParameter("releaseReference");
     try {
       // approve() enforces separation of duties (the approver cannot be the submitter); approval then

--- a/src/main/java/com/simisinc/platform/application/login/StepUpAuthCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/StepUpAuthCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.domain.model.User;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Step-up re-authentication for sensitive actions (IA-2 / AC-6). Verifies the acting user's identity
+ * via password or (when MFA is enrolled) a TOTP code before a high-privilege action is allowed.
+ * The caller is responsible for recording the step-up in the session and auditing the outcome.
+ */
+public class StepUpAuthCommand {
+
+  private static Log LOG = LogFactory.getLog(StepUpAuthCommand.class);
+
+  private StepUpAuthCommand() {
+  }
+
+  /**
+   * Returns true when the supplied credential matches the user's stored password, or when the user
+   * has MFA enrolled and the supplied TOTP code is valid. At least one of password or totpCode must
+   * be non-blank; if both are supplied, either match succeeds.
+   */
+  public static boolean verify(User user, String password, String totpCode) {
+    if (user == null) {
+      return false;
+    }
+    if (StringUtils.isNotBlank(password)) {
+      try {
+        if (UserPasswordCommand.verify(password, user.getPassword())) {
+          return true;
+        }
+      } catch (Exception e) {
+        LOG.warn("Step-up password verify error for user id " + user.getId() + ": " + e.getMessage());
+      }
+    }
+    if (user.getMfaEnabled() && StringUtils.isNotBlank(totpCode)
+        && StringUtils.isNotBlank(user.getMfaSecret())) {
+      return TotpCommand.verifyCode(user.getMfaSecret(), totpCode);
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
@@ -65,6 +65,10 @@ public class UserSession implements Serializable {
   private long lastOrderId = -1;
   private boolean showSiteConfirmation = true;
   private boolean showSiteNewsletterSignup = true;
+  private long stepUpVerifiedAt = 0L;
+
+  // Step-up re-auth window: 5 minutes from the last successful step-up verification.
+  static final long STEP_UP_WINDOW_MS = 300_000L;
 
   public UserSession() {
   }
@@ -249,5 +253,18 @@ public class UserSession implements Serializable {
 
   public void setShowSiteNewsletterSignup(boolean showSiteNewsletterSignup) {
     this.showSiteNewsletterSignup = showSiteNewsletterSignup;
+  }
+
+  public boolean isStepUpValid() {
+    return stepUpVerifiedAt > 0
+        && (System.currentTimeMillis() - stepUpVerifiedAt) < STEP_UP_WINDOW_MS;
+  }
+
+  public void recordStepUp() {
+    stepUpVerifiedAt = System.currentTimeMillis();
+  }
+
+  public void clearStepUp() {
+    stepUpVerifiedAt = 0L;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
@@ -51,6 +51,11 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
   static String PREFIX_PREFERENCE = "prefix";
 
+  // Prefixes whose properties gate privileged access controls or audit behavior.
+  // Changes to these require a recent step-up re-authentication (IA-2 / AC-6).
+  private static final java.util.Set<String> SECURITY_PREFIXES = new java.util.HashSet<>(
+      java.util.Arrays.asList("mfa", "content.review", "security"));
+
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -81,8 +86,14 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
   public WidgetContext post(WidgetContext context) {
 
-    // Load the properties
+    // Security-sensitive prefixes require a recent step-up re-authentication (IA-2 / AC-6).
     String prefix = context.getPreferences().get(PREFIX_PREFERENCE);
+    if (isSecuritySensitivePrefix(prefix) && !context.getUserSession().isStepUpValid()) {
+      context.setRedirect("/step-up-auth?return=" + context.getUri());
+      return context;
+    }
+
+    // Load the properties
     List<SiteProperty> siteProperties = new ArrayList<>();
     String[] prefixList = prefix.split(",");
     for (String thisPrefix : prefixList) {
@@ -186,5 +197,17 @@ public class SitePropertiesEditorWidget extends GenericWidget {
       context.setErrorMessage("Values could not be saved");
     }
     return context;
+  }
+
+  private static boolean isSecuritySensitivePrefix(String prefix) {
+    if (StringUtils.isBlank(prefix)) {
+      return false;
+    }
+    for (String p : prefix.split(",")) {
+      if (SECURITY_PREFIXES.contains(p.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -87,6 +87,11 @@ public class UserDetailsWidget extends GenericWidget {
     context.setRedirect("/admin/user-details?userId=" + userId);
     String action = context.getParameter("action");
     if ("resetPassword".equals(action)) {
+      // Resetting another user's password requires a recent step-up re-authentication (IA-2 / AC-6).
+      if (!context.getUserSession().isStepUpValid()) {
+        context.setRedirect("/step-up-auth?return=/admin/user-details%3FuserId%3D" + userId);
+        return context;
+      }
       return resetPassword(context, user);
     } else if ("suspendAccount".equals(action)) {
       return suspendAccount(context, user);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -84,6 +84,12 @@ public class UserFormWidget extends GenericWidget {
 
   public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
 
+    // Changing another user's roles requires a recent step-up re-authentication (IA-2 / AC-6).
+    if (!context.getUserSession().isStepUpValid()) {
+      context.setRedirect("/step-up-auth?return=" + context.getUri());
+      return context;
+    }
+
     // Populate the fields
     User userBean = new User();
     BeanUtils.populate(userBean, context.getParameterMap());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/StepUpAuthWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/StepUpAuthWidget.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.login;
+
+import com.simisinc.platform.application.login.StepUpAuthCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Step-up re-authentication challenge widget (IA-2 / AC-6). Presents a password or TOTP form to
+ * re-verify the acting user's identity before a sensitive action is permitted. On success, marks the
+ * session and redirects back to the originating page; on failure, re-displays the form with an error.
+ */
+public class StepUpAuthWidget extends GenericWidget {
+
+  static final long serialVersionUID = -1937504882716093401L;
+
+  static String JSP = "/login/step-up-auth.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    if (!context.getUserSession().isLoggedIn()) {
+      return context;
+    }
+    context.getRequest().setAttribute("returnUrl", safeReturnUrl(context.getParameter("return")));
+    User user = UserRepository.findByUserId(context.getUserId());
+    if (user != null) {
+      context.getRequest().setAttribute("mfaEnabled", user.getMfaEnabled() ? "true" : "false");
+    }
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+    if (!context.getUserSession().isLoggedIn()) {
+      return context;
+    }
+    String returnUrl = safeReturnUrl(context.getParameter("returnUrl"));
+    User user = UserRepository.findByUserId(context.getUserId());
+    if (user == null) {
+      context.setErrorMessage("Unable to verify identity. Please try again.");
+      context.getRequest().setAttribute("returnUrl", returnUrl);
+      context.setJsp(JSP);
+      return context;
+    }
+    String password = context.getParameter("password");
+    String totpCode = context.getParameter("code");
+    if (StepUpAuthCommand.verify(user, password, totpCode)) {
+      context.getUserSession().recordStepUp();
+      AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "stepup.auth",
+          AuditEventCommand.SUCCESS, "user", String.valueOf(user.getId()), user.getEmail(), null);
+      LOG.info("Step-up re-auth succeeded for user id " + user.getId());
+      context.setRedirect(returnUrl);
+      return context;
+    }
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "stepup.auth",
+        AuditEventCommand.FAILURE, "user", String.valueOf(user.getId()), user.getEmail(), null);
+    context.setErrorMessage("Verification failed. Please check your password or authenticator code.");
+    context.getRequest().setAttribute("returnUrl", returnUrl);
+    context.getRequest().setAttribute("mfaEnabled", user.getMfaEnabled() ? "true" : "false");
+    context.setJsp(JSP);
+    return context;
+  }
+
+  private static String safeReturnUrl(String url) {
+    if (StringUtils.isBlank(url) || !url.startsWith("/")) {
+      return "/";
+    }
+    return url;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
@@ -109,6 +109,11 @@ public class MyMfaSettingsWidget extends GenericWidget {
     }
 
     if ("disable".equals(action)) {
+      // Disabling MFA requires a recent step-up re-authentication (IA-2 / AC-6).
+      if (!context.getUserSession().isStepUpValid()) {
+        context.setRedirect("/step-up-auth?return=" + context.getUri());
+        return context;
+      }
       UserMfaCommand.disable(user);
       UserMfaRecoveryCodeCommand.clear(user);
       context.setSuccessMessage("Two-factor authentication has been turned off.");

--- a/src/main/webapp/WEB-INF/jsp/login/step-up-auth.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/step-up-auth.jsp
@@ -1,0 +1,53 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<form method="post">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}" />
+  <input type="hidden" name="token" value="${userSession.formToken}" />
+  <input type="hidden" name="returnUrl" value="${fn:escapeXml(returnUrl)}" />
+  <%-- Form Content --%>
+  <div class="dialog-header">
+    <h1><i class="fa fa-lock"></i> Confirm your identity</h1>
+    <p>This action requires you to re-verify your identity.</p>
+  </div>
+  <%@include file="../page_messages.jspf" %>
+  <div class="grid-x grid-margin-x">
+    <div class="small-12 cell">
+      <c:choose>
+        <c:when test="${mfaEnabled eq 'true'}">
+          <p>Enter your password <strong>or</strong> the 6-digit code from your authenticator app.</p>
+          <label>Password
+            <input name="password" type="password" placeholder="Password" autocomplete="current-password" autofocus>
+          </label>
+          <label>Authenticator code
+            <input name="code" type="text" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" placeholder="123456">
+          </label>
+        </c:when>
+        <c:otherwise>
+          <p>Enter your password to continue.</p>
+          <label>Password
+            <input name="password" type="password" placeholder="Password" autocomplete="current-password" autofocus required>
+          </label>
+        </c:otherwise>
+      </c:choose>
+      <p><input type="submit" class="button primary radius expanded" value="Verify"></p>
+    </div>
+  </div>
+</form>

--- a/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
@@ -202,6 +202,15 @@
     </section>
   </page>
 
+  <!-- Step-up re-authentication -->
+  <page name="/step-up-auth" title="Confirm Identity" class="platform-dialog">
+    <section class="align-center">
+      <column class="small-12 medium-8 large-6 cell">
+        <widget name="stepUpAuth" class="callout box radius" />
+      </column>
+    </section>
+  </page>
+
   <!-- Content Editing -->
   <page name="/content-editor" role="admin,content-manager" title="Content Editor" class="full-page">
     <section>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -23,6 +23,7 @@
   <widget name="register" class="com.simisinc.platform.presentation.widgets.register.RegisterWidget" />
   <widget name="forgotPassword" class="com.simisinc.platform.presentation.widgets.login.ForgotPasswordWidget" />
   <widget name="accountValidation" class="com.simisinc.platform.presentation.widgets.login.AccountValidationWidget" />
+  <widget name="stepUpAuth" class="com.simisinc.platform.presentation.widgets.login.StepUpAuthWidget" />
   <!-- Content Management -->
   <widget name="logo" class="com.simisinc.platform.presentation.widgets.cms.LogoWidget" />
   <widget name="copyright" class="com.simisinc.platform.presentation.widgets.cms.CopyrightWidget" />

--- a/src/test/java/com/simisinc/platform/WidgetBase.java
+++ b/src/test/java/com/simisinc/platform/WidgetBase.java
@@ -214,6 +214,10 @@ public class WidgetBase {
     widgetContext.getCoreData().put("userId", String.valueOf(userSession.getUserId()));
   }
 
+  public static void grantStepUp(WidgetContext widgetContext) {
+    widgetContext.getUserSession().recordStepUp();
+  }
+
   public static void logout(WidgetContext widgetContext) {
     // User information
     UserSession userSession = new UserSession();

--- a/src/test/java/com/simisinc/platform/application/login/StepUpAuthCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/StepUpAuthCommandTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.domain.model.User;
+import org.apache.commons.codec.binary.Base32;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+
+/**
+ * Tests for StepUpAuthCommand: password verification, TOTP verification, and null-safety.
+ */
+class StepUpAuthCommandTest {
+
+  private static User userWithPassword(String plaintext) {
+    User user = new User();
+    user.setId(1L);
+    user.setPassword(UserPasswordCommand.hash(plaintext));
+    user.setMfaEnabled(false);
+    return user;
+  }
+
+  private static User userWithPasswordAndMfa(String plaintext, String mfaSecret) {
+    User user = userWithPassword(plaintext);
+    user.setMfaEnabled(true);
+    user.setMfaSecret(mfaSecret);
+    return user;
+  }
+
+  private static String generateBase32Secret() {
+    byte[] bytes = new byte[20];
+    new SecureRandom().nextBytes(bytes);
+    return new Base32().encodeAsString(bytes);
+  }
+
+  @Test
+  void nullUserReturnsFalse() {
+    assertFalse(StepUpAuthCommand.verify(null, "password", null));
+  }
+
+  @Test
+  void correctPasswordSucceeds() {
+    User user = userWithPassword("correct-password");
+    assertTrue(StepUpAuthCommand.verify(user, "correct-password", null));
+  }
+
+  @Test
+  void wrongPasswordFails() {
+    User user = userWithPassword("correct-password");
+    assertFalse(StepUpAuthCommand.verify(user, "wrong-password", null));
+  }
+
+  @Test
+  void blankPasswordFails() {
+    User user = userWithPassword("correct-password");
+    assertFalse(StepUpAuthCommand.verify(user, "", null));
+    assertFalse(StepUpAuthCommand.verify(user, null, null));
+  }
+
+  @Test
+  void totpIgnoredWhenMfaNotEnabled() {
+    // A user without MFA should not be able to step up via a TOTP code
+    String secret = generateBase32Secret();
+    User user = userWithPassword("correct-password");
+    user.setMfaEnabled(false);
+    user.setMfaSecret(secret);
+    // Generate a valid TOTP code for this secret
+    String code = currentTotpCode(secret);
+    // TOTP alone should not succeed when MFA is not enabled
+    assertFalse(StepUpAuthCommand.verify(user, "", code));
+    assertFalse(StepUpAuthCommand.verify(user, null, code));
+  }
+
+  @Test
+  void validTotpCodeSucceeds() {
+    String secret = generateBase32Secret();
+    User user = userWithPasswordAndMfa("some-password", secret);
+    String code = currentTotpCode(secret);
+    assertTrue(StepUpAuthCommand.verify(user, null, code));
+    assertTrue(StepUpAuthCommand.verify(user, "", code));
+  }
+
+  @Test
+  void invalidTotpCodeFails() {
+    String secret = generateBase32Secret();
+    User user = userWithPasswordAndMfa("some-password", secret);
+    assertFalse(StepUpAuthCommand.verify(user, null, "000000"));
+  }
+
+  @Test
+  void passwordSucceedsEvenWhenMfaEnabled() {
+    String secret = generateBase32Secret();
+    User user = userWithPasswordAndMfa("correct-password", secret);
+    assertTrue(StepUpAuthCommand.verify(user, "correct-password", null));
+  }
+
+  /** Generates the current TOTP code for a given Base32 secret using TotpCommand's own clock. */
+  private static String currentTotpCode(String secret) {
+    long epoch = Instant.now().getEpochSecond();
+    long step = epoch / 30;
+    try {
+      javax.crypto.Mac mac = javax.crypto.Mac.getInstance("HmacSHA1");
+      byte[] keyBytes = new Base32().decode(secret);
+      mac.init(new javax.crypto.spec.SecretKeySpec(keyBytes, "HmacSHA1"));
+      byte[] data = java.nio.ByteBuffer.allocate(8).putLong(step).array();
+      byte[] hash = mac.doFinal(data);
+      int offset = hash[hash.length - 1] & 0x0F;
+      int code = ((hash[offset] & 0x7F) << 24)
+          | ((hash[offset + 1] & 0xFF) << 16)
+          | ((hash[offset + 2] & 0xFF) << 8)
+          | (hash[offset + 3] & 0xFF);
+      return String.format("%06d", code % 1_000_000);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -43,6 +43,7 @@ import com.simisinc.platform.presentation.controller.AuditEventCommand;
  * role -- e.g. a community-manager (level 90) granting admin (level 100), a full privilege escalation.
  * These verify the editor can only set roles at or below their own level, admins are unaffected, and a
  * higher role the target already holds is neither grantable nor strippable by a lower editor.
+ * Step-up re-auth tests verify the gate redirects when the session has not been recently verified.
  *
  * @author Elizabeth Houser
  */
@@ -72,8 +73,20 @@ class UserFormWidgetTest extends WidgetBase {
   }
 
   @Test
+  void postWithoutStepUpRedirectsToChallenge() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "id", "-1");
+    // Do NOT call grantStepUp — the session has no recorded step-up
+    new UserFormWidget().post(widgetContext);
+    Assertions.assertNotNull(widgetContext.getRedirect(), "no step-up → must redirect");
+    Assertions.assertTrue(widgetContext.getRedirect().contains("/step-up-auth"),
+        "redirect must point to the step-up challenge page");
+  }
+
+  @Test
   void communityManagerCannotGrantAdminButKeepsAllowedRoles() throws Exception {
     setRoles(widgetContext, COMMUNITY_MANAGER);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "-1");        // create
     addQueryParameter(widgetContext, "roleId1", "1");    // content-editor (70) -- allowed
     addQueryParameter(widgetContext, "roleId4", "4");    // admin (100) -- must be refused
@@ -99,6 +112,7 @@ class UserFormWidgetTest extends WidgetBase {
   @Test
   void adminCanGrantAdmin() throws Exception {
     setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "-1");
     addQueryParameter(widgetContext, "roleId4", "4");    // admin
 
@@ -122,6 +136,7 @@ class UserFormWidgetTest extends WidgetBase {
   @Test
   void communityManagerCannotStripHigherRoleTheTargetAlreadyHolds() throws Exception {
     setRoles(widgetContext, COMMUNITY_MANAGER);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "5");         // editing an existing user
     addQueryParameter(widgetContext, "roleId1", "1");    // submits content-editor; admin left unchecked
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
@@ -151,9 +151,27 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
   }
 
   @Test
+  void postDisableWithoutStepUpRedirectsToStepUpAuth() {
+    addQueryParameter(widgetContext, "action", "disable");
+    when(request.getRequestURI()).thenReturn("/my-account");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().post(widgetContext);
+    }
+    // No step-up: must redirect to the step-up challenge, not disable MFA
+    Assertions.assertEquals("/step-up-auth?return=/my-account", widgetContext.getRedirect());
+    Assertions.assertNull(widgetContext.getSuccessMessage());
+  }
+
+  @Test
   void postDisableTurnsOffAndRedirects() {
     addQueryParameter(widgetContext, "action", "disable");
     when(request.getRequestURI()).thenReturn("/my-account");
+    // A valid step-up is required to disable MFA (IA-2 / AC-6)
+    grantStepUp(widgetContext);
     User user = new User();
     user.setId(1L);
     user.setMfaEnabled(true);


### PR DESCRIPTION
Closes #298

## Summary

- Adds a 5-minute step-up re-authentication gate to five sensitive action paths: changing another user's roles, resetting another user's password, disabling MFA on an account, saving security-sensitive site properties (`mfa`, `content.review`, `security` prefixes), and approving content for publication
- `UserSession` gains `stepUpVerifiedAt`, `isStepUpValid()`, `recordStepUp()`, and `clearStepUp()` with a 5-minute window (`STEP_UP_WINDOW_MS`)
- `StepUpAuthCommand.verify()` accepts a correct password **or** a valid TOTP code (when MFA is enrolled); either credential satisfies the challenge
- `StepUpAuthWidget` + `/WEB-INF/jsp/login/step-up-auth.jsp` serve the challenge form; on success the session is stamped and a `AUTHORIZATION / stepup.auth` audit event is recorded; on failure the form redisplays with an error
- `/step-up-auth` page added to `cms-layout.xml` (any logged-in user, `platform-dialog` class); `stepUpAuth` widget registered in `widget-library.xml`
- Each gated action redirects to `/step-up-auth?return=<originating-path>` when the session has no valid step-up; the user re-submits the form after verifying

## Test plan

- [ ] Build clean (`ant compile-test`); 289 JSPs compile (`ant compile-jsp`); full test suite passes (`ant test`)
- [ ] As an admin without a recent step-up, submit the user-edit form → redirected to `/step-up-auth`; verify with password → returned to form; re-submit → roles saved
- [ ] Attempt to disable MFA on own account without step-up → redirected; verify → disable succeeds; step-up audit event appears in audit log as `stepup.auth / success`
- [ ] Save `mfa.*` settings on `/admin/security-settings` without step-up → redirected; verify → saved; wrong password → error shown, `stepup.auth / failure` in audit log
- [ ] Non-security prefix (e.g. `site`, `social`) saves without requiring step-up
- [ ] Approve content without step-up → redirected; verify → approval proceeds; step-up window then covers subsequent approvals within 5 minutes
- [ ] Verify step-up expires: record a step-up, wait 5+ minutes (or manually test with a shortened window), attempt a gated action → redirected again