### PR TITLE
Visual Editor P2 PR2: inline content editing with contenteditable + saveDraft

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -433,8 +433,28 @@ public class ContentHtmlCommand {
       return rejectContent(context, content);
     } else if ("deleteContent".equals(action)) {
       return deleteContent(context, content);
+    } else if ("saveDraft".equals(action)) {
+      return saveDraft(context, content);
     }
 
+    return context;
+  }
+
+  private static WidgetContext saveDraft(WidgetContext context, Content content) {
+    String html = context.getParameter("html");
+    if (StringUtils.isBlank(html)) {
+      context.setJson("{\"success\":false,\"error\":\"No content provided\"}");
+      return context;
+    }
+    try {
+      SaveContentCommand.saveSafeContent(content.getUniqueId(), html, context.getUserId(), false);
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.saveDraft", AuditEventCommand.SUCCESS,
+          "content", String.valueOf(content.getId()), content.getUniqueId(), null);
+      context.setJson("{\"success\":true}");
+    } catch (Exception e) {
+      LOG.error("saveDraft failed for uniqueId " + content.getUniqueId(), e);
+      context.setJson("{\"success\":false,\"error\":\"Save failed\"}");
+    }
     return context;
   }
 

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -74,7 +74,7 @@
       </div>
     </c:when>
     <c:otherwise>
-      <div class="platform-content">${contentHtml}</div>
+      <div class="platform-content"<c:if test="${pageEditMode eq 'true' && !empty uniqueId}"> data-content-unique-id="<c:out value="${uniqueId}"/>" data-widget-id="<c:out value="${widgetContext.uniqueId}"/>" data-page-uri="<c:out value="${widgetContext.uri}"/>"</c:if>>${contentHtml}</div>
     </c:otherwise>
   </c:choose>
 </div>

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -134,3 +134,123 @@ a.sc-editor-handle:hover {
   opacity: 0.85;
   color: #fff;
 }
+
+/* ── Inline content editor ── */
+
+/* Active editing state */
+.platform-content[contenteditable="true"] {
+  outline: 2px solid #0056b3;
+  outline-offset: 3px;
+  min-height: 2em;
+  cursor: text;
+}
+
+.platform-content[contenteditable="true"]:focus {
+  outline-color: #003d82;
+}
+
+/* Floating inline toolbar (appears above the content block) */
+#sc-inline-toolbar {
+  position: absolute;
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  z-index: 10000;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  font-family: sans-serif;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+#sc-inline-toolbar button {
+  background: transparent;
+  border: none;
+  color: #ccc;
+  padding: 3px 7px;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 13px;
+  line-height: 1.4;
+  min-width: 26px;
+  font-family: sans-serif;
+}
+
+#sc-inline-toolbar button:hover,
+#sc-inline-toolbar button.sc-active {
+  background: #0056b3;
+  color: #fff;
+}
+
+#sc-inline-toolbar .sc-inline-sep {
+  width: 1px;
+  background: #444;
+  height: 18px;
+  margin: 0 3px;
+  flex-shrink: 0;
+}
+
+/* Action buttons bar (Save / Discard) rendered inside the widget area */
+.sc-inline-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  align-items: center;
+}
+
+.sc-inline-actions .button {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+}
+
+.sc-inline-save-msg {
+  font-size: 0.75rem;
+  color: #28a745;
+  margin-left: 4px;
+}
+
+/* Dim the editor widget outline while actively editing */
+body.page-edit-mode [data-editor-widget].sc-editing {
+  outline-color: #0056b3;
+}
+
+/* Link prompt overlay */
+#sc-link-prompt {
+  position: absolute;
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 6px 8px;
+  z-index: 10001;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+}
+
+#sc-link-prompt input[type="text"] {
+  background: #2a2a3e;
+  border: 1px solid #555;
+  color: #eee;
+  padding: 3px 6px;
+  font-size: 12px;
+  border-radius: 3px;
+  width: 220px;
+}
+
+#sc-link-prompt button {
+  background: #0056b3;
+  border: none;
+  color: #fff;
+  padding: 3px 8px;
+  font-size: 12px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+#sc-link-prompt button.sc-cancel {
+  background: #555;
+}

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -9,6 +9,288 @@
   var pagePath = toolbar ? toolbar.dataset.pagePath : '';
   var ctx = toolbar ? (toolbar.dataset.ctx || '') : '';
 
+  // ── Shared inline toolbar + link prompt DOM ──────────────────────────────
+
+  var inlineToolbar = null;
+  var linkPrompt = null;
+  var activeContent = null;     // the .platform-content div currently being edited
+  var activeWidget = null;      // its [data-editor-widget] ancestor
+  var savedSelection = null;    // Selection saved before link prompt opens
+  var originalHtml = null;      // snapshot before editing begins (for Discard)
+  var actionsBar = null;        // Save/Discard bar for the active widget
+
+  function buildInlineToolbar() {
+    var t = document.createElement('div');
+    t.id = 'sc-inline-toolbar';
+    t.setAttribute('role', 'toolbar');
+    t.setAttribute('aria-label', 'Text format');
+    t.style.display = 'none';
+    t.innerHTML =
+      '<button type="button" data-cmd="bold" title="Bold (Ctrl+B)"><b>B</b></button>' +
+      '<button type="button" data-cmd="italic" title="Italic (Ctrl+I)"><i>I</i></button>' +
+      '<button type="button" data-cmd="underline" title="Underline (Ctrl+U)"><u>U</u></button>' +
+      '<div class="sc-inline-sep" aria-hidden="true"></div>' +
+      '<button type="button" data-cmd="link" title="Insert / edit link">&#128279;</button>' +
+      '<button type="button" data-cmd="unlink" title="Remove link">&#10006;</button>';
+    document.body.appendChild(t);
+
+    t.addEventListener('mousedown', function (e) {
+      e.preventDefault(); // keep selection alive
+      var btn = e.target.closest('button[data-cmd]');
+      if (!btn) return;
+      var cmd = btn.dataset.cmd;
+      if (cmd === 'link') {
+        openLinkPrompt();
+      } else if (cmd === 'unlink') {
+        document.execCommand('unlink', false, null);
+      } else {
+        document.execCommand(cmd, false, null);
+      }
+      updateToolbarState();
+    });
+    return t;
+  }
+
+  function buildLinkPrompt() {
+    var p = document.createElement('div');
+    p.id = 'sc-link-prompt';
+    p.style.display = 'none';
+    p.innerHTML =
+      '<input type="text" placeholder="https://" aria-label="URL"/>' +
+      '<button type="button">OK</button>' +
+      '<button type="button" class="sc-cancel">Cancel</button>';
+    document.body.appendChild(p);
+
+    var input = p.querySelector('input');
+    var ok = p.querySelector('button:not(.sc-cancel)');
+    var cancel = p.querySelector('.sc-cancel');
+
+    ok.addEventListener('click', function () {
+      var url = input.value.trim();
+      if (url) {
+        restoreSelection();
+        document.execCommand('createLink', false, url);
+      }
+      p.style.display = 'none';
+      input.value = '';
+    });
+    cancel.addEventListener('click', function () {
+      p.style.display = 'none';
+      input.value = '';
+      restoreSelection();
+    });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') ok.click();
+      if (e.key === 'Escape') cancel.click();
+    });
+    return p;
+  }
+
+  function saveSelection() {
+    var sel = window.getSelection();
+    if (sel && sel.rangeCount) {
+      savedSelection = sel.getRangeAt(0).cloneRange();
+    }
+  }
+
+  function restoreSelection() {
+    if (!savedSelection) return;
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(savedSelection);
+  }
+
+  function openLinkPrompt() {
+    saveSelection();
+    // Check if cursor is on an existing link
+    var sel = window.getSelection();
+    var existing = '';
+    if (sel && sel.rangeCount) {
+      var node = sel.anchorNode;
+      while (node && node !== activeContent) {
+        if (node.nodeName === 'A') { existing = node.href; break; }
+        node = node.parentNode;
+      }
+    }
+    linkPrompt.querySelector('input').value = existing;
+    positionNear(linkPrompt, inlineToolbar);
+    linkPrompt.style.display = 'flex';
+    linkPrompt.querySelector('input').focus();
+  }
+
+  function positionAboveSelection(el) {
+    var sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
+    var rect = sel.getRangeAt(0).getBoundingClientRect();
+    var elH = el.offsetHeight || 32;
+    el.style.top = (window.scrollY + rect.top - elH - 6) + 'px';
+    el.style.left = (window.scrollX + rect.left) + 'px';
+  }
+
+  function positionNear(el, anchor) {
+    var rect = anchor.getBoundingClientRect();
+    el.style.top = (window.scrollY + rect.bottom + 4) + 'px';
+    el.style.left = (window.scrollX + rect.left) + 'px';
+  }
+
+  function showInlineToolbar() {
+    var sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !activeContent) {
+      inlineToolbar.style.display = 'none';
+      return;
+    }
+    if (!activeContent.contains(sel.anchorNode)) {
+      inlineToolbar.style.display = 'none';
+      return;
+    }
+    updateToolbarState();
+    inlineToolbar.style.display = 'flex';
+    positionAboveSelection(inlineToolbar);
+  }
+
+  function updateToolbarState() {
+    ['bold', 'italic', 'underline'].forEach(function (cmd) {
+      var btn = inlineToolbar.querySelector('[data-cmd="' + cmd + '"]');
+      if (btn) {
+        btn.classList.toggle('sc-active', document.queryCommandState(cmd));
+      }
+    });
+  }
+
+  function hideInlineToolbar() {
+    if (inlineToolbar) inlineToolbar.style.display = 'none';
+  }
+
+  // ── Actions bar (Save / Discard) ─────────────────────────────────────────
+
+  function buildActionsBar(widgetEl) {
+    var bar = document.createElement('div');
+    bar.className = 'sc-inline-actions';
+    bar.innerHTML =
+      '<button type="button" class="button small success sc-save-btn">Save Draft</button>' +
+      '<button type="button" class="button small hollow secondary sc-discard-btn">Discard</button>' +
+      '<span class="sc-inline-save-msg" aria-live="polite"></span>';
+    widgetEl.appendChild(bar);
+
+    bar.querySelector('.sc-save-btn').addEventListener('click', function () {
+      saveContentDraft(bar);
+    });
+    bar.querySelector('.sc-discard-btn').addEventListener('click', function () {
+      discardEdit();
+    });
+    return bar;
+  }
+
+  function setStatus(bar, msg, isError) {
+    var span = bar.querySelector('.sc-inline-save-msg');
+    if (!span) return;
+    span.textContent = msg;
+    span.style.color = isError ? '#dc3545' : '#28a745';
+  }
+
+  // ── Activate / deactivate inline editing ─────────────────────────────────
+
+  function activateEdit(contentEl) {
+    if (activeContent === contentEl) return;
+    if (activeContent) deactivateEdit(false);
+
+    activeContent = contentEl;
+    activeWidget = contentEl.closest('[data-editor-widget]');
+    originalHtml = contentEl.innerHTML;
+
+    contentEl.setAttribute('contenteditable', 'true');
+    contentEl.setAttribute('spellcheck', 'true');
+    if (activeWidget) activeWidget.classList.add('sc-editing');
+
+    actionsBar = buildActionsBar(activeWidget || contentEl.parentElement);
+    contentEl.focus();
+    setToolbarStatus('Editing…');
+  }
+
+  function deactivateEdit(keepChanges) {
+    if (!activeContent) return;
+    if (!keepChanges && originalHtml !== null) {
+      activeContent.innerHTML = originalHtml;
+    }
+    activeContent.removeAttribute('contenteditable');
+    activeContent.removeAttribute('spellcheck');
+    if (activeWidget) activeWidget.classList.remove('sc-editing');
+    if (actionsBar && actionsBar.parentNode) actionsBar.parentNode.removeChild(actionsBar);
+    hideInlineToolbar();
+    actionsBar = null;
+    activeContent = null;
+    activeWidget = null;
+    originalHtml = null;
+    savedSelection = null;
+    setToolbarStatus('');
+  }
+
+  function discardEdit() {
+    deactivateEdit(false);
+  }
+
+  function setToolbarStatus(msg) {
+    var el = document.getElementById('sc-editor-status');
+    if (el) el.textContent = msg;
+  }
+
+  // ── AJAX save ─────────────────────────────────────────────────────────────
+
+  function saveContentDraft(bar) {
+    if (!activeContent) return;
+    var uniqueId = activeContent.dataset.contentUniqueId;
+    var widgetId = activeContent.dataset.widgetId;
+    var pageUri = activeContent.dataset.pageUri || window.location.pathname;
+    var token = (typeof mainToken !== 'undefined') ? mainToken : '';
+
+    if (!uniqueId || !widgetId || !token) {
+      setStatus(bar, 'Missing parameters', true);
+      return;
+    }
+
+    var saveBtn = bar.querySelector('.sc-save-btn');
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving…';
+    setStatus(bar, '');
+
+    var qs = new URLSearchParams();
+    qs.append('action', 'saveDraft');
+    qs.append('widget', widgetId);
+    qs.append('token', token);
+
+    var body = new URLSearchParams();
+    body.append('html', activeContent.innerHTML);
+
+    fetch(pageUri + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: body.toString()
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (data.success) {
+        setStatus(bar, 'Saved');
+        setToolbarStatus('Draft saved');
+        originalHtml = activeContent.innerHTML; // update snapshot so Discard doesn't clobber
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save Draft';
+      } else {
+        throw new Error(data.error || 'Unknown error');
+      }
+    })
+    .catch(function (err) {
+      setStatus(bar, 'Error: ' + err.message, true);
+      setToolbarStatus('');
+      saveBtn.disabled = false;
+      saveBtn.textContent = 'Save Draft';
+    });
+  }
+
+  // ── Handle overlay labels ─────────────────────────────────────────────────
+
   function insertHandle(el, type, label, href) {
     var handle;
     if (href) {
@@ -21,13 +303,17 @@
     handle.className = 'sc-editor-handle sc-editor-handle-' + type;
     handle.textContent = label;
     handle.setAttribute('aria-hidden', 'true');
-    // Ensure the parent has a stacking context for absolute positioning
     var pos = window.getComputedStyle(el).position;
     if (pos === 'static') {
       el.style.position = 'relative';
     }
     el.insertBefore(handle, el.firstChild);
   }
+
+  // ── Bootstrap ─────────────────────────────────────────────────────────────
+
+  inlineToolbar = buildInlineToolbar();
+  linkPrompt = buildLinkPrompt();
 
   // Sections
   document.querySelectorAll('[data-editor-section]').forEach(function (el) {
@@ -42,11 +328,46 @@
     insertHandle(el, 'column', 'Col ' + (colIdx + 1));
   });
 
-  // Widgets — content widgets get no link (inline editor in PR2);
-  // non-content widgets link to the XML designer as fallback
+  // Widgets
   document.querySelectorAll('[data-editor-widget]').forEach(function (el) {
     var isContentWidget = !!el.querySelector('[data-content-unique-id]');
     var href = isContentWidget ? null : (ctx + '/admin/web-page-designer?webPage=' + encodeURIComponent(pagePath));
     insertHandle(el, 'widget', isContentWidget ? 'Content' : 'Widget', href);
   });
+
+  // Click on a content block → activate inline editor
+  document.addEventListener('click', function (e) {
+    var contentEl = e.target.closest('.platform-content[data-content-unique-id]');
+    if (contentEl) {
+      e.preventDefault();
+      activateEdit(contentEl);
+      return;
+    }
+    // Click outside the active editor (not on toolbar or actions bar) → deactivate
+    if (activeContent) {
+      var inToolbar = inlineToolbar && inlineToolbar.contains(e.target);
+      var inPrompt = linkPrompt && linkPrompt.contains(e.target);
+      var inActions = actionsBar && actionsBar.contains(e.target);
+      var inContent = activeContent.contains(e.target);
+      if (!inToolbar && !inPrompt && !inActions && !inContent) {
+        deactivateEdit(true);
+      }
+    }
+  });
+
+  // Show/reposition toolbar on selection change
+  document.addEventListener('selectionchange', function () {
+    if (!activeContent) return;
+    showInlineToolbar();
+  });
+
+  // Keyboard shortcut: Escape exits editor
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && activeContent) {
+      deactivateEdit(true);
+    }
+  });
+
+  // Hide floating toolbar when window scrolls (will reposition on next selection)
+  window.addEventListener('scroll', hideInlineToolbar, {passive: true});
 })();


### PR DESCRIPTION
> **Stacks on PR #331** — merge that first; this branch includes those changes.

## Summary

Adds click-to-edit for content blocks in visual editor mode.

- **`saveDraft` action** in `ContentHtmlCommand`: receives HTML from the inline editor, sanitizes it via `SaveContentCommand.saveSafeContent(publish=false)` (same sanitizer as the full content editor), stores as `draftContent`, and returns `{"success":true}` as a JSON short-circuit response. The existing `WebContainerCommand.setJson()` path handles this cleanly — no page re-render occurs.
- **`content.jsp`**: `.platform-content` gains three `data-*` attributes when `pageEditMode` is true — `data-content-unique-id`, `data-widget-id`, `data-page-uri` — giving the JS everything it needs to dispatch the AJAX save without server round-trips.
- **`platform-editor.js`**: full inline editor lifecycle
  - Click any `.platform-content[data-content-unique-id]` div → `contenteditable="true"` activates; original HTML snapshotted for Discard
  - Floating toolbar (bold / italic / underline / link / unlink) positioned above the selection; link button opens an inline URL prompt that preserves the selection range
  - Save Draft → POST to `?action=saveDraft&widget=…&token=…` (action/token in URL, HTML body in POST body to keep URLs log-clean)
  - Discard → restores snapshot; Escape exits (keeps changes); click outside exits
  - Status bar in the fixed toolbar reflects active state and save result
- **`platform-editor.css`**: active contenteditable outline, floating toolbar, link prompt, Save/Discard action bar

## Design notes

- Uses `contenteditable` + `document.execCommand` — no Quill bundle needed. Content stored as HTML (format 0), which the server already renders natively. Blocks previously saved as Quill Delta remain readable; inline edits store as HTML from that point forward.
- Images and complex media: use the existing `/content-editor` link (visible when `showEditor` is true).
- `saveSafeContent` runs Jsoup sanitization on every save, so inline edits cannot introduce XSS.

## Test plan

- [ ] `?editMode=true` → click a content widget → blue outline + actions bar appears
- [ ] Select text → floating toolbar appears above selection; bold/italic/underline/link apply
- [ ] Escape exits without saving (original HTML restored)
- [ ] Save Draft → `{"success":true}`; status reads "Draft saved"; reload confirms draft is visible
- [ ] Non-editor user visiting `?editMode=true` → no `data-*` attrs emitted, no editor activated