### PR TITLE
docs: add security audit cadence to pipeline.md and SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,21 @@ Please include: affected version/commit, a description and steps to reproduce.
 
 Security fixes are applied to the 'main' branch. We do not maintain patched builds of older versions.
 
+## Audit Cadence
+
+Security checks run at multiple frequencies:
+
+- **Every PR** — CodeQL, Trivy, XSS gate, and a keyword labeler that applies
+  the `security` label automatically; labelled PRs receive an extra reviewer pass.
+- **Weekly** — An automated agent scans open security PRs and issues and files
+  a staleness alert if any item has had no activity in 14 days.
+- **Quarterly** — Maintainers review the open security backlog, re-triage VEX
+  items, and audit `provided`-scope dependencies that Dependabot skips.
+- **Annually / on major changes** — Threat-model review and, for
+  customer-facing deployments, a penetration test.
+
+See `docs/pipeline.md` for the full DevSecOps pipeline and per-PR checklist.
+
 ## Scope
 
 This policy covers the code in this repository. It does **not** cover any

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -61,3 +61,50 @@ ant -lib lib/war package
 The application and database images are built, scanned with Trivy, and published
 with a signed CycloneDX SBOM and build-provenance attestation
 (`.github/workflows/publish-images.yml` and `.github/workflows/sbom.yml`).
+
+## Security Audit Cadence
+
+Security is enforced at multiple layers, from per-commit automation through
+periodic human review. The table below summarises what runs when and who owns it.
+
+| Frequency | What | Owner |
+|-----------|------|-------|
+| Every push / PR | CodeQL SAST, `unescaped-el` XSS gate, Trivy image scan, keyword security labeler | CI (automatic) |
+| Per PR | Hand-review any PR carrying the `security` label for auth, session, permissions, or crypto changes | Reviewer |
+| Weekly (Monday) | Cloud agent scans open security PRs and issues; files a GitHub issue if any item has had no activity in 14+ days | Automated routine |
+| Quarterly | Audit open security issue backlog; re-triage VEX items for CVEs that have gained exploitability evidence; check `provided`-scope dependencies (e.g. `tomcat-servlet-api`) that Dependabot skips | Maintainer |
+| Annually / on major changes | Full threat-model review after new auth flows, infra changes, or external integrations; penetration test for customer-facing deployments | Maintainer |
+| Event-driven | Triage any CVE in a direct dependency within the current sprint; full security sweep before a major release cut | Maintainer |
+
+### Per-PR security review checklist
+
+When a PR carries the `security` label, reviewers should verify:
+
+- Authentication and session changes do not weaken existing controls (step-up gates, MFA, cookie flags).
+- Authorization checks are deny-by-default; new admin-layout pages go through the access gate (`completeness` CI check enforces this).
+- User-supplied input that reaches HTML output is HTML-encoded; EL expressions are escaped (`unescaped-el` CI check enforces this for JSPs).
+- Cryptographic operations use approved algorithms (Argon2 for passwords; AES-GCM for data at rest).
+- No secrets, tokens, or credentials are logged or returned in API responses.
+- New tests cover the security-critical path; `security` label PRs without tests should be flagged for follow-up.
+
+### Quarterly dependency audit
+
+Dependabot covers compile- and test-scope dependencies. `provided`-scope
+libraries (those supplied by the runtime container) are excluded because they
+are not vendored into the WAR. Run the drift check manually and cross-reference
+against the current NVD feed:
+
+```bash
+python3 tools/check-dependency-drift.py
+```
+
+For `provided`-scope libraries (currently `tomcat-servlet-api`), track the
+Tomcat release notes directly and update the hold rationale in
+`.github/dependabot.yml` when the servlet API version changes.
+
+### VEX triage
+
+Trivy findings that are assessed as `not_affected` are recorded in
+`docker/app/vex.json`. During each quarterly review, re-open any item whose
+`justification` may no longer hold (e.g. a previously unexploitable CVE now
+has a public PoC) and either patch or re-justify with updated evidence.


### PR DESCRIPTION
## Summary

- Adds a **Security Audit Cadence** section to `docs/pipeline.md` with a frequency table (continuous CI, per-PR, weekly automated agent, quarterly, annual/event-driven), a per-PR reviewer checklist, guidance on auditing `provided`-scope dependencies Dependabot skips, and VEX triage instructions
- Adds an **Audit Cadence** section to `SECURITY.md` with a concise summary of the same schedule and a pointer to `docs/pipeline.md`

## Test plan

- [ ] Docs render correctly in GitHub's markdown preview
- [ ] Links to workflow files and scripts are accurate