### PR TITLE
Migrate state-changing GET actions to POST; add Referrer-Policy header (#358)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -161,6 +161,7 @@ public class PageServlet extends HttpServlet {
     // X-Frame-Options above for modern browsers. A stricter script-src policy needs nonces across the JSPs and is
     // left to a later, report-only-first rollout.
     response.setHeader("Content-Security-Policy", "base-uri 'self'; object-src 'none'; frame-ancestors 'self'");
+    response.setHeader("Referrer-Policy", "same-origin");
     // Advertise HTTPS-only via HSTS, but only when the deployment is configured for SSL. Sending this from a
     // site that cannot serve HTTPS would make browsers refuse it for the max-age, so it is gated on system.ssl
     // rather than the per-request scheme, which also stays correct behind a TLS-terminating proxy.

--- a/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
@@ -64,7 +64,7 @@
     <tr>
       <td nowrap="true">
         <c:out value="${text:trim(record.ipAddress, 24, true)}" />
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&blockedIPListId=${record.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(record.ipAddress)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(record.ipAddress)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&blockedIPListId=${record.id}');"><i class="fa fa-remove"></i></a>
       </td>
       <td><c:out value='${geoip:location(record.ipAddress, " ")}'/></td>
       <td nowrap="true"><small<c:if test="${fn:length(record.reason) > 40}"> title="<c:out value="${record.reason}" />"</c:if>><c:out value="${text:trim(record.reason, 40, true)}" /></small></td>

--- a/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
@@ -27,7 +27,7 @@
     if (!confirm("Are you sure you want to delete this blog and all of its posts?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + blogId;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + blogId);
   }
 </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-list.jsp
@@ -27,7 +27,7 @@
     if (!confirm("Are you sure you want to delete this calendar and all of its events?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + calendarId;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + calendarId);
   }
 </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/admin/collection-categories-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/collection-categories-list.jsp
@@ -61,7 +61,7 @@
           </c:otherwise>
         </c:choose>
         <a href="${ctx}/admin/category?collectionId=${collection.id}&categoryId=${category.id}"><c:out value="${category.name}" /></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&categoryId=${category.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(category.name)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(category.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&categoryId=${category.id}');"><i class="fa fa-remove"></i></a>
         <c:if test="${!empty category.description}">
           <br /><small><c:out value="${category.description}" /></small>
         </c:if>

--- a/src/main/webapp/WEB-INF/jsp/admin/collection-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/collection-details.jsp
@@ -37,7 +37,7 @@
   <button class="button small radius secondary float-left margin-left-10"><i class="fa fa-download"></i> Download Items</button>
 </form>
 --%>
-<a class="button small radius alert margin-left-10" href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&collectionId=${collection.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(collection.name)}" />?');"><i class="fa fa-remove"></i> Delete</a>
+<a class="button small radius alert margin-left-10" href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(collection.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&collectionId=${collection.id}');"><i class="fa fa-remove"></i> Delete</a>
 <p class="callout box radius">
   <c:if test="${!empty collection.description}">
     <small class="subheader"><c:out value="${collection.description}" /></small><br />

--- a/src/main/webapp/WEB-INF/jsp/admin/collection-relationships-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/collection-relationships-list.jsp
@@ -58,7 +58,7 @@
             <a href="${ctx}/admin/collection-details?collectionId=${relationship.relatedCollectionId}"><c:out value="${collection:name(relationship.relatedCollectionId)}" /></a>
           </c:otherwise>
         </c:choose>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&relationshipId=${relationship.id}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape('this relationship')}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to remove <c:out value="${js:escape('this relationship')}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&relationshipId=${relationship.id}');"><i class="fa fa-remove"></i></a>
       </td>
     </tr>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/datasets-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/datasets-list.jsp
@@ -136,7 +136,7 @@
       <td>
         <a title="Modify dataset" href="${ctx}/admin/dataset-mapper?datasetId=${dataset.id}"><small><i class="${font:fas()} fa-edit"></i></small></a>
         <a href="${ctx}/assets/dataset/${dataset.url}"><i class="fa fa-download"></i></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&datasetId=${dataset.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(dataset.name)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(dataset.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&datasetId=${dataset.id}');"><i class="fa fa-remove"></i></a>
         <%--<a href="${ctx}/admin/dataset?datasetId=${dataset.id}"><i class="fas fa-edit"></i></a>--%>
       </td>
     </tr>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-details.jsp
@@ -30,7 +30,7 @@
   <c:if test="${userSession.hasRole('admin')}">
     <small>
       <a href="${ctx}/admin/folder?folderId=${folder.id}&returnPage=${widgetContext.uri}?folderId=${folder.id}"><i class="${font:fas()} fa-edit"></i></a>
-      <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&folderId=${folder.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(folder.name)}" />?');"><i class="fa fa-remove"></i></a>
+      <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(folder.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&folderId=${folder.id}');"><i class="fa fa-remove"></i></a>
     </small>
   </c:if>
 </h3>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -112,7 +112,7 @@
           <a title="Download file" href="${ctx}/assets/file/${file.url}"><i class="fa fa-download"></i></a>
         </c:if>
         <c:if test="${canDelete eq 'true'}">
-          <a title="Delete file" href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&fileId=${file.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(file.filename)}" />?');"><i class="fa fa-remove"></i></a>
+          <a title="Delete file" href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(file.filename)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&fileId=${file.id}');"><i class="fa fa-remove"></i></a>
         </c:if>
       </td>
       <td class="text-center" nowrap>

--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -28,19 +28,19 @@
     if (!confirm("Mark as processed?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=markAsProcessed&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId;
+    postAction('${widgetContext.uri}?action=markAsProcessed&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId);
   }
   function claimForm(dataId) {
     if (!confirm("Add this record to your list?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=claim&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId;
+    postAction('${widgetContext.uri}?action=claim&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId);
   }
   function archiveForm(dataId) {
     if (!confirm("Are you sure you want to archive this record and hide it?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=archive&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId;
+    postAction('${widgetContext.uri}?action=archive&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&dataId=' + dataId);
   }
 </script>
 <c:if test="${!empty title}">

--- a/src/main/webapp/WEB-INF/jsp/admin/groups-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/groups-list.jsp
@@ -44,7 +44,7 @@
       <td class="text-center"><fmt:formatNumber value="${group.userCount}" /></td>
       <td>
         <a href="${ctx}/admin/group?groupId=${group.id}"><i class="${font:fas()} fa-edit"></i></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&groupId=${group.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(group.name)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(group.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&groupId=${group.id}');"><i class="fa fa-remove"></i></a>
       </td>
     </tr>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-lists.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-lists.jsp
@@ -69,7 +69,7 @@
       <td class="text-center">
         <a href="${ctx}/admin/mailing-list?mailingListId=${mailingList.id}&returnPage=/admin/mailing-lists"><i class="${font:fas()} fa-edit"></i></a>
         <c:if test="${mailingList.memberCount lt 11}">
-          <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(mailingList.name)}" />?');"><i class="fa fa-remove"></i></a>
+          <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(mailingList.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}');"><i class="fa fa-remove"></i></a>
         </c:if>
       </td>
     </tr>

--- a/src/main/webapp/WEB-INF/jsp/admin/product-categories-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/product-categories-list.jsp
@@ -64,7 +64,7 @@
       </td>
       <td>
         <a href="${ctx}/admin/product-category?productCategoryId=${productCategory.id}&returnPage=/admin/product-categories"><i class="fa fa-edit"></i></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&productCategoryId=${productCategory.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(productCategory.name)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(productCategory.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&productCategoryId=${productCategory.id}');"><i class="fa fa-remove"></i></a>
       </td>
     </tr>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/product-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/product-list.jsp
@@ -131,7 +131,7 @@
           </c:if>
           <a href="${ctx}/admin/product?productId=${product.id}&returnPage=/admin/products"><i class="fa fa-edit"></i></a>
           <c:if test="${product.orderCount eq 0}">
-            <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&productId=${product.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(product.name)}" />?');"><i class="fa fa-remove"></i></a>
+            <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(product.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&productId=${product.id}');"><i class="fa fa-remove"></i></a>
           </c:if>
         </td>
       </tr>

--- a/src/main/webapp/WEB-INF/jsp/admin/sales-tax-nexus-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sales-tax-nexus-list.jsp
@@ -47,7 +47,7 @@
       <td><c:out value="${address.country}" /></td>
       <td>
         <a href="${ctx}/admin/sales-tax-nexus-address?addressId=${address.id}&returnPage=/admin/sales-tax-nexus"><i class="fa fa-edit"></i></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&addressId=${address.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(address.street)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(address.street)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&addressId=${address.id}');"><i class="fa fa-remove"></i></a>
       </td>
     </tr>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/shipping-rates-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/shipping-rates-list.jsp
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a href="${ctx}/admin/shipping-rate?shippingRateId=${shippingRate.id}&returnPage=/admin/shipping-rates"><i class="fa fa-edit"></i></a>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&shippingRateId=${shippingRate.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(shippingRate.shippingCode)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(shippingRate.shippingCode)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&shippingRateId=${shippingRate.id}');"><i class="fa fa-remove"></i></a>
       </td>
     </tr>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -121,14 +121,14 @@
     if (!confirm("Are you sure you want to delete this menu tab and all of its submenu items?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index);
   }
 
   function deleteMenuItem(index) {
     if (!confirm("Are you sure you want to delete this sub menu item?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index);
   }
 
   <%--

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
@@ -146,14 +146,14 @@
     if (!confirm("Are you sure you want to delete this menu tab and all of its submenu items?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index);
   }
 
   function deleteMenuItem(index) {
     if (!confirm("Are you sure you want to delete this sub menu item?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index);
   }
 
   <%--

--- a/src/main/webapp/WEB-INF/jsp/admin/sub-folder-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sub-folder-details.jsp
@@ -29,7 +29,7 @@
   <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
     <small>
       <a href="${ctx}/admin/sub-folder?subFolderId=${subFolder.id}&returnPage=${widgetContext.uri}/admin/sub-folder-details%3FsubFolderId=${subFolder.id}%26folderId=${subFolder.folderId}"><i class="fa fa-edit"></i></a>
-      <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&subFolderId=${subFolder.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(subFolder.name)}" />?');"><i class="fa fa-remove"></i></a>
+      <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(subFolder.name)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&subFolderId=${subFolder.id}');"><i class="fa fa-remove"></i></a>
     </small>
   </c:if>
 </h3>

--- a/src/main/webapp/WEB-INF/jsp/admin/theme-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/theme-editor.jsp
@@ -24,7 +24,7 @@ function deleteTheme(themeId) {
   if (!confirm("Are you sure you want to DELETE this theme?")) {
     return;
   }
-  window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id='+themeId;
+  postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id='+themeId);
 }
 </script>
 <%-- Title and Message block --%>
@@ -37,7 +37,7 @@ function deleteTheme(themeId) {
   <ol>
     <c:forEach items="${themeList}" var="thisTheme">
       <li>
-        <a href="${widgetContext.uri}?action=restore&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=${thisTheme.id}"><c:out value="${thisTheme.name}"/></a>
+        <a href="#" onclick="postAction('${widgetContext.uri}?action=restore&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=${thisTheme.id}'); return false;"><c:out value="${thisTheme.name}"/></a>
         <a href="javascript:deleteTheme(${thisTheme.id})"><i class="fa fa-trash-o"></i></a>
       </li>
     </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -31,31 +31,31 @@
     if (!confirm("Are you sure you want to reset the password on this account? An email with instructions will be sent to the user.")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=resetPassword&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+    postAction('${widgetContext.uri}?action=resetPassword&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}');
   }
   function suspendAccount() {
     if (!confirm("Are you sure you want to SUSPEND this user account?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=suspendAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+    postAction('${widgetContext.uri}?action=suspendAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}');
   }
   function restoreAccount() {
     if (!confirm("Are you sure you want to RESTORE this user account?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=restoreAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+    postAction('${widgetContext.uri}?action=restoreAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}');
   }
   function deleteAccount() {
     if (!confirm("Are you sure you want to DELETE this user account?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=deleteAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+    postAction('${widgetContext.uri}?action=deleteAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}');
   }
   function unlockAccount() {
     if (!confirm("Are you sure you want to UNLOCK this user account? This clears the failed login attempts and lockout.")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?action=unlockAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}';
+    postAction('${widgetContext.uri}?action=unlockAccount&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&userId=${user.id}');
   }
 </script>
 <div style="margin-top: 6px;background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;">

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -45,7 +45,7 @@
           if (!confirm("Are you sure you want to DELETE this page?")) {
               return;
           }
-          window.location.href = '${widgetContext.uri}?action=deletePage&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&webPageId=${webPage.id}';
+          postAction('${widgetContext.uri}?action=deletePage&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&webPageId=${webPage.id}');
       }
     </c:if>
 </script>

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-list-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-list-editor.jsp
@@ -37,7 +37,7 @@
     <c:forEach items="${webPageList}" var="webPage">
     <tr>
       <td>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&webPageId=${group.id}" onclick="return confirm('Are you sure you want to delete <c:out value="${js:escape(webPage.link)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(webPage.link)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&webPageId=${group.id}');"><i class="fa fa-remove"></i></a>
         <a href="${ctx}/admin/web-page?webPageId=${group.id}"><i class="fa fa-edit"></i></a>
       </td>
       <td>

--- a/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
@@ -26,7 +26,7 @@
     if (!confirm("Are you sure you want to delete this wiki and all of its pages?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + wikiId;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + wikiId);
   }
 </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -382,7 +382,7 @@
       if (!confirm("Are you sure you want to DELETE this event?")) {
         return;
       }
-      window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + encodeURIComponent(document.getElementById('id').value);
+      postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&id=' + encodeURIComponent(document.getElementById('id').value));
     }
     // Handle the modal and click event
     var eventLink = $('#eventLink');

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-details.jsp
@@ -32,7 +32,7 @@
       if (!confirm("Are you sure you want to DELETE this post?")) {
         return;
       }
-      window.location.href = '${widgetContext.uri}?action=deletePost&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&blogPostId=${blogPost.id}';
+      postAction('${widgetContext.uri}?action=deletePost&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&blogPostId=${blogPost.id}');
     }
   </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
@@ -133,14 +133,14 @@
     if (!confirm("Are you sure you want to delete this menu tab and all of its submenu items?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index);
   }
 
   function deleteMenuItem(index) {
     if (!confirm("Are you sure you want to delete this sub menu item?")) {
       return;
     }
-    window.location.href = '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index;
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index);
   }
 
   var menuItems = dragula([

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
@@ -44,7 +44,7 @@
   }
 
   function removeItem${widgetContext.uniqueId}(itemId) {
-    window.location.href = '${widgetContext.uri}?action=removeItem&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&itemId=' + itemId;
+    postAction('${widgetContext.uri}?action=removeItem&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&itemId=' + itemId);
   }
 
   function showPromoCodeEntry(e) {

--- a/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
@@ -31,7 +31,7 @@
       if (!confirm("Are you sure you want to remove the relationship?")) {
         return;
       }
-      window.location.href = '${widgetContext.uri}?action=removeRelationship&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&relatedItemId=' + relatedItemId;
+      postAction('${widgetContext.uri}?action=removeRelationship&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&relatedItemId=' + relatedItemId);
     }
   </script>
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -696,6 +696,26 @@
           }, 0);
         }
       });
+      function postAction(url) {
+        var parser = document.createElement('a');
+        parser.href = url;
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = parser.pathname;
+        new URLSearchParams(parser.search).forEach(function(value, key) {
+          var input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = key;
+          input.value = value;
+          form.appendChild(input);
+        });
+        document.body.appendChild(form);
+        form.submit();
+      }
+      function confirmPostAction(message, url) {
+        if (confirm(message)) { postAction(url); }
+        return false;
+      }
     </script>
   <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin')}">
     <c:if test="${!empty analyticsPropertyMap['analytics.service'] && 'google' eq analyticsPropertyMap['analytics.service'] && !empty analyticsPropertyMap['analytics.google.key']}">


### PR DESCRIPTION
## Summary
- Adds `Referrer-Policy: same-origin` to `PageServlet.java` alongside the existing security headers (X-Frame-Options, CSP, HSTS); prevents the session `formToken` from leaking to external origins via the `Referer` header when a user navigates away from a token-bearing URL
- All 40 state-changing widget action calls now submit via POST instead of GET, keeping tokens out of server access logs and browser history:
  - Two JS helpers added to `main.jsp`: `postAction(url)` builds and submits a hidden form; `confirmPostAction(message, url)` shows `confirm()` first
  - 24 `window.location.href = '...'` calls converted to `postAction(...)`
  - 15 `<a href="...?command=delete...">` confirm-dialog anchors converted to `confirmPostAction(...)`
  - 1 no-confirm anchor converted to `postAction(...)` + `return false`
- Existing token validation in the widget framework is unchanged; tokens move from query string to POST body

## Test plan
- [ ] Admin delete operations (page, blog, wiki, calendar, folder, collection, file, group, category, product, etc.) still work and show confirm dialog where expected
- [ ] Non-delete admin actions (mark as processed, claim, archive, suspend/restore/delete account, restore theme) still work
- [ ] Blog post delete from public-facing page works (blog-post-details)
- [ ] Cart item removal still works
- [ ] `Referrer-Policy: same-origin` header is present on page responses (DevTools → Network → Response Headers)

Closes #358