### PR TITLE
Prevent TOTP code replay within the 90-second validity window

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/TotpCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/TotpCommand.java
@@ -30,6 +30,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 /**
  * Time-based one-time password support (TOTP, RFC 6238) for multi-factor authentication. Generates the shared secret
  * and the otpauth:// enrollment URI an authenticator app consumes, and verifies user-supplied codes. This is the
@@ -48,6 +51,12 @@ public class TotpCommand {
   private static final int ALLOWED_DRIFT_STEPS = 1;   // accept the adjacent steps to tolerate clock skew
   private static final String HMAC_ALGORITHM = "HmacSHA1";
   private static final int[] DIGITS_DIVISOR = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000 };
+
+  // Replay-prevention cache: key = "userId:code", TTL 90s = 3 * PERIOD_SECONDS (covers ±1 drift window)
+  private static final Cache<String, Boolean> REPLAY_CACHE = Caffeine.newBuilder()
+      .maximumSize(10_000)
+      .expireAfterWrite(90, java.util.concurrent.TimeUnit.SECONDS)
+      .build();
 
   private TotpCommand() {
     // Static utility, not instantiated
@@ -91,6 +100,28 @@ public class TotpCommand {
    */
   public static boolean verifyCode(String base32Secret, String code) {
     return verifyCode(base32Secret, code, Instant.now().getEpochSecond());
+  }
+
+  /**
+   * Verifies a code and marks it as used so it cannot be replayed within the same validity window (90 seconds).
+   * Callers that have the user ID should prefer this over verifyCode to prevent replay attacks.
+   *
+   * @param base32Secret the user's Base32 secret
+   * @param code the code entered by the user
+   * @param userId the authenticated user's ID (used as part of the replay-cache key)
+   * @return true when the code is valid and has not already been used by this user
+   */
+  public static boolean verifyCodeAndMarkUsed(String base32Secret, String code, long userId) {
+    if (!verifyCode(base32Secret, code)) {
+      return false;
+    }
+    String cacheKey = userId + ":" + code.trim();
+    if (REPLAY_CACHE.getIfPresent(cacheKey) != null) {
+      LOG.warn("TOTP replay detected for user id: " + userId);
+      return false;
+    }
+    REPLAY_CACHE.put(cacheKey, Boolean.TRUE);
+    return true;
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
@@ -77,7 +77,7 @@ public class UserMfaCommand {
     if (user == null || StringUtils.isBlank(user.getMfaSecret())) {
       return false;
     }
-    if (!TotpCommand.verifyCode(user.getMfaSecret(), code)) {
+    if (!TotpCommand.verifyCodeAndMarkUsed(user.getMfaSecret(), code, user.getId())) {
       LOG.debug("MFA enrollment code did not verify for user: " + user.getId());
       return false;
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -125,9 +125,9 @@ public class LoginWidget extends GenericWidget {
       }
       User user = UserRepository.findByUserId(mfaPendingUserId);
       String code = context.getParameter("code");
-      // Accept either a current TOTP code or a single-use recovery code
+      // Accept either a current TOTP code (replay-protected) or a single-use recovery code
       boolean verified = user != null && user.getMfaEnabled()
-          && (TotpCommand.verifyCode(user.getMfaSecret(), code)
+          && (TotpCommand.verifyCodeAndMarkUsed(user.getMfaSecret(), code, user.getId())
               || UserMfaRecoveryCodeCommand.consume(user, code));
       if (!verified) {
         SaveAuditEventCommand.recordAuthentication("authentication.mfa.verify.failure", "failure",

--- a/src/test/java/com/simisinc/platform/application/login/TotpCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/TotpCommandTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 
 import org.apache.commons.codec.binary.Base32;
 import org.junit.jupiter.api.Test;
@@ -95,5 +96,42 @@ class TotpCommandTest {
     assertTrue(uri.contains("issuer=SimIS%20CMS"));
     assertTrue(uri.contains("digits=6"));
     assertTrue(uri.contains("period=30"));
+  }
+
+  @Test
+  void verifyCodeAndMarkUsedSucceedsOnFirstUse() {
+    long now = Instant.now().getEpochSecond();
+    long userId = 42L;
+    String code = TotpCommand.generateCode(RFC_SECRET, now / 30L);
+    assertTrue(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userId));
+  }
+
+  @Test
+  void verifyCodeAndMarkUsedRejectsReplay() {
+    long now = Instant.now().getEpochSecond();
+    long userId = 43L;
+    String code = TotpCommand.generateCode(RFC_SECRET, now / 30L);
+    assertTrue(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userId), "first use must succeed");
+    assertFalse(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userId), "immediate replay must fail");
+  }
+
+  @Test
+  void verifyCodeAndMarkUsedIsolatesReplayByUser() {
+    long now = Instant.now().getEpochSecond();
+    long userA = 44L;
+    long userB = 45L;
+    String code = TotpCommand.generateCode(RFC_SECRET, now / 30L);
+    assertTrue(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userA), "user A first use must succeed");
+    assertTrue(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userB), "same code for user B must still succeed");
+    assertFalse(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, code, userA), "user A replay must fail");
+  }
+
+  @Test
+  void verifyCodeAndMarkUsedRejectsWrongCode() {
+    long now = 1700003000L;
+    long userId = 46L;
+    String correct = TotpCommand.generateCode(RFC_SECRET, now / 30L);
+    String wrong = correct.equals("000000") ? "111111" : "000000";
+    assertFalse(TotpCommand.verifyCodeAndMarkUsed(RFC_SECRET, wrong, userId));
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -104,7 +104,7 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
-      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      totp.when(() -> TotpCommand.verifyCodeAndMarkUsed(anyString(), anyString(), anyLong())).thenReturn(false);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(false);
@@ -134,7 +134,7 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
-      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(true);
+      totp.when(() -> TotpCommand.verifyCodeAndMarkUsed(anyString(), anyString(), anyLong())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
@@ -173,7 +173,7 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
       // TOTP fails, but a recovery code is accepted
-      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      totp.when(() -> TotpCommand.verifyCodeAndMarkUsed(anyString(), anyString(), anyLong())).thenReturn(false);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(true);
@@ -261,7 +261,7 @@ class LoginWidgetTest extends WidgetBase {
       widget.post(widgetContext);
 
       // A brute-forcer never even gets to a code comparison while locked out
-      totp.verify(() -> TotpCommand.verifyCode(anyString(), anyString()), never());
+      totp.verify(() -> TotpCommand.verifyCodeAndMarkUsed(anyString(), anyString(), anyLong()), never());
     }
 
     // Rejected with the rate-limit message; still pending; nothing established
@@ -287,7 +287,7 @@ class LoginWidgetTest extends WidgetBase {
         MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       userRepo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(mfaUser(42L));
-      totp.when(() -> TotpCommand.verifyCode(anyString(), anyString())).thenReturn(false);
+      totp.when(() -> TotpCommand.verifyCodeAndMarkUsed(anyString(), anyString(), anyLong())).thenReturn(false);
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       recovery.when(() -> UserMfaRecoveryCodeCommand.consume(any(), anyString())).thenReturn(false);


### PR DESCRIPTION
## Summary
- Adds a self-contained Caffeine cache to `TotpCommand` keyed by `userId+code` with a 90-second TTL (3 × the 30-second TOTP step). A code that has already been accepted for a given user is rejected for the remainder of its validity window, preventing replay attacks.
- New `verifyCodeAndMarkUsed(secret, code, userId)` method checks validity then the replay cache atomically; `LoginWidget` and `UserMfaCommand.confirmEnrollment()` are updated to call it instead of the bare `verifyCode()`.
- Four new `TotpCommandTest` cases cover first-use success, immediate replay rejection, per-user cache isolation, and wrong-code rejection. `LoginWidgetTest` stubs updated to match the new method name.

## Security context
Closes POA&M item 21 — TOTP replay window. Without this fix a code sniffed or shoulder-surfed during its 90-second validity window could be submitted a second time to authenticate independently.

## Test plan
- [ ] `ant test` passes (all test classes, 0 failures)
- [ ] Valid TOTP code accepted on first use; immediate re-submission of the same code is rejected
- [ ] Different user with the same code value still succeeds (cache is keyed per-user)
- [ ] Recovery code path unaffected (`UserMfaRecoveryCodeCommand.consume` still works alongside the new gate)