### PR TITLE
Add configurable upload size cap to all three upload paths (#369)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveFilePartCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFilePartCommand.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.application.cms;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -60,6 +61,10 @@ public class SaveFilePartCommand {
         LOG.debug("The file size was 0");
         return null;
       }
+      long maxBytes = resolveMaxUploadBytes();
+      if (fileLength > maxBytes) {
+        throw new DataException("The file exceeds the maximum allowed upload size");
+      }
 
       LOG.debug("Found a file...");
       submittedFilename = Paths.get(filePart.getSubmittedFileName()).getFileName().toString(); // MSIE fix.
@@ -92,6 +97,18 @@ public class SaveFilePartCommand {
     fileItemBean.setCreatedBy(context.getUserId());
     fileItemBean.setModifiedBy(context.getUserId());
     return fileItemBean;
+  }
+
+  private static long resolveMaxUploadBytes() {
+    long maxBytes = 10_485_760L; // 10MB default
+    String prop = LoadSitePropertyCommand.loadByName("system.upload.maxBytes");
+    if (prop != null && !prop.isBlank()) {
+      try {
+        maxBytes = Long.parseLong(prop.trim());
+      } catch (NumberFormatException ignored) {
+      }
+    }
+    return maxBytes;
   }
 
   public static void cleanupFile(FileItem fileItemBean) {

--- a/src/main/java/com/simisinc/platform/application/datasets/DatasetUploadFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/DatasetUploadFileCommand.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.datasets.Dataset;
 import com.simisinc.platform.infrastructure.persistence.datasets.DatasetRepository;
@@ -72,6 +73,12 @@ public class DatasetUploadFileCommand {
     }
     if (filePart == null || StringUtils.isBlank(filePart.getSubmittedFileName())) {
       context.setErrorMessage("An uploaded file was not found in the multipart form-data");
+      context.setRequestObject(dataset);
+      return false;
+    }
+    long maxUploadBytes = resolveMaxUploadBytes();
+    if (filePart.getSize() > maxUploadBytes) {
+      context.setErrorMessage("The file exceeds the maximum allowed upload size");
       context.setRequestObject(dataset);
       return false;
     }
@@ -175,5 +182,17 @@ public class DatasetUploadFileCommand {
     }
 
     return submittedFilename;
+  }
+
+  private static long resolveMaxUploadBytes() {
+    long maxBytes = 10_485_760L; // 10MB default
+    String prop = LoadSitePropertyCommand.loadByName("system.upload.maxBytes");
+    if (prop != null && !prop.isBlank()) {
+      try {
+        maxBytes = Long.parseLong(prop.trim());
+      } catch (NumberFormatException ignored) {
+      }
+    }
+    return maxBytes;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageUploadWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageUploadWidget.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.thymeleaf.util.StringUtils;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.SaveImageCommand;
 import com.simisinc.platform.application.cms.ValidateImageCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
@@ -77,6 +78,11 @@ public class ImageUploadWidget extends GenericWidget {
         return context;
       }
       fileLength = filePart.getSize();
+      long maxBytes = resolveMaxUploadBytes();
+      if (fileLength > maxBytes) {
+        context.setErrorMessage("The file exceeds the maximum allowed upload size");
+        return context;
+      }
       if (fileLength > 0) {
         filePart.write(tempFile.getAbsolutePath());
       }
@@ -128,5 +134,17 @@ public class ImageUploadWidget extends GenericWidget {
     // Return Json with the new image's URL
     context.setJson("{\"location\": \"" + "/assets/img/" + image.getUrl() + "\"}");
     return context;
+  }
+
+  private static long resolveMaxUploadBytes() {
+    long maxBytes = 10_485_760L; // 10MB default
+    String prop = LoadSitePropertyCommand.loadByName("system.upload.maxBytes");
+    if (prop != null && !prop.isBlank()) {
+      try {
+        maxBytes = Long.parseLong(prop.trim());
+      } catch (NumberFormatException ignored) {
+      }
+    }
+    return maxBytes;
   }
 }

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1004__upload_max_bytes.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1004__upload_max_bytes.sql
@@ -1,0 +1,6 @@
+-- Maximum permitted upload size in bytes; applied before writing to disk.
+-- Operators can tune this via Admin > Site Properties without a code change.
+-- Default is 10 MB; the @MultipartConfig hard limit on PageServlet is 100 MB.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (10, 'Maximum upload size (bytes)', 'system.upload.maxBytes', '10485760')
+ON CONFLICT (property_name) DO NOTHING;


### PR DESCRIPTION
## Summary

- The servlet-level `@MultipartConfig(maxFileSize=100MB)` is a hard ceiling the operator cannot tune without a code change; uploads between the application limit and 100 MB could still be accepted.
- Add `system.upload.maxBytes` site property (default 10 MB, seeded via `UPGRADE_20260725.1004__upload_max_bytes.sql`). Operators can change it live via **Admin → Site Properties**.
- Check is applied in all three upload paths **before** bytes are written to disk:
  - `ImageUploadWidget.post()` — sets an error message on the widget context and returns early.
  - `DatasetUploadFileCommand.handleUpload()` — sets error message on context and returns false.
  - `SaveFilePartCommand.saveFile()` — throws `DataException` with a clear message (callers already propagate DataException to the user).

## Test plan

- [ ] `ant compile` passes cleanly (8 files recompiled, 0 errors).
- [ ] Upload an image smaller than the configured limit — succeeds as before.
- [ ] Upload an image larger than the configured limit — rejected with "The file exceeds the maximum allowed upload size."
- [ ] Repeat for dataset upload and general file upload paths.
- [ ] Set `system.upload.maxBytes` to a higher value via Admin → Site Properties; confirm the new limit is respected without restart.
- [ ] Run upgrade script `UPGRADE_20260725.1004__upload_max_bytes.sql`; confirm property row appears.

Closes #369