### PR TITLE
Require explicit AccessPolicy on allowsUser() — deny-by-default for empty role/group lists

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommand.java
@@ -59,19 +59,19 @@ public class ValidateUserAccessToWebPageCommand {
       return false;
     }
     // Best to place the group list at the page level, to cover the whole page
-    if (!WebComponentCommand.allowsUser(pageRef, userSession)) {
+    if (!WebComponentCommand.allowsUser(pageRef, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
       return false;
     }
     for (Section section : pageRef.getSections()) {
-      if (!WebComponentCommand.allowsUser(section, userSession)) {
+      if (!WebComponentCommand.allowsUser(section, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
         return false;
       }
       for (Column column : section.getColumns()) {
-        if (!WebComponentCommand.allowsUser(column, userSession)) {
+        if (!WebComponentCommand.allowsUser(column, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
           return false;
         }
         for (Widget widget : column.getWidgets()) {
-          if (!WebComponentCommand.allowsUser(widget, userSession)) {
+          if (!WebComponentCommand.allowsUser(widget, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
             return false;
           }
           // @note the widget content response is not tested

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -290,7 +290,7 @@ public class PageServlet extends HttpServlet {
       }
 
       // Verify the user has access to the page
-      if (!WebComponentCommand.allowsUser(pageRef, userSession)) {
+      if (!WebComponentCommand.allowsUser(pageRef, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
         LOG.warn("PAGE NOT ALLOWED: " + pagePath + " " +
             (!pageRef.getRoles().isEmpty() ? "[roles=" + pageRef.getRoles().toString() + "]" + " " : "") +
             (!pageRef.getGroups().isEmpty() ? "[groups=" + pageRef.getGroups().toString() + "]" + " " : "") +

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebComponentCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebComponentCommand.java
@@ -23,7 +23,20 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * Verifies a user's access to the specified web component
+ * Verifies a user's access to the specified web component.
+ *
+ * <p>Access decisions are made against an explicit {@link AccessPolicy}:
+ * <ul>
+ *   <li>{@link AccessPolicy#PUBLIC} — a resource with no declared roles or groups is
+ *       reachable by any visitor (the correct posture for public CMS content).</li>
+ *   <li>{@link AccessPolicy#RESTRICTED} — a resource with no declared roles or groups
+ *       is denied; an explicit role or group match is required (the correct posture for
+ *       any newly-declared protected resource).</li>
+ * </ul>
+ *
+ * <p>The {@link AccessPolicy} parameter is required on every call so that the access
+ * posture is visible at the call site. This aligns with the deny-by-default posture of
+ * {@code EditorPermissionCommand} and closes SSP AC-3 / AC-6 (issue #299).
  *
  * @author matt rajkowski
  * @created 4/10/2022 8:51 AM
@@ -33,25 +46,35 @@ public class WebComponentCommand implements Serializable {
   static final long serialVersionUID = 536435325324169646L;
   private static Log LOG = LogFactory.getLog(WebComponentCommand.class);
 
-  public static boolean allowsUser(Page page, UserSession userSession) {
-    return allowsUser(page.getRoles(), page.getGroups(), userSession);
+  /**
+   * Declares the access posture of a resource when no roles or groups are configured.
+   */
+  public enum AccessPolicy {
+    /** No role/group restriction — any visitor is permitted (public CMS content). */
+    PUBLIC,
+    /** Explicit role or group required — no declaration means no access. */
+    RESTRICTED
   }
 
-  public static boolean allowsUser(Section section, UserSession userSession) {
-    return allowsUser(section.getRoles(), section.getGroups(), userSession);
+  public static boolean allowsUser(Page page, UserSession userSession, AccessPolicy policy) {
+    return allowsUser(page.getRoles(), page.getGroups(), userSession, policy);
   }
 
-  public static boolean allowsUser(Column column, UserSession userSession) {
-    return allowsUser(column.getRoles(), column.getGroups(), userSession);
+  public static boolean allowsUser(Section section, UserSession userSession, AccessPolicy policy) {
+    return allowsUser(section.getRoles(), section.getGroups(), userSession, policy);
   }
 
-  public static boolean allowsUser(Widget widget, UserSession userSession) {
-    return allowsUser(widget.getRoles(), widget.getGroups(), userSession);
+  public static boolean allowsUser(Column column, UserSession userSession, AccessPolicy policy) {
+    return allowsUser(column.getRoles(), column.getGroups(), userSession, policy);
   }
 
-  public static boolean allowsUser(List<String> roles, List<String> groups, UserSession userSession) {
+  public static boolean allowsUser(Widget widget, UserSession userSession, AccessPolicy policy) {
+    return allowsUser(widget.getRoles(), widget.getGroups(), userSession, policy);
+  }
+
+  public static boolean allowsUser(List<String> roles, List<String> groups, UserSession userSession, AccessPolicy policy) {
     if (roles.isEmpty() && groups.isEmpty()) {
-      return true;
+      return policy == AccessPolicy.PUBLIC;
     }
 
     // Roles can be for a user that is either logged in/out

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -91,7 +91,7 @@ public class WebContainerCommand implements Serializable {
     for (Section section : sections) {
 
       // Check the user's role and groups
-      if (!WebComponentCommand.allowsUser(section, userSession)) {
+      if (!WebComponentCommand.allowsUser(section, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
         LOG.debug("SECTION NOT ALLOWED: " +
             (!section.getRoles().isEmpty() ? "[roles=" + section.getRoles().toString() + "]" + " " : "") +
             (!section.getGroups().isEmpty() ? "[groups=" + section.getGroups().toString() + "]" + " " : "") +
@@ -106,7 +106,7 @@ public class WebContainerCommand implements Serializable {
       for (Column column : section.getColumns()) {
 
         // Check the user's role and groups
-        if (!WebComponentCommand.allowsUser(column, userSession)) {
+        if (!WebComponentCommand.allowsUser(column, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
           LOG.debug("COLUMN NOT ALLOWED: " +
               (!column.getRoles().isEmpty() ? "[roles=" + column.getRoles().toString() + "]" + " " : "") +
               (!column.getGroups().isEmpty() ? "[groups=" + column.getGroups().toString() + "]" + " " : "") +
@@ -131,7 +131,7 @@ public class WebContainerCommand implements Serializable {
           }
 
           // Check the user's role and groups
-          if (!WebComponentCommand.allowsUser(widget, userSession)) {
+          if (!WebComponentCommand.allowsUser(widget, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
             LOG.debug("WIDGET NOT ALLOWED: " + widget.getWidgetName() + " " +
                 (!widget.getRoles().isEmpty() ? "[roles=" + widget.getRoles().toString() + "]" + " " : "") +
                 (!widget.getGroups().isEmpty() ? "[groups=" + widget.getGroups().toString() + "]" + " " : "") +

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/MenuWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/MenuWidget.java
@@ -326,7 +326,7 @@ public class MenuWidget extends GenericWidget {
           .collect(toList());
     }
 
-    return WebComponentCommand.allowsUser(roles, groups, context.getUserSession());
+    return WebComponentCommand.allowsUser(roles, groups, context.getUserSession(), WebComponentCommand.AccessPolicy.RESTRICTED);
   }
 
   private static boolean checkRules(String ruleValue) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
@@ -124,19 +124,19 @@ public class WebPageSearchResultsWidget extends GenericWidget {
         if (pageRef == null) {
           continue;
         }
-        if (!WebComponentCommand.allowsUser(pageRef, userSession)) {
+        if (!WebComponentCommand.allowsUser(pageRef, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
           continue;
         }
         for (Section section : pageRef.getSections()) {
-          if (!WebComponentCommand.allowsUser(section, userSession)) {
+          if (!WebComponentCommand.allowsUser(section, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
             continue;
           }
           for (Column column : section.getColumns()) {
-            if (!WebComponentCommand.allowsUser(column, userSession)) {
+            if (!WebComponentCommand.allowsUser(column, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
               continue;
             }
             for (Widget widget : column.getWidgets()) {
-              if (!WebComponentCommand.allowsUser(widget, userSession)) {
+              if (!WebComponentCommand.allowsUser(widget, userSession, WebComponentCommand.AccessPolicy.PUBLIC)) {
                 continue;
               }
               // Check the widget

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
@@ -56,12 +56,12 @@ class WebComponentCommandTest {
     // Component information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin AND any of these: testers
     roles.add("admin");
     groups.add("testers");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -88,12 +88,12 @@ class WebComponentCommandTest {
     // Component information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin, users
     roles.add("admin");
     roles.add("users");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -120,15 +120,15 @@ class WebComponentCommandTest {
     // Component information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: testers
     groups.add("testers");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: testers, researchers
     groups.add("researchers");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -159,12 +159,12 @@ class WebComponentCommandTest {
     // Any of these: admin AND any of these: testers
     roles.add("admin");
     groups.add("testers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin, users AND any of these: researchers
     roles.add("users");
     groups.add("researchers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -195,15 +195,15 @@ class WebComponentCommandTest {
     // Any of these: admin AND any of these: testers
     roles.add("admin");
     groups.add("testers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin AND any of these: testers, researchers
     groups.add("researchers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin, users AND any of these: testers, researchers
     roles.add("users");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -225,12 +225,12 @@ class WebComponentCommandTest {
     // Component access information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin AND any of these: testers
     roles.add("admin");
     groups.add("testers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -255,11 +255,11 @@ class WebComponentCommandTest {
     List<String> groups = new ArrayList<>();
 
     // Any of these: admin
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin, users
     roles.add("users");
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -284,11 +284,11 @@ class WebComponentCommandTest {
     groups.add("testers");
 
     // Any of these: testers
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: testers, researchers
     groups.add("researchers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -299,13 +299,13 @@ class WebComponentCommandTest {
     // Component information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Component access information (roles and groups required)
     roles.add("guest");
 
     // Any of these: admin AND any of these: testers
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
 
@@ -317,14 +317,14 @@ class WebComponentCommandTest {
     // Component information (no additional roles/groups required)
     List<String> roles = new ArrayList<>();
     List<String> groups = new ArrayList<>();
-    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Component access information (roles and groups required)
     roles.add("admin");
     groups.add("testers");
 
     // Any of these: admin AND any of these: testers
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -338,11 +338,11 @@ class WebComponentCommandTest {
     List<String> groups = new ArrayList<>();
 
     // Any of these: admin
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: admin, users
     roles.add("users");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 
   @Test
@@ -356,10 +356,48 @@ class WebComponentCommandTest {
 
     // Any of these: testers
     groups.add("testers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
 
     // Any of these: testers, researchers
     groups.add("researchers");
-    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
+  }
+
+  @Test
+  void restrictedPolicyDeniesEmptyRolesAndGroupsTest() {
+    List<String> roles = new ArrayList<>();
+    List<String> groups = new ArrayList<>();
+
+    // Guest (not logged in) — no roles/groups declared — RESTRICTED denies
+    UserSession guestSession = new UserSession();
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, guestSession, WebComponentCommand.AccessPolicy.RESTRICTED));
+
+    // Logged-in user with no roles/groups declared — RESTRICTED still denies
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(new ArrayList<>());
+    user.setGroupList(new ArrayList<>());
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.RESTRICTED));
+  }
+
+  @Test
+  void publicPolicyAllowsEmptyRolesAndGroupsTest() {
+    List<String> roles = new ArrayList<>();
+    List<String> groups = new ArrayList<>();
+
+    // Guest — PUBLIC allows when no restrictions declared
+    UserSession guestSession = new UserSession();
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, guestSession, WebComponentCommand.AccessPolicy.PUBLIC));
+
+    // Logged-in user — PUBLIC allows when no restrictions declared
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(new ArrayList<>());
+    user.setGroupList(new ArrayList<>());
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, userSession, WebComponentCommand.AccessPolicy.PUBLIC));
   }
 }


### PR DESCRIPTION
## Summary

- Adds `WebComponentCommand.AccessPolicy` enum (`PUBLIC` / `RESTRICTED`) and requires it as an explicit parameter on all four `allowsUser()` overloads
- Empty roles/groups now return a value determined by the caller's declared posture rather than silently allowing access, closing the AC-3/AC-6 ambiguity documented in issue #299
- All 13 call sites updated: CMS rendering paths (page, section, column, widget traversal) pass `PUBLIC` — preserving existing behaviour; `MenuWidget` passes `RESTRICTED` because roles are always non-empty at that call site by construction
- Tests updated from old 3-arg signature; two new cases verify the deny-by-default path for `RESTRICTED` and the allow-by-default path for `PUBLIC`

## Files changed

| File | Change |
|------|--------|
| `WebComponentCommand.java` | Add `AccessPolicy` enum; rewrite overloads to require policy parameter |
| `WebContainerCommand.java` | Update 3 calls → `PUBLIC` |
| `PageServlet.java` | Update 1 call → `PUBLIC` |
| `ValidateUserAccessToWebPageCommand.java` | Update 4 calls → `PUBLIC` |
| `WebPageSearchResultsWidget.java` | Update 4 calls → `PUBLIC` |
| `MenuWidget.java` | Update 1 call → `RESTRICTED` |
| `WebComponentCommandTest.java` | Update all tests; add `restrictedPolicyDeniesEmptyRolesAndGroupsTest` and `publicPolicyAllowsEmptyRolesAndGroupsTest` |

## Test plan

- [x] All 14 `WebComponentCommandTest` cases pass (`ant ci-test`)
- [x] Clean compile with no errors
- [x] Pre-existing failures in `BlockedIPListCommandTest`, `CaptchaCommandTest`, `ContentWidgetTest` are unrelated to this change

Closes #299