### PR TITLE
A11y: add accessible names to menu toggles, logo images, and social links (WCAG 4.1.2 / 1.1.1)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
@@ -25,7 +25,7 @@
 <jsp:useBean id="themePropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="view" class="java.lang.String" scope="request"/>
 <div class="title-bar hide-for-medium" data-responsive-toggle="platform-small-toggle-menu"  data-hide-for="medium">
-  <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu"></button>
+  <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu" aria-label="Open menu" aria-controls="platform-small-toggle-menu" aria-expanded="false"></button>
   <c:set var="logoSrc" scope="request" value=""/>
   <c:choose>
     <c:when test="${view eq 'white'}">

--- a/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
@@ -96,7 +96,7 @@
 </style>
 <%-- Small Menu --%>
 <div class="item-menu title-bar" data-responsive-toggle="responsive-item-menu" data-hide-for="medium">
-  <button class="menu-icon" type="button" data-toggle="responsive-item-menu"></button>
+  <button class="menu-icon" type="button" data-toggle="responsive-item-menu" aria-label="Open menu" aria-controls="responsive-item-menu" aria-expanded="false"></button>
   <div class="title-bar-title">
     <c:out value="${item.name}"/>
     <c:forEach items="${itemTabList}" var="tab">

--- a/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
@@ -24,20 +24,20 @@
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'all-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:when>
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'color-and-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.mixed']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:when>
@@ -47,10 +47,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-footer.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-footer.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:otherwise>
@@ -77,22 +77,22 @@
           <c:if test="${!empty socialPropertyMap}">
             <p class="text-center medium-text-right">
               <c:if test="${!empty socialPropertyMap['social.facebook.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>" aria-label="Facebook"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.twitter.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-twitter fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>" aria-label="Twitter"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-twitter fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.linkedin.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-linkedin fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>" aria-label="LinkedIn"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-linkedin fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.instagram.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-instagram fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>" aria-label="Instagram"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-instagram fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.youtube.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-youtube fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>" aria-label="YouTube"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-youtube fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.flickr.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-flickr fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>" aria-label="Flickr"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-flickr fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
             </p>
           </c:if>

--- a/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
@@ -18,17 +18,17 @@
   <%-- Small Title Bar--%>
   <div id="platform-small-menu" class="hide-for-medium" style="position: fixed; z-index: 1001;top: 0;width:100%;">
     <div class="title-bar" data-responsive-toggle="platform-small-toggle-menu">
-      <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu"></button>
+      <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu" aria-label="Open menu" aria-controls="platform-small-toggle-menu" aria-expanded="false"></button>
       <div class="logo">
         <c:choose>
           <c:when test="${themePropertyMap['theme.logo.color'] eq 'text-only' or themePropertyMap['theme.logo.color'] eq 'none'}">
             <a href="${ctx}/">Home</a>
           </c:when>
           <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" /></a>
+            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
           </c:when>
           <c:otherwise>
-            <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" /></a>
+            <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
           </c:otherwise>
         </c:choose>
       </div>
@@ -399,20 +399,20 @@
               <c:when test="${themePropertyMap['theme.logo.color'] eq 'all-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:otherwise>
                 </c:choose>
               </c:when>
               <c:when test="${themePropertyMap['theme.logo.color'] eq 'color-and-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.mixed']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:otherwise>
                 </c:choose>
               </c:when>
@@ -422,10 +422,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:otherwise>
                 </c:choose>
               </c:otherwise>


### PR DESCRIPTION
## Summary

Three categories of missing accessible names fixed across header, footer, and two menu fragments:

**Mobile menu toggle buttons** — `layout-header-standard.jspf`, `toggle-menu.jsp`, `item-menu.jsp`
- `aria-label="Open menu"` gives the button a name for screen readers
- `aria-controls` points to the off-canvas/responsive menu element the button controls
- `aria-expanded="false"` declares the initial collapsed state (WCAG 4.1.2 Name, Role, Value)

**Logo `<img>` elements** — `layout-header-standard.jspf`, `layout-footer-standard.jspf`
- `alt` set to the site name (`c:out`-escaped) on all 8 header logo variants (small-screen + desktop, all four theme color paths) and all 6 footer logo variants
- Images that are the sole child of a Home link had no accessible link name without this (WCAG 1.1.1 Non-text Content, 2.4.4 Link Purpose)

**Footer social icon links** — `layout-footer-standard.jspf`
- `aria-label` added to each `<a>` (Facebook, Twitter, LinkedIn, Instagram, YouTube, Flickr)
- `aria-hidden="true"` added to the decorative `fa-stack` spans so the icon glyphs are not double-announced (WCAG 4.1.2)

No CSS, JS, or visual change.

## Files changed

| File | Changes |
|------|---------|
| `layout-header-standard.jspf` | Toggle button + 8 logo img alts |
| `layout-footer-standard.jspf` | 6 logo img alts + 6 social link aria-labels |
| `cms/toggle-menu.jsp` | Toggle button |
| `items/item-menu.jsp` | Toggle button |

## Test plan

- [x] JSP compilation clean — 0 errors (`ant compile-jsp`)
- [ ] VoiceOver/NVDA: focus the mobile menu toggle — announces "Open menu, button, collapsed"
- [ ] Focus the Home logo link — announces site name + "link"
- [ ] Tab through footer social links — each announces its platform name

Closes #302