### PR TITLE
Fix incomplete DNT/GPC suppression in analytics tracking

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -314,6 +314,8 @@ public class WebRequestFilter implements Filter {
     // Make sure the web visitor has session information
     LOG.debug("Checking session...");
     UserSession userSession = (UserSession) session.getAttribute(SessionConstants.USER);
+    boolean doNotTrack = DoNotTrackCommand.isDoNotTrack(httpServletRequest.getHeader("DNT"),
+        httpServletRequest.getHeader("Sec-GPC"));
     boolean doSaveSession = false;
     if (userSession == null) {
       synchronized (httpServletRequest.getSession()) {
@@ -325,9 +327,7 @@ public class WebRequestFilter implements Filter {
               ipAddress, referer, userAgent);
           httpServletRequest.getSession().setAttribute(SessionConstants.USER, userSession);
           // Skip tracking for monitoring apps, and for requests that ask not to be tracked (DNT / GPC)
-          if (httpServletRequest.getHeader("X-Monitor") == null
-              && !DoNotTrackCommand.isDoNotTrack(httpServletRequest.getHeader("DNT"),
-                  httpServletRequest.getHeader("Sec-GPC"))) {
+          if (httpServletRequest.getHeader("X-Monitor") == null && !doNotTrack) {
             doSaveSession = true;
           }
         }
@@ -370,22 +370,22 @@ public class WebRequestFilter implements Filter {
         }
       }
 
-      // Make sure the visitor has a token
-      if (visitor == null) {
+      // Make sure the visitor has a token (skipped for DNT / GPC requests — no row, no cookie)
+      if (visitor == null && !doNotTrack) {
         // Create and store a new token
         LOG.debug("Creating a visitor token...");
         visitor = (cookielessAnalytics && StringUtils.isNotBlank(visitorToken))
             ? SaveVisitorCommand.saveVisitor(userSession, visitorToken)
             : SaveVisitorCommand.saveVisitor(userSession);
-      } else {
+      } else if (visitor != null) {
         // Make sure the sessionId is set
         if (doSaveSession) {
           SessionRepository.updateVisitorId(userSession, visitor);
         }
       }
 
-      // Persist the visitor identity in a cookie -- skipped entirely when running cookieless
-      if (!cookielessAnalytics) {
+      // Persist the visitor identity in a cookie -- skipped when running cookieless or when DNT/GPC is signaled
+      if (!cookielessAnalytics && !doNotTrack) {
         int oneYearSecondsInt = 365 * 24 * 60 * 60;
         Cookie cookie = new Cookie(CookieConstants.VISITOR_TOKEN, visitor.getToken());
         if (request.isSecure()) {

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -697,7 +697,8 @@
         }
       });
     </script>
-  <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin')}">
+  <c:set var="doNotTrack" value="${header['DNT'] eq '1' or header['Sec-GPC'] eq '1'}" />
+  <c:if test="${!doNotTrack && !fn:startsWith(pageRenderInfo.name, '/admin')}">
     <c:if test="${!empty analyticsPropertyMap['analytics.service'] && 'google' eq analyticsPropertyMap['analytics.service'] && !empty analyticsPropertyMap['analytics.google.key']}">
       <script async src="https://www.googletagmanager.com/gtag/js?id=${js:escape(analyticsPropertyMap['analytics.google.key'])}"></script>
       <script>


### PR DESCRIPTION
## Summary

When `DNT: 1` or `Sec-GPC: 1` is present, the session-save path was correctly skipped but the visitor-identity path still ran in `WebRequestFilter`:

- `SaveVisitorCommand.saveVisitor()` wrote a persistent visitor row  
- A 1-year `VISITOR_TOKEN` cookie was set in the response  

These now also respect the DNT/GPC signal.

Additionally, the three third-party analytics script injections in `main.jsp` (Google Analytics/GTM, Simpli.fi, BrandCDN) are now suppressed when DNT or GPC is signaled.

## Changes

- **`WebRequestFilter.java`** — extract `doNotTrack` from the inline session guard; gate `SaveVisitorCommand.saveVisitor()` and the `VISITOR_TOKEN` cookie on `!doNotTrack`; fix the returning-visitor else branch to an explicit `else if (visitor != null)` so the new null+doNotTrack case falls through cleanly.
- **`main.jsp`** — set a `doNotTrack` JSTL variable from `${header['DNT']}` / `${header['Sec-GPC']}`; wrap all three analytics script blocks in `!doNotTrack`.

## Controls

Privacy SSP artifact / POA&M item 19. Closes #324.

## Test plan

- [ ] Verify clean build (`ant compile-test compile-jsp test`)
- [ ] Request with `DNT: 1` — confirm no new visitor row in DB, no `VISITOR_TOKEN` cookie in response
- [ ] Request with `Sec-GPC: 1` — same
- [ ] Request without DNT/GPC — confirm visitor row and cookie created normally
- [ ] Page with Google Analytics configured — confirm script injected without DNT, suppressed with DNT