### PR TITLE
fix: add ARIA live-region semantics to flash/status messages (WCAG 4.1.3) (#303)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/global-message.jsp
+++ b/src/main/webapp/WEB-INF/jsp/global-message.jsp
@@ -18,22 +18,24 @@
 <jsp:useBean id="messageValue" class="java.lang.String" scope="request"/>
 <c:choose>
   <c:when test="${'error' eq messageType}">
-    <div class="callout radius alert">
+    <div class="callout radius alert" role="alert" tabindex="-1">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
+    <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
   </c:when>
   <c:when test="${'warning' eq messageType}">
-    <div class="callout radius warning">
+    <div class="callout radius warning" role="alert" tabindex="-1">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
+    <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
   </c:when>
   <c:when test="${'success' eq messageType}">
-    <div class="callout radius success">
+    <div class="callout radius success" role="status">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
   </c:when>
   <c:otherwise>
-    <div class="callout radius">
+    <div class="callout radius" role="status">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
   </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/page_messages.jspf
+++ b/src/main/webapp/WEB-INF/jsp/page_messages.jspf
@@ -15,17 +15,19 @@
   --%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <c:if test="${!empty errorMessage}">
-  <div class="callout radius alert">
+  <div class="callout radius alert" role="alert" tabindex="-1">
     <p class="text-center"><c:out value="${errorMessage}" /></p>
   </div>
+  <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty warningMessage}">
-  <div class="callout radius warning">
+  <div class="callout radius warning" role="alert" tabindex="-1">
     <p class="text-center"><c:out value="${warningMessage}" /></p>
   </div>
+  <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty successMessage}">
-  <div class="callout radius success" data-closable>
+  <div class="callout radius success" role="status" data-closable>
     <p class="text-center" style="margin-bottom:0"><c:out value="${successMessage}" /></p>
     <%--<button class="close-button" aria-label="Dismiss alert" type="button" data-close>--%>
       <%--<span aria-hidden="true">&times;</span>--%>
@@ -33,7 +35,7 @@
   </div>
 </c:if>
 <c:if test="${!empty message}">
-  <div class="callout radius">
+  <div class="callout radius" role="status">
     <p class="text-center"><c:out value="${message}" /></p>
   </div>
 </c:if>


### PR DESCRIPTION
## Summary

Closes #303.

Flash and status messages (login errors, form validation, admin saves, governed workflow feedback) had no live-region semantics. Screen-reader users got no announcement when a message appeared without a focus change.

## Changes

**`page_messages.jspf`** and **`global-message.jsp`**

| Message type | Before | After |
|---|---|---|
| error | bare `<div class="callout alert">` | `role="alert"` + `tabindex="-1"` + focus script |
| warning | bare `<div class="callout warning">` | `role="alert"` + `tabindex="-1"` + focus script |
| success | bare `<div class="callout success">` | `role="status"` |
| info/message | bare `<div class="callout">` | `role="status"` |

- **`role="alert"`** (implies `aria-live="assertive"`) — screen reader announces error/warning immediately; appropriate for actionable feedback.
- **`role="status"`** (implies `aria-live="polite"`) — screen reader announces success/info without interrupting; user finishes current task first.
- **Focus movement** — a `DOMContentLoaded` script moves focus to the first `[role="alert"]` on the page. On a page reload after a form error, AT users land directly on the error rather than re-reading from the top (WCAG 3.3.1).
- **`tabindex="-1"`** — makes non-interactive `<div>` programmatically focusable without adding it to the tab order.

## Follow-on

Per-field error association (`aria-describedby` mapping error text to the offending `<input>`) requires widget-by-widget changes and is tracked as follow-on work in this issue.

## Verification

```
ant compile-jsp   # 0 errors
```