### PR TITLE
A11y: add skip-to-main link and <main> landmark (WCAG 2.4.1 / 1.3.1)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   --%>
 <c:set var="stickyMarginTop" scope="request" value="8"/>
-<article>
+<main id="main">
   <div class="${rendererClass}">
     <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin') && userSession.hasRole('admin')}">
       <div class="platform-content-container">
@@ -128,4 +128,4 @@
       </div>
     </c:if>
   </div>
-</article>
+</main>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -323,6 +323,7 @@
     </c:if>
 </head>
 <body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty pageRenderInfo.cssClass}"> class="<c:out value="${pageRenderInfo.cssClass}" />"</c:if>>
+  <a class="show-on-focus" href="#main">Skip to main content</a>
   <c:choose>
     <c:when test="${fn:startsWith(pageRenderInfo.name, '/admin') && pageRenderInfo.name ne '/admin/web-page' && pageRenderInfo.name ne '/admin/web-page-designer' && pageRenderInfo.name ne '/admin/web-container-designer' && pageRenderInfo.name ne '/admin/css-editor'}">
       <%-- Draw the admin menu--%>


### PR DESCRIPTION
## Summary

- Replaces `<article>` with `<main id="main">` in `layout-body-renderer.jspf` — the single shared body renderer for all page layouts (public, admin, container) — giving screen readers a named landmark to jump to
- Adds a visually-hidden-until-focused skip link as the first focusable child of `<body>` using Foundation's built-in `.show-on-focus` class (hidden via `clip:rect(0,0,0,0)` at rest; reveals at `:focus`), pointing to `#main`

Together these satisfy WCAG 2.4.1 Bypass Blocks (A) and 1.3.1 Info and Relationships (A) with the minimum diff: no new CSS, no new JS, no layout risk.

## Files changed

| File | Change |
|------|--------|
| `layout-body-renderer.jspf:17,131` | `<article>` / `</article>` → `<main id="main">` / `</main>` |
| `main.jsp:326` | Skip link added immediately after `<body>` open tag |

## Test plan

- [x] JSP compilation clean — 0 errors (`ant compile-jsp`)
- [ ] Tab into any public page — first Tab press shows "Skip to main content" link in focus; pressing Enter jumps focus to `#main`
- [ ] Same behaviour on an admin page (`/admin/*`)
- [ ] Screen reader (VoiceOver / NVDA) announces "main" landmark

Closes #300