### PR TITLE
Rehash MFA recovery codes from SHA-256 to argon2id (M7 AC-3)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommand.java
@@ -20,12 +20,15 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.UserPasswordCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
 import com.simisinc.platform.infrastructure.persistence.login.UserMfaRecoveryCodeRepository;
+
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
 
 /**
  * Generates and verifies multi-factor authentication recovery codes -- single-use backup codes a user falls back on
@@ -83,7 +86,17 @@ public class UserMfaRecoveryCodeCommand {
     if (normalized.length() != CODE_LENGTH) {
       return false;
     }
-    UserMfaRecoveryCode match = UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(user.getId(), hash(normalized));
+    List<UserMfaRecoveryCode> codes = UserMfaRecoveryCodeRepository.findAllUnusedByUserId(user.getId());
+    if (codes == null) {
+      return false;
+    }
+    UserMfaRecoveryCode match = null;
+    for (UserMfaRecoveryCode code : codes) {
+      if (verifyCode(normalized, code.getCodeHash())) {
+        match = code;
+        break;
+      }
+    }
     if (match == null) {
       return false;
     }
@@ -133,7 +146,16 @@ public class UserMfaRecoveryCodeCommand {
     return input.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
   }
 
-  private static String hash(String normalizedCode) {
-    return DigestUtils.sha256Hex(normalizedCode);
+  static String hash(String normalizedCode) {
+    Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2id);
+    return argon2.hash(1, 1024, 1, normalizedCode.toCharArray());
+  }
+
+  private static boolean verifyCode(String normalizedCode, String storedHash) {
+    if (storedHash == null) {
+      return false;
+    }
+    Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2id);
+    return argon2.verify(storedHash, normalizedCode.toCharArray());
   }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserMfaRecoveryCodeRepository.java
@@ -18,18 +18,21 @@ package com.simisinc.platform.infrastructure.persistence.login;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.simisinc.platform.domain.model.login.UserMfaRecoveryCode;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.SqlUtils;
 
 /**
- * Persists and retrieves multi-factor authentication recovery codes. Codes are stored only as SHA-256 hashes and are
- * looked up by hash, so verification is a single indexed query rather than a per-row comparison.
+ * Persists and retrieves multi-factor authentication recovery codes. Codes are stored as argon2id hashes; verification
+ * loads all unused codes for the user and checks each hash in application code.
  *
  * @author SimIS Inc.
  * @created 2026-07-17
@@ -54,17 +57,19 @@ public class UserMfaRecoveryCodeRepository {
     return record;
   }
 
-  public static UserMfaRecoveryCode findUnusedByUserIdAndHash(long userId, String codeHash) {
-    if (userId < 1 || StringUtils.isBlank(codeHash)) {
+  public static List<UserMfaRecoveryCode> findAllUnusedByUserId(long userId) {
+    if (userId < 1) {
       return null;
     }
-    return (UserMfaRecoveryCode) DB.selectRecordFrom(
+    DataResult result = DB.selectAllFrom(
         TABLE_NAME,
-        new SqlUtils()
-            .add("user_id = ?", userId)
-            .add("code_hash = ?", codeHash)
-            .add("used = false"),
+        new SqlUtils().add("user_id = ?", userId).add("used = false"),
+        new DataConstraints().setDefaultColumnToSortBy("recovery_code_id").setUseCount(false),
         UserMfaRecoveryCodeRepository::buildRecord);
+    if (result.hasRecords()) {
+      return (List<UserMfaRecoveryCode>) result.getRecords();
+    }
+    return null;
   }
 
   /**

--- a/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/UserMfaRecoveryCodeCommandTest.java
@@ -21,13 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
 import java.util.List;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -71,12 +69,12 @@ class UserMfaRecoveryCodeCommandTest {
   void consumeAcceptsAMatchingCodeIgnoringCaseAndDashes() {
     UserMfaRecoveryCode stored = new UserMfaRecoveryCode();
     stored.setId(5L);
-    String expectedHash = DigestUtils.sha256Hex("abcdefghij"); // the normalized form of the code below
+    stored.setCodeHash(UserMfaRecoveryCodeCommand.hash("abcdefghij")); // real argon2id hash of the normalized code
     try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
-      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+      repo.when(() -> UserMfaRecoveryCodeRepository.findAllUnusedByUserId(1L)).thenReturn(List.of(stored));
       repo.when(() -> UserMfaRecoveryCodeRepository.markUsed(stored)).thenReturn(true);
 
-      // The same code, typed with a dash and in upper case, both normalize to the stored hash
+      // The same code, typed with a dash and in upper case, both normalize and verify against the stored hash
       assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "abcde-fghij"));
       assertTrue(UserMfaRecoveryCodeCommand.consume(user(1L), "ABCDEFGHIJ"));
       repo.verify(() -> UserMfaRecoveryCodeRepository.markUsed(stored), times(2));
@@ -87,9 +85,9 @@ class UserMfaRecoveryCodeCommandTest {
   void consumeReturnsFalseWhenTheCodeWasAlreadyConsumedConcurrently() {
     UserMfaRecoveryCode stored = new UserMfaRecoveryCode();
     stored.setId(5L);
-    String expectedHash = DigestUtils.sha256Hex("abcdefghij");
+    stored.setCodeHash(UserMfaRecoveryCodeCommand.hash("abcdefghij"));
     try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
-      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(1L, expectedHash)).thenReturn(stored);
+      repo.when(() -> UserMfaRecoveryCodeRepository.findAllUnusedByUserId(1L)).thenReturn(List.of(stored));
       // The lookup found the code unused, but a concurrent request flipped it first:
       // the atomic update affects no row, so this login must NOT succeed.
       repo.when(() -> UserMfaRecoveryCodeRepository.markUsed(stored)).thenReturn(false);
@@ -101,7 +99,7 @@ class UserMfaRecoveryCodeCommandTest {
   @Test
   void consumeRejectsAnUnknownCode() {
     try (MockedStatic<UserMfaRecoveryCodeRepository> repo = mockStatic(UserMfaRecoveryCodeRepository.class)) {
-      repo.when(() -> UserMfaRecoveryCodeRepository.findUnusedByUserIdAndHash(anyLong(), anyString())).thenReturn(null);
+      repo.when(() -> UserMfaRecoveryCodeRepository.findAllUnusedByUserId(anyLong())).thenReturn(null);
       assertFalse(UserMfaRecoveryCodeCommand.consume(user(1L), "zzzzz-zzzzz"));
     }
   }


### PR DESCRIPTION
## Summary

- Replaces unsalted SHA-256 hashing of MFA recovery codes with argon2id (t=1, m=1024)
- Since argon2 uses a random salt per hash, switches from a direct DB hash-lookup to a fetch-all-unused + iterate-and-verify approach (at most 10 codes per user, ~2-5ms each)
- Makes `hash()` package-private so the test can compute expected hashes without duplicating the algorithm

## Security rationale

SHA-256 without a salt is reversible via precomputed table: any attacker who reads the `user_mfa_recovery_codes` table can recover all plaintext codes instantly. Argon2id eliminates that with per-code random salts and a memory-hard cost function, making offline brute-force orders of magnitude more expensive.

## Test plan

- [ ] `UserMfaRecoveryCodeCommandTest` (7 tests): generate, consume (match/concurrent/unknown/blank-length), clear, countRemaining — all pass
- [ ] Full suite: `ant -noinput -buildfile build.xml -lib lib/war clean compile-test test` passes with no failures