### PR TITLE
Fix username enumeration in login and forgot-password flows (M7 IA-3)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/AuthenticateLoginCommand.java
@@ -78,13 +78,6 @@ public class AuthenticateLoginCommand {
       }
       throw new LoginException(INVALID_CREDENTIALS);
     }
-    if (user.isNotValidated()) {
-      LOG.debug("Account not validated");
-      throw new LoginException("This account needs to be validated by email. Please check your email for instructions.");
-    }
-    if (!user.isEnabled()) {
-      throw new LoginException("The account has been suspended. Please contact an administrator.");
-    }
 
     // Account lockout (#295): a locked account cannot log in even with the correct password, until the
     // lock expires or an administrator clears it. Checked before the credentials cache so a lock always wins.
@@ -98,14 +91,31 @@ public class AuthenticateLoginCommand {
     Cache cache = CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE);
     String comparison = (String) cache.getIfPresent(user.getId());
     if (comparison != null && comparison.equals(username + ":" + password)) {
+      // Credentials confirmed via cache; check status before returning so a
+      // suspension that happened after caching still takes effect.
+      if (user.isNotValidated()) {
+        LOG.debug("Account not validated");
+        throw new LoginException("This account needs to be validated by email. Please check your email for instructions.");
+      }
+      if (!user.isEnabled()) {
+        throw new LoginException("The account has been suspended. Please contact an administrator.");
+      }
       return user;
     }
 
     // Verify the password
     boolean verified = UserPasswordCommand.verify(password, user.getPassword());
     if (verified) {
-      // Hash matches password
+      // Hash matches password — check account status now that the credential is confirmed.
+      // Doing so after verification avoids leaking account existence via differing error messages.
       LOG.debug("User validated");
+      if (user.isNotValidated()) {
+        LOG.debug("Account not validated");
+        throw new LoginException("This account needs to be validated by email. Please check your email for instructions.");
+      }
+      if (!user.isEnabled()) {
+        throw new LoginException("The account has been suspended. Please contact an administrator.");
+      }
       // Clear any prior failed-attempt / lockout state on a successful login (#295)
       if (user.getFailedAttemptCount() > 0 || user.getLockedUntil() != null) {
         UserRepository.resetLockout(user.getId());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/ForgotPasswordWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/ForgotPasswordWidget.java
@@ -87,9 +87,11 @@ public class ForgotPasswordWidget extends GenericWidget {
     if (user == null) {
       if (!RateLimitCommand.isIpAllowedRightNow(context.getUserSession().getIpAddress(), true)) {
         context.setWarningMessage(RateLimitCommand.INVALID_ATTEMPTS);
-      } else {
-        context.setWarningMessage("Check the username and try again");
+        return context;
       }
+      // Always show the same success message whether the username exists or not, to prevent enumeration.
+      context.setSuccessMessage("If the email you specified exists in our system, we've sent a password reset link to it.");
+      context.setJsp(SUCCESS_JSP);
       return context;
     }
 

--- a/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/AuthenticateLoginCommandTest.java
@@ -193,37 +193,58 @@ class AuthenticateLoginCommandTest {
   }
 
   @Test
-  void anUnvalidatedAccountIsRejected() {
+  @SuppressWarnings("unchecked")
+  void anUnvalidatedAccountIsRejectedAfterCredentialVerification() {
+    // Status checks happen AFTER credential verification to prevent username enumeration.
+    // A correct password on an unvalidated account should still show the validation error.
+    String password = "correct";
     User user = new User();
     user.setId(3L);
-    user.setEnabled(true); // validated left null -> isNotValidated() is true
+    user.setEnabled(true);
+    user.setPassword(UserPasswordCommand.hash(password)); // validated left null -> isNotValidated() is true
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(any())).thenReturn(null);
     try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
-        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       loadUser.when(() -> LoadUserCommand.loadUser("unvalidated@example.com")).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
 
       LoginException ex = assertThrows(LoginException.class,
-          () -> AuthenticateLoginCommand.getAuthenticatedUser("unvalidated@example.com", "pw", IP_ADDRESS));
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("unvalidated@example.com", password, IP_ADDRESS));
       assertTrue(ex.getMessage().toLowerCase().contains("validated"), ex.getMessage());
+      // A correct password on an inactive account must NOT increment the failed-attempt counter
+      userRepo.verify(() -> UserRepository.updateLockoutState(anyLong(), anyInt(), any()), never());
     }
   }
 
   @Test
-  void aSuspendedAccountIsRejected() {
+  @SuppressWarnings("unchecked")
+  void aSuspendedAccountIsRejectedAfterCredentialVerification() {
+    String password = "correct";
     User user = new User();
     user.setId(4L);
     user.setValidated(new Timestamp(System.currentTimeMillis()));
     user.setEnabled(false); // suspended
+    user.setPassword(UserPasswordCommand.hash(password));
+    Cache credentialsCache = mock(Cache.class);
+    when(credentialsCache.getIfPresent(any())).thenReturn(null);
     try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
-        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+        MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
       rateLimit.when(() -> RateLimitCommand.isUsernameAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(anyString(), anyBoolean())).thenReturn(true);
       loadUser.when(() -> LoadUserCommand.loadUser("suspended@example.com")).thenReturn(user);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE)).thenReturn(credentialsCache);
 
       LoginException ex = assertThrows(LoginException.class,
-          () -> AuthenticateLoginCommand.getAuthenticatedUser("suspended@example.com", "pw", IP_ADDRESS));
+          () -> AuthenticateLoginCommand.getAuthenticatedUser("suspended@example.com", password, IP_ADDRESS));
       assertTrue(ex.getMessage().toLowerCase().contains("suspended"), ex.getMessage());
+      userRepo.verify(() -> UserRepository.updateLockoutState(anyLong(), anyInt(), any()), never());
     }
   }
 


### PR DESCRIPTION
## Summary

- Moves account-status checks (not validated, suspended) to AFTER credential verification in `AuthenticateLoginCommand` — an attacker can no longer distinguish a valid-but-inactive account from an unknown username
- `ForgotPasswordWidget` now returns the same success message whether the submitted username exists or not, eliminating the distinct "Check the username" response that previously revealed account existence
- Tests updated to reflect the reordering: status-check tests now supply the correct password, and add a new assertion that a correct-password-but-inactive login does NOT increment the failed-attempt counter

## Security rationale

Previously, "account needs validation email" and "account suspended" were returned before the password was checked. An attacker submitting any password could enumerate valid usernames by comparing that response to the generic INVALID_CREDENTIALS message. The fix defers those messages until after the credential is confirmed.

## Test plan

- [ ] `AuthenticateLoginCommandTest` (14 tests): all branches including updated unvalidated/suspended tests — 0 failures
- [ ] Full suite: `ant -noinput -buildfile build.xml -lib lib/war clean compile-test test` passes with no failures