### PR TITLE
Visual Editor P2 PR1: edit-mode toggle, page overlay scaffold, draft preview

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/WebPageXmlLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/WebPageXmlLayoutCommand.java
@@ -159,6 +159,20 @@ public class WebPageXmlLayoutCommand {
     return pageRef;
   }
 
+  public static Page parseFreshDraft(WebPage webPage, String pagePath) {
+    XMLPageLoader fresh = new XMLPageLoader(new HashMap<>());
+    fresh.setWidgetLibrary(pages.getWidgetLibrary());
+    WebPage draftView = new WebPage();
+    draftView.setLink(webPage.getLink());
+    draftView.setPageXml(webPage.getDraftPageXml());
+    try {
+      return fresh.addFromXml(pagePath, draftView);
+    } catch (Exception e) {
+      LOG.error("Could not parse draft layout for: " + pagePath, e);
+      return null;
+    }
+  }
+
   private static Page locatePage(String pagePath) {
     LOG.debug("Locate page: " + pagePath);
 

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -234,9 +234,33 @@ public class PageServlet extends HttpServlet {
         request.setAttribute(MASTER_WEB_PAGE, webPage);
       }
 
+      // Edit-mode toggle: ?editMode=true/false (requires canEditContent permission)
+      String editModeParam = request.getParameter("editMode");
+      if (editModeParam != null) {
+        if ("true".equals(editModeParam) && EditorPermissionCommand.canEditContent(userSession)) {
+          request.getSession().setAttribute(SessionConstants.PAGE_EDIT_MODE, "true");
+        } else {
+          request.getSession().removeAttribute(SessionConstants.PAGE_EDIT_MODE);
+        }
+      }
+      boolean pageEditMode = "true".equals(request.getSession().getAttribute(SessionConstants.PAGE_EDIT_MODE))
+          && EditorPermissionCommand.canEditContent(userSession);
+      if (pageEditMode) {
+        request.setAttribute("pageEditMode", "true");
+      }
+
       // Determine the Page XML Layout for this request
       Page pageRef = WebPageXmlLayoutCommand.retrievePageForRequest(webPage, pagePath);
       Map<String, String> widgetLibrary = WebPageXmlLayoutCommand.getWidgetLibrary();
+
+      // In edit mode, layout builders preview the draft layout (bypasses cache)
+      if (pageEditMode && EditorPermissionCommand.canBuildLayout(userSession)
+          && webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml())) {
+        Page draftRef = WebPageXmlLayoutCommand.parseFreshDraft(webPage, pagePath);
+        if (draftRef != null) {
+          pageRef = draftRef;
+        }
+      }
 
       // Load the properties
       Map<String, String> systemPropertyMap = LoadSitePropertyCommand.loadAsMap("system");

--- a/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SessionConstants.java
@@ -32,4 +32,5 @@ public class SessionConstants {
   public static final String OAUTH_STATE = "oauthState";
   public static final String MFA_PENDING_USER_ID = "mfaPendingUserId";
   public static final String MFA_PENDING_SINCE = "mfaPendingSince";
+  public static final String PAGE_EDIT_MODE = "pageEditMode";
 }

--- a/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
@@ -34,13 +34,13 @@
       <%-- Determine the section container CSS --%>
       <c:choose>
         <c:when test="${empty section.cssClass && fn:startsWith(pageRenderInfo.name, '/admin')}">
-          <div id="<c:out value="${sectionId}"/>" class="grid-x grid-padding-x"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if>>
+          <div id="<c:out value="${sectionId}"/>" class="grid-x grid-padding-x"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
         </c:when>
         <c:when test="${!empty section.cssClass && (fn:contains(section.cssClass,'grid') || fn:contains(section.cssClass,'platform-no-margin'))}">
-          <div id="<c:out value="${sectionId}"/>" class="<c:out value="${section.cssClass}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if>>
+          <div id="<c:out value="${sectionId}"/>" class="<c:out value="${section.cssClass}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
         </c:when>
         <c:otherwise>
-          <div class="full-container" id="<c:out value="${sectionId}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if>>
+          <div class="full-container" id="<c:out value="${sectionId}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
 <%--          <div class="full-container"<c:if test="${!empty section.htmlId}"> id="${section.htmlId}"</c:if>>--%>
             <div class="grid-container">
               <div class="grid-x grid-margin-x<c:if test="${!empty section.cssClass}"> <c:out value="${section.cssClass}"/></c:if>">
@@ -65,28 +65,28 @@
         </c:if>
         <c:choose>
           <c:when test="${!empty column.cssClass}">
-            <div id="<c:out value="${columnId}"/>" class="<c:out value="${column.cssClass}"/>"<c:if test="${!empty column.cssStyle}"> style="<c:out value="${column.cssStyle}" />"</c:if><c:if test="${column.sticky}"> data-sticky-container</c:if>>
+            <div id="<c:out value="${columnId}"/>" class="<c:out value="${column.cssClass}"/>"<c:if test="${!empty column.cssStyle}"> style="<c:out value="${column.cssStyle}" />"</c:if><c:if test="${column.sticky}"> data-sticky-container</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-column="${sectionStatus.index}-${columnStatus.index}"</c:if>>
           </c:when>
           <c:otherwise>
-            <div id="<c:out value="${columnId}"/>" class="small-12 cell"<c:if test="${!empty column.cssStyle}"> style="<c:out value="${column.cssStyle}" />"</c:if><c:if test="${column.sticky}"> data-sticky-container</c:if>>
+            <div id="<c:out value="${columnId}"/>" class="small-12 cell"<c:if test="${!empty column.cssStyle}"> style="<c:out value="${column.cssStyle}" />"</c:if><c:if test="${column.sticky}"> data-sticky-container</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-column="${sectionStatus.index}-${columnStatus.index}"</c:if>>
           </c:otherwise>
         </c:choose>
         <c:if test="${section.sticky && column.sticky}"><div class="sticky" data-sticky data-sticky-on="medium" data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>:top" data-btm-anchor="platform-footer"></c:if>
-        <c:forEach items="${column.widgetRenderInfoList}" var="widget">
+        <c:forEach items="${column.widgetRenderInfoList}" var="widget" varStatus="widgetStatus">
           <c:if test="${widget.hr}">
             <hr />
           </c:if>
           <c:choose>
-            <c:when test="${empty widget.cssClass && empty widget.htmlId && empty widget.cssStyle && !widget.sticky}">
+            <c:when test="${empty widget.cssClass && empty widget.htmlId && empty widget.cssStyle && !widget.sticky && pageEditMode ne 'true'}">
               ${widget.content}
             </c:when>
             <c:when test="${!empty widget.cssClass}">
-              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if>>
+              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}"</c:if>>
                 ${widget.content}
               </div>
             </c:when>
             <c:otherwise>
-              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if>>
+              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}"</c:if>>
                 ${widget.content}
               </div>
             </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -280,6 +280,9 @@
   <c:if test="${!empty includeStylesheet}">
     <link rel="stylesheet" type="text/css" href="${ctx}/css/custom/stylesheet${includeStylesheet}.css?v=${includeStylesheetLastModified}" />
   </c:if>
+  <c:if test="${pageEditMode eq 'true'}">
+    <link rel="stylesheet" type="text/css" href="${ctx}/css/platform-editor.css?v=<%= VERSION %>" />
+  </c:if>
   <c:if test="${!empty pageCollection}">
     <style>
         <c:choose>
@@ -322,7 +325,22 @@
       <script src="${ctx}/javascript/platform-theme.js"></script>
     </c:if>
 </head>
-<body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty pageRenderInfo.cssClass}"> class="<c:out value="${pageRenderInfo.cssClass}" />"</c:if>>
+<c:set var="bodyClass" value="${pageRenderInfo.cssClass}"/>
+<c:if test="${pageEditMode eq 'true'}">
+  <c:choose>
+    <c:when test="${!empty pageRenderInfo.cssClass}"><c:set var="bodyClass" value="${pageRenderInfo.cssClass} page-edit-mode"/></c:when>
+    <c:otherwise><c:set var="bodyClass" value="page-edit-mode"/></c:otherwise>
+  </c:choose>
+</c:if>
+<body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty bodyClass}"> class="<c:out value="${bodyClass}" />"</c:if>>
+  <c:if test="${pageEditMode eq 'true'}">
+    <div id="sc-editor-toolbar" role="toolbar" aria-label="Page editor" data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>" data-ctx="${ctx}">
+      <span id="sc-editor-toolbar-title">Visual Editor</span>
+      <a href="${ctx}/admin/web-page-designer?webPage=<c:out value="${pageRenderInfo.pagePath}"/>" class="button small hollow secondary"><i class="fa fa-fw fa-code"></i> XML</a>
+      <a href="?editMode=false" id="sc-editor-exit" class="button small hollow secondary"><i class="fa fa-fw fa-times"></i> Exit</a>
+      <span id="sc-editor-status" aria-live="polite"></span>
+    </div>
+  </c:if>
   <c:choose>
     <c:when test="${fn:startsWith(pageRenderInfo.name, '/admin') && pageRenderInfo.name ne '/admin/web-page' && pageRenderInfo.name ne '/admin/web-page-designer' && pageRenderInfo.name ne '/admin/web-container-designer' && pageRenderInfo.name ne '/admin/css-editor'}">
       <%-- Draw the admin menu--%>
@@ -713,6 +731,9 @@
     <c:if test="${!empty analyticsPropertyMap['analytics.brandcdn.value'] && !empty analyticsPropertyMap['analytics.brandcdn.value2']}">
       <script type="text/javascript" src="//tag.brandcdn.com/autoscript/${js:escape(analyticsPropertyMap['analytics.brandcdn.value'])}/${js:escape(analyticsPropertyMap['analytics.brandcdn.value2'])}"></script>
     </c:if>
+  </c:if>
+  <c:if test="${pageEditMode eq 'true'}">
+    <script src="${ctx}/javascript/platform-editor.js?v=<%= VERSION %>"></script>
   </c:if>
 </body>
 </html>

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -1,0 +1,136 @@
+/* Visual Page Editor Overlay */
+
+#sc-editor-toolbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 44px;
+  background: #1a1a2e;
+  border-bottom: 2px solid #0056b3;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  gap: 0.75rem;
+  z-index: 9999;
+  font-family: sans-serif;
+  box-sizing: border-box;
+}
+
+#sc-editor-toolbar .button {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+}
+
+#sc-editor-toolbar a.button {
+  color: #ccc;
+  border-color: #555;
+}
+
+#sc-editor-toolbar a.button:hover {
+  color: #fff;
+  border-color: #aaa;
+}
+
+#sc-editor-toolbar-title {
+  color: #aaa;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-right: 0.5rem;
+}
+
+#sc-editor-status {
+  color: #aaa;
+  font-size: 0.75rem;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+body.page-edit-mode {
+  padding-top: 44px;
+}
+
+/* Section outlines */
+body.page-edit-mode [data-editor-section] {
+  outline: 2px dashed rgba(0, 86, 179, 0.4);
+  outline-offset: -2px;
+  position: relative;
+  min-height: 40px;
+}
+
+body.page-edit-mode [data-editor-section]:hover {
+  outline-color: rgba(0, 86, 179, 0.85);
+}
+
+/* Column outlines */
+body.page-edit-mode [data-editor-column] {
+  outline: 1px dashed rgba(40, 167, 69, 0.35);
+  outline-offset: -1px;
+  position: relative;
+  min-height: 20px;
+}
+
+body.page-edit-mode [data-editor-column]:hover {
+  outline-color: rgba(40, 167, 69, 0.75);
+}
+
+/* Widget outlines */
+body.page-edit-mode [data-editor-widget] {
+  outline: 1px dashed rgba(220, 53, 69, 0.25);
+  outline-offset: -1px;
+  position: relative;
+}
+
+body.page-edit-mode [data-editor-widget]:hover {
+  outline-color: rgba(220, 53, 69, 0.65);
+}
+
+/* Floating labels that appear on hover */
+.sc-editor-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 10px;
+  padding: 2px 6px;
+  line-height: 16px;
+  z-index: 100;
+  font-family: sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  display: none;
+  border-radius: 0 0 3px 0;
+}
+
+.sc-editor-handle-section {
+  background: #0056b3;
+  color: #fff;
+}
+
+.sc-editor-handle-column {
+  background: #28a745;
+  color: #fff;
+}
+
+.sc-editor-handle-widget {
+  background: #dc3545;
+  color: #fff;
+}
+
+body.page-edit-mode [data-editor-section]:hover > .sc-editor-handle,
+body.page-edit-mode [data-editor-column]:hover > .sc-editor-handle,
+body.page-edit-mode [data-editor-widget]:hover > .sc-editor-handle {
+  display: block;
+}
+
+/* Link handle for non-content widgets */
+a.sc-editor-handle {
+  text-decoration: none;
+}
+
+a.sc-editor-handle:hover {
+  opacity: 0.85;
+  color: #fff;
+}

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -1,0 +1,52 @@
+(function () {
+  'use strict';
+
+  if (!document.body.classList.contains('page-edit-mode')) {
+    return;
+  }
+
+  var toolbar = document.getElementById('sc-editor-toolbar');
+  var pagePath = toolbar ? toolbar.dataset.pagePath : '';
+  var ctx = toolbar ? (toolbar.dataset.ctx || '') : '';
+
+  function insertHandle(el, type, label, href) {
+    var handle;
+    if (href) {
+      handle = document.createElement('a');
+      handle.href = href;
+      handle.title = 'Edit in XML designer';
+    } else {
+      handle = document.createElement('span');
+    }
+    handle.className = 'sc-editor-handle sc-editor-handle-' + type;
+    handle.textContent = label;
+    handle.setAttribute('aria-hidden', 'true');
+    // Ensure the parent has a stacking context for absolute positioning
+    var pos = window.getComputedStyle(el).position;
+    if (pos === 'static') {
+      el.style.position = 'relative';
+    }
+    el.insertBefore(handle, el.firstChild);
+  }
+
+  // Sections
+  document.querySelectorAll('[data-editor-section]').forEach(function (el) {
+    var idx = parseInt(el.dataset.editorSection, 10);
+    insertHandle(el, 'section', 'Section ' + (idx + 1));
+  });
+
+  // Columns
+  document.querySelectorAll('[data-editor-column]').forEach(function (el) {
+    var parts = el.dataset.editorColumn.split('-');
+    var colIdx = parseInt(parts[1], 10);
+    insertHandle(el, 'column', 'Col ' + (colIdx + 1));
+  });
+
+  // Widgets — content widgets get no link (inline editor in PR2);
+  // non-content widgets link to the XML designer as fallback
+  document.querySelectorAll('[data-editor-widget]').forEach(function (el) {
+    var isContentWidget = !!el.querySelector('[data-content-unique-id]');
+    var href = isContentWidget ? null : (ctx + '/admin/web-page-designer?webPage=' + encodeURIComponent(pagePath));
+    insertHandle(el, 'widget', isContentWidget ? 'Content' : 'Widget', href);
+  });
+})();


### PR DESCRIPTION
## Summary

- **Edit-mode toggle**: `?editMode=true` activates a session-scoped edit overlay for any user with `canEditContent` (admin / content-manager / content-editor); `?editMode=false` clears it. Checks permission on every request so a role downgrade takes effect immediately.
- **Overlay scaffold**: `layout-body-renderer.jspf` emits `data-editor-section`, `data-editor-column`, and `data-editor-widget` attributes when `pageEditMode` is active. Bare widgets (no id / class / style / sticky) that would normally render unwrapped are always wrapped in edit mode so JS has a stable anchor. `varStatus="widgetStatus"` added to the widget `forEach` for the composite `s-c-w` index key.
- **Editor toolbar**: fixed 44px bar at the top of the page with a "Visual Editor" label, XML-designer fallback link, and Exit button. CSS pushes page content down by the toolbar height.
- **Draft layout preview**: if the user also has `canBuildLayout` and the page has a non-blank `draftPageXml`, `PageServlet` calls `WebPageXmlLayoutCommand.parseFreshDraft()` which parses the draft XML into a throwaway `XMLPageLoader` (not cached) and substitutes the resulting `Page` for the live one. Allows builders to preview staged layout changes before publishing.
- **`platform-editor.css`**: dashed section (blue) / column (green) / widget (red) outlines, colour-coded floating labels on hover, fixed toolbar styles.
- **`platform-editor.js`**: injects handle elements at render time; non-content widgets get a link handle to the XML designer; content widgets get a plain label as a hook for the PR2 inline Quill editor.

## What this PR does NOT include

- Inline text editing (PR2)
- Drag-to-reorder (PR3)
- Draft publish flow (PR4)

## Test plan

- [ ] Visit any front-end page as admin → no visible change; no extra attributes in source
- [ ] Visit `/?editMode=true` as admin → fixed toolbar appears; `body.page-edit-mode` class present; section/column/widget outlines visible in inspector
- [ ] Visit `/?editMode=true` as content-editor role → toolbar appears (canEditContent)
- [ ] `?editMode=true` as anonymous / logged-out user → ignored; no toolbar
- [ ] `?editMode=false` clears the session flag and removes the toolbar
- [ ] Page with a `draftPageXml` + `canBuildLayout` user in edit mode → draft layout rendered (not the live layout)
- [ ] Same page without edit mode → live layout rendered (draft not visible)
- [ ] Bare widget (no class/id/style/sticky) in edit mode has a wrapper div with `data-editor-widget`; outside edit mode renders unwrapped (no regression)