### PR TITLE
Prevent double-submit on admin forms with data-disable-on-submit (#372)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-upload-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-upload-form.jsp
@@ -56,7 +56,7 @@
     </select>
   </label>
   <div class="button-container">
-    <input type="submit" class="button radius success" value="Add Dataset"/>
+    <input type="submit" class="button radius success" value="Add Dataset" data-disable-on-submit="Uploading..."/>
     <a class="button radius secondary" href="${ctx}/admin/datasets">Cancel</a>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
@@ -35,6 +35,6 @@
     <p>Site Invitation Message</p>
   </label>
   <div class="button-container">
-    <input type="submit" class="button radius success expanded" value="Send Mail"/>
+    <input type="submit" class="button radius success expanded" value="Send Mail" data-disable-on-submit="Sending..."/>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -139,7 +139,7 @@
     </div>
   </div>
   <div class="button-container">
-    <input type="submit" class="button radius success" value="Save" />
+    <input type="submit" class="button radius success" value="Save" data-disable-on-submit="Saving..." />
     <c:choose>
       <c:when test="${!empty returnPage}">
         <a href="${returnPage}" class="button radius secondary">Cancel</a>

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
@@ -100,7 +100,7 @@
   </div>
 --%>
   <div class="button-container">
-    <input type="submit" class="button radius success" value="Save"/>
+    <input type="submit" class="button radius success" value="Save" data-disable-on-submit="Saving..."/>
     <c:choose>
       <c:when test="${!empty returnPage}">
         <a href="${returnPage}" class="button radius secondary">Cancel</a>

--- a/src/main/webapp/WEB-INF/jsp/items/item-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-form.jsp
@@ -39,6 +39,6 @@
     <input type="text" placeholder="Describe it..." name="summary" value="<c:out value="${item.summary}"/>">
   </label>
   <div class="button-container">
-    <input type="submit" class="button radius success expanded" value="Save"/>
+    <input type="submit" class="button radius success expanded" value="Save" data-disable-on-submit="Saving..."/>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -695,6 +695,14 @@
               scrollTop: hash.offset().top-headerHeight
           }, 0);
         }
+        $(document).on('submit', 'form', function() {
+          $(this).find('[data-disable-on-submit]').each(function() {
+            var btn = $(this);
+            btn.prop('disabled', true);
+            var loadingText = btn.data('disable-on-submit');
+            if (btn.is('input')) { btn.val(loadingText); } else { btn.text(loadingText); }
+          });
+        });
       });
     </script>
   <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin')}">


### PR DESCRIPTION
## Summary

- Several admin forms could be double-submitted if the user clicked the save/send button twice before the server responded, risking duplicate records or operations.
- Add a single jQuery delegate handler in `main.jsp` that fires on any `form` submit: it finds `[data-disable-on-submit]` buttons, disables them, and replaces the label with the attribute value (so the text itself becomes the progress indicator — no spinner library needed).
- Validation errors naturally re-enable the button because the server re-renders the page fresh.
- Wire the attribute to five forms:
  | Form | Button | Loading label |
  |------|--------|---------------|
  | `cms/web-page-editor.jsp` | Save | Saving... |
  | `admin/web-page-form.jsp` | Save | Saving... |
  | `items/item-form.jsp` | Save | Saving... |
  | `admin/dataset-upload-form.jsp` | Add Dataset | Uploading... |
  | `admin/send-mail-form.jsp` | Send Mail | Sending... |
- The order-processing forms (`place-order-button.jsp`, `ship-order.jsp`, `cancel-order.jsp`) already had their own per-page double-submit guards; those are untouched.

## Test plan

- [ ] Open web page editor, click Save — button disables and shows "Saving..."; page reloads to success state.
- [ ] Introduce a validation error; submit — button shows loading; page reloads with error and button is re-enabled.
- [ ] Repeat for collection item save, dataset upload, and send-mail forms.
- [ ] Rapid double-click on Save — second click is a no-op (button disabled).

Closes #372