### PR TITLE
Harden Host-header redirect validation across PageServlet and both request filters (GH-362)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/HostnameCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/HostnameCommand.java
@@ -89,4 +89,26 @@ public class HostnameCommand {
     return hostnameAllowList != null && !hostnameAllowList.isEmpty() && hostnameAllowList.contains(hostname);
   }
 
+  /**
+   * Restricts a request URI so it is safe to append to a base URL in a redirect Location header.
+   * Rejects protocol-relative paths, backslash variants, and control characters that could change
+   * the redirect host or split the header. Anything unexpected collapses to "/".
+   *
+   * @param requestURI the value of HttpServletRequest.getRequestURI()
+   * @return the same path when it is a plain absolute path, otherwise "/"
+   */
+  public static String safeRedirectPath(String requestURI) {
+    if (requestURI == null || !requestURI.startsWith("/") || requestURI.startsWith("//")
+        || requestURI.startsWith("/\\")) {
+      return "/";
+    }
+    for (int i = 0; i < requestURI.length(); i++) {
+      char c = requestURI.charAt(i);
+      if (c < 0x20 || c == 0x7f) {
+        return "/";
+      }
+    }
+    return requestURI;
+  }
+
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -220,12 +220,21 @@ public class PageServlet extends HttpServlet {
         if (StringUtils.isNotBlank(redirectLocation)) {
           // Handle a redirect immediately
           if (!redirectLocation.startsWith("http:") && !redirectLocation.startsWith("https:")) {
-            redirectLocation =
-                scheme + "://" +
-                    serverName +
-                    (port != 80 ? ":" + port : "") +
-                    (redirectLocation.startsWith("/") ? "" : "/") +
-                    redirectLocation;
+            String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
+            String baseUrl;
+            if (siteUrl != null) {
+              try {
+                java.net.URI siteUri = new java.net.URI(siteUrl);
+                int sitePort = siteUri.getPort();
+                baseUrl = siteUri.getScheme() + "://" + siteUri.getHost() +
+                    (sitePort != -1 ? ":" + sitePort : "");
+              } catch (java.net.URISyntaxException e) {
+                baseUrl = scheme + "://" + serverName + (port != 80 ? ":" + port : "");
+              }
+            } else {
+              baseUrl = scheme + "://" + serverName + (port != 80 ? ":" + port : "");
+            }
+            redirectLocation = baseUrl + (redirectLocation.startsWith("/") ? "" : "/") + redirectLocation;
           }
           response.setHeader("Location", redirectLocation);
           response.setStatus(SC_MOVED_PERMANENTLY);

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -184,17 +184,22 @@ public class WebRequestFilter implements Filter {
     if (requireSSL && !"https".equalsIgnoreCase(scheme)) {
       if (!"localhost".equals(request.getServerName()) && !InetAddressUtils.isIPv4(request.getServerName())
           && !InetAddressUtils.isIPv6(request.getServerName())) {
-        String requestURL = httpServletRequest.getRequestURL().toString();
-        requestURL = StringUtils.replace(requestURL, "http://", "https://");
-        // The request URL is built from the client-supplied Host header, so it is only echoed back when the
-        // hostname is named by an allow list. Otherwise prefer the configured site, because the allow list is
-        // empty unless an operator created hostname-allow-list.csv, and an empty list vouches for nothing.
-        String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
-        if (siteUrl != null && !HostnameCommand.isExplicitlyAllowed(request.getServerName())) {
-          requestURL = StringUtils.removeEnd(siteUrl, "/") + safeRedirectPath(requestURI);
+        String redirectURL;
+        if (HostnameCommand.isExplicitlyAllowed(request.getServerName())) {
+          // Operator-listed hostname: safe to echo the Host header back in the Location
+          redirectURL = StringUtils.replace(httpServletRequest.getRequestURL().toString(), "http://", "https://");
+        } else {
+          String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
+          if (siteUrl == null) {
+            // No site.url and no allow list — cannot determine the canonical host safely; skip SSL redirect
+            LOG.warn("SSL redirect skipped: site.url is not configured and hostname is not allow-listed");
+            chain.doFilter(request, servletResponse);
+            return;
+          }
+          redirectURL = StringUtils.removeEnd(siteUrl, "/") + safeRedirectPath(requestURI);
         }
-        LOG.debug("Redirecting to: " + requestURL);
-        do301(servletResponse, requestURL);
+        LOG.debug("Redirecting to: " + redirectURL);
+        do301(servletResponse, redirectURL);
         return;
       }
     }
@@ -561,19 +566,7 @@ public class WebRequestFilter implements Filter {
    * @return the same path when it is a plain absolute path, otherwise "/"
    */
   static String safeRedirectPath(String requestURI) {
-    // Must be an absolute path; reject protocol-relative ("//host") and backslash variants a browser reads as a host
-    if (requestURI == null || !requestURI.startsWith("/") || requestURI.startsWith("//")
-        || requestURI.startsWith("/\\")) {
-      return "/";
-    }
-    // Reject control characters, including the CR and LF that could split the response header
-    for (int i = 0; i < requestURI.length(); i++) {
-      char c = requestURI.charAt(i);
-      if (c < 0x20 || c == 0x7f) {
-        return "/";
-      }
-    }
-    return requestURI;
+    return HostnameCommand.safeRedirectPath(requestURI);
   }
 
   private void doHealthCheck(ServletRequest request, ServletResponse servletResponse) throws IOException {

--- a/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
@@ -127,10 +127,20 @@ public class RestRequestFilter implements Filter {
       if (!isLocal
           && !InetAddressUtils.isIPv4(request.getServerName())
           && !InetAddressUtils.isIPv6(request.getServerName())) {
-        String requestURL = ((HttpServletRequest) request).getRequestURL().toString();
-        requestURL = StringUtils.replace(requestURL, "http://", "https://");
-        LOG.debug("Redirecting to: " + requestURL);
-        do301(servletResponse, requestURL);
+        String redirectURL;
+        if (HostnameCommand.isExplicitlyAllowed(request.getServerName())) {
+          redirectURL = StringUtils.replace(((HttpServletRequest) request).getRequestURL().toString(), "http://", "https://");
+        } else {
+          String siteUrl = StringUtils.trimToNull(LoadSitePropertyCommand.loadByName("site.url"));
+          if (siteUrl == null) {
+            LOG.warn("SSL redirect skipped: site.url is not configured and hostname is not allow-listed");
+            chain.doFilter(request, servletResponse);
+            return;
+          }
+          redirectURL = StringUtils.removeEnd(siteUrl, "/") + HostnameCommand.safeRedirectPath(requestURI);
+        }
+        LOG.debug("Redirecting to: " + redirectURL);
+        do301(servletResponse, redirectURL);
         return;
       }
     }

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
@@ -120,7 +120,9 @@ class WebRequestFilterTest {
   }
 
   @Test
-  void sslRedirectFallsBackToTheRequestUrlWhenSiteUrlIsNotConfigured() throws Exception {
+  void sslRedirectIsSkippedWhenSiteUrlIsBlankAndHostnameIsNotAllowListed() throws Exception {
+    // When site.url is blank and the hostname is not on the allow-list the filter cannot safely determine the
+    // canonical redirect target, so it passes the request through rather than echoing the untrusted Host header.
     HttpServletResponse response = mock(HttpServletResponse.class);
     FilterChain chain = mock(FilterChain.class);
 
@@ -133,10 +135,12 @@ class WebRequestFilterTest {
       blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
       siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn("");
 
+      HttpServletRequest request = httpRequestOverPlainHttp("www.example.com");
       WebRequestFilter filter = filterRequiringSSL(siteProperties);
-      filter.doFilter(httpRequestOverPlainHttp("www.example.com"), response, chain);
+      filter.doFilter(request, response, chain);
 
-      verify(response).setHeader("Location", "https://www.example.com/about");
+      verify(response, never()).setHeader(anyString(), anyString());
+      verify(chain).doFilter(request, response);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes Host-header injection in redirect \`Location\` headers across three sites.

**\`PageServlet\` — relative-path page redirect (HIGH)**
- DB-stored \`redirectUrl\` values that are relative paths were assembled using \`getScheme()\` + \`getServerName()\` + \`getServerPort()\`, all of which reflect the client-supplied \`Host\` header. Now loads \`site.url\` from config via \`java.net.URI\`; falls back to the request host only when \`site.url\` is unconfigured.

**\`RestRequestFilter\` — SSL redirect (HIGH)**
- Had no \`site.url\` fallback at all: \`getRequestURL()\` (Host-header derived) was always written verbatim into \`Location\`. Now: if the hostname is operator-listed in \`hostname-allow-list.csv\`, echoes it back (explicit trust); otherwise uses \`site.url\` + \`safeRedirectPath()\`; skips the redirect entirely if neither is configured.

**\`WebRequestFilter\` — SSL redirect (MEDIUM)**
- Previously fell through to raw \`getRequestURL()\` when \`site.url\` was null and the hostname was not allow-listed. Now skips the redirect in that case and logs a warning.

**\`HostnameCommand.safeRedirectPath()\` (new)**
- Centralises path sanitisation (rejects \`//host\`, backslash, and header-splitting control characters). Both filters delegate to this one implementation.

## Test plan

- [ ] SSL redirect (\`requireSSL=true\`): verify \`Location\` uses the configured \`site.url\` origin, not the \`Host\` header
- [ ] Send \`Host: evil.example.com\` with an HTTP request — \`Location\` must not contain \`evil.example.com\`
- [ ] Allow-listed hostname: redirect echoes the allow-listed host
- [ ] No \`site.url\` configured, no allow list: SSL redirect is skipped (warning logged)
- [ ] REST API (\`/api/*\`): same Host-header test
- [ ] Relative-path page redirect: \`Location\` uses \`site.url\` as the base

Closes #362