### PR TITLE
ci: push signed images to ACR with federated credential (#246)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -32,6 +32,10 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
+  # ACR_REGISTRY is the full login-server hostname (e.g. simiscms.azurecr.io).
+  # Set via a repository variable so the same workflow runs in forks without
+  # touching ACR. When the variable is absent the ACR steps are skipped.
+  ACR_REGISTRY: ${{ vars.ACR_LOGIN_SERVER }}
 
 jobs:
   publish:
@@ -61,6 +65,34 @@ jobs:
 
       - name: Sign in to the registry
         run: echo '${{ secrets.GITHUB_TOKEN }}' | docker login "$REGISTRY" -u '${{ github.actor }}' --password-stdin
+
+      # Resolve the version tag used for ACR pushes: the release tag name on a
+      # release event (e.g. v1.2.3), the commit SHA for every other trigger.
+      # Stored in VERSION_TAG so both image push steps can reference it.
+      - name: Resolve image version tag
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            echo "VERSION_TAG=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+          else
+            echo "VERSION_TAG=$GITHUB_SHA" >> "$GITHUB_ENV"
+          fi
+
+      # Workload-identity federation: no client secret is stored anywhere.
+      # Requires a federated credential in Azure AD scoped to this repo and the
+      # 'publish' environment (or branch/tag, per the federation subject).
+      # The three identifiers are non-sensitive and live as repository variables.
+      # Skip when ACR_REGISTRY is not set (forks, local branches).
+      - name: Sign in to Azure (OIDC)
+        if: env.ACR_REGISTRY != ''
+        uses: azure/login@a457d4c18e4d2c624a7c0db7c0a1dc41d1e74aff # v2.3.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign in to ACR
+        if: env.ACR_REGISTRY != ''
+        run: az acr login --name "$ACR_REGISTRY"
 
       # Syft generates the per-image SBOMs below (the same tool sbom.yml uses for
       # the WAR). Installed once here, before the images are built and scanned.
@@ -104,6 +136,18 @@ jobs:
         run: |
           docker push "$IMAGE_PREFIX/simis-cms:latest"
           docker push "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA"
+
+      # Mirror to ACR with a version tag (release tag or commit SHA) plus
+      # :latest. App Service follows :latest via its managed identity pull;
+      # the version tag lets a rollback pin to a known-good image without
+      # rebuilding. Skipped when ACR_REGISTRY is not set.
+      - name: Push the application image to ACR
+        if: env.ACR_REGISTRY != ''
+        run: |
+          docker tag "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA" "$ACR_REGISTRY/simis-cms:$VERSION_TAG"
+          docker tag "$IMAGE_PREFIX/simis-cms:$GITHUB_SHA" "$ACR_REGISTRY/simis-cms:latest"
+          docker push "$ACR_REGISTRY/simis-cms:$VERSION_TAG"
+          docker push "$ACR_REGISTRY/simis-cms:latest"
 
       # Signed build provenance: proves this exact image was built by this
       # workflow, from this commit -- verifiable with `gh attestation verify`.
@@ -198,6 +242,15 @@ jobs:
 
       - name: Publish the database image latest tag
         run: docker push "$IMAGE_PREFIX/simis-cms-db:latest"
+
+      # Same version-tag + :latest pattern as the application image above.
+      - name: Push the database image to ACR
+        if: env.ACR_REGISTRY != ''
+        run: |
+          docker tag "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA" "$ACR_REGISTRY/simis-cms-db:$VERSION_TAG"
+          docker tag "$IMAGE_PREFIX/simis-cms-db:$GITHUB_SHA" "$ACR_REGISTRY/simis-cms-db:latest"
+          docker push "$ACR_REGISTRY/simis-cms-db:$VERSION_TAG"
+          docker push "$ACR_REGISTRY/simis-cms-db:latest"
 
       - name: Attest the database image
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4


### PR DESCRIPTION
## Summary
- Extends `publish-images.yml` to mirror both images to Azure Container Registry on every publish run
- Authentication uses OIDC workload-identity federation — no registry password or client secret is stored anywhere
- ACR pushes land **after the existing Trivy scan gates** pass, preserving the "no vulnerable image reaches :latest" ordering
- All ACR steps are conditional on `vars.ACR_LOGIN_SERVER` being set, so the workflow still runs unchanged in forks

## How it works

**Auth flow**
1. `azure/login` exchanges the runner's OIDC token for an Azure AD access token using a federated credential configured in Azure AD for this repo
2. `az acr login` uses that token to authenticate to ACR — App Service then pulls using its own managed identity (`AcrPull`), so no registry credential lives in app settings

**Version tags**
| Trigger | ACR tags |
|---|---|
| `release` | `v1.2.3` + `latest` |
| `push` to main / schedule | `<commit-sha>` + `latest` |

`latest` lets App Service follow the rolling image; the version/SHA tag enables rollback pinning without rebuilding.

**Gate ordering preserved**
- App image: scan → gate → GHCR push → **ACR push** → attest/SBOM
- DB image: scan → commit-tag push → digest capture → gate → GHCR :latest → **ACR push** → attest/SBOM

## Required setup (before this workflow is useful)
Set these **repository variables** (Settings → Secrets and variables → Variables):
- `ACR_LOGIN_SERVER` — full login server, e.g. `simiscms.azurecr.io`
- `AZURE_CLIENT_ID` — app registration client ID
- `AZURE_TENANT_ID` — Azure AD tenant ID
- `AZURE_SUBSCRIPTION_ID` — subscription containing the registry

Configure a **federated credential** in the Azure AD app registration scoped to `repo:SimisRnD/simis-cms:ref:refs/heads/main` (and `refs/tags/*` for release triggers).

## Note on azure/login SHA
`azure/login@a457d4c18e4d2c624a7c0db7c0a1dc41d1e74aff # v2.3.0` — please verify this SHA matches the v2.3.0 tag on `Azure/login` before merging, per project pinning convention.

## Test plan
- [ ] Trigger `workflow_dispatch` with `ACR_LOGIN_SERVER` set; confirm both images appear in ACR with `<sha>` and `latest` tags
- [ ] Cut a test release tag; confirm images appear with the version tag (e.g. `v0.0.1-test`) in ACR
- [ ] Remove `ACR_LOGIN_SERVER` variable; confirm workflow completes without error (ACR steps skip cleanly)
- [ ] Confirm no registry credential appears in workflow logs or job summaries