### PR TITLE
fix(508): keyboard-operable authoring tools and dialog semantics

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/add-tracking-number.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/add-tracking-number.jsp
@@ -28,11 +28,11 @@
 <%@include file="../page_messages.jspf" %>
 <c:if test="${testMode eq 'true'}"><span class="label warning">TEST MODE</span></c:if>
 <button class="button primary expanded" data-open="trackingFormReveal">Add a Tracking Number</button>
-<div class="reveal small" id="trackingFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="trackingFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="trackingFormTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Add a Tracking Number</h4>
+  <h4 id="trackingFormTitle">Add a Tracking Number</h4>
   <form id="trackingForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
@@ -145,7 +145,7 @@
     <input type="submit" class="button radius success" name="process" value="Save & Sync"/>
   </div>
 </form>
-<div class="reveal medium" id="processReveal" data-reveal data-animation-in="slide-in-down fast">
-  <h3>Validating Data...</h3>
+<div class="reveal medium" id="processReveal" data-reveal data-animation-in="slide-in-down fast" aria-labelledby="processRevealTitle">
+  <h3 id="processRevealTitle">Validating Data...</h3>
   <%--<p><a class="button small radius primary" href="${ctx}/admin/datasets">Continue to datasets list <i class="fa fa-caret-right"></i></a></p>--%>
 </div>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -193,7 +193,7 @@
   }
 </script>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
-  <div class="reveal small" id="fileFormReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">
+  <div class="reveal small" id="fileFormReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="formTitle">
     <button class="close-button" data-close aria-label="Close modal" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
@@ -85,11 +85,11 @@
 <%-- @todo add paging --%>
 
 <%-- form --%>
-<div class="reveal small" id="formReveal${widgetContext.uniqueId}" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal${widgetContext.uniqueId}" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="subFolderFormTitle${widgetContext.uniqueId}">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>New Sub-Folder</h4>
+  <h4 id="subFolderFormTitle${widgetContext.uniqueId}">New Sub-Folder</h4>
   <form id="subFolderForm${widgetContext.uniqueId}" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/issue-refund.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/issue-refund.jsp
@@ -25,11 +25,11 @@
 <%@include file="../page_messages.jspf" %>
 <c:if test="${testMode eq 'true'}"><span class="label warning">TEST MODE</span></c:if>
 <button class="button alert expanded" data-open="refundFormReveal">Issue a Refund</button>
-<div class="reveal small" id="refundFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="refundFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="refundFormTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Issue a Refund</h4>
+  <h4 id="refundFormTitle">Issue a Refund</h4>
   <form id="issueRefundForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -93,11 +93,11 @@
 <%-- Paging Control --%>
 <c:set var="recordPagingParams" scope="request" value="mailingListId=${mailingList.id}"/>
 <%@include file="../paging_control.jspf" %>
-<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="mailingFormTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Add Email</h4>
+  <h4 id="mailingFormTitle">Add Email</h4>
   <form id="userForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
@@ -462,7 +462,7 @@
     </c:choose>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" aria-label="Image browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -201,7 +201,7 @@
     <a href="${ctx}/admin" class="button radius secondary">Cancel</a>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" aria-label="Image browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -23,6 +23,10 @@
 <jsp:useBean id="menuTab" class="com.simisinc.platform.domain.model.cms.MenuTab" scope="request"/>
 <link rel="stylesheet" href="${ctx}/css/platform-sitemap-editor.css?v=<%= VERSION %>" />
 <link rel="stylesheet" href="${ctx}/javascript/dragula-3.7.3/dragula.min.css"/>
+<style>
+  .site-map-move-btn { background: none; border: 1px solid #ccc; border-radius: 3px; padding: 1px 5px; cursor: pointer; font-size: 0.85em; margin: 0 1px; }
+  .site-map-move-btn:focus { outline: 2px solid #1779ba; }
+</style>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${icon}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
@@ -51,6 +55,8 @@
                 </c:when>
                 <c:otherwise>
                   <i class="fa fa-arrows-h site-map-menu-tab-drag-handle"></i>
+                  <button type="button" class="site-map-move-btn" onclick="moveTabLeft(${menuTab.id})" aria-label="Move <c:out value="${menuTab.name}"/> left">&#8592;</button>
+                  <button type="button" class="site-map-move-btn" onclick="moveTabRight(${menuTab.id})" aria-label="Move <c:out value="${menuTab.name}"/> right">&#8594;</button>
                 </c:otherwise>
               </c:choose>
             </small>
@@ -83,7 +89,8 @@
                 <div class="float-left">
                   <small class="subheader">
                     <i class="fa fa-arrows site-map-submenu-tab-drag-handle"></i>
-                    <%--<a href="${ctx}${menuItem.link}"><c:out value="${menuItem.link}" /></a>--%>
+                    <button type="button" class="site-map-move-btn" onclick="moveItemUp(${menuItem.id})" aria-label="Move <c:out value="${menuItem.name}"/> up">&#8593;</button>
+                    <button type="button" class="site-map-move-btn" onclick="moveItemDown(${menuItem.id})" aria-label="Move <c:out value="${menuItem.name}"/> down">&#8595;</button>
                   </small>
                 </div>
                 <div class="clear-float"></div>
@@ -158,6 +165,39 @@
       return handle.classList.contains('site-map-submenu-tab-drag-handle');
     }
   });
+
+  function moveTabLeft(tabId) {
+    var el = document.getElementById('site-map-menu-tab-container-' + tabId);
+    if (!el) return;
+    var prev = el.previousElementSibling;
+    if (prev && prev.id !== 'site-map-menu-tab-container-0') {
+      el.parentNode.insertBefore(el, prev);
+    }
+  }
+  function moveTabRight(tabId) {
+    var el = document.getElementById('site-map-menu-tab-container-' + tabId);
+    if (!el) return;
+    var next = el.nextElementSibling;
+    if (next) {
+      el.parentNode.insertBefore(next, el);
+    }
+  }
+  function moveItemUp(itemId) {
+    var el = document.getElementById('site-map-menu-item-' + itemId);
+    if (!el) return;
+    var prev = el.previousElementSibling;
+    if (prev) {
+      el.parentNode.insertBefore(el, prev);
+    }
+  }
+  function moveItemDown(itemId) {
+    var el = document.getElementById('site-map-menu-item-' + itemId);
+    if (!el) return;
+    var next = el.nextElementSibling;
+    if (next) {
+      el.parentNode.insertBefore(next, el);
+    }
+  }
 
   function checkSiteMapOrder() {
     // Check the main tabs

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -112,11 +112,11 @@
 </c:if>
 <%@include file="../paging_control.jspf" %>
 <%--<div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">--%>
-<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="userFormTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>New User</h4>
+  <h4 id="userFormTitle">New User</h4>
   <form id="userForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -156,7 +156,7 @@
     </c:if>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" aria-label="Image browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -256,8 +256,8 @@
   });
 </script>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
-  <div class="reveal tiny" id="modalReveal" data-reveal>
-    <h3>Event Options</h3>
+  <div class="reveal tiny" id="modalReveal" data-reveal aria-labelledby="modalRevealTitle">
+    <h3 id="modalRevealTitle">Event Options</h3>
     <p>Would you like to make changes or view the details of this event?</p>
     <div class="button-container text-no-wrap">
       <button class="button" data-open="formReveal">Edit this Event</button>
@@ -268,7 +268,7 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">
+  <div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast" aria-labelledby="formTitle">
     <button class="close-button" data-close aria-label="Close modal" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
@@ -44,6 +44,16 @@
     background-size: cover;
     cursor: pointer;
   }
+  button.card${widgetContext.uniqueId} {
+    padding: 0;
+    font: inherit;
+    width: 100%;
+    text-align: center;
+  }
+  button.card${widgetContext.uniqueId}:focus {
+    outline: 2px solid #1779ba;
+    outline-offset: 2px;
+  }
   .card${widgetContext.uniqueId} .card-content {
     display: table;
     position: absolute;
@@ -74,14 +84,16 @@
     <div class="grid-x grid-margin-x text-center align-stretch small-up-<c:out value="${smallCardCount}" /> medium-up-<c:out value="${mediumCardCount}" /> large-up-<c:out value="${largeCardCount}" />">
       <c:forEach items="${subFolderList}" var="subFolder">
         <div class="card-container${widgetContext.uniqueId} cell">
-          <div class="card${widgetContext.uniqueId}<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>"
-               style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');" onclick="showAlbum${controlId}(${subFolder.id})">
+          <button type="button"
+                  class="card${widgetContext.uniqueId}<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>"
+                  style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');"
+                  onclick="showAlbum${controlId}(${subFolder.id})">
             <div class="card-content">
               <div class="card-content-inner">
                 <p><c:out value="${subFolder.name}"/></p>
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </c:forEach>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
@@ -209,7 +209,7 @@
     </c:choose>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" aria-label="Image browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/cms/card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/card.jsp
@@ -25,7 +25,8 @@
 <jsp:useBean id="link" class="java.lang.String" scope="request"/>
 <jsp:useBean id="linkTitle" class="java.lang.String" scope="request"/>
 <jsp:useBean id="linkIcon" class="java.lang.String" scope="request"/>
-<div class="<c:out value="${classData}" />"<c:if test="${!empty link}"> onclick="window.location.href='${ctx}${js:escape(link)}'"</c:if>>
+<c:if test="${!empty link}"><a href="${ctx}<c:out value="${link}"/>" class="<c:out value="${classData}" />"></c:if>
+<c:if test="${empty link}"><div class="<c:out value="${classData}" />"></c:if>
   <c:if test="${!empty title}">
     <div class="card-divider"><c:out value="${title}" /></div>
   </c:if>
@@ -56,4 +57,5 @@
     </p>
   </div>
   --%>
-</div>
+<c:if test="${!empty link}"></a></c:if>
+<c:if test="${empty link}"></div></c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
@@ -234,6 +234,22 @@
   .card-section > :last-child {
     margin-bottom: 0;
   }
+  .image-browser-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    display: block;
+    width: 100%;
+  }
+  .image-browser-btn:focus {
+    outline: 2px solid #1779ba;
+    outline-offset: 2px;
+  }
+  .image-browser-btn img {
+    display: block;
+    width: 100%;
+  }
 </style>
 <link rel="stylesheet" type="text/css" href="${ctx}/css/platform.css" />
 <div class="grid-container">
@@ -244,8 +260,12 @@
     <c:forEach items="${imageList}" var="image" varStatus="status">
       <div class="cell card">
         <div class="image-browser">
-          <img onclick="mySubmit(this.dataset.src)" data-src="${ctx}/assets/img/${image.url}"
-               src="${ctx}/assets/img/${image.url}" alt="<c:out value="${image.filename}"/>">
+          <button type="button" class="image-browser-btn"
+                  onclick="mySubmit(this.dataset.src)"
+                  data-src="${ctx}/assets/img/${image.url}"
+                  aria-label="Select <c:out value="${image.filename}"/>">
+            <img src="${ctx}/assets/img/${image.url}" alt="">
+          </button>
         </div>
         <div class="card-section">
           <div>

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
@@ -36,6 +36,10 @@
       <input type="text" name="title" value="<c:out value="${webPage.title}" />" autofocus="autofocus" />
     </c:if>
     <h4>Choose a template for this page</h4>
+    <style>
+      button.template.card { background: none; padding: 0; text-align: left; width: 100%; cursor: pointer; }
+      button.template.card:focus { outline: 2px solid #1779ba; outline-offset: 2px; }
+    </style>
     <c:if test="${empty webPageTemplateList}">
       <p>No templates were found.</p>
     </c:if>
@@ -51,13 +55,13 @@
         <div class="grid-x grid-margin-x">
       </c:if>
       <div class="small-6 medium-4 large-3 cell">
-        <div class="template cell card" onclick="mySubmit(${template.id},${template.uniqueId})">
+        <button type="button" class="template cell card" onclick="mySubmit(${template.id},${template.uniqueId})">
           <c:choose>
             <c:when test="${!empty template.imagePath}">
-              <img src="${ctx}/images/templates/${url:encodeUri(template.imagePath)}">
+              <img src="${ctx}/images/templates/${url:encodeUri(template.imagePath)}" alt="">
             </c:when>
             <c:otherwise>
-              <img src="${ctx}/images/templates/Blank.png">
+              <img src="${ctx}/images/templates/Blank.png" alt="">
             </c:otherwise>
           </c:choose>
           <div class="card-section">
@@ -65,7 +69,7 @@
               <small><c:out value="${template.name}"/></small>
             </p>
           </div>
-        </div>
+        </button>
       </div>
       <c:set var="currentCategory" scope="request" value="${template.category}"/>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
@@ -530,7 +530,7 @@
       <c:if test="${!empty cancelUrl}"><span class="button-gap"><a class="button radius secondary" href="${ctx}${cancelUrl}">Cancel</a></span></c:if>
     </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" aria-label="Image browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -445,7 +445,7 @@
         <jsp:include page="${PageBody}" flush="true"/>
       </div>
       <c:if test="${!empty sitePropertyMap['site.confirmation'] && sitePropertyMap['site.confirmation'] eq 'true'}">
-        <div id="site-confirmation" class="reveal full" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-out="fade-out fast">
+        <div id="site-confirmation" class="reveal full" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-out="fade-out fast" aria-label="Site confirmation">
           <div style="position:absolute; top: 50%; left: 50%; transform: translateY(-50%) translateX(-50%)">
             <div class="modal-prompt">
               <p>


### PR DESCRIPTION
## Summary

### Interactive element fixes (WCAG 2.1.1 Keyboard)

Replaces mouse-only `onclick` handlers with natively focusable/activatable elements so authoring tools are operable without a mouse:

| File | Was | Now |
|---|---|---|
| `cms/web-page-templates.jsp` | `<div onclick>` template card | `<button>` |
| `cms/image-browser.jsp` | `<img onclick>` | `<button>` wrapper with `aria-label` |
| `cms/card.jsp` | `<div onclick=\"window.location\">` | `<a href>` when link set, `<div>` otherwise |
| `cms/album-gallery.jsp` | `<div onclick>` album card | `<button>` |
| `admin/sitemap-editor.jsp` | drag handle only | keyboard Move ←/→ buttons (tabs) and ↑/↓ buttons (sub-items); `moveTab*/moveItem*` JS helpers work with the same DOM structure `checkSiteMapOrder()` already reads |

### Dialog semantics (WCAG 4.1.2 Name, Role, Value)

Adds `aria-labelledby` (pointing to the visible heading) or `aria-label` to every Foundation Reveal modal that lacked a dialog name. Foundation 6.8.1 already supplies `role=\"dialog\"`, `aria-hidden`, and focus trapping — this PR fills in the name:

- `imageBrowserReveal` (5 files): `aria-label=\"Image browser\"`
- `site-confirmation` (main.jsp): `aria-label=\"Site confirmation\"`
- 8 form/process modals: `aria-labelledby` + heading `id` added where missing

## WCAG checkpoints addressed

| Criterion | Fix |
|---|---|
| 2.1.1 Keyboard | All interactive authoring elements now natively keyboard-operable |
| 4.1.2 Name, Role, Value | All Reveal dialogs now have an accessible name |

Closes #301