### PR TITLE
Visual Editor P2 – PR4: draft publish and discard flow

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommand.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reorders sections/columns/widgets in a page's draft XML layout.
+ * Receives a JSON descriptor of the new order (original indices → new positions),
+ * rewrites the DOM, and persists to draftPageXml via WebPageRepository.
+ */
+public class SaveDraftLayoutCommand {
+
+  private static Log LOG = LogFactory.getLog(SaveDraftLayoutCommand.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * @param webPage    the page whose layout is being changed
+   * @param layoutJson JSON string: {"sections":[{"s":origIdx,"columns":[{"c":origIdx,"widgets":[origIdx,...]},...]},...]}
+   */
+  public static void saveDraftLayout(WebPage webPage, String layoutJson) throws DataException {
+    if (webPage == null || webPage.getId() == -1) {
+      throw new DataException("Page not found");
+    }
+
+    String sourceXml = StringUtils.isNotBlank(webPage.getDraftPageXml())
+        ? webPage.getDraftPageXml()
+        : webPage.getPageXml();
+    if (StringUtils.isBlank(sourceXml)) {
+      throw new DataException("Page has no XML layout to reorder");
+    }
+    if (StringUtils.isBlank(layoutJson)) {
+      throw new DataException("Layout description is required");
+    }
+
+    try {
+      // Parse source XML
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setExpandEntityReferences(false);
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      Document doc = builder.parse(new InputSource(new StringReader(sourceXml)));
+
+      Element pageEl = doc.getDocumentElement();
+      List<Element> sections = childElements(pageEl, "section");
+
+      // Parse layout JSON
+      JsonNode root = MAPPER.readTree(layoutJson);
+      JsonNode sectionsNode = root.get("sections");
+      if (sectionsNode == null || !sectionsNode.isArray()) {
+        throw new DataException("Invalid layout: missing sections array");
+      }
+
+      // Validate all indices are in-range before touching the DOM
+      for (JsonNode sNode : sectionsNode) {
+        int sIdx = sNode.path("s").asInt(-1);
+        if (sIdx < 0 || sIdx >= sections.size()) {
+          throw new DataException("Invalid layout: section index " + sIdx + " out of range");
+        }
+        Element sectionEl = sections.get(sIdx);
+        List<Element> columns = childElements(sectionEl, "column");
+        JsonNode colsNode = sNode.get("columns");
+        if (colsNode == null) continue;
+        for (JsonNode cNode : colsNode) {
+          int cIdx = cNode.path("c").asInt(-1);
+          if (cIdx < 0 || cIdx >= columns.size()) {
+            throw new DataException("Invalid layout: column index " + cIdx + " in section " + sIdx + " out of range");
+          }
+          Element colEl = columns.get(cIdx);
+          List<Element> widgets = childElements(colEl, "widget");
+          JsonNode widgetsNode = cNode.get("widgets");
+          if (widgetsNode == null) continue;
+          for (JsonNode wNode : widgetsNode) {
+            int wIdx = wNode.asInt(-1);
+            if (wIdx < 0 || wIdx >= widgets.size()) {
+              throw new DataException("Invalid layout: widget index " + wIdx + " out of range");
+            }
+          }
+        }
+      }
+
+      // Detach all sections from the page root
+      for (Element s : sections) {
+        pageEl.removeChild(s);
+      }
+
+      // Re-attach in new order with reordered columns and widgets
+      for (JsonNode sNode : sectionsNode) {
+        int sIdx = sNode.path("s").asInt();
+        Element sectionEl = sections.get(sIdx);
+
+        JsonNode colsNode = sNode.get("columns");
+        if (colsNode != null && colsNode.isArray()) {
+          List<Element> columns = childElements(sectionEl, "column");
+          for (Element c : columns) sectionEl.removeChild(c);
+
+          for (JsonNode cNode : colsNode) {
+            int cIdx = cNode.path("c").asInt();
+            Element colEl = columns.get(cIdx);
+
+            JsonNode widgetsNode = cNode.get("widgets");
+            if (widgetsNode != null && widgetsNode.isArray()) {
+              List<Element> widgets = childElements(colEl, "widget");
+              for (Element w : widgets) colEl.removeChild(w);
+              for (JsonNode wNode : widgetsNode) {
+                colEl.appendChild(widgets.get(wNode.asInt()));
+              }
+            }
+
+            sectionEl.appendChild(colEl);
+          }
+        }
+
+        pageEl.appendChild(sectionEl);
+      }
+
+      // Serialize
+      TransformerFactory tf = TransformerFactory.newInstance();
+      tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      Transformer transformer = tf.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      StringWriter sw = new StringWriter();
+      transformer.transform(new DOMSource(doc), new StreamResult(sw));
+      String newXml = sw.toString().trim();
+
+      // Persist
+      webPage.setDraftPageXml(newXml);
+      webPage.setDraft(true);
+      WebPageRepository.save(webPage);
+      WebPageXmlLayoutCommand.removeCustomPage(webPage.getLink());
+      LOG.debug("Draft layout saved for: " + webPage.getLink());
+
+    } catch (DataException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.error("saveDraftLayout failed for " + webPage.getLink(), e);
+      throw new DataException("Could not save draft layout: " + e.getMessage());
+    }
+  }
+
+  private static List<Element> childElements(Element parent, String tagName) {
+    List<Element> result = new ArrayList<>();
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node child = children.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE && tagName.equals(child.getNodeName())) {
+        result.add((Element) child);
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -43,6 +43,7 @@ import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -247,6 +248,40 @@ public class PageServlet extends HttpServlet {
           && EditorPermissionCommand.canEditContent(userSession);
       if (pageEditMode) {
         request.setAttribute("pageEditMode", "true");
+      }
+
+      // saveDraftLayout: reorder sections/columns/widgets, persist to draftPageXml
+      if ("saveDraftLayout".equals(request.getParameter("action"))
+          && request.getParameter("widget") == null
+          && pageEditMode
+          && EditorPermissionCommand.canBuildLayout(userSession)) {
+        String formToken = request.getParameter("token");
+        if (!userSession.getFormToken().equals(formToken)) {
+          LOG.warn("saveDraftLayout CSRF token mismatch from " + request.getRemoteAddr());
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          PrintWriter out = response.getWriter();
+          out.print("{\"success\":false,\"error\":\"Session expired\"}");
+          return;
+        }
+        if (webPage == null || webPage.getId() == -1) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"Page not found\"}");
+          return;
+        }
+        String layoutJson = request.getParameter("layout");
+        response.setContentType("application/json");
+        try {
+          SaveDraftLayoutCommand.saveDraftLayout(webPage, layoutJson);
+          response.getWriter().print("{\"success\":true}");
+        } catch (Exception e) {
+          LOG.error("saveDraftLayout failed for " + pagePath, e);
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          String msg = e.getMessage() != null ? e.getMessage().replace("\"", "'") : "Save failed";
+          response.getWriter().print("{\"success\":false,\"error\":\"" + msg + "\"}");
+        }
+        return;
       }
 
       // Determine the Page XML Layout for this request

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.Stylesheet;
 import com.simisinc.platform.domain.model.cms.TableOfContents;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
@@ -246,8 +247,15 @@ public class PageServlet extends HttpServlet {
       }
       boolean pageEditMode = "true".equals(request.getSession().getAttribute(SessionConstants.PAGE_EDIT_MODE))
           && EditorPermissionCommand.canEditContent(userSession);
+      boolean pageLayoutMode = pageEditMode && EditorPermissionCommand.canBuildLayout(userSession);
       if (pageEditMode) {
         request.setAttribute("pageEditMode", "true");
+      }
+      if (pageLayoutMode) {
+        request.setAttribute("pageLayoutMode", "true");
+        if (webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml())) {
+          request.setAttribute("hasDraft", "true");
+        }
       }
 
       // saveDraftLayout: reorder sections/columns/widgets, persist to draftPageXml
@@ -281,6 +289,62 @@ public class PageServlet extends HttpServlet {
           String msg = e.getMessage() != null ? e.getMessage().replace("\"", "'") : "Save failed";
           response.getWriter().print("{\"success\":false,\"error\":\"" + msg + "\"}");
         }
+        return;
+      }
+
+      // publishDraft: promote draftPageXml → pageXml
+      if ("publishDraft".equals(request.getParameter("action"))
+          && request.getParameter("widget") == null
+          && pageLayoutMode) {
+        String formToken = request.getParameter("token");
+        if (!userSession.getFormToken().equals(formToken)) {
+          LOG.warn("publishDraft CSRF token mismatch from " + request.getRemoteAddr());
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          response.getWriter().print("{\"success\":false,\"error\":\"Session expired\"}");
+          return;
+        }
+        if (webPage == null || webPage.getId() == -1) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"Page not found\"}");
+          return;
+        }
+        if (StringUtils.isBlank(webPage.getDraftPageXml())) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"No draft to publish\"}");
+          return;
+        }
+        response.setContentType("application/json");
+        WebPageRepository.publish(webPage);
+        LOG.info("Draft published for " + pagePath + " by user " + userSession.getUserId());
+        response.getWriter().print("{\"success\":true}");
+        return;
+      }
+
+      // discardDraft: clear draftPageXml without publishing
+      if ("discardDraft".equals(request.getParameter("action"))
+          && request.getParameter("widget") == null
+          && pageLayoutMode) {
+        String formToken = request.getParameter("token");
+        if (!userSession.getFormToken().equals(formToken)) {
+          LOG.warn("discardDraft CSRF token mismatch from " + request.getRemoteAddr());
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          response.getWriter().print("{\"success\":false,\"error\":\"Session expired\"}");
+          return;
+        }
+        if (webPage == null || webPage.getId() == -1) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"Page not found\"}");
+          return;
+        }
+        response.setContentType("application/json");
+        WebPageRepository.removeDraft(webPage);
+        LOG.info("Draft discarded for " + pagePath + " by user " + userSession.getUserId());
+        response.getWriter().print("{\"success\":true}");
         return;
       }
 

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -251,12 +251,9 @@ public class PageServlet extends HttpServlet {
       if (pageEditMode) {
         request.setAttribute("pageEditMode", "true");
       }
-      if (pageLayoutMode) {
-        request.setAttribute("pageLayoutMode", "true");
-        if (webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml())) {
-          request.setAttribute("hasDraft", "true");
-        }
-      }
+      boolean hasDraft = pageLayoutMode && webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml());
+      request.setAttribute("pageLayoutMode", pageLayoutMode ? "true" : "false");
+      request.setAttribute("hasDraft", hasDraft ? "true" : "false");
 
       // saveDraftLayout: reorder sections/columns/widgets, persist to draftPageXml
       if ("saveDraftLayout".equals(request.getParameter("action"))

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -334,7 +334,11 @@
 </c:if>
 <body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty bodyClass}"> class="<c:out value="${bodyClass}" />"</c:if>>
   <c:if test="${pageEditMode eq 'true'}">
-    <div id="sc-editor-toolbar" role="toolbar" aria-label="Page editor" data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>" data-ctx="${ctx}">
+    <div id="sc-editor-toolbar" role="toolbar" aria-label="Page editor"
+         data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>"
+         data-ctx="${ctx}"
+         data-layout-mode="${pageLayoutMode eq 'true' ? 'true' : 'false'}"
+         data-has-draft="${hasDraft eq 'true' ? 'true' : 'false'}">
       <span id="sc-editor-toolbar-title">Visual Editor</span>
       <a href="${ctx}/admin/web-page-designer?webPage=<c:out value="${pageRenderInfo.pagePath}"/>" class="button small hollow secondary"><i class="fa fa-fw fa-code"></i> XML</a>
       <a href="?editMode=false" id="sc-editor-exit" class="button small hollow secondary"><i class="fa fa-fw fa-times"></i> Exit</a>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -337,8 +337,8 @@
     <div id="sc-editor-toolbar" role="toolbar" aria-label="Page editor"
          data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>"
          data-ctx="${ctx}"
-         data-layout-mode="${pageLayoutMode eq 'true' ? 'true' : 'false'}"
-         data-has-draft="${hasDraft eq 'true' ? 'true' : 'false'}">
+         data-layout-mode="<c:out value="${pageLayoutMode}"/>"
+         data-has-draft="<c:out value="${hasDraft}"/>">
       <span id="sc-editor-toolbar-title">Visual Editor</span>
       <a href="${ctx}/admin/web-page-designer?webPage=<c:out value="${pageRenderInfo.pagePath}"/>" class="button small hollow secondary"><i class="fa fa-fw fa-code"></i> XML</a>
       <a href="?editMode=false" id="sc-editor-exit" class="button small hollow secondary"><i class="fa fa-fw fa-times"></i> Exit</a>

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -217,6 +217,117 @@ body.page-edit-mode [data-editor-widget].sc-editing {
   outline-color: #0056b3;
 }
 
+/* ── Drag-to-reorder layout ── */
+
+/* Drag handles on section and widget overlays */
+.sc-editor-drag-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  font-size: 14px;
+  line-height: 1;
+  z-index: 101;
+  border-radius: 0 0 0 3px;
+  color: #fff;
+  font-family: sans-serif;
+  user-select: none;
+}
+
+.sc-editor-drag-handle:active {
+  cursor: grabbing;
+}
+
+.sc-drag-handle-section {
+  background: #0056b3;
+}
+
+.sc-drag-handle-widget {
+  background: #dc3545;
+}
+
+body.page-edit-mode [data-editor-section]:hover > .sc-editor-drag-handle,
+body.page-edit-mode [data-editor-widget]:hover > .sc-editor-drag-handle {
+  display: flex;
+}
+
+/* Element being dragged */
+body.page-edit-mode [data-editor-section].sc-dragging,
+body.page-edit-mode [data-editor-widget].sc-dragging {
+  opacity: 0.4;
+  outline-style: solid !important;
+}
+
+/* Drop insertion indicator */
+.sc-drop-indicator {
+  height: 3px;
+  background: #0056b3;
+  border-radius: 2px;
+  pointer-events: none;
+  margin: 0;
+  transition: opacity 0.1s;
+}
+
+/* Keyboard move buttons (WCAG 2.5.7) */
+.sc-move-btns {
+  position: absolute;
+  top: 0;
+  right: 26px;
+  display: none;
+  gap: 2px;
+  z-index: 101;
+}
+
+body.page-edit-mode [data-editor-section]:hover > .sc-move-btns,
+body.page-edit-mode [data-editor-widget]:hover > .sc-move-btns {
+  display: flex;
+}
+
+.sc-move-btns button {
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255,255,255,0.3);
+  color: #fff;
+  font-size: 11px;
+  padding: 2px 5px;
+  cursor: pointer;
+  border-radius: 2px;
+  line-height: 1.2;
+  font-family: sans-serif;
+}
+
+.sc-move-btns button:hover {
+  background: #0056b3;
+  border-color: #0056b3;
+}
+
+/* Save Layout button in toolbar */
+#sc-save-layout-btn {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+}
+
+/* Unsaved layout change indicator */
+#sc-layout-dirty-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f0ad4e;
+  margin-left: 4px;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+#sc-layout-dirty-dot.sc-visible {
+  opacity: 1;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -328,6 +328,97 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-move-btns {
   opacity: 1;
 }
 
+/* ── Draft publish / discard ── */
+
+#sc-publish-btn {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+}
+
+#sc-discard-draft-btn {
+  margin-bottom: 0;
+  font-size: 0.75rem;
+  color: #ccc;
+  border-color: #555;
+}
+
+#sc-discard-draft-btn:hover {
+  color: #fff;
+  border-color: #aaa;
+}
+
+/* Confirm modal overlay */
+#sc-confirm-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 10002;
+  align-items: center;
+  justify-content: center;
+}
+
+#sc-confirm-modal.sc-visible {
+  display: flex;
+}
+
+#sc-confirm-modal-box {
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 1.25rem 1.5rem;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.6);
+  font-family: sans-serif;
+}
+
+#sc-confirm-modal-msg {
+  color: #eee;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+#sc-confirm-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+#sc-confirm-modal-actions button {
+  font-size: 0.8rem;
+  padding: 6px 16px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  font-family: sans-serif;
+}
+
+#sc-confirm-ok {
+  background: #0056b3;
+  color: #fff;
+}
+
+#sc-confirm-ok.sc-danger {
+  background: #c0392b;
+}
+
+#sc-confirm-ok:hover {
+  opacity: 0.9;
+}
+
+#sc-confirm-cancel {
+  background: #3a3a4e;
+  color: #ccc;
+  border: 1px solid #555 !important;
+}
+
+#sc-confirm-cancel:hover {
+  background: #4a4a5e;
+  color: #fff;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -234,7 +234,7 @@
     if (el) el.textContent = msg;
   }
 
-  // ── AJAX save ─────────────────────────────────────────────────────────────
+  // ── AJAX save (content) ──────────────────────────────────────────────────
 
   function saveContentDraft(bar) {
     if (!activeContent) return;
@@ -274,7 +274,7 @@
       if (data.success) {
         setStatus(bar, 'Saved');
         setToolbarStatus('Draft saved');
-        originalHtml = activeContent.innerHTML; // update snapshot so Discard doesn't clobber
+        originalHtml = activeContent.innerHTML;
         saveBtn.disabled = false;
         saveBtn.textContent = 'Save Draft';
       } else {
@@ -310,15 +310,268 @@
     el.insertBefore(handle, el.firstChild);
   }
 
+  // ── Drag-to-reorder layout ───────────────────────────────────────────────
+
+  var layoutDirty = false;
+  var dragSrcEl = null;      // element being dragged
+  var dragSrcType = null;    // 'section' or 'widget'
+  var dropIndicator = null;
+
+  function getToken() {
+    return (typeof mainToken !== 'undefined') ? mainToken : '';
+  }
+
+  function markLayoutDirty() {
+    layoutDirty = true;
+    var dot = document.getElementById('sc-layout-dirty-dot');
+    if (dot) dot.classList.add('sc-visible');
+    var btn = document.getElementById('sc-save-layout-btn');
+    if (btn) btn.disabled = false;
+  }
+
+  function markLayoutClean() {
+    layoutDirty = false;
+    var dot = document.getElementById('sc-layout-dirty-dot');
+    if (dot) dot.classList.remove('sc-visible');
+    var btn = document.getElementById('sc-save-layout-btn');
+    if (btn) btn.disabled = true;
+  }
+
+  // Build the layout JSON from current DOM order.
+  // Uses the data-editor-* original indices stored on each element.
+  function buildLayoutJson() {
+    var sections = [];
+    document.querySelectorAll('[data-editor-section]').forEach(function (sectionEl) {
+      var sIdx = parseInt(sectionEl.dataset.editorSection, 10);
+      var columns = [];
+      sectionEl.querySelectorAll(':scope > [data-editor-column]').forEach(function (colEl) {
+        var parts = colEl.dataset.editorColumn.split('-');
+        var cIdx = parseInt(parts[1], 10);
+        var widgets = [];
+        colEl.querySelectorAll(':scope > [data-editor-widget]').forEach(function (widgetEl) {
+          var wParts = widgetEl.dataset.editorWidget.split('-');
+          widgets.push(parseInt(wParts[2], 10));
+        });
+        columns.push({c: cIdx, widgets: widgets});
+      });
+      sections.push({s: sIdx, columns: columns});
+    });
+    return JSON.stringify({sections: sections});
+  }
+
+  function insertDragHandle(el, type) {
+    var handle = document.createElement('span');
+    handle.className = 'sc-editor-drag-handle sc-drag-handle-' + type;
+    handle.textContent = '⠿';
+    handle.setAttribute('aria-hidden', 'true');
+    handle.setAttribute('draggable', 'false'); // handle is just visual; draggable is on el
+    el.appendChild(handle);
+
+    // mousedown on handle initiates the drag by setting draggable on parent
+    handle.addEventListener('mousedown', function (e) {
+      e.stopPropagation();
+      el.setAttribute('draggable', 'true');
+    });
+    el.addEventListener('dragend', function () {
+      el.removeAttribute('draggable');
+    });
+  }
+
+  function insertMoveButtons(el, type) {
+    var btns = document.createElement('div');
+    btns.className = 'sc-move-btns';
+    btns.setAttribute('aria-label', 'Move ' + type);
+    btns.innerHTML =
+      '<button type="button" aria-label="Move ' + type + ' up" title="Move up">▲</button>' +
+      '<button type="button" aria-label="Move ' + type + ' down" title="Move down">▼</button>';
+    el.appendChild(btns);
+
+    var upBtn = btns.querySelector('button:first-child');
+    var dnBtn = btns.querySelector('button:last-child');
+
+    upBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var prev = prevSibling(el, el.dataset.editorSection !== undefined ? 'section' : 'widget');
+      if (prev) {
+        el.parentNode.insertBefore(el, prev);
+        markLayoutDirty();
+        upBtn.focus();
+      }
+    });
+    dnBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var next = nextSibling(el, el.dataset.editorSection !== undefined ? 'section' : 'widget');
+      if (next) {
+        el.parentNode.insertBefore(next, el);
+        markLayoutDirty();
+        dnBtn.focus();
+      }
+    });
+  }
+
+  function prevSibling(el, type) {
+    var attr = type === 'section' ? 'data-editor-section' : 'data-editor-widget';
+    var sib = el.previousElementSibling;
+    while (sib) {
+      if (sib.hasAttribute(attr)) return sib;
+      sib = sib.previousElementSibling;
+    }
+    return null;
+  }
+
+  function nextSibling(el, type) {
+    var attr = type === 'section' ? 'data-editor-section' : 'data-editor-widget';
+    var sib = el.nextElementSibling;
+    while (sib) {
+      if (sib.hasAttribute(attr)) return sib;
+      sib = sib.nextElementSibling;
+    }
+    return null;
+  }
+
+  function ensureDropIndicator() {
+    if (!dropIndicator) {
+      dropIndicator = document.createElement('div');
+      dropIndicator.className = 'sc-drop-indicator';
+      dropIndicator.id = 'sc-drop-indicator';
+    }
+    return dropIndicator;
+  }
+
+  function removeDropIndicator() {
+    if (dropIndicator && dropIndicator.parentNode) {
+      dropIndicator.parentNode.removeChild(dropIndicator);
+    }
+  }
+
+  // Attach HTML5 drag events to a draggable element (section or widget)
+  function makeDraggable(el, type) {
+    el.addEventListener('dragstart', function (e) {
+      dragSrcEl = el;
+      dragSrcType = type;
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', type); // required for Firefox
+      // Defer so the browser captures the pre-dragging look
+      setTimeout(function () { el.classList.add('sc-dragging'); }, 0);
+    });
+
+    el.addEventListener('dragend', function () {
+      el.classList.remove('sc-dragging');
+      el.removeAttribute('draggable');
+      removeDropIndicator();
+      dragSrcEl = null;
+      dragSrcType = null;
+    });
+
+    el.addEventListener('dragover', function (e) {
+      if (!dragSrcEl || dragSrcType !== type) return;
+      if (dragSrcEl === el) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+
+      var rect = el.getBoundingClientRect();
+      var mid = rect.top + rect.height / 2;
+      var ind = ensureDropIndicator();
+      if (e.clientY < mid) {
+        el.parentNode.insertBefore(ind, el);
+      } else {
+        if (el.nextElementSibling) {
+          el.parentNode.insertBefore(ind, el.nextElementSibling);
+        } else {
+          el.parentNode.appendChild(ind);
+        }
+      }
+    });
+
+    el.addEventListener('dragleave', function (e) {
+      // Only remove indicator if we're leaving entirely out of this element
+      if (!el.contains(e.relatedTarget)) {
+        removeDropIndicator();
+      }
+    });
+
+    el.addEventListener('drop', function (e) {
+      if (!dragSrcEl || dragSrcType !== type || dragSrcEl === el) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      var ind = ensureDropIndicator();
+      if (ind.parentNode) {
+        ind.parentNode.insertBefore(dragSrcEl, ind);
+      }
+      removeDropIndicator();
+      markLayoutDirty();
+    });
+  }
+
+  // ── Save Layout button and AJAX post ─────────────────────────────────────
+
+  function buildSaveLayoutButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'sc-save-layout-btn';
+    btn.className = 'button small success';
+    btn.disabled = true;
+    btn.innerHTML = 'Save Layout<span id="sc-layout-dirty-dot" aria-hidden="true"></span>';
+    btn.addEventListener('click', saveLayout);
+    toolbar.appendChild(btn);
+  }
+
+  function saveLayout() {
+    var btn = document.getElementById('sc-save-layout-btn');
+    var token = getToken();
+    if (!token) {
+      setToolbarStatus('No session token');
+      return;
+    }
+
+    btn.disabled = true;
+    btn.textContent = 'Saving…';
+    setToolbarStatus('Saving layout…');
+
+    var qs = new URLSearchParams();
+    qs.append('action', 'saveDraftLayout');
+    qs.append('token', token);
+    qs.append('layout', buildLayoutJson());
+
+    fetch(window.location.pathname + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (data.success) {
+        markLayoutClean();
+        btn.innerHTML = 'Save Layout<span id="sc-layout-dirty-dot" aria-hidden="true"></span>';
+        btn.disabled = true;
+        setToolbarStatus('Layout saved — reload to see');
+      } else {
+        throw new Error(data.error || 'Unknown error');
+      }
+    })
+    .catch(function (err) {
+      setToolbarStatus('Layout save failed: ' + err.message);
+      btn.innerHTML = 'Save Layout<span id="sc-layout-dirty-dot" aria-hidden="true"></span>';
+      markLayoutDirty(); // re-enables button
+    });
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────────
 
   inlineToolbar = buildInlineToolbar();
   linkPrompt = buildLinkPrompt();
+  buildSaveLayoutButton();
 
   // Sections
   document.querySelectorAll('[data-editor-section]').forEach(function (el) {
     var idx = parseInt(el.dataset.editorSection, 10);
     insertHandle(el, 'section', 'Section ' + (idx + 1));
+    insertDragHandle(el, 'section');
+    insertMoveButtons(el, 'section');
+    makeDraggable(el, 'section');
   });
 
   // Columns
@@ -333,10 +586,15 @@
     var isContentWidget = !!el.querySelector('[data-content-unique-id]');
     var href = isContentWidget ? null : (ctx + '/admin/web-page-designer?webPage=' + encodeURIComponent(pagePath));
     insertHandle(el, 'widget', isContentWidget ? 'Content' : 'Widget', href);
+    insertDragHandle(el, 'widget');
+    insertMoveButtons(el, 'widget');
+    makeDraggable(el, 'widget');
   });
 
   // Click on a content block → activate inline editor
   document.addEventListener('click', function (e) {
+    if (e.target.closest('.sc-editor-drag-handle, .sc-move-btns, .sc-editor-handle')) return;
+
     var contentEl = e.target.closest('.platform-content[data-content-unique-id]');
     if (contentEl) {
       e.preventDefault();

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -8,6 +8,7 @@
   var toolbar = document.getElementById('sc-editor-toolbar');
   var pagePath = toolbar ? toolbar.dataset.pagePath : '';
   var ctx = toolbar ? (toolbar.dataset.ctx || '') : '';
+  var layoutMode = toolbar ? toolbar.dataset.layoutMode === 'true' : false;
 
   // ── Shared inline toolbar + link prompt DOM ──────────────────────────────
 
@@ -277,6 +278,7 @@
         originalHtml = activeContent.innerHTML;
         saveBtn.disabled = false;
         saveBtn.textContent = 'Save Draft';
+        markHasDraft();
       } else {
         throw new Error(data.error || 'Unknown error');
       }
@@ -335,6 +337,14 @@
     if (dot) dot.classList.remove('sc-visible');
     var btn = document.getElementById('sc-save-layout-btn');
     if (btn) btn.disabled = true;
+  }
+
+  function markHasDraft() {
+    if (toolbar) toolbar.dataset.hasDraft = 'true';
+    var pub = document.getElementById('sc-publish-btn');
+    var dis = document.getElementById('sc-discard-draft-btn');
+    if (pub) pub.style.display = '';
+    if (dis) dis.style.display = '';
   }
 
   // Build the layout JSON from current DOM order.
@@ -504,6 +514,162 @@
     });
   }
 
+  // ── Confirm modal ────────────────────────────────────────────────────────
+
+  var confirmCallback = null;
+
+  function buildConfirmModal() {
+    var overlay = document.createElement('div');
+    overlay.id = 'sc-confirm-modal';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.innerHTML =
+      '<div id="sc-confirm-modal-box">' +
+        '<p id="sc-confirm-modal-msg"></p>' +
+        '<div id="sc-confirm-modal-actions">' +
+          '<button type="button" id="sc-confirm-cancel">Cancel</button>' +
+          '<button type="button" id="sc-confirm-ok">Confirm</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(overlay);
+
+    document.getElementById('sc-confirm-ok').addEventListener('click', function () {
+      overlay.classList.remove('sc-visible');
+      if (typeof confirmCallback === 'function') {
+        var cb = confirmCallback;
+        confirmCallback = null;
+        cb();
+      }
+    });
+    document.getElementById('sc-confirm-cancel').addEventListener('click', function () {
+      overlay.classList.remove('sc-visible');
+      confirmCallback = null;
+    });
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) {
+        overlay.classList.remove('sc-visible');
+        confirmCallback = null;
+      }
+    });
+    return overlay;
+  }
+
+  function showConfirm(msg, okLabel, isDanger, callback) {
+    document.getElementById('sc-confirm-modal-msg').textContent = msg;
+    var okBtn = document.getElementById('sc-confirm-ok');
+    okBtn.textContent = okLabel || 'Confirm';
+    okBtn.classList.toggle('sc-danger', !!isDanger);
+    confirmCallback = callback;
+    document.getElementById('sc-confirm-modal').classList.add('sc-visible');
+    okBtn.focus();
+  }
+
+  // ── Publish draft ────────────────────────────────────────────────────────
+
+  function buildPublishButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'sc-publish-btn';
+    btn.className = 'button small success';
+    btn.textContent = 'Publish';
+    if (toolbar.dataset.hasDraft !== 'true') btn.style.display = 'none';
+    btn.addEventListener('click', function () {
+      showConfirm(
+        'Publish this draft? The current live page will be replaced.',
+        'Publish', false, doPublishDraft
+      );
+    });
+    var exitBtn = document.getElementById('sc-editor-exit');
+    if (exitBtn) toolbar.insertBefore(btn, exitBtn);
+    else toolbar.appendChild(btn);
+    return btn;
+  }
+
+  function buildDiscardDraftButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'sc-discard-draft-btn';
+    btn.className = 'button small hollow secondary';
+    btn.textContent = 'Discard Draft';
+    if (toolbar.dataset.hasDraft !== 'true') btn.style.display = 'none';
+    btn.addEventListener('click', function () {
+      showConfirm(
+        'Discard all draft changes? This cannot be undone.',
+        'Discard', true, doDiscardDraft
+      );
+    });
+    var exitBtn = document.getElementById('sc-editor-exit');
+    if (exitBtn) toolbar.insertBefore(btn, exitBtn);
+    else toolbar.appendChild(btn);
+    return btn;
+  }
+
+  function doPublishDraft() {
+    var btn = document.getElementById('sc-publish-btn');
+    btn.disabled = true;
+    btn.textContent = 'Publishing…';
+    setToolbarStatus('Publishing…');
+
+    var qs = new URLSearchParams();
+    qs.append('action', 'publishDraft');
+    qs.append('token', getToken());
+
+    fetch(window.location.pathname + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (data.success) {
+        setToolbarStatus('Published! Reloading…');
+        window.location.reload();
+      } else {
+        throw new Error(data.error || 'Publish failed');
+      }
+    })
+    .catch(function (err) {
+      setToolbarStatus('Publish failed: ' + err.message);
+      btn.disabled = false;
+      btn.textContent = 'Publish';
+    });
+  }
+
+  function doDiscardDraft() {
+    var btn = document.getElementById('sc-discard-draft-btn');
+    btn.disabled = true;
+    btn.textContent = 'Discarding…';
+    setToolbarStatus('Discarding draft…');
+
+    var qs = new URLSearchParams();
+    qs.append('action', 'discardDraft');
+    qs.append('token', getToken());
+
+    fetch(window.location.pathname + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (data.success) {
+        setToolbarStatus('Draft discarded. Reloading…');
+        window.location.reload();
+      } else {
+        throw new Error(data.error || 'Discard failed');
+      }
+    })
+    .catch(function (err) {
+      setToolbarStatus('Discard failed: ' + err.message);
+      btn.disabled = false;
+      btn.textContent = 'Discard Draft';
+    });
+  }
+
   // ── Save Layout button and AJAX post ─────────────────────────────────────
 
   function buildSaveLayoutButton() {
@@ -514,7 +680,9 @@
     btn.disabled = true;
     btn.innerHTML = 'Save Layout<span id="sc-layout-dirty-dot" aria-hidden="true"></span>';
     btn.addEventListener('click', saveLayout);
-    toolbar.appendChild(btn);
+    var exitBtn = document.getElementById('sc-editor-exit');
+    if (exitBtn) toolbar.insertBefore(btn, exitBtn);
+    else toolbar.appendChild(btn);
   }
 
   function saveLayout() {
@@ -548,6 +716,7 @@
         btn.innerHTML = 'Save Layout<span id="sc-layout-dirty-dot" aria-hidden="true"></span>';
         btn.disabled = true;
         setToolbarStatus('Layout saved — reload to see');
+        markHasDraft();
       } else {
         throw new Error(data.error || 'Unknown error');
       }
@@ -563,15 +732,23 @@
 
   inlineToolbar = buildInlineToolbar();
   linkPrompt = buildLinkPrompt();
-  buildSaveLayoutButton();
+  buildConfirmModal();
+
+  if (layoutMode) {
+    buildSaveLayoutButton();      // inserts before Exit
+    buildPublishButton();         // inserts before Exit (right of Save Layout)
+    buildDiscardDraftButton();    // inserts before Exit (between Save Layout and Publish)
+  }
 
   // Sections
   document.querySelectorAll('[data-editor-section]').forEach(function (el) {
     var idx = parseInt(el.dataset.editorSection, 10);
     insertHandle(el, 'section', 'Section ' + (idx + 1));
-    insertDragHandle(el, 'section');
-    insertMoveButtons(el, 'section');
-    makeDraggable(el, 'section');
+    if (layoutMode) {
+      insertDragHandle(el, 'section');
+      insertMoveButtons(el, 'section');
+      makeDraggable(el, 'section');
+    }
   });
 
   // Columns
@@ -586,9 +763,11 @@
     var isContentWidget = !!el.querySelector('[data-content-unique-id]');
     var href = isContentWidget ? null : (ctx + '/admin/web-page-designer?webPage=' + encodeURIComponent(pagePath));
     insertHandle(el, 'widget', isContentWidget ? 'Content' : 'Widget', href);
-    insertDragHandle(el, 'widget');
-    insertMoveButtons(el, 'widget');
-    makeDraggable(el, 'widget');
+    if (layoutMode) {
+      insertDragHandle(el, 'widget');
+      insertMoveButtons(el, 'widget');
+      makeDraggable(el, 'widget');
+    }
   });
 
   // Click on a content block → activate inline editor


### PR DESCRIPTION
## What this does

Final PR in the Visual Editor P2 series. Closes the edit loop — layout builders can now promote a saved draft to the live page with one click (with a confirm step), or throw it away.

**Depends on:** PR #331, PR #332, and PR #333 — all must be merged first.

## Changes

### `PageServlet.java`
- New `pageLayoutMode` boolean (`pageEditMode && canBuildLayout`) drives a `pageLayoutMode` request attribute and a `hasDraft` attribute (set when `draftPageXml` is non-blank)
- `publishDraft` action handler: CSRF check → `canBuildLayout` gate → `WebPageRepository.publish()` → `{"success":true}` — the repo method copies `draft_page_xml` → `page_xml`, clears the draft, and invalidates the cache in one SQL statement
- `discardDraft` action handler: CSRF check → `canBuildLayout` gate → `WebPageRepository.removeDraft()` → `{"success":true}`

### `main.jsp`
- Toolbar `<div>` gains `data-layout-mode` and `data-has-draft` attributes read from request attributes set above

### `platform-editor.css`
- `#sc-publish-btn`, `#sc-discard-draft-btn` button styles
- Custom confirm modal (`#sc-confirm-modal`) — dark theme, matches the rest of the editor chrome; no `window.confirm()`

### `platform-editor.js`
- `layoutMode` variable read from `toolbar.dataset.layoutMode` — all layout controls (drag handles, ▲/▼ buttons, Save Layout, Publish, Discard Draft) only build when `true`; content-editors (`content-editor` role) see the inline edit overlay only
- `buildConfirmModal()` — reusable custom dialog; `showConfirm(msg, okLabel, isDanger, cb)` triggers it
- `buildPublishButton()` / `buildDiscardDraftButton()` — hidden by default when no draft; shown immediately after any successful save (content or layout) via `markHasDraft()`
- `doPublishDraft()` / `doDiscardDraft()` — POST with CSRF token, then `window.location.reload()` on success

## Testing checklist
- [ ] Layout builder: enter edit mode → drag sections → Save Layout → **Publish** button appears → click → confirm → page reloads with published layout
- [ ] Layout builder: enter edit mode → save some content → **Discard Draft** → confirm → page reloads showing live version
- [ ] Content editor role: enter edit mode → no drag handles, no Save Layout / Publish / Discard buttons visible
- [ ] CSRF: tamper token → 403 JSON
- [ ] No draft on page load (`hasDraft=false`): Publish + Discard Draft buttons are hidden until a save succeeds
- [ ] `publishDraft` when `draftPageXml` is null (already published) → 400 JSON `{"success":false,"error":"No draft to publish"}`