### PR TITLE
Content scheduling: add publish_at and expires_at to web pages (#371)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveWebPageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveWebPageCommand.java
@@ -125,6 +125,8 @@ public class SaveWebPageCommand {
     webPage.setDraft(webPageBean.getDraft());
     webPage.setSitemapPriority(webPageBean.getSitemapPriority());
     webPage.setSitemapChangeFrequency(webPageBean.getSitemapChangeFrequency());
+    webPage.setPublishAt(webPageBean.getPublishAt());
+    webPage.setExpiresAt(webPageBean.getExpiresAt());
     WebPage result = WebPageRepository.save(webPage);
 
     if (result != null) {

--- a/src/main/java/com/simisinc/platform/domain/model/cms/WebPage.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/WebPage.java
@@ -55,6 +55,8 @@ public class WebPage extends Entity {
   private String draftPageXml = null;
   private String template = null;
   private String comments = null;
+  private Timestamp publishAt = null;
+  private Timestamp expiresAt = null;
 
   public WebPage() {
   }
@@ -250,5 +252,21 @@ public class WebPage extends Entity {
 
   public void setSitemapChangeFrequency(String sitemapChangeFrequency) {
     this.sitemapChangeFrequency = sitemapChangeFrequency;
+  }
+
+  public Timestamp getPublishAt() {
+    return publishAt;
+  }
+
+  public void setPublishAt(Timestamp publishAt) {
+    this.publishAt = publishAt;
+  }
+
+  public Timestamp getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(Timestamp expiresAt) {
+    this.expiresAt = expiresAt;
   }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -126,7 +126,9 @@ public class WebPageRepository {
         .add("page_image_url", record.getImageUrl())
         .add("has_redirect", StringUtils.trimToNull(record.getRedirectUrl()) != null)
         .add("sitemap_priority", record.getSitemapPriority())
-        .add("sitemap_changefreq", StringUtils.trimToNull(record.getSitemapChangeFrequency()));
+        .add("sitemap_changefreq", StringUtils.trimToNull(record.getSitemapChangeFrequency()))
+        .add("publish_at", record.getPublishAt())
+        .add("expires_at", record.getExpiresAt());
     record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
     if (record.getId() == -1) {
       LOG.error("An id was not set!");
@@ -162,7 +164,9 @@ public class WebPageRepository {
         .add("page_image_url", record.getImageUrl())
         .add("has_redirect", StringUtils.trimToNull(record.getRedirectUrl()) != null)
         .add("sitemap_priority", record.getSitemapPriority())
-        .add("sitemap_changefreq", StringUtils.trimToNull(record.getSitemapChangeFrequency()));
+        .add("sitemap_changefreq", StringUtils.trimToNull(record.getSitemapChangeFrequency()))
+        .add("publish_at", record.getPublishAt())
+        .add("expires_at", record.getExpiresAt());
     SqlUtils where = new SqlUtils()
         .add("web_page_id = ?", record.getId());
     if (DB.update(TABLE_NAME, updateValues, where)) {
@@ -243,6 +247,8 @@ public class WebPageRepository {
       record.setShowInSitemap(rs.getBoolean("show_in_sitemap"));
       record.setSitemapPriority(rs.getBigDecimal("sitemap_priority"));
       record.setSitemapChangeFrequency(rs.getString("sitemap_changefreq"));
+      record.setPublishAt(rs.getTimestamp("publish_at"));
+      record.setExpiresAt(rs.getTimestamp("expires_at"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -215,6 +215,20 @@ public class PageServlet extends HttpServlet {
             return;
           }
         }
+        // Enforce publish schedule and expiry for non-editors
+        if (!userSession.hasRole("admin") && !userSession.hasRole("content-manager")) {
+          Timestamp now = new Timestamp(System.currentTimeMillis());
+          if (webPage.getPublishAt() != null && webPage.getPublishAt().after(now)) {
+            controllerSession.clearAllWidgetData();
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+          }
+          if (webPage.getExpiresAt() != null && webPage.getExpiresAt().before(now)) {
+            controllerSession.clearAllWidgetData();
+            response.sendError(HttpServletResponse.SC_GONE);
+            return;
+          }
+        }
         // Determine if this is a redirect
         String redirectLocation = webPage.getRedirectUrl();
         if (StringUtils.isNotBlank(redirectLocation)) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
@@ -116,11 +116,29 @@ public class WebPageFormWidget extends GenericWidget {
 
     // Parse optional scheduling timestamps (BeanUtils cannot convert String → Timestamp)
     String publishAtStr = context.getParameter("publishAt");
-    webPageBean.setPublishAt(StringUtils.isBlank(publishAtStr) ? null
-        : Timestamp.valueOf(publishAtStr.replace("T", " ") + ":00"));
+    if (StringUtils.isBlank(publishAtStr)) {
+      webPageBean.setPublishAt(null);
+    } else {
+      try {
+        webPageBean.setPublishAt(Timestamp.valueOf(publishAtStr.replace("T", " ") + ":00"));
+      } catch (IllegalArgumentException e) {
+        context.setErrorMessage("Go live date format is not valid");
+        context.setRequestObject(webPageBean);
+        return context;
+      }
+    }
     String expiresAtStr = context.getParameter("expiresAt");
-    webPageBean.setExpiresAt(StringUtils.isBlank(expiresAtStr) ? null
-        : Timestamp.valueOf(expiresAtStr.replace("T", " ") + ":00"));
+    if (StringUtils.isBlank(expiresAtStr)) {
+      webPageBean.setExpiresAt(null);
+    } else {
+      try {
+        webPageBean.setExpiresAt(Timestamp.valueOf(expiresAtStr.replace("T", " ") + ":00"));
+      } catch (IllegalArgumentException e) {
+        context.setErrorMessage("Expire date format is not valid");
+        context.setRequestObject(webPageBean);
+        return context;
+      }
+    }
 
     // Set the server values
     webPageBean.setCreatedBy(context.getUserId());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
@@ -29,6 +29,7 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;
+import java.sql.Timestamp;
 
 /**
  * Widget for displaying a system administration form to add/update web pages
@@ -112,6 +113,14 @@ public class WebPageFormWidget extends GenericWidget {
     if (StringUtils.isBlank(showInSitemap)) {
       webPageBean.setShowInSitemap(false);
     }
+
+    // Parse optional scheduling timestamps (BeanUtils cannot convert String → Timestamp)
+    String publishAtStr = context.getParameter("publishAt");
+    webPageBean.setPublishAt(StringUtils.isBlank(publishAtStr) ? null
+        : Timestamp.valueOf(publishAtStr.replace("T", " ") + ":00"));
+    String expiresAtStr = context.getParameter("expiresAt");
+    webPageBean.setExpiresAt(StringUtils.isBlank(expiresAtStr) ? null
+        : Timestamp.valueOf(expiresAtStr.replace("T", " ") + ":00"));
 
     // Set the server values
     webPageBean.setCreatedBy(context.getUserId());

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -120,7 +120,9 @@ CREATE TABLE web_pages (
   show_in_sitemap BOOLEAN DEFAULT true,
   has_redirect BOOLEAN DEFAULT false,
   sitemap_priority NUMERIC(2,1) DEFAULT 0.5,
-  sitemap_changefreq VARCHAR(20)
+  sitemap_changefreq VARCHAR(20),
+  publish_at TIMESTAMP,
+  expires_at TIMESTAMP
 );
 CREATE INDEX web_pages_link_idx ON web_pages(link);
 CREATE INDEX web_pages_search_idx ON web_pages(searchable);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__web_page_scheduling.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__web_page_scheduling.sql
@@ -1,0 +1,5 @@
+-- Adds optional scheduling fields to web_pages so editors can set a future go-live
+-- date (publish_at) and an automatic expiry date (expires_at). Both are nullable;
+-- existing pages with null values behave identically to today.
+ALTER TABLE web_pages ADD COLUMN IF NOT EXISTS publish_at TIMESTAMP;
+ALTER TABLE web_pages ADD COLUMN IF NOT EXISTS expires_at TIMESTAMP;

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -91,6 +91,20 @@
         </div>
       </label>
       <div class="grid-x grid-padding-x">
+        <div class="small-12 medium-6 cell">
+          <c:set var="publishAtFormatted"><c:if test="${!empty webPage.publishAt}"><fmt:formatDate pattern="yyyy-MM-dd'T'HH:mm" value="${webPage.publishAt}"/></c:if></c:set>
+          <label>Go live at (optional)
+            <input type="datetime-local" name="publishAt" value="${publishAtFormatted}">
+          </label>
+        </div>
+        <div class="small-12 medium-6 cell">
+          <c:set var="expiresAtFormatted"><c:if test="${!empty webPage.expiresAt}"><fmt:formatDate pattern="yyyy-MM-dd'T'HH:mm" value="${webPage.expiresAt}"/></c:if></c:set>
+          <label>Expire at (optional)
+            <input type="datetime-local" name="expiresAt" value="${expiresAtFormatted}">
+          </label>
+        </div>
+      </div>
+      <div class="grid-x grid-padding-x">
         <div class="small-12 medium-3 cell">
           <label>Show in Sitemap.xml?
             <div class="switch large">


### PR DESCRIPTION
## Summary
- Adds optional `publish_at` and `expires_at` timestamp fields to `WebPage`, persisted in two new nullable columns on `web_pages`
- `PageServlet` checks both fields at request time (after the existing draft check): future `publish_at` → 404 for non-editors; past `expires_at` → 410 Gone for non-editors; admins and content-managers bypass both
- `WebPageFormWidget` parses the `datetime-local` input strings and sets the fields on the bean; `SaveWebPageCommand` passes them through to the repository
- `web-page-form.jsp` adds two optional date-time pickers ("Go live at" / "Expire at") below the Publish switch
- No behavior change for pages with both fields null (all existing pages)

## Migration
`UPGRADE_20260725.1002__web_page_scheduling.sql` — two `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`

## Test plan
- [ ] Existing pages with no schedule: behavior identical to before
- [ ] Set `publish_at` to a future time: page returns 404 to visitors, visible to admin/content-manager
- [ ] Set `publish_at` to a past time: page loads normally for visitors
- [ ] Set `expires_at` to a past time: page returns 410 to visitors, visible to admin/content-manager
- [ ] Set `expires_at` to a future time: page loads normally for visitors
- [ ] Form round-trip: save a page with both dates, reload form, dates pre-fill correctly
- [ ] Clearing both fields (blank inputs) saves null and restores normal behavior