### PR TITLE
Responsive: fix admin sidebar, table overflow, confirmation wrap, and upload text (WCAG 1.4.10)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
@@ -43,7 +43,7 @@
     autoProcessQueue: false,
     parallelUploads: 2,
     maxFilesize: 55,
-    dictDefaultMessage: 'Drag and Drop files from your desktop here<br/><br/>(Click for file chooser)',
+    dictDefaultMessage: 'Drag and drop files here, or click to browse',
     init: function() {
       var submitButton = document.querySelector("#submit-all");
       myDropzone = this; // closure

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -427,6 +427,10 @@
           </c:if>
         </div>
         <div class="off-canvas-content" data-off-canvas-content>
+          <div class="title-bar hide-for-medium">
+            <button class="menu-icon" type="button" data-toggle="offCanvas" aria-label="Open admin menu" aria-controls="offCanvas" aria-expanded="false"></button>
+            <div class="title-bar-title">Admin</div>
+          </div>
           <div class="web-content admin-web-content">
             <jsp:include page="${PageBody}" flush="true"/>
           </div>
@@ -458,7 +462,7 @@
                   </c:otherwise>
                 </c:choose>
               </p>
-              <p style="white-space: nowrap">
+              <p>
                 <c:if test="${!empty sitePropertyMap['site.confirmation.line1']}">
                   <c:out value="${sitePropertyMap['site.confirmation.line1']}" />
                 </c:if>

--- a/src/main/webapp/css/platform.css
+++ b/src/main/webapp/css/platform.css
@@ -284,7 +284,7 @@ table td .input-group {
 /* Content and Editor */
 
 .web-content {
-  overflow-x: hidden;
+  overflow-x: auto;
 }
 .admin-web-content {
   min-height: 500px;


### PR DESCRIPTION
## Summary

Four responsive/reflow fixes concentrated in the admin UI:

**Admin sidebar toggle** — `main.jsp`
- Adds a `title-bar` div with `hide-for-medium` + a `data-toggle="offCanvas"` button inside `off-canvas-content`, immediately before the page body. Below 640px the sidebar is completely hidden by `reveal-for-medium`; this button makes it reachable without a mouse. Pattern mirrors `items/item-menu.jsp`. (WCAG 1.4.10 Reflow, AA)

**Wide table overflow** — `platform.css`
- Changes `.web-content { overflow-x: hidden }` to `overflow-x: auto`. Hidden was silently clipping non-responsive admin tables (Audit Log, Users, etc.) with no scroll affordance. Auto adds a scrollbar when content overflows, so no columns are lost. (WCAG 1.4.10)

**Site-confirmation gate** — `main.jsp`
- Removes `white-space: nowrap` from the confirmation prompt paragraph, allowing the text to wrap on narrow screens instead of overflowing horizontally. (WCAG 1.4.10)

**Upload drop-zone instruction** — `admin/folder-file-drop-zone.jsp`
- Replaces `"Drag and Drop files from your desktop here (Click for file chooser)"` with `"Drag and drop files here, or click to browse"` — both interaction paths presented equally, no device assumption.

## Files changed

| File | Change |
|------|--------|
| `main.jsp` | +3 lines (toggle button) + remove `white-space:nowrap` |
| `platform.css` | `overflow-x: hidden` → `auto` |
| `admin/folder-file-drop-zone.jsp` | Update `dictDefaultMessage` |

## Test plan

- [x] JSP compilation clean — 0 errors (`ant compile-jsp`)
- [ ] Resize browser to < 640px on any `/admin/*` page — hamburger button appears in top bar; tap opens sidebar
- [ ] Audit Log at < 640px or 400% zoom — table scrolls horizontally, no columns clipped
- [ ] Confirmation modal at < 640px — text wraps, no horizontal overflow
- [ ] Folder upload drop-zone shows new instruction text

Closes #304