### PR TITLE
Step-up re-authentication for sensitive admin actions (IA-2 / AC-6)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -24,7 +24,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.login.StepUpAuthCommand;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.cms.Content;
@@ -467,6 +470,40 @@ public class ContentHtmlCommand {
       context.setErrorMessage(e.getMessage());
     }
     return context;
+  }
+
+  /**
+   * Handles a POST-based content approval with step-up re-authentication.
+   * Must be called after {@code execute()} has already set the JSP on the context so that a
+   * step-up prompt can re-render the same page.
+   */
+  public static WidgetContext performContentApproval(WidgetContext context) {
+    if (!EditorPermissionCommand.canEditContent(context.getUserSession())) {
+      return context;
+    }
+    String uniqueId = context.getPreferences().get("uniqueId");
+    if (uniqueId == null) {
+      return context;
+    }
+    uniqueId = ContentHtmlCommand.checkForBlogPreferences(context, uniqueId);
+    Content content = LoadContentCommand.loadContentByUniqueId(uniqueId);
+    if (content == null) {
+      return context;
+    }
+    String stepUpCredential = context.getParameter("stepUpCredential");
+    if (!StepUpAuthCommand.isValid(context.getUserSession())) {
+      if (StringUtils.isBlank(stepUpCredential)) {
+        context.addSharedRequestValue("stepUpRequired", "true");
+        return context;
+      }
+      User actingUser = LoadUserCommand.loadUser(context.getUserId());
+      if (!StepUpAuthCommand.verify(context.getUserSession(), actingUser, stepUpCredential)) {
+        context.setErrorMessage("Re-authentication failed. Enter your password or authenticator code.");
+        context.addSharedRequestValue("stepUpRequired", "true");
+        return context;
+      }
+    }
+    return approveContent(context, content);
   }
 
   private static WidgetContext approveContent(WidgetContext context, Content content) {

--- a/src/main/java/com/simisinc/platform/application/login/StepUpAuthCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/StepUpAuthCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.UserPasswordCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+/**
+ * Manages step-up re-authentication for sensitive privileged actions (IA-2 / AC-6).
+ *
+ * <p>A step-up token is proof that the acting administrator re-verified their identity
+ * within the last {@link #STEP_UP_VALIDITY_MS} milliseconds. Sensitive actions — changing
+ * another user's roles or password, disabling MFA on an account, approving content for
+ * publication — should call {@link #isValid(UserSession)} before proceeding and
+ * redirect / reject the request when it returns {@code false}.
+ *
+ * <p>The step-up token is stored as a timestamp on the session object (not in the database)
+ * and expires after 5 minutes. Every verification attempt, successful or not, is written to
+ * the audit log.
+ *
+ * @author SimIS Inc.
+ */
+public class StepUpAuthCommand {
+
+  private static Log LOG = LogFactory.getLog(StepUpAuthCommand.class);
+
+  /** Step-up tokens are valid for 5 minutes. */
+  public static final long STEP_UP_VALIDITY_MS = 5 * 60 * 1000L;
+
+  private StepUpAuthCommand() {
+  }
+
+  /**
+   * Returns {@code true} if the session holds a step-up token that has not yet expired.
+   */
+  public static boolean isValid(UserSession session) {
+    return session != null && session.getStepUpExpiresAt() > System.currentTimeMillis();
+  }
+
+  /**
+   * Verifies a step-up credential and, on success, stamps the session with a fresh expiry.
+   *
+   * <p>A 6-digit numeric string is tried as a TOTP code first (when MFA is enrolled on the
+   * account); anything else — or a 6-digit code when MFA is not enrolled — is tried as a
+   * password.  Every attempt, successful or not, is written to the audit log as a
+   * {@code step-up.verify} authentication event.
+   *
+   * @param session    the current user session (expiry is written here on success)
+   * @param user       the acting user's full record (password hash, MFA secret)
+   * @param credential password or 6-digit TOTP code
+   * @return {@code true} if the credential was accepted
+   */
+  public static boolean verify(UserSession session, User user, String credential) {
+    if (session == null || user == null || StringUtils.isBlank(credential)) {
+      return false;
+    }
+    boolean verified = false;
+    // Try TOTP first when the credential looks like a 6-digit code and MFA is enrolled
+    if (credential.matches("\\d{6}") && user.getMfaEnabled()) {
+      verified = TotpCommand.verifyCode(user.getMfaSecret(), credential);
+    }
+    // Fall back to password
+    if (!verified && StringUtils.isNotBlank(user.getPassword())) {
+      verified = UserPasswordCommand.verify(credential, user.getPassword());
+    }
+    String outcome = verified ? "success" : "failure";
+    SaveAuditEventCommand.recordAuthentication("step-up.verify", outcome,
+        session.getUserId(), null, session.getIpAddress(), session.getSessionId(), null);
+    if (verified) {
+      session.setStepUpExpiresAt(System.currentTimeMillis() + STEP_UP_VALIDITY_MS);
+      LOG.debug("Step-up verified for user " + session.getUserId());
+    }
+    return verified;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/UserSession.java
@@ -59,6 +59,7 @@ public class UserSession implements Serializable {
   private List<Role> roleList = null;
   private List<Group> groupList = null;
   private long loginTime = -1;
+  private long stepUpExpiresAt = 0L;
   private String formToken = UUID.randomUUID().toString();
   private boolean cookieChecked = false;
   private Cart cart = null;
@@ -197,6 +198,14 @@ public class UserSession implements Serializable {
 
   public long getLoginTime() {
     return loginTime;
+  }
+
+  public long getStepUpExpiresAt() {
+    return stepUpExpiresAt;
+  }
+
+  public void setStepUpExpiresAt(long stepUpExpiresAt) {
+    this.stepUpExpiresAt = stepUpExpiresAt;
   }
 
   public String getFormToken() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SitePropertiesEditorWidget.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.application.admin.AnalyticsTrackingIdCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.admin.SecretSitePropertiesCommand;
 import com.simisinc.platform.application.cms.ColorCommand;
+import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.domain.model.SiteProperty;
 import com.simisinc.platform.infrastructure.persistence.SitePropertyRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
@@ -34,7 +35,10 @@ import jakarta.servlet.jsp.jstl.core.Config;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 
 /**
@@ -51,6 +55,9 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
   static String PREFIX_PREFERENCE = "prefix";
 
+  // Prefixes controlling security-sensitive behaviour; changes require a recent step-up (IA-2 / AC-6).
+  private static final Set<String> SECURITY_PREFIXES =
+      new HashSet<>(Arrays.asList("mfa", "content.review", "security"));
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -81,8 +88,14 @@ public class SitePropertiesEditorWidget extends GenericWidget {
 
   public WidgetContext post(WidgetContext context) {
 
-    // Load the properties
+    // Gate security-sensitive prefix changes behind a recent step-up (IA-2 / AC-6).
     String prefix = context.getPreferences().get(PREFIX_PREFERENCE);
+    if (isSecuritySensitivePrefix(prefix) && !StepUpAuthCommand.isValid(context.getUserSession())) {
+      context.setRedirect("/step-up-auth?return=" + context.getUri());
+      return context;
+    }
+
+    // Load the properties
     List<SiteProperty> siteProperties = new ArrayList<>();
     String[] prefixList = prefix.split(",");
     for (String thisPrefix : prefixList) {
@@ -186,5 +199,17 @@ public class SitePropertiesEditorWidget extends GenericWidget {
       context.setErrorMessage("Values could not be saved");
     }
     return context;
+  }
+
+  private static boolean isSecuritySensitivePrefix(String prefix) {
+    if (StringUtils.isBlank(prefix)) {
+      return false;
+    }
+    for (String p : prefix.split(",")) {
+      if (SECURITY_PREFIXES.contains(p.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -16,7 +16,10 @@
 
 package com.simisinc.platform.presentation.widgets.admin.login;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.domain.events.cms.UserPasswordResetEvent;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
@@ -72,6 +75,40 @@ public class UserDetailsWidget extends GenericWidget {
 
     // Show the editor
     context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+    long userId = context.getParameterAsLong("userId");
+    User user = LoadUserCommand.loadUser(userId);
+    if (user == null) {
+      context.setErrorMessage("The user record was not found");
+      context.setJsp(INVALID_USER_JSP);
+      return context;
+    }
+    String action = context.getParameter("action");
+    if ("resetPassword".equals(action)) {
+      String stepUpCredential = context.getParameter("stepUpCredential");
+      if (!StepUpAuthCommand.isValid(context.getUserSession())) {
+        if (StringUtils.isBlank(stepUpCredential)) {
+          context.addSharedRequestValue("stepUpRequired", "true");
+          context.getRequest().setAttribute("user", user);
+          context.setJsp(JSP);
+          return context;
+        }
+        User actingUser = LoadUserCommand.loadUser(context.getUserId());
+        if (!StepUpAuthCommand.verify(context.getUserSession(), actingUser, stepUpCredential)) {
+          context.setErrorMessage("Re-authentication failed. Enter your password or authenticator code.");
+          context.addSharedRequestValue("stepUpRequired", "true");
+          context.getRequest().setAttribute("user", user);
+          context.setJsp(JSP);
+          return context;
+        }
+      }
+      context.setRedirect("/admin/user-details?userId=" + userId);
+      return resetPassword(context, user);
+    }
+    context.setRedirect("/admin/user-details?userId=" + userId);
     return context;
   }
 

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -22,8 +22,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
@@ -83,6 +86,23 @@ public class UserFormWidget extends GenericWidget {
 
 
   public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    // Require a recent step-up before saving role or group changes
+    String stepUpCredential = context.getParameter("stepUpCredential");
+    if (!StepUpAuthCommand.isValid(context.getUserSession())) {
+      if (StringUtils.isBlank(stepUpCredential)) {
+        context.addSharedRequestValue("stepUpRequired", "true");
+        context.setJsp(JSP);
+        return context;
+      }
+      User actingUser = LoadUserCommand.loadUser(context.getUserId());
+      if (!StepUpAuthCommand.verify(context.getUserSession(), actingUser, stepUpCredential)) {
+        context.setErrorMessage("Re-authentication failed. Enter your password or authenticator code.");
+        context.addSharedRequestValue("stepUpRequired", "true");
+        context.setJsp(JSP);
+        return context;
+      }
+    }
 
     // Populate the fields
     User userBean = new User();

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
@@ -118,4 +118,17 @@ public class ContentWidget extends GenericWidget {
     // Publish or Delete content based on the browser action
     return ContentHtmlCommand.performWebAction(context);
   }
+
+  public WidgetContext post(WidgetContext context) {
+    // The approve form is POSTed so the step-up credential never travels over GET
+    String action = context.getParameter("action");
+    if ("approve".equals(action)) {
+      execute(context);
+      if (!context.hasJsp()) {
+        return context;
+      }
+      return ContentHtmlCommand.performContentApproval(context);
+    }
+    return context;
+  }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidget.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.application.login.UserMfaCommand;
 import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.User;
@@ -109,6 +111,21 @@ public class MyMfaSettingsWidget extends GenericWidget {
     }
 
     if ("disable".equals(action)) {
+      String stepUpCredential = context.getParameter("stepUpCredential");
+      if (!StepUpAuthCommand.isValid(context.getUserSession())) {
+        if (StringUtils.isBlank(stepUpCredential)) {
+          context.addSharedRequestValue("stepUpRequired", "true");
+          showView(context, user);
+          return context;
+        }
+        User actingUser = LoadUserCommand.loadUser(context.getUserId());
+        if (!StepUpAuthCommand.verify(context.getUserSession(), actingUser, stepUpCredential)) {
+          context.setErrorMessage("Re-authentication failed. Enter your password or authenticator code.");
+          context.addSharedRequestValue("stepUpRequired", "true");
+          showView(context, user);
+          return context;
+        }
+      }
       UserMfaCommand.disable(user);
       UserMfaRecoveryCodeCommand.clear(user);
       context.setSuccessMessage("Two-factor authentication has been turned off.");

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -27,12 +27,6 @@
 <jsp:useBean id="groupList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="userLogin" class="com.simisinc.platform.domain.model.login.UserLogin" scope="request"/>
 <script>
-  function resetPassword() {
-    if (!confirm("Are you sure you want to reset the password on this account? An email with instructions will be sent to the user.")) {
-      return;
-    }
-    window.location.href = '${widgetContext.uri}?action=resetPassword&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
-  }
   function suspendAccount() {
     if (!confirm("Are you sure you want to SUSPEND this user account?")) {
       return;
@@ -66,7 +60,7 @@
         <a href="#">Actions</a>
         <ul class="menu">
           <c:if test="${user.enabled}">
-            <li><a href="javascript:resetPassword()">Reset Password</a></li>
+            <li><a href="#" data-open="resetPasswordReveal">Reset Password</a></li>
             <li><a href="javascript:suspendAccount()">Suspend Account</a></li>
           </c:if>
           <c:if test="${!user.enabled}">
@@ -350,3 +344,28 @@
 </div>
 <hr>
 <p><a href="${ctx}/admin/users"><i class="fa fa-angle-double-left"></i> Back to list</a></p>
+<div class="reveal" id="resetPasswordReveal" role="dialog" aria-modal="true" aria-labelledby="resetPasswordRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="resetPasswordRevealTitle">Reset Password</h4>
+  <p>An email with password reset instructions will be sent to <strong><c:out value="${user.email}" /></strong>.</p>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="action" value="resetPassword"/>
+    <input type="hidden" name="userId" value="${user.id}"/>
+    <div class="grid-x grid-padding-x">
+      <div class="small-12 cell">
+        <label for="resetStepUpCredential">Your password or authenticator code <span class="required">*</span>
+          <input type="password" id="resetStepUpCredential" name="stepUpCredential" maxlength="255"
+                 placeholder="Password or 6-digit code" required
+                 title="Re-authentication required to reset another user's password"/>
+        </label>
+      </div>
+    </div>
+    <input type="submit" class="button warning radius" value="Send Reset Email"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
@@ -284,6 +284,20 @@
     </div>
   </div>
   </div>
+  <c:if test="${widgetContext.sharedRequestValueMap['stepUpRequired'] eq 'true'}">
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="small-12 cell">
+          <div class="callout radius warning">
+            <p><strong>Re-authentication required</strong> — enter your password or 6-digit authenticator code to save this user's roles and groups.</p>
+            <input type="password" name="stepUpCredential" maxlength="255"
+                   placeholder="Password or authenticator code"
+                   title="Enter your password or 6-digit authenticator code"/>
+          </div>
+        </div>
+      </div>
+    </div>
+  </c:if>
 </form>
 <script>
   $(document).ready(function () {

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -46,13 +46,16 @@
                trail ("cleared per PA case ...", "CO email dated ..."), which is what makes the trail
                exportable assessment evidence rather than just a timestamp. A GET form produces the
                same request shape as the action links beside it. --%>
-          <form method="get" action="${widgetContext.uri}" class="platform-content-review-form">
+          <form method="post" action="${widgetContext.uri}" class="platform-content-review-form">
             <input type="hidden" name="action" value="approve"/>
             <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
             <input type="hidden" name="token" value="${userSession.formToken}"/>
             <input type="text" name="releaseReference" maxlength="255"
                    placeholder="Release authority (e.g. cleared per PA case 2026-114)"
                    title="Optional: the approval authority to record in the audit trail"/>
+            <input type="password" name="stepUpCredential" maxlength="255"
+                   placeholder="Your password or authenticator code"
+                   title="Re-authentication required to approve content"/>
             <button type="submit" class="hollow button small success"
                     onclick="return confirm('Approve and publish this content?');">APPROVE</button>
           </form>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-mfa-settings.jsp
@@ -59,6 +59,9 @@
       <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
       <input type="hidden" name="token" value="${userSession.formToken}"/>
       <input type="hidden" name="action" value="disable"/>
+      <input type="password" name="stepUpCredential" maxlength="255"
+             placeholder="Your password or authenticator code" required
+             title="Enter your password or 6-digit authenticator code to confirm"/>
       <input type="submit" class="button alert radius" value="Turn off two-factor authentication"
              onclick="return confirm('Turn off two-factor authentication for your account?');"/>
     </form>

--- a/src/test/java/com/simisinc/platform/WidgetBase.java
+++ b/src/test/java/com/simisinc/platform/WidgetBase.java
@@ -195,6 +195,10 @@ public class WidgetBase {
     }
   }
 
+  public static void grantStepUp(WidgetContext context) {
+    context.getUserSession().setStepUpExpiresAt(System.currentTimeMillis() + 300_000L);
+  }
+
   public static void login(WidgetContext widgetContext) {
     // Widgets are accessed by users and guests
     List<Role> roleList = new ArrayList<>();

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -72,8 +72,24 @@ class UserFormWidgetTest extends WidgetBase {
   }
 
   @Test
+  void postWithoutStepUpShowsReAuthPanel() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "roleId4", "4");
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      new UserFormWidget().post(widgetContext);
+    }
+    Assertions.assertEquals("true", widgetContext.getSharedRequestValue("stepUpRequired"));
+    Assertions.assertNull(widgetContext.getRedirect());
+  }
+
+  @Test
   void communityManagerCannotGrantAdminButKeepsAllowedRoles() throws Exception {
     setRoles(widgetContext, COMMUNITY_MANAGER);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "-1");        // create
     addQueryParameter(widgetContext, "roleId1", "1");    // content-editor (70) -- allowed
     addQueryParameter(widgetContext, "roleId4", "4");    // admin (100) -- must be refused
@@ -99,6 +115,7 @@ class UserFormWidgetTest extends WidgetBase {
   @Test
   void adminCanGrantAdmin() throws Exception {
     setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "-1");
     addQueryParameter(widgetContext, "roleId4", "4");    // admin
 
@@ -122,6 +139,7 @@ class UserFormWidgetTest extends WidgetBase {
   @Test
   void communityManagerCannotStripHigherRoleTheTargetAlreadyHolds() throws Exception {
     setRoles(widgetContext, COMMUNITY_MANAGER);
+    grantStepUp(widgetContext);
     addQueryParameter(widgetContext, "id", "5");         // editing an existing user
     addQueryParameter(widgetContext, "roleId1", "1");    // submits content-editor; admin left unchecked
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/userProfile/MyMfaSettingsWidgetTest.java
@@ -151,9 +151,26 @@ class MyMfaSettingsWidgetTest extends WidgetBase {
   }
 
   @Test
+  void postDisableWithoutStepUpShowsReAuthPanel() {
+    addQueryParameter(widgetContext, "action", "disable");
+    User user = new User();
+    user.setId(1L);
+    user.setMfaEnabled(true);
+    try (MockedStatic<UserRepository> repo = mockStatic(UserRepository.class)) {
+      repo.when(() -> UserRepository.findByUserId(anyLong())).thenReturn(user);
+      new MyMfaSettingsWidget().post(widgetContext);
+    }
+    Assertions.assertEquals("true", widgetContext.getSharedRequestValue("stepUpRequired"));
+    Assertions.assertEquals(MyMfaSettingsWidget.JSP, widgetContext.getJsp());
+    Assertions.assertNull(widgetContext.getSuccessMessage());
+  }
+
+  @Test
   void postDisableTurnsOffAndRedirects() {
     addQueryParameter(widgetContext, "action", "disable");
     when(request.getRequestURI()).thenReturn("/my-account");
+    // Disabling MFA requires a recent step-up (AC-6 / IA-2).
+    grantStepUp(widgetContext);
     User user = new User();
     user.setId(1L);
     user.setMfaEnabled(true);


### PR DESCRIPTION
## Summary

- Adds `StepUpAuthCommand` — issues a 5-minute session-scoped re-auth token after the acting user verifies their identity with a password or TOTP code. Every attempt (success or failure) is written to the audit log as `step-up.verify`.
- Adds `stepUpExpiresAt` to `UserSession` to track the token expiry.
- Gates four sensitive operations behind a valid step-up token:
  - **User role / group changes** (`UserFormWidget.post()`) — step-up prompt shown inline in the edit form.
  - **Password reset** (`UserDetailsWidget.post()`) — `resetPassword` converted from a JS `window.location.href` GET to a Foundation Reveal modal POST; credential field always visible in the modal.
  - **MFA disable** (`MyMfaSettingsWidget.post()`) — credential field added inline to the disable form.
  - **Content approval** (`ContentHtmlCommand.performContentApproval()` / `ContentWidget.post()`) — approve form converted from GET to POST; credential field added inline.

## Test plan

- [ ] Edit a user's roles while step-up is expired → prompted for credential; wrong credential → error; correct credential → saves and step-up token is stamped (next edit within 5 min skips prompt).
- [ ] Reset password via the new modal → credential required; correct → reset email sent, redirect back with success message.
- [ ] Disable MFA on own account → credential required in disable form.
- [ ] Approve governed-publishing content → credential required in the inline form.
- [ ] Verify audit log shows `step-up.verify success/failure` entries for each scenario.
- [ ] After 5 minutes the token expires and the prompt reappears.

Closes #298.