### PR TITLE
Expire password-reset and account-validation tokens after 24 hours

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/User.java
+++ b/src/main/java/com/simisinc/platform/domain/model/User.java
@@ -55,6 +55,7 @@ public class User extends Entity {
   private String mfaSecret = null;
   private boolean mfaEnabled = false;
   private String accountToken = null;
+  private Timestamp accountTokenExpires = null;
   private Timestamp validated = null;
   private int failedAttemptCount = 0;
   private Timestamp lockedUntil = null;
@@ -265,6 +266,14 @@ public class User extends Entity {
 
   public void setAccountToken(String accountToken) {
     this.accountToken = accountToken;
+  }
+
+  public Timestamp getAccountTokenExpires() {
+    return accountTokenExpires;
+  }
+
+  public void setAccountTokenExpires(Timestamp accountTokenExpires) {
+    this.accountTokenExpires = accountTokenExpires;
   }
 
   public Timestamp getValidated() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -129,7 +129,8 @@ public class UserRepository {
     return (User) DB.selectRecordFrom(
         TABLE_NAME,
         new SqlUtils()
-            .add("account_token = ?", token),
+            .add("account_token = ?", token)
+            .add("(account_token_expires IS NULL OR account_token_expires > NOW())"),
         UserRepository::buildRecord);
   }
 
@@ -410,13 +411,16 @@ public class UserRepository {
 
   public static User createAccountToken(User record) {
     String newToken = UUID.randomUUID().toString();
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 86_400_000L); // 24 hours
     SqlUtils updateValues = new SqlUtils()
         .add("account_token", newToken)
+        .add("account_token_expires", expires)
         .add("modified", new Timestamp(System.currentTimeMillis()));
     SqlUtils where = new SqlUtils()
         .add("user_id = ?", record.getId());
     if (DB.update(TABLE_NAME, updateValues, where)) {
       record.setAccountToken(newToken);
+      record.setAccountTokenExpires(expires);
       return record;
     }
     LOG.error("createAccountToken failed!");
@@ -539,6 +543,7 @@ public class UserRepository {
       record.setCreated(rs.getTimestamp("created"));
       record.setModified(rs.getTimestamp("modified"));
       record.setAccountToken(rs.getString("account_token"));
+      record.setAccountTokenExpires(rs.getTimestamp("account_token_expires"));
       record.setValidated(rs.getTimestamp("validated"));
       record.setCreatedBy(rs.getLong("created_by"));
       record.setModifiedBy(rs.getLong("modified_by"));

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1001__account_token_expires.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1001__account_token_expires.sql
@@ -1,0 +1,4 @@
+-- Reset and validation tokens expire after 24 hours (M7 / IA-5 token lifetime).
+-- account_token_expires: when set, findByAccountToken() rejects tokens past this time.
+-- NULL means no expiry (pre-migration rows and admin-issued tokens remain valid until cleared).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS account_token_expires TIMESTAMP(3);


### PR DESCRIPTION
## Summary
- Adds `account_token_expires TIMESTAMP(3)` to the `users` table via `UPGRADE_20260725.1001__account_token_expires.sql`.
- `UserRepository.createAccountToken()` now stamps a 24-hour expiry on every new token it issues. The `User` domain model carries the new field.
- `UserRepository.findByAccountToken()` filters out expired tokens with `AND (account_token_expires IS NULL OR account_token_expires > NOW())`.
- Pre-migration rows (`account_token_expires IS NULL`) keep their existing behavior — any outstanding reset links sent before the migration land remain valid until the token is consumed or cleared.

## Security context
Closes POA&M item 20 — unbounded reset-token lifetime. Without this fix a password-reset link extracted from a log, inbox, or browser history remained usable indefinitely.

## Test plan
- [ ] `ant test` passes (BUILD SUCCESSFUL, 0 failures)
- [ ] Sending a password-reset email and clicking the link within 24 hours completes the reset
- [ ] Attempting to reuse a reset link after 24 hours is rejected (user not found → invalid-token error page)
- [ ] Existing admin-issued validation tokens (no expiry set) continue to work across the migration