### PR TITLE
fix: admin UI responsive/reflow gaps below 640px — WCAG 1.4.10 (#304)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
@@ -33,44 +33,67 @@
     <i class="fa fa-folder-open-o"></i> <c:out value="${subFolder.name}" />
   </c:if>
 </h4>
-<%-- Identical to: --%>
-<%--<form action="" method="post" enctype="multipart/form-data">--%>
-  <%--<input type="file" name="file" />--%>
-<%--</form>--%>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script>
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,
     maxFilesize: 55,
-    dictDefaultMessage: 'Drag and Drop files from your desktop here<br/><br/>(Click for file chooser)',
+    clickable: '#dz-browse',
+    dictDefaultMessage: 'Drag and drop files here (max 55 MB)<br/><br/>or use the Browse button below',
     init: function() {
       var submitButton = document.querySelector("#submit-all");
-      myDropzone = this; // closure
+      var errorRegion  = document.querySelector("#upload-errors");
+      var statusRegion = document.querySelector("#upload-status");
+      var errorCount   = 0;
+      var successCount = 0;
+      myDropzone = this;
+
       submitButton.addEventListener("click", function() {
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         myDropzone.processQueue();
       });
+
       this.on("addedfile", function() {
         if (submitButton.classList.contains('primary')) {
           submitButton.classList.add('success');
           submitButton.classList.remove('primary');
         }
       });
-      var _this = this;
+
+      this.on("success", function() {
+        successCount++;
+        myDropzone.processQueue();
+      });
+
+      this.on("error", function(file, message) {
+        errorCount++;
+        var msg = document.createElement('p');
+        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
+        errorRegion.appendChild(msg);
+      });
+
+      this.on("queuecomplete", function() {
+        if (errorCount === 0 && successCount > 0) {
+          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
+          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
+        }
+      });
+
       document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        _this.removeAllFiles(true);
+        myDropzone.removeAllFiles(true);
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         if (submitButton.classList.contains('success')) {
           submitButton.classList.add('primary');
           submitButton.classList.remove('success');
         }
       });
-    },
-    success: function() {
-      myDropzone = this; // closure
-      myDropzone.processQueue();
-    },
-    queuecomplete: function() {
-      window.location.href= '' + window.location.href;
     }
   };
 </script>
@@ -87,5 +110,8 @@
     <input name="file" type="file" multiple />
   </div>
 </form>
+<div id="upload-errors" role="alert" aria-live="assertive" class="callout alert"></div>
+<div id="upload-status" role="status" aria-live="polite"></div>
 <button class="button primary no-gap" id="submit-all">Upload All Files</button>
+<button type="button" class="button secondary no-gap" id="dz-browse">Browse Files</button>
 <button class="button secondary no-gap" id="clear-dropzone">Reset</button>

--- a/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
@@ -28,44 +28,67 @@
 <h4>
   <i class="fa fa-folder-open-o"></i> <c:out value="${folder.name}" />
 </h4>
-<%-- Identical to: --%>
-<%--<form action="" method="post" enctype="multipart/form-data">--%>
-  <%--<input type="file" name="file" />--%>
-<%--</form>--%>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script>
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,
     maxFilesize: 20,
-    dictDefaultMessage: 'Drag and Drop files from your desktop here<br/><br/>(Click for file chooser)',
+    clickable: '#dz-browse',
+    dictDefaultMessage: 'Drag and drop files here (max 20 MB)<br/><br/>or use the Browse button below',
     init: function() {
       var submitButton = document.querySelector("#submit-all");
-      myDropzone = this; // closure
+      var errorRegion  = document.querySelector("#upload-errors");
+      var statusRegion = document.querySelector("#upload-status");
+      var errorCount   = 0;
+      var successCount = 0;
+      myDropzone = this;
+
       submitButton.addEventListener("click", function() {
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         myDropzone.processQueue();
       });
+
       this.on("addedfile", function() {
         if (submitButton.classList.contains('primary')) {
           submitButton.classList.add('success');
           submitButton.classList.remove('primary');
         }
       });
-      var _this = this;
+
+      this.on("success", function() {
+        successCount++;
+        myDropzone.processQueue();
+      });
+
+      this.on("error", function(file, message) {
+        errorCount++;
+        var msg = document.createElement('p');
+        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
+        errorRegion.appendChild(msg);
+      });
+
+      this.on("queuecomplete", function() {
+        if (errorCount === 0 && successCount > 0) {
+          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
+          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
+        }
+      });
+
       document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        _this.removeAllFiles(true);
+        myDropzone.removeAllFiles(true);
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         if (submitButton.classList.contains('success')) {
           submitButton.classList.add('primary');
           submitButton.classList.remove('success');
         }
       });
-    },
-    success: function() {
-      myDropzone = this; // closure
-      myDropzone.processQueue();
-    },
-    queuecomplete: function() {
-      window.location.href= '' + window.location.href;
     }
   };
 </script>
@@ -79,5 +102,8 @@
     <input name="file" type="file" multiple />
   </div>
 </form>
+<div id="upload-errors" role="alert" aria-live="assertive" class="callout alert"></div>
+<div id="upload-status" role="status" aria-live="polite"></div>
 <button class="button primary no-gap" id="submit-all">Upload All Files</button>
+<button type="button" class="button secondary no-gap" id="dz-browse">Browse Files</button>
 <button class="button secondary no-gap" id="clear-dropzone">Reset</button>

--- a/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
@@ -30,44 +30,67 @@
   <i class="fa fa-folder-open-o"></i> <c:out value="${folder.name}" />
 </h4>
 </c:if>
-<%-- Identical to: --%>
-<%--<form action="" method="post" enctype="multipart/form-data">--%>
-  <%--<input type="file" name="file" />--%>
-<%--</form>--%>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script>
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,
     maxFilesize: 100,
-    dictDefaultMessage: 'Drag and Drop files from your desktop here (max 100MB)<br/><br/>(Click for file chooser)',
+    clickable: '#dz-browse',
+    dictDefaultMessage: 'Drag and drop files here (max 100 MB)<br/><br/>or use the Browse button below',
     init: function() {
       var submitButton = document.querySelector("#submit-all");
-      myDropzone = this; // closure
+      var errorRegion  = document.querySelector("#upload-errors");
+      var statusRegion = document.querySelector("#upload-status");
+      var errorCount   = 0;
+      var successCount = 0;
+      myDropzone = this;
+
       submitButton.addEventListener("click", function() {
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         myDropzone.processQueue();
       });
+
       this.on("addedfile", function() {
         if (submitButton.classList.contains('primary')) {
           submitButton.classList.add('success');
           submitButton.classList.remove('primary');
         }
       });
-      var _this = this;
+
+      this.on("success", function() {
+        successCount++;
+        myDropzone.processQueue();
+      });
+
+      this.on("error", function(file, message) {
+        errorCount++;
+        var msg = document.createElement('p');
+        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
+        errorRegion.appendChild(msg);
+      });
+
+      this.on("queuecomplete", function() {
+        if (errorCount === 0 && successCount > 0) {
+          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
+          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
+        }
+      });
+
       document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        _this.removeAllFiles(true);
+        myDropzone.removeAllFiles(true);
+        errorCount = 0;
+        successCount = 0;
+        errorRegion.innerHTML = '';
+        statusRegion.textContent = '';
         if (submitButton.classList.contains('success')) {
           submitButton.classList.add('primary');
           submitButton.classList.remove('success');
         }
       });
-    },
-    success: function() {
-      myDropzone = this; // closure
-      myDropzone.processQueue();
-    },
-    queuecomplete: function() {
-      window.location.href= '' + window.location.href;
     }
   };
 </script>
@@ -81,5 +104,8 @@
     <input name="file" type="file" multiple />
   </div>
 </form>
+<div id="upload-errors" role="alert" aria-live="assertive" class="callout alert"></div>
+<div id="upload-status" role="status" aria-live="polite"></div>
 <button class="button primary no-gap" id="submit-all">Upload All Files</button>
+<button type="button" class="button secondary no-gap" id="dz-browse">Browse Files</button>
 <button class="button secondary no-gap" id="clear-dropzone">Reset</button>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -427,6 +427,10 @@
           </c:if>
         </div>
         <div class="off-canvas-content" data-off-canvas-content>
+          <div class="title-bar hide-for-medium" aria-label="Admin navigation">
+            <button class="menu-icon" type="button" data-toggle="offCanvas" aria-label="Open admin menu"></button>
+            <div class="title-bar-title">Admin Menu</div>
+          </div>
           <div class="web-content admin-web-content">
             <jsp:include page="${PageBody}" flush="true"/>
           </div>
@@ -458,7 +462,7 @@
                   </c:otherwise>
                 </c:choose>
               </p>
-              <p style="white-space: nowrap">
+              <p>
                 <c:if test="${!empty sitePropertyMap['site.confirmation.line1']}">
                   <c:out value="${sitePropertyMap['site.confirmation.line1']}" />
                 </c:if>

--- a/src/main/webapp/css/platform.css
+++ b/src/main/webapp/css/platform.css
@@ -288,6 +288,7 @@ table td .input-group {
 }
 .admin-web-content {
   min-height: 500px;
+  overflow-x: auto;
 }
 .admin-web-content .platform-body {
   margin-top: 10px;


### PR DESCRIPTION
## Summary

Closes #304.

Three changes fix the admin UI on small screens and at high zoom levels. The fourth item (upload widget instruction) is addressed by PR #345.

## Changes

**`main.jsp` — admin sidebar toggle (WCAG 1.4.10)**

The off-canvas admin menu had no toggle below 640px; `reveal-for-medium` hides it and there was no button to open it. Added a Foundation title-bar with `data-toggle="offCanvas"` inside `off-canvas-content`, styled `hide-for-medium` so it only appears on small screens.

**`css/platform.css` — wide admin tables scroll instead of clip (WCAG 1.4.10)**

`.web-content { overflow-x: hidden }` was the parent of every admin page, silently clipping wide tables (Audit Log, Datasets, etc.) with no scrollbar. Added `overflow-x: auto` to `.admin-web-content` — higher specificity wins over the parent rule; the public `.web-content` pages are unaffected.

**`main.jsp` — confirmation gate wraps on narrow screens (WCAG 1.4.10)**

`<p style="white-space: nowrap">` on the site-confirmation overlay forced the prompt onto one line wider than the viewport on phones. Removed the inline style.

## Note

The upload widget drop-zone instruction (`admin/folder-file-drop-zone.jsp:46`) is handled in PR #345 — that PR updates `dictDefaultMessage` to state the size cap and adds a focusable Browse button as a first-class touch/keyboard alternative.

## Verification

```
ant compile-jsp   # 0 errors
```