### PR TITLE
fix: add accessible names to icon controls and logo images (WCAG 4.1.2 / 1.1.1) (#302)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -45,15 +45,16 @@
     }
 </script>
 <form id="tableOptionsForm" method="get" autocomplete="off" class="float-right">
+  <label for="statusFilter" class="show-for-sr">Status</label>
   <select id="statusFilter" name="statusFilter" class="float-left width-auto margin-right-10">
     <option value="any"<c:if test="${statusFilter eq 'any'}"> selected</c:if>>Any Status</option>
     <option value="active"<c:if test="${statusFilter eq 'active'}"> selected</c:if>>Active List</option>
     <option value="inactive"<c:if test="${statusFilter eq 'inactive'}"> selected</c:if>>Inactive List</option>
   </select>
   <div class="input-group no-gap width-auto">
-    <input class="input-group-field" type="search" name="query" placeholder="<c:if test="${empty query}">Search...</c:if>"<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if> autocomplete="off">
+    <input class="input-group-field" type="search" name="query" aria-label="Search users" placeholder="<c:if test="${empty query}">Search...</c:if>"<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if> autocomplete="off">
     <div class="input-group-button">
-      <button type="submit" class="button search"><i class="fa fa-search"></i></button>
+      <button type="submit" class="button search" aria-label="Search"><i class="fa fa-search" aria-hidden="true"></i></button>
     </div>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
@@ -25,7 +25,7 @@
 <jsp:useBean id="themePropertyMap" class="java.util.HashMap" scope="request"/>
 <jsp:useBean id="view" class="java.lang.String" scope="request"/>
 <div class="title-bar hide-for-medium" data-responsive-toggle="platform-small-toggle-menu"  data-hide-for="medium">
-  <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu"></button>
+  <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu" aria-label="Open menu" aria-controls="platform-small-toggle-menu" aria-expanded="false"></button>
   <c:set var="logoSrc" scope="request" value=""/>
   <c:choose>
     <c:when test="${view eq 'white'}">

--- a/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
@@ -96,7 +96,7 @@
 </style>
 <%-- Small Menu --%>
 <div class="item-menu title-bar" data-responsive-toggle="responsive-item-menu" data-hide-for="medium">
-  <button class="menu-icon" type="button" data-toggle="responsive-item-menu"></button>
+  <button class="menu-icon" type="button" data-toggle="responsive-item-menu" aria-label="Open menu" aria-controls="responsive-item-menu" aria-expanded="false"></button>
   <div class="title-bar-title">
     <c:out value="${item.name}"/>
     <c:forEach items="${itemTabList}" var="tab">

--- a/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
@@ -24,20 +24,20 @@
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'all-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:when>
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'color-and-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.mixed']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:when>
@@ -47,10 +47,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:when>
                   <c:otherwise>
-                    <img src="${systemPropertyMap['system.www.context']}/images/logo-footer.png" width="134" />
+                    <img src="${systemPropertyMap['system.www.context']}/images/logo-footer.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
                   </c:otherwise>
                 </c:choose>
               </c:otherwise>
@@ -77,22 +77,22 @@
           <c:if test="${!empty socialPropertyMap}">
             <p class="text-center medium-text-right">
               <c:if test="${!empty socialPropertyMap['social.facebook.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="Facebook" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.twitter.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-twitter fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="Twitter" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-twitter fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.linkedin.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-linkedin fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-linkedin fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.instagram.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-instagram fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="Instagram" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-instagram fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.youtube.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-youtube fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="YouTube" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-youtube fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
               <c:if test="${!empty socialPropertyMap['social.flickr.url']}">
-                <a target="_blank" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>"><span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-flickr fa-stack-1x fa-inverse"></i></span></a>
+                <a target="_blank" rel="noopener noreferrer" aria-label="Flickr" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-flickr fa-stack-1x fa-inverse"></i></span></a>
               </c:if>
             </p>
           </c:if>

--- a/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
@@ -18,17 +18,17 @@
   <%-- Small Title Bar--%>
   <div id="platform-small-menu" class="hide-for-medium" style="position: fixed; z-index: 1001;top: 0;width:100%;">
     <div class="title-bar" data-responsive-toggle="platform-small-toggle-menu">
-      <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu"></button>
+      <button class="menu-icon" type="button" data-toggle="platform-small-toggle-menu" aria-label="Open menu" aria-controls="platform-small-toggle-menu" aria-expanded="false"></button>
       <div class="logo">
         <c:choose>
           <c:when test="${themePropertyMap['theme.logo.color'] eq 'text-only' or themePropertyMap['theme.logo.color'] eq 'none'}">
             <a href="${ctx}/">Home</a>
           </c:when>
           <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" /></a>
+            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
           </c:when>
           <c:otherwise>
-            <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" /></a>
+            <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-white-color.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
           </c:otherwise>
         </c:choose>
       </div>
@@ -155,10 +155,10 @@
                         <a href="${ctx}/"><c:out value="${sitePropertyMap['site.name']}"/></a>
                       </c:when>
                       <c:when test="${!empty sitePropertyMap['site.logo']}">
-                        <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" /></a>
+                        <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
                       </c:when>
                       <c:otherwise>
-                        <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" /></a>
+                        <a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
                       </c:otherwise>
                     </c:choose>
                   </div>
@@ -422,10 +422,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="${systemPropertyMap['system.www.context']}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
                   </c:otherwise>
                 </c:choose>
               </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -482,8 +482,8 @@
       <c:choose>
         <c:when test="${!empty requestPricingRule.promoCode}">
           <div id="site-promo-overlay" class="animated slideInUp faster delay-1s hide-for-print">
-            <button id="site-promo-close-button" class="close-button" type="button">
-              <span><i class="${font:fal()} fa-circle-xmark"></i></span>
+            <button id="site-promo-close-button" class="close-button" type="button" aria-label="Close">
+              <span aria-hidden="true"><i class="${font:fal()} fa-circle-xmark"></i></span>
             </button>
             <h4>Thanks for visiting!</h4>
             <p>We've added a promo code for use on your next purchase</p>
@@ -491,8 +491,8 @@
         </c:when>
         <c:when test="${!empty requestOverlayHeadline}">
           <div id="site-newsletter-overlay" class="animated slideInUp faster delay-3s hide-for-print">
-            <button id="site-newsletter-close-button" class="close-button" type="button">
-              <span><i class="${font:fal()} fa-circle-xmark"></i></span>
+            <button id="site-newsletter-close-button" class="close-button" type="button" aria-label="Close">
+              <span aria-hidden="true"><i class="${font:fal()} fa-circle-xmark"></i></span>
             </button>
             <h4><c:out value="${requestOverlayHeadline}" /></h4>
             <p><c:out value="${requestOverlayMessage}" /></p>


### PR DESCRIPTION
## Summary

Closes #302.

Multiple icon-only controls and logo images had no accessible name — screen readers announced bare "button"/"link" or a raw filename.

## Changes

**Mobile menu toggle buttons** — `layout-header-standard.jspf`, `cms/toggle-menu.jsp`, `items/item-menu.jsp`
- Added `aria-label="Open menu"`, `aria-controls="<target-id>"`, and `aria-expanded="false"` to each empty `<button class="menu-icon">`. Foundation JS updates `aria-expanded` on toggle. (WCAG 4.1.2)

**Logo images** — `layout-header-standard.jspf`, `layout-footer-standard.jspf`
- All logo `<img>` elements now carry `alt="${sitePropertyMap['site.name']}"` so the site name is the accessible text for both the image and its enclosing home link. (WCAG 1.1.1, 2.4.4)

**Footer social-media links** — `layout-footer-standard.jspf`
- Icon-only Font Awesome stacks get `aria-label` per platform (Facebook, Twitter, LinkedIn, Instagram, YouTube, Flickr) and `aria-hidden="true"` on the `<span>` so AT reads the label rather than glyph names.
- Added `rel="noopener noreferrer"` on all `target="_blank"` social links. (WCAG 4.1.2)

**Admin user-list search** — `admin/users-list.jsp`
- Visually-hidden `<label for="statusFilter">` for the status select.
- `aria-label="Search users"` on the search input.
- `aria-label="Search"` + `aria-hidden="true"` on the icon inside the icon-only submit button. (WCAG 4.1.2)

**Overlay close buttons** — `main.jsp`
- `aria-label="Close"` on both the promo and newsletter close buttons; `aria-hidden="true"` on the inner icon span. (WCAG 4.1.2)

## Verification

```
ant compile-jsp   # 0 errors
```