### PR TITLE
A11y: authoring tools not keyboard-operable (#301)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/add-tracking-number.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/add-tracking-number.jsp
@@ -28,11 +28,11 @@
 <%@include file="../page_messages.jspf" %>
 <c:if test="${testMode eq 'true'}"><span class="label warning">TEST MODE</span></c:if>
 <button class="button primary expanded" data-open="trackingFormReveal">Add a Tracking Number</button>
-<div class="reveal small" id="trackingFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="trackingFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="trackingFormRevealTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Add a Tracking Number</h4>
+  <h4 id="trackingFormRevealTitle">Add a Tracking Number</h4>
   <form id="trackingForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
@@ -145,7 +145,7 @@
     <input type="submit" class="button radius success" name="process" value="Save & Sync"/>
   </div>
 </form>
-<div class="reveal medium" id="processReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal medium" id="processReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Validating Data">
   <h3>Validating Data...</h3>
   <%--<p><a class="button small radius primary" href="${ctx}/admin/datasets">Continue to datasets list <i class="fa fa-caret-right"></i></a></p>--%>
 </div>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -193,7 +193,7 @@
   }
 </script>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
-  <div class="reveal small" id="fileFormReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">
+  <div class="reveal small" id="fileFormReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="formTitle">
     <button class="close-button" data-close aria-label="Close modal" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
@@ -85,11 +85,11 @@
 <%-- @todo add paging --%>
 
 <%-- form --%>
-<div class="reveal small" id="formReveal${widgetContext.uniqueId}" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal${widgetContext.uniqueId}" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="subFolderFormRevealTitle${widgetContext.uniqueId}">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>New Sub-Folder</h4>
+  <h4 id="subFolderFormRevealTitle${widgetContext.uniqueId}">New Sub-Folder</h4>
   <form id="subFolderForm${widgetContext.uniqueId}" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/issue-refund.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/issue-refund.jsp
@@ -25,11 +25,11 @@
 <%@include file="../page_messages.jspf" %>
 <c:if test="${testMode eq 'true'}"><span class="label warning">TEST MODE</span></c:if>
 <button class="button alert expanded" data-open="refundFormReveal">Issue a Refund</button>
-<div class="reveal small" id="refundFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="refundFormReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="refundFormRevealTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Issue a Refund</h4>
+  <h4 id="refundFormRevealTitle">Issue a Refund</h4>
   <form id="issueRefundForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -93,11 +93,11 @@
 <%-- Paging Control --%>
 <c:set var="recordPagingParams" scope="request" value="mailingListId=${mailingList.id}"/>
 <%@include file="../paging_control.jspf" %>
-<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="mailingFormRevealTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>Add Email</h4>
+  <h4 id="mailingFormRevealTitle">Add Email</h4>
   <form id="userForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
@@ -462,7 +462,7 @@
     </c:choose>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -201,7 +201,7 @@
     <a href="${ctx}/admin" class="button radius secondary">Cancel</a>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -51,8 +51,10 @@
                 </c:when>
                 <c:otherwise>
                   <i class="fa fa-arrows-h site-map-menu-tab-drag-handle" aria-hidden="true"></i>
-                  <button type="button" class="button tiny secondary no-gap margin-left-5" onclick="moveSitemapTabUp(this)" aria-label="Move tab left">&#9664;</button>
-                  <button type="button" class="button tiny secondary no-gap" onclick="moveSitemapTabDown(this)" aria-label="Move tab right">&#9654;</button>
+                  <button type="button" class="button tiny secondary" style="margin:0 2px" aria-label="Move tab left"
+                          onclick="moveTabLeft('site-map-menu-tab-container-${menuTab.id}')">&#9664;</button>
+                  <button type="button" class="button tiny secondary" style="margin:0 2px" aria-label="Move tab right"
+                          onclick="moveTabRight('site-map-menu-tab-container-${menuTab.id}')">&#9654;</button>
                 </c:otherwise>
               </c:choose>
             </small>
@@ -84,7 +86,11 @@
                 --%>
                 <div class="float-left">
                   <small class="subheader">
-                    <i class="fa fa-arrows site-map-submenu-tab-drag-handle"></i>
+                    <i class="fa fa-arrows site-map-submenu-tab-drag-handle" aria-hidden="true"></i>
+                    <button type="button" class="button tiny secondary" style="margin:0 2px" aria-label="Move item up"
+                            onclick="moveItemUp('site-map-menu-item-${menuItem.id}')">&#9650;</button>
+                    <button type="button" class="button tiny secondary" style="margin:0 2px" aria-label="Move item down"
+                            onclick="moveItemDown('site-map-menu-item-${menuItem.id}')">&#9660;</button>
                     <%--<a href="${ctx}${menuItem.link}"><c:out value="${menuItem.link}" /></a>--%>
                   </small>
                 </div>
@@ -192,16 +198,26 @@
     return true;
   }
 
-  function moveSitemapTabUp(btn) {
-    var tab = btn.closest('.site-map-menu-tab');
-    var prev = tab.previousElementSibling;
-    if (!prev || prev.id === 'site-map-menu-tab-container-0') return;
-    tab.parentNode.insertBefore(tab, prev);
+  function moveTabLeft(id) {
+    var el = document.getElementById(id);
+    var prev = el.previousElementSibling;
+    if (prev && prev.id !== 'site-map-menu-tab-container-0') {
+      el.parentNode.insertBefore(el, prev);
+    }
   }
-
-  function moveSitemapTabDown(btn) {
-    var tab = btn.closest('.site-map-menu-tab');
-    var next = tab.nextElementSibling;
-    if (next) tab.parentNode.insertBefore(next, tab);
+  function moveTabRight(id) {
+    var el = document.getElementById(id);
+    var next = el.nextElementSibling;
+    if (next) { el.parentNode.insertBefore(next, el); }
+  }
+  function moveItemUp(id) {
+    var el = document.getElementById(id);
+    var prev = el.previousElementSibling;
+    if (prev) el.parentNode.insertBefore(el, prev);
+  }
+  function moveItemDown(id) {
+    var el = document.getElementById(id);
+    var next = el.nextElementSibling;
+    if (next) el.parentNode.insertBefore(next, el);
   }
 </script>

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -50,7 +50,9 @@
                   <a href="${ctx}${menuTab.link}"><c:out value="${menuTab.link}"/></a>
                 </c:when>
                 <c:otherwise>
-                  <i class="fa fa-arrows-h site-map-menu-tab-drag-handle"></i>
+                  <i class="fa fa-arrows-h site-map-menu-tab-drag-handle" aria-hidden="true"></i>
+                  <button type="button" class="button tiny secondary no-gap margin-left-5" onclick="moveSitemapTabUp(this)" aria-label="Move tab left">&#9664;</button>
+                  <button type="button" class="button tiny secondary no-gap" onclick="moveSitemapTabDown(this)" aria-label="Move tab right">&#9654;</button>
                 </c:otherwise>
               </c:choose>
             </small>
@@ -188,5 +190,18 @@
     menuItemOrderField.value = menuItemOrder;
 
     return true;
+  }
+
+  function moveSitemapTabUp(btn) {
+    var tab = btn.closest('.site-map-menu-tab');
+    var prev = tab.previousElementSibling;
+    if (!prev || prev.id === 'site-map-menu-tab-container-0') return;
+    tab.parentNode.insertBefore(tab, prev);
+  }
+
+  function moveSitemapTabDown(btn) {
+    var tab = btn.closest('.site-map-menu-tab');
+    var next = tab.nextElementSibling;
+    if (next) tab.parentNode.insertBefore(next, tab);
   }
 </script>

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -113,11 +113,11 @@
 </c:if>
 <%@include file="../paging_control.jspf" %>
 <%--<div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">--%>
-<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast">
+<div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="userFormRevealTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
-  <h4>New User</h4>
+  <h4 id="userFormRevealTitle">New User</h4>
   <form id="userForm" method="post" autocomplete="off">
     <%-- Required by controller --%>
     <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -156,7 +156,7 @@
     </c:if>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -256,8 +256,8 @@
   });
 </script>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
-  <div class="reveal tiny" id="modalReveal" data-reveal>
-    <h3>Event Options</h3>
+  <div class="reveal tiny" id="modalReveal" data-reveal role="dialog" aria-modal="true" aria-labelledby="modalRevealTitle">
+    <h3 id="modalRevealTitle">Event Options</h3>
     <p>Would you like to make changes or view the details of this event?</p>
     <div class="button-container text-no-wrap">
       <button class="button" data-open="formReveal">Edit this Event</button>
@@ -268,7 +268,7 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast">
+  <div class="reveal small" id="formReveal" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="formTitle">
     <button class="close-button" data-close aria-label="Close modal" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
@@ -74,18 +74,16 @@
     <div class="grid-x grid-margin-x text-center align-stretch small-up-<c:out value="${smallCardCount}" /> medium-up-<c:out value="${mediumCardCount}" /> large-up-<c:out value="${largeCardCount}" />">
       <c:forEach items="${subFolderList}" var="subFolder">
         <div class="card-container${widgetContext.uniqueId} cell">
-          <div class="card${widgetContext.uniqueId}<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>"
-               style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');"
-               role="button" tabindex="0" aria-label="<c:out value="${subFolder.name}"/>"
-               onclick="showAlbum${controlId}(${subFolder.id})"
-               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showAlbum${controlId}(${subFolder.id});}"
-               >
+          <button type="button" class="card${widgetContext.uniqueId}<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>"
+                  style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');"
+                  onclick="showAlbum${controlId}(${subFolder.id})"
+                  aria-label="<c:out value="${subFolder.name}"/>">
             <div class="card-content">
               <div class="card-content-inner">
-                <p><c:out value="${subFolder.name}"/></p>
+                <p aria-hidden="true"><c:out value="${subFolder.name}"/></p>
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </c:forEach>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/album-gallery.jsp
@@ -75,7 +75,11 @@
       <c:forEach items="${subFolderList}" var="subFolder">
         <div class="card-container${widgetContext.uniqueId} cell">
           <div class="card${widgetContext.uniqueId}<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>"
-               style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');" onclick="showAlbum${controlId}(${subFolder.id})">
+               style="background-image:url('${ctx}/assets/view/${subFolder.posterFileItem.url}');"
+               role="button" tabindex="0" aria-label="<c:out value="${subFolder.name}"/>"
+               onclick="showAlbum${controlId}(${subFolder.id})"
+               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showAlbum${controlId}(${subFolder.id});}"
+               >
             <div class="card-content">
               <div class="card-content-inner">
                 <p><c:out value="${subFolder.name}"/></p>

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
@@ -209,7 +209,7 @@
     </c:choose>
   </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/cms/card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/card.jsp
@@ -25,7 +25,7 @@
 <jsp:useBean id="link" class="java.lang.String" scope="request"/>
 <jsp:useBean id="linkTitle" class="java.lang.String" scope="request"/>
 <jsp:useBean id="linkIcon" class="java.lang.String" scope="request"/>
-<div class="<c:out value="${classData}" />"<c:if test="${!empty link}"> onclick="window.location.href='${ctx}${js:escape(link)}'"</c:if>>
+<c:choose><c:when test="${!empty link}"><a class="<c:out value="${classData}"/>" href="${ctx}<c:out value="${link}"/>"></c:when><c:otherwise><div class="<c:out value="${classData}"/>"></c:otherwise></c:choose>
   <c:if test="${!empty title}">
     <div class="card-divider"><c:out value="${title}" /></div>
   </c:if>
@@ -56,4 +56,4 @@
     </p>
   </div>
   --%>
-</div>
+<c:choose><c:when test="${!empty link}"></a></c:when><c:otherwise></div></c:otherwise></c:choose>

--- a/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
@@ -42,6 +42,7 @@
     <button id="reveal-button${widgetContext.uniqueId}" class="reveal-button-text" data-toggle="modal${widgetContext.uniqueId}"><div class="button-reveal-content">${card1}</div></button>
     <c:if test="${!empty card2}">
       <div class="reveal<c:if test="${!empty size}"> <c:out value="${size}" /></c:if>" id="modal${widgetContext.uniqueId}"
+           role="dialog" aria-modal="true"
            data-reveal
            data-reset-on-close="true"
            <c:choose>

--- a/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
@@ -244,8 +244,9 @@
     <c:forEach items="${imageList}" var="image" varStatus="status">
       <div class="cell card">
         <div class="image-browser">
-          <img onclick="mySubmit(this.dataset.src)" data-src="${ctx}/assets/img/${image.url}"
-               src="${ctx}/assets/img/${image.url}" alt="<c:out value="${image.filename}"/>">
+          <button type="button" class="image-browser-select" onclick="mySubmit(this.dataset.src)" data-src="${ctx}/assets/img/${image.url}" aria-label="Select <c:out value="${image.filename}"/>">
+            <img src="${ctx}/assets/img/${image.url}" alt="">
+          </button>
         </div>
         <div class="card-section">
           <div>

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
@@ -51,13 +51,13 @@
         <div class="grid-x grid-margin-x">
       </c:if>
       <div class="small-6 medium-4 large-3 cell">
-        <div class="template cell card" onclick="mySubmit(${template.id},${template.uniqueId})">
+        <button type="button" class="template cell card" onclick="mySubmit(${template.id},${template.uniqueId})" aria-label="<c:out value="${template.name}"/>">
           <c:choose>
             <c:when test="${!empty template.imagePath}">
-              <img src="${ctx}/images/templates/${url:encodeUri(template.imagePath)}">
+              <img src="${ctx}/images/templates/${url:encodeUri(template.imagePath)}" alt="">
             </c:when>
             <c:otherwise>
-              <img src="${ctx}/images/templates/Blank.png">
+              <img src="${ctx}/images/templates/Blank.png" alt="">
             </c:otherwise>
           </c:choose>
           <div class="card-section">
@@ -65,7 +65,7 @@
               <small><c:out value="${template.name}"/></small>
             </p>
           </div>
-        </div>
+        </button>
       </div>
       <c:set var="currentCategory" scope="request" value="${template.category}"/>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
@@ -530,7 +530,7 @@
       <c:if test="${!empty cancelUrl}"><span class="button-gap"><a class="button radius secondary" href="${ctx}<c:out value="${cancelUrl}"/>">Cancel</a></span></c:if>
     </div>
 </form>
-<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
+<div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">
   <h3>Loading...</h3>
 </div>
 <script>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -449,7 +449,7 @@
         <jsp:include page="${PageBody}" flush="true"/>
       </div>
       <c:if test="${!empty sitePropertyMap['site.confirmation'] && sitePropertyMap['site.confirmation'] eq 'true'}">
-        <div id="site-confirmation" class="reveal full" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-out="fade-out fast">
+        <div id="site-confirmation" class="reveal full" data-reveal data-close-on-esc="false" data-close-on-click="false" data-animation-out="fade-out fast" role="dialog" aria-modal="true" aria-label="Site Confirmation">
           <div style="position:absolute; top: 50%; left: 50%; transform: translateY(-50%) translateX(-50%)">
             <div class="modal-prompt">
               <p>


### PR DESCRIPTION
## Summary

- **Template picker** (`cms/web-page-templates.jsp`): Replaced `<div onclick>` with `<button type="button" aria-label>` so keyboard users can tab to and activate templates.
- **Image browser** (`cms/image-browser.jsp`): Wrapped each `<img onclick>` in a `<button type="button" aria-label="Select {filename}">` so it is focusable and operable.
- **Card widget** (`cms/card.jsp`): When a link is set, renders a native `<a href>` instead of a `<div onclick=window.location>` (WCAG 2.1.1 — native semantics).
- **Album gallery** (`cms/album-gallery.jsp`): Added `role="button" tabindex="0" aria-label` and `onkeydown` Enter/Space handler to the onclick div.
- **Sitemap editor** (`admin/sitemap-editor.jsp`): Added Move Left / Move Right `<button>` controls next to the Dragula drag handle for every non-Home tab, backed by `moveSitemapTabUp(btn)` / `moveSitemapTabDown(btn)` JS functions that reorder DOM elements and integrate with the existing `checkSiteMapOrder()` serialization.
- **16 Reveal modals** across `admin/` and `cms/`: Added `role="dialog" aria-modal="true"` to every Foundation Reveal `<div data-reveal>`; modals with static headings also got `aria-labelledby` pointing to the heading element.

## Test plan

- [ ] Tab to template cards in the page-template picker and press Enter — form submits with the selected template
- [ ] Tab to images in image-browser.jsp and press Enter/Space — `mySubmit` fires
- [ ] Card with `link` set renders as `<a>` — tab-focusable without JS, native keyboard activation
- [ ] Album gallery cards respond to Enter and Space keypresses as well as click
- [ ] Sitemap editor: Move Left / Move Right buttons reorder tabs correctly; Save persists new order (same result as drag)
- [ ] Each Reveal modal announces role="dialog" and title to screen reader on open (NVDA/VoiceOver)