### PR TITLE
Add CSRF token validation to logout (#359)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebRequestFilter.java
@@ -170,6 +170,18 @@ public class WebRequestFilter implements Filter {
 
     // Handle logouts immediately
     if (resource.equals("/logout")) {
+      // CSRF: validate the session token before processing logout
+      HttpSession httpSession = httpServletRequest.getSession(false);
+      if (httpSession != null) {
+        UserSession logoutUserSession = (UserSession) httpSession.getAttribute(SessionConstants.USER);
+        if (logoutUserSession != null && logoutUserSession.isLoggedIn()) {
+          String providedToken = httpServletRequest.getParameter("token");
+          if (!logoutUserSession.getFormToken().equals(providedToken)) {
+            do302(servletResponse, contextPath + "/");
+            return;
+          }
+        }
+      }
       // Log out of the system
       LogoutCommand.logout((HttpServletRequest) request, ((HttpServletResponse) servletResponse));
       // Redirect to OAuth Provider via the home page

--- a/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
@@ -133,7 +133,7 @@
             <c:if test="${userSession.hasRole('admin') || userSession.hasRole('content-manager') || userSession.hasRole('community-manager') || userSession.hasRole('data-manager') || userSession.hasRole('ecommerce-manager')}">
               <li><a href="${ctx}/admin"><i class="fa fa-cog fa-fw"></i> Admin</a></li>
             </c:if>
-            <li><a href="${ctx}/logout"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
+            <li><a href="${ctx}/logout?token=${userSession.formToken}"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
           </ul>
         </li>
         <%--<li class="menu-text"><a class="no-menu" href="#"><i class="fa fa-bell fa-fw"></i></a></li>--%>
@@ -200,7 +200,7 @@
                             <c:if test="${userSession.hasRole('admin') || userSession.hasRole('content-manager') || userSession.hasRole('community-manager') || userSession.hasRole('data-manager') || userSession.hasRole('ecommerce-manager')}">
                               <li><a href="${ctx}/admin"><i class="fa fa-cog fa-fw"></i> Admin</a></li>
                             </c:if>
-                            <li><a href="${ctx}/logout"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
+                            <li><a href="${ctx}/logout?token=${userSession.formToken}"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
                           </ul>
                         </li>
                         <%--<li class="menu-text"><a class="no-menu" href="#"><i class="fa fa-bell fa-fw"></i></a></li>--%>
@@ -307,7 +307,7 @@
                       <c:if test="${userSession.hasRole('admin') || userSession.hasRole('content-manager') || userSession.hasRole('community-manager') || userSession.hasRole('data-manager') || userSession.hasRole('ecommerce-manager')}">
                         <li><a href="${ctx}/admin"><i class="fa fa-cog fa-fw"></i> Admin</a></li>
                       </c:if>
-                      <li><a href="${ctx}/logout"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
+                      <li><a href="${ctx}/logout?token=${userSession.formToken}"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
                     </ul>
                   </li>
                   <%--<li class="menu-text"><a class="no-menu" href="#"><i class="fa fa-bell fa-fw"></i></a></li>--%>
@@ -553,7 +553,7 @@
                     <c:if test="${userSession.hasRole('admin') || userSession.hasRole('content-manager') || userSession.hasRole('community-manager') || userSession.hasRole('data-manager') || userSession.hasRole('ecommerce-manager')}">
                       <li><a href="${ctx}/admin"><i class="fa fa-cog fa-fw"></i> Admin</a></li>
                     </c:if>
-                    <li><a href="${ctx}/logout"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
+                    <li><a href="${ctx}/logout?token=${userSession.formToken}"><i class="fa fa-sign-out fa-fw"></i> Log Out</a></li>
                   </ul>
                 </li>
                 <%--<li class="menu-text"><a class="no-menu" href="#"><i class="fa fa-bell fa-fw"></i></a></li>--%>


### PR DESCRIPTION
## Summary
- Fixes CSRF vulnerability on the `/logout` endpoint in `WebRequestFilter.java`
- A GET-based logout with no CSRF protection lets any third-party page silently sign out a logged-in user by embedding a link or image pointing at `/logout`
- Fix: `WebRequestFilter` now validates the session `formToken` against a `token` query parameter before calling `LogoutCommand.logout()`; requests from users who are not logged in pass through unchanged
- All four logout links in `layout-header-standard.jspf` now carry `?token=${userSession.formToken}` so legitimate sign-outs work correctly

## Test plan
- [ ] Logged-in user clicks Log Out — should sign out successfully
- [ ] Logged-in user navigates directly to `/logout` without a token — should be redirected to home, session unchanged
- [ ] Logged-in user navigates to `/logout?token=wrong` — should be redirected to home, session unchanged
- [ ] Unauthenticated request to `/logout` — no error, redirects normally

Closes #359