### PR TITLE
Cap paged dataset downloads at a configurable row limit (#363)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.github.fge.jackson.JsonLoader;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.admin.SaveTextFileCommand;
 import com.simisinc.platform.application.elearning.PERLSCourseListCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
@@ -48,6 +49,8 @@ import com.simisinc.platform.infrastructure.persistence.datasets.DatasetReposito
 public class DatasetDownloadRemoteFileCommand {
 
   private static Log LOG = LogFactory.getLog(DatasetDownloadRemoteFileCommand.class);
+
+  static final int DEFAULT_MAX_ROWS = 100_000;
 
   public static boolean handleRemoteFileDownload(Dataset dataset, long userId) throws DataException {
     if (StringUtils.isBlank(dataset.getSourceUrl())) {
@@ -199,8 +202,17 @@ public class DatasetDownloadRemoteFileCommand {
         return false;
       }
 
+      // Load the configurable row cap to prevent unbounded heap accumulation
+      int maxRows = DEFAULT_MAX_ROWS;
+      String maxRowsProp = LoadSitePropertyCommand.loadByName("dataset.maxRows");
+      if (org.apache.commons.lang3.StringUtils.isNotBlank(maxRowsProp)) {
+        try {
+          maxRows = Integer.parseInt(maxRowsProp.trim());
+        } catch (NumberFormatException ignored) {
+        }
+      }
       // Append any pages
-      appendNextUrls(jsonRecordsNode, json, jsonPagingPath, jsonRecordsPath);
+      appendNextUrls(jsonRecordsNode, json, jsonPagingPath, jsonRecordsPath, maxRows);
 
       // Write the whole JSON to a file
       SaveTextFileCommand.save(json.toPrettyString(), tempFile);
@@ -213,10 +225,16 @@ public class DatasetDownloadRemoteFileCommand {
   }
 
   private static void appendNextUrls(JsonNode jsonRecordsNode, JsonNode currentJson, String jsonPagingPath,
-      String jsonRecordsPath) throws IOException {
+      String jsonRecordsPath, int maxRows) throws IOException {
 
     if (currentJson == null) {
       throw new IOException("currentJson is null");
+    }
+
+    // Stop accumulating pages once the cap is reached to prevent heap exhaustion
+    if (((ArrayNode) jsonRecordsNode).size() >= maxRows) {
+      LOG.warn("Dataset paged download reached the configured row cap of " + maxRows + "; stopping to prevent unbounded accumulation");
+      return;
     }
 
     // Advance to the paging path
@@ -278,7 +296,7 @@ public class DatasetDownloadRemoteFileCommand {
     }
 
     // Keep going
-    appendNextUrls(jsonRecordsNode, nextJson, jsonPagingPath, jsonRecordsPath);
+    appendNextUrls(jsonRecordsNode, nextJson, jsonPagingPath, jsonRecordsPath, maxRows);
   }
 
 }

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1003__dataset_max_rows.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1003__dataset_max_rows.sql
@@ -1,0 +1,6 @@
+-- Cap for paged remote dataset downloads; prevents unbounded heap accumulation
+-- from sources that serve an excessive number of pages. Operators can tune this
+-- via Admin > Site Properties without a code change.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (10, 'Dataset max rows (paged download)', 'dataset.maxRows', '100000')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommandTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.datasets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.admin.SaveTextFileCommand;
+import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.application.http.RemoteUrlValidationCommand;
+
+/**
+ * Verifies that the paged dataset download respects the row cap.
+ */
+class DatasetDownloadRemoteFileCommandTest {
+
+  @TempDir
+  File tempDir;
+
+  // Three pages; each has 3 records. "next" at the top level points to the next URL.
+  private static final String PAGE_1 =
+      "{\"data\":[{\"id\":1},{\"id\":2},{\"id\":3}],\"next\":\"https://example.com/page2\"}";
+  private static final String PAGE_2 =
+      "{\"data\":[{\"id\":4},{\"id\":5},{\"id\":6}],\"next\":\"https://example.com/page3\"}";
+  private static final String PAGE_3 =
+      "{\"data\":[{\"id\":7},{\"id\":8},{\"id\":9}]}";
+
+  @Test
+  void rowCapStopsAccumulationBeforeThirdPage() throws Exception {
+    File output = new File(tempDir, "out.json");
+
+    try (MockedStatic<HttpGetCommand> httpMock = mockStatic(HttpGetCommand.class);
+         MockedStatic<RemoteUrlValidationCommand> validMock = mockStatic(RemoteUrlValidationCommand.class);
+         MockedStatic<LoadSitePropertyCommand> propMock = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<SaveTextFileCommand> saveMock = mockStatic(SaveTextFileCommand.class)) {
+
+      // Pages returned in sequence; page 3 should never be fetched when cap=5
+      httpMock.when(() -> HttpGetCommand.execute(any())).thenReturn(PAGE_1, PAGE_2, PAGE_3);
+      validMock.when(() -> RemoteUrlValidationCommand.isFetchAllowed(any())).thenReturn(true);
+      propMock.when(() -> LoadSitePropertyCommand.loadByName("dataset.maxRows")).thenReturn("5");
+      saveMock.when(() -> SaveTextFileCommand.save(any(), any())).thenReturn(output);
+
+      boolean result = DatasetDownloadRemoteFileCommand.downloadPagedFile(
+          "https://example.com/page1", "next", "data", output);
+
+      Assertions.assertTrue(result, "downloadPagedFile should return true");
+      // Page 1 fetched by downloadPagedFile itself; page 2 fetched inside appendNextUrls.
+      // After page 2's records are appended (total 6 >= cap 5), the recursive call returns
+      // immediately — page 3 must NOT be fetched.
+      httpMock.verify(() -> HttpGetCommand.execute(any()), times(2));
+    }
+  }
+
+  @Test
+  void withoutCapDefaultAllowsMultiplePages() throws Exception {
+    // When dataset.maxRows is absent, the default (100_000) applies and all pages accumulate normally.
+    File output = new File(tempDir, "out-default.json");
+
+    try (MockedStatic<HttpGetCommand> httpMock = mockStatic(HttpGetCommand.class);
+         MockedStatic<RemoteUrlValidationCommand> validMock = mockStatic(RemoteUrlValidationCommand.class);
+         MockedStatic<LoadSitePropertyCommand> propMock = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<SaveTextFileCommand> saveMock = mockStatic(SaveTextFileCommand.class)) {
+
+      // PAGE_3 has no "next", so paging stops naturally after 3 pages
+      httpMock.when(() -> HttpGetCommand.execute(any())).thenReturn(PAGE_1, PAGE_2, PAGE_3);
+      validMock.when(() -> RemoteUrlValidationCommand.isFetchAllowed(any())).thenReturn(true);
+      propMock.when(() -> LoadSitePropertyCommand.loadByName("dataset.maxRows")).thenReturn(null);
+      saveMock.when(() -> SaveTextFileCommand.save(any(), any())).thenReturn(output);
+
+      boolean result = DatasetDownloadRemoteFileCommand.downloadPagedFile(
+          "https://example.com/page1", "next", "data", output);
+
+      Assertions.assertTrue(result);
+      // All three pages should be fetched: initial URL + page2 + page3
+      httpMock.verify(() -> HttpGetCommand.execute(any()), times(3));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `DatasetDownloadRemoteFileCommand.appendNextUrls` was recursively unbounded; a source serving thousands of pages could exhaust the heap.
- Add `DEFAULT_MAX_ROWS = 100_000` and a `dataset.maxRows` site property (readable without a code change via Admin → Site Properties) checked at the start of each recursive call.
- Soft cap — stops fetching additional pages once the threshold is reached but does not truncate already-fetched records.
- Add `UPGRADE_20260725.1003__dataset_max_rows.sql` to seed the property.
- Add `DatasetDownloadRemoteFileCommandTest` with two tests: one confirming the cap stops early, one confirming normal multi-page downloads still complete.

## Test plan

- [ ] `ant compile-test` passes cleanly.
- [ ] `DatasetDownloadRemoteFileCommandTest` (row cap fires, default allows all pages) — both tests pass once the pre-existing `HealthCommandTest` blocker is resolved.
- [ ] Locally: configure a paged dataset source, set `dataset.maxRows` to a small number, confirm download stops at the cap.
- [ ] Upgrade script: run `UPGRADE_20260725.1003__dataset_max_rows.sql` against a dev DB; confirm the row appears in `site_properties` and the Admin UI shows it.

Closes #363