### PR TITLE
Add per-request CSP nonce and enforce script-src across all JSPs (GH-364)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -46,6 +46,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
+import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.*;
@@ -65,6 +66,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_MOVED_PERMANENTLY;
 public class PageServlet extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(PageServlet.class);
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   // Widget Cache
   private Map<String, Object> widgetInstances = new HashMap<>();
@@ -157,12 +159,12 @@ public class PageServlet extends HttpServlet {
     response.setHeader("X-Frame-Options", "SAMEORIGIN");
     response.setHeader("X-Content-Type-Options", "nosniff");
     response.setHeader("X-XSS-Protection", "1; mode=block");
-    // A conservative Content-Security-Policy baseline. These directives harden real attack surface -- injected
-    // base tags, plugin/object embedding, and clickjacking -- without restricting script or style sources, so the
-    // existing inline scripts and author-embedded content are unaffected. frame-ancestors mirrors the
-    // X-Frame-Options above for modern browsers. A stricter script-src policy needs nonces across the JSPs and is
-    // left to a later, report-only-first rollout.
-    response.setHeader("Content-Security-Policy", "base-uri 'self'; object-src 'none'; frame-ancestors 'self'");
+    byte[] nonceBytes = new byte[16];
+    SECURE_RANDOM.nextBytes(nonceBytes);
+    String cspNonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes);
+    request.setAttribute("cspNonce", cspNonce);
+    response.setHeader("Content-Security-Policy",
+        "base-uri 'self'; object-src 'none'; frame-ancestors 'self'; script-src 'self' 'nonce-" + cspNonce + "'");
     // Advertise HTTPS-only via HSTS, but only when the deployment is configured for SSL. Sending this from a
     // site that cannot serve HTTPS would make browsers refuse it for the max-age, so it is gated on system.ssl
     // rather than the per-request scheme, which also stays correct behind a TLS-terminating proxy.

--- a/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
@@ -37,7 +37,7 @@
   <label for="file" class="button small secondary radius float-left margin-left-0"><i class="fa fa-upload"></i> Upload CSV File</label>
   <input type="file" id="file" name="file" accept="text/csv" class="show-for-sr">
 </form>
-<script>
+<script nonce="${cspNonce}">
   document.getElementById("file").onchange = function() {
     document.getElementById("fileForm").submit();
   }

--- a/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
@@ -22,7 +22,7 @@
 <jsp:useBean id="blogList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="blogPostCount" class="java.util.HashMap" scope="request"/>
 <c:if test="${userSession.hasRole('admin')}">
-<script>
+<script nonce="${cspNonce}">
   function deleteBlog(blogId) {
     if (!confirm("Are you sure you want to delete this blog and all of its posts?")) {
       return;

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-form.jsp
@@ -61,7 +61,7 @@
     </c:choose>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function() {
     var target = document.getElementById('color');
     $("[id='color']").spectrum({

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-list.jsp
@@ -22,7 +22,7 @@
 <jsp:useBean id="calendarList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="calendarEventCount" class="java.util.HashMap" scope="request"/>
 <c:if test="${userSession.hasRole('admin')}">
-<script>
+<script nonce="${cspNonce}">
   function deleteCalendar(calendarId) {
     if (!confirm("Are you sure you want to delete this calendar and all of its events?")) {
       return;

--- a/src/main/webapp/WEB-INF/jsp/admin/cancel-order.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/cancel-order.jsp
@@ -32,7 +32,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="cancelOrderButton" class="button alert expanded">Cancel Order</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function cancelOrder() {
     if (document.getElementById("cancelOrderButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/category-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/category-form.jsp
@@ -61,7 +61,7 @@
     <input type="submit" class="button radius success" value="Save" />
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   var colorIdList = [];
   colorIdList.push('headerBgColor');
   colorIdList.push('headerTextColor');

--- a/src/main/webapp/WEB-INF/jsp/admin/check-order-tracking.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/check-order-tracking.jsp
@@ -32,7 +32,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="checkOrderTrackingButton" class="button primary expanded">Check Order Status</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function checkOrderTracking() {
     if (document.getElementById("checkOrderTrackingButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/collection-theme-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/collection-theme-editor.jsp
@@ -129,7 +129,7 @@
     <a href="${returnPage}" class="button radius secondary">Cancel</a>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   <%-- Map the variable property to the mapped CSS classes --%>
   var colorIdList = [];
   var colorSelectorList = [];

--- a/src/main/webapp/WEB-INF/jsp/admin/custom-fields-form-json.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/custom-fields-form-json.jsp
@@ -59,7 +59,7 @@
   </div>
   <p><input type="submit" class="button radius success" value="Save"/></p>
 </form>
-<script>
+<script nonce="${cspNonce}">
   // Hook up ACE editor to all textareas with data-editor attribute
   $(function() {
     $('textarea[data-editor]').each(function() {

--- a/src/main/webapp/WEB-INF/jsp/admin/customer-list-search-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/customer-list-search-form.jsp
@@ -53,7 +53,7 @@
     <input id="resetButton" type="reset" class="button radius secondary expanded" value="Reset"/>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function () {
     $('#resetButton').click(function (event) {
       event.preventDefault();

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-preview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-preview.jsp
@@ -40,7 +40,7 @@
   }
 </style>
 <div id="dataset-preview"></div>
-<script>
+<script nonce="${cspNonce}">
   var colHeaders = [
     <c:choose>
       <c:when test="${empty dataset.fieldTitles}">

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-source.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-source.jsp
@@ -23,7 +23,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="dataset" class="com.simisinc.platform.domain.model.datasets.Dataset" scope="request"/>
 <jsp:useBean id="columnConfiguration" class="java.lang.String" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function() {
     $('textarea').keypress(function(event) {
       if (event.keyCode === 13) {

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-sync.jsp
@@ -28,7 +28,7 @@
 <jsp:useBean id="fieldOptionsList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="sampleRow" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="columnConfiguration" class="java.lang.String" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
   function checkForm() {
     return true;
   }

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
@@ -34,7 +34,7 @@
   </c:if>
 </h4>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -132,7 +132,7 @@
     </c:forEach>
   </tbody>
 </table>
-<script>
+<script nonce="${cspNonce}">
   // ClipboardJS.isSupported()
   var clipboard = new ClipboardJS('.clipboard');
   clipboard.on('success', function(e) {

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-sub-folders-list.jsp
@@ -115,7 +115,7 @@
         <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="startDate${widgetContext.uniqueId}" name="startDate" value="">
       </div>
     </label>
-    <script>
+    <script nonce="${cspNonce}">
       $(function(){
         $('#startDate${widgetContext.uniqueId}').fdatepicker({
           format: 'mm-dd-yyyy hh:ii',

--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -23,7 +23,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="formDataList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
   function markFormAsProcessed(dataId) {
     if (!confirm("Mark as processed?")) {
       return;

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -48,7 +48,7 @@
   <input type="hidden" name="mailingListId" value="${mailingList.id}" />
   <button class="button small secondary radius float-left margin-left-10"><i class="fa fa-download"></i> Download CSV File</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   document.getElementById("file").onchange = function() {
     document.getElementById("fileForm").submit();
   }

--- a/src/main/webapp/WEB-INF/jsp/admin/order-list-search-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/order-list-search-form.jsp
@@ -53,7 +53,7 @@
     <input id="resetButton" type="reset" class="button radius secondary expanded" value="Reset"/>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function () {
     $('#resetButton').click(function (event) {
       event.preventDefault();

--- a/src/main/webapp/WEB-INF/jsp/admin/pricing-rule-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/pricing-rule-form.jsp
@@ -179,7 +179,7 @@
               <input class="input-group-field" type="text" placeholder="" id="fromDate" name="fromDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${pricingRule.fromDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function () {
               $('#fromDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -196,7 +196,7 @@
               <input class="input-group-field" type="text" placeholder="" id="toDate" name="toDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${pricingRule.toDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function () {
               $('#toDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',

--- a/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/product-form.jsp
@@ -23,7 +23,7 @@
 <jsp:useBean id="product" class="com.simisinc.platform.domain.model.ecommerce.Product" scope="request"/>
 <jsp:useBean id="fulfillmentOptionList" class="java.util.ArrayList" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   tinymce.init({
     license_key: 'gpl',
     selector: 'textarea',
@@ -40,7 +40,7 @@
   });
 </script>
 <%-- Handle image uploads --%>
-<script>
+<script nonce="${cspNonce}">
   function SavePhoto(e) {
     var file = e.files[0]; // similar to: document.getElementById("file").files[0]
     var formData = new FormData();
@@ -420,7 +420,7 @@
             <input class="input-group-field" type="text" placeholder="Display right away, or choose a specific date and time..." id="activeDate" name="activeDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${product.activeDate}" />">
           </div>
         </label>
-        <script>
+        <script nonce="${cspNonce}">
           $(function () {
             $('#activeDate').fdatepicker({
               format: 'mm-dd-yyyy hh:ii',
@@ -437,7 +437,7 @@
             <input class="input-group-field" type="text" placeholder="" id="deactivateOnDate" name="deactivateOnDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${product.deactivateOnDate}" />">
           </div>
         </label>
-        <script>
+        <script nonce="${cspNonce}">
           $(function () {
             // yyyy-MM-dd HH:mm:ss.fffffffff
             $('#deactivateOnDate').fdatepicker({
@@ -465,7 +465,7 @@
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
   <h3>Loading...</h3>
 </div>
-<script>
+<script nonce="${cspNonce}">
   $('#imageBrowserReveal').on('open.zf.reveal', function () {
     $('#imageBrowserReveal').html("<h3>Loading...</h3>");
     $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/admin/send-order-cancellation-confirmation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-order-cancellation-confirmation.jsp
@@ -31,7 +31,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="sendOrderCancellationConfirmationButton" class="button primary expanded">Send Order Cancellation Confirmation</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function sendOrderCancellationConfirmation() {
     if (document.getElementById("sendOrderCancellationConfirmationButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/send-order-confirmation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-order-confirmation.jsp
@@ -31,7 +31,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="sendOrderConfirmationButton" class="button primary expanded">Send Order Confirmation</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function sendOrderConfirmation() {
     if (document.getElementById("sendOrderConfirmationButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/send-order-refund-confirmation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-order-refund-confirmation.jsp
@@ -31,7 +31,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="sendOrderRefundConfirmationButton" class="button primary expanded">Send Refund Confirmation</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function sendOrderRefundConfirmation() {
     if (document.getElementById("sendOrderRefundConfirmationButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/send-shipping-confirmation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-shipping-confirmation.jsp
@@ -31,7 +31,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="sendShippingConfirmationButton" class="button primary expanded">Send Shipping Confirmation</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function sendShippingConfirmation() {
     if (document.getElementById("sendShippingConfirmationButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/ship-order.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/ship-order.jsp
@@ -32,7 +32,7 @@
   <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
   <button id="shipOrderButton" class="button primary expanded">Send Order to Shipping</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function shipOrder() {
     if (document.getElementById("shipOrderButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -22,7 +22,7 @@
 <link href="${ctx}/css/spectrum-1.8.1/spectrum.css" rel="stylesheet">
 <script src="${ctx}/javascript/spectrum-1.8.1/spectrum.js"></script>
 <%-- Handle image uploads --%>
-<script>
+<script nonce="${cspNonce}">
 
   var currentPhotoId = 'none';
   function SetPhotoId(id) {
@@ -204,7 +204,7 @@
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
   <h3>Loading...</h3>
 </div>
-<script>
+<script nonce="${cspNonce}">
   <%-- Map the variable property to the mapped CSS classes --%>
   var colorIdList = [];
   var colorSelectorList = [];
@@ -326,7 +326,7 @@
     }
   });
 </script>
-<script>
+<script nonce="${cspNonce}">
   $('#imageBrowserReveal').on('open.zf.reveal', function () {
     $('#imageBrowserReveal').html("<h3>Loading...</h3>");
     $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
@@ -46,7 +46,7 @@
     </c:forEach>
   </tbody>
 </table>
-<script>
+<script nonce="${cspNonce}">
   var chartContext = document.getElementById("myChart-${widgetContext.uniqueId}").getContext('2d');
   var myChart = new Chart(chartContext, {
     type: "bar",

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-card.jsp
@@ -67,7 +67,7 @@
     </div>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function updateFontSize${widgetContext.uniqueId}() {
     let value = Math.round($('#icon${widgetContext.uniqueId}').closest('.cell').outerWidth()*.6);
     $("#icon${widgetContext.uniqueId}").css({'font-size': value + 'px'});

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
@@ -46,7 +46,7 @@
     </c:forEach>
   </tbody>
 </table>
-<script>
+<script nonce="${cspNonce}">
   var chartContext = document.getElementById("myChart-${widgetContext.uniqueId}").getContext('2d');
   var myChart = new Chart(chartContext, {
     type: "line",

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-locations-map.jsp
@@ -38,7 +38,7 @@
 <c:if test="${empty sessionList}">
   <p>No locations were found</p>
 </c:if>
-<script>
+<script nonce="${cspNonce}">
   <%--var mymap = L.map('mapid${widgetContext.uniqueId}').fitWorld();--%>
   var map${widgetContext.uniqueId} = L.map('mapid${widgetContext.uniqueId}', {
     <c:choose>

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-table.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-table.jsp
@@ -57,7 +57,7 @@
 </table>
 </div>
 <c:if test="${!empty optionsList}">
-<script>
+<script nonce="${cspNonce}">
   // Interval to update the highlighted tab data
   var currentValue = '<c:out value="${optionsList.entrySet().toArray()[0].value}"/>';
   var updateIntervalFunction = function() {

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -104,7 +104,7 @@
   </div>
 </form>
 <script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   var menuTabs = dragula([document.getElementById('site-map-container')], {
     direction: 'horizontal',
     moves: function (el, container, handle) {

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
@@ -129,7 +129,7 @@
   </div>
 </form>
 <script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   var menuTabs = dragula([document.getElementById('site-map-container')], {
     direction: 'horizontal',
     moves: function (el, container, handle) {

--- a/src/main/webapp/WEB-INF/jsp/admin/sub-folder-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sub-folder-form.jsp
@@ -52,7 +52,7 @@
       <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="startDate${widgetContext.uniqueId}" name="startDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${subFolder.startDate}" />">
     </div>
   </label>
-  <script>
+  <script nonce="${cspNonce}">
     $(function () {
       $('#startDate').fdatepicker({
         format: 'mm-dd-yyyy hh:ii',

--- a/src/main/webapp/WEB-INF/jsp/admin/theme-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/theme-editor.jsp
@@ -19,7 +19,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="theme" class="com.simisinc.platform.domain.model.cms.Theme" scope="request"/>
 <jsp:useBean id="themeList" class="java.util.ArrayList" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
 function deleteTheme(themeId) {
   if (!confirm("Are you sure you want to DELETE this theme?")) {
     return;

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -26,7 +26,7 @@
 <jsp:useBean id="roleList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="groupList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="userLogin" class="com.simisinc.platform.domain.model.login.UserLogin" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
   function resetPassword() {
     if (!confirm("Are you sure you want to reset the password on this account? An email with instructions will be sent to the user.")) {
       return;

--- a/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
@@ -285,7 +285,7 @@
   </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function () {
     // Dynamically set the position of the header
     var container = document.getElementById('sticky-container');

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -39,7 +39,7 @@
   <label for="file" class="button small secondary radius margin-left-10"><i class="fa fa-upload"></i> Upload CSV File</label>
   <input type="file" id="file" name="file" accept="text/csv" class="show-for-sr">
 </form>
-<script>
+<script nonce="${cspNonce}">
     document.getElementById("file").onchange = function() {
         document.getElementById("fileForm").submit();
     }
@@ -57,7 +57,7 @@
     </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   document.getElementById("statusFilter").onchange = function() {
     document.getElementById("tableOptionsForm").submit();
   }
@@ -183,7 +183,7 @@
     </div>
   </form>
 </div>
-<%--<script>--%>
+<%--<script nonce="${cspNonce}">--%>
 <%--  $(document).on('open.zf.reveal', '[data-reveal]', function () {--%>
 <%--    let modal = $(this);--%>
 <%--    modal.find('[autofocus]').focus();--%>

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -19,7 +19,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="webPage" class="com.simisinc.platform.domain.model.cms.WebPage" scope="request"/>
 <%-- Handle image uploads --%>
-<script>
+<script nonce="${cspNonce}">
     function SavePhoto(e) {
         var file = e.files[0]; // similar to: document.getElementById("file").files[0]
         var formData = new FormData();
@@ -159,7 +159,7 @@
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
   <h3>Loading...</h3>
 </div>
-<script>
+<script nonce="${cspNonce}">
     $('#imageBrowserReveal').on('open.zf.reveal', function () {
         $('#imageBrowserReveal').html("<h3>Loading...</h3>");
         $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
@@ -21,7 +21,7 @@
 <jsp:useBean id="wikiList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="wikiPageCount" class="java.util.HashMap" scope="request"/>
 <c:if test="${userSession.hasRole('admin')}">
-<script>
+<script nonce="${cspNonce}">
   function deleteWiki(wikiId) {
     if (!confirm("Are you sure you want to delete this wiki and all of its pages?")) {
       return;

--- a/src/main/webapp/WEB-INF/jsp/calendar/calendar-event-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/calendar-event-details.jsp
@@ -168,7 +168,7 @@
     </c:choose>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function goBack() {
     window.history.back();
   }

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -59,7 +59,7 @@
 <%@include file="../page_messages.jspf" %>
 <div id="calendar"><c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}"><small><i class="fa fa-calendar-plus-o"></i> Select a date range to create events</small></c:if></div>
 <div id="tooltip" class="tooltip top align-center under-reveal" style="display:none"></div>
-<script>
+<script nonce="${cspNonce}">
   function showTooltip(el, event) {
     let content = "<h5>" + event.title+"</h5>";
     if (event.allDay === undefined || !event.allDay) {
@@ -324,7 +324,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="startDate" name="startDate" value="" required>
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               $('#startDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -341,7 +341,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="endDate" name="endDate" value="" required>
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               $('#endDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -377,7 +377,7 @@
       </div>
     </form>
   </div>
-  <script>
+  <script nonce="${cspNonce}">
     function deleteCalendarEvent() {
       if (!confirm("Are you sure you want to DELETE this event?")) {
         return;

--- a/src/main/webapp/WEB-INF/jsp/calendar/small-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/small-calendar.jsp
@@ -39,7 +39,7 @@
 <%-- Render the widget --%>
 <div id="calendar-small"></div>
 <div id="tooltip" class="tooltip top align-center under-reveal" style="display:none"></div>
-<script>
+<script nonce="${cspNonce}">
   function showTooltip(el, event) {
     let content = "<h5>" + event.title+"</h5>";
     if (event.allDay === undefined || !event.allDay) {

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
@@ -22,7 +22,7 @@
 <jsp:useBean id="blog" class="com.simisinc.platform.domain.model.cms.Blog" scope="request"/>
 <jsp:useBean id="blogPost" class="com.simisinc.platform.domain.model.cms.BlogPost" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   tinymce.init({
     license_key: 'gpl',
     selector: 'textarea',
@@ -76,7 +76,7 @@
   }
 </script>
 <%-- Handle banner image uploads --%>
-<script>
+<script nonce="${cspNonce}">
   function SavePhoto(e) {
     var file = e.files[0]; // similar to: document.getElementById("file").files[0]
     var formData = new FormData();
@@ -167,7 +167,7 @@
             <input class="input-group-field" type="text" placeholder="Publish right away, or choose a specific date and time..." id="startDate" name="startDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${blogPost.startDate}" />">
           </div>
         </label>
-        <script>
+        <script nonce="${cspNonce}">
           $(function () {
             $('#startDate').fdatepicker({
               format: 'mm-dd-yyyy hh:ii',
@@ -184,7 +184,7 @@
             <input class="input-group-field" type="text" placeholder="" id="endDate" name="endDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${blogPost.endDate}" />">
           </div>
         </label>
-        <script>
+        <script nonce="${cspNonce}">
           $(function () {
             // yyyy-MM-dd HH:mm:ss.fffffffff
             $('#endDate').fdatepicker({
@@ -212,7 +212,7 @@
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
   <h3>Loading...</h3>
 </div>
-<script>
+<script nonce="${cspNonce}">
   $('#imageBrowserReveal').on('open.zf.reveal', function () {
     $('#imageBrowserReveal').html("<h3>Loading...</h3>");
     $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-details.jsp
@@ -27,7 +27,7 @@
 <jsp:useBean id="showAuthor" class="java.lang.String" scope="request"/>
 <jsp:useBean id="showDate" class="java.lang.String" scope="request"/>
 <c:if test="${userSession.hasRole('admin') || userSession.hasRole('content-manager')}">
-  <script>
+  <script nonce="${cspNonce}">
     function deletePost() {
       if (!confirm("Are you sure you want to DELETE this post?")) {
         return;

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-masonry.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-masonry.jsp
@@ -108,7 +108,7 @@
     </p>
   </c:otherwise>
 </c:choose>
-<script>
+<script nonce="${cspNonce}">
   var $grid = $('#masonry-container${widgetContext.uniqueId}').imagesLoaded( function() {
     $grid.masonry({
       itemSelector: '.cell'

--- a/src/main/webapp/WEB-INF/jsp/cms/content-card-slider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-card-slider.jsp
@@ -67,7 +67,7 @@
 </c:if>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
     var swiper${widgetContext.uniqueId} = new Swiper("#swiper${widgetContext.uniqueId}", {
         slidesPerView: <c:out value="${smallCardCount}" />,
         centerInsufficientSlides: true,

--- a/src/main/webapp/WEB-INF/jsp/cms/content-code-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-code-editor.jsp
@@ -18,7 +18,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="codeContent" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
 tinymce.init({
     license_key: 'gpl',
   selector: 'textarea',

--- a/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
@@ -20,7 +20,7 @@
 <jsp:useBean id="content" class="com.simisinc.platform.domain.model.cms.Content" scope="request"/>
 <jsp:useBean id="isDraft" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   $(window).on('resize', function () {
     setTimeout(function () {
       var container = document.getElementsByClassName("tox-tinymce")[0];

--- a/src/main/webapp/WEB-INF/jsp/cms/content-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-gallery.jsp
@@ -50,7 +50,7 @@
     </c:if>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function changeImage${widgetContext.uniqueId}(index) {
     var image = $('#gallery-image${widgetContext.uniqueId} img');
     var thumb = $('#image${widgetContext.uniqueId}' + index + ' img');

--- a/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
@@ -82,7 +82,7 @@
     </c:if>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
   // Attach to the modal display event; auto-play first modal video
   document.addEventListener("DOMContentLoaded", function () {
     $('#modal${widgetContext.uniqueId}').on('open.zf.reveal', function () {

--- a/src/main/webapp/WEB-INF/jsp/cms/css-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/css-editor.jsp
@@ -147,7 +147,7 @@
     </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   // Hook up ACE editor to all textareas with data-editor attribute
   $(function() {
     $('textarea[data-editor]').each(function() {

--- a/src/main/webapp/WEB-INF/jsp/cms/file-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/file-browser.jsp
@@ -61,7 +61,7 @@
     </div>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   <c:choose>
     <c:when test="${!empty inputId}">
     function mySubmit(itemUrl) {

--- a/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
@@ -29,7 +29,7 @@
   <i class="fa fa-folder-open-o"></i> <c:out value="${folder.name}" />
 </h4>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,

--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -24,9 +24,9 @@
 <jsp:useBean id="formFieldList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-<script src='https://www.google.com/recaptcha/api.js'></script>
+<script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
 </c:if>
-<script>
+<script nonce="${cspNonce}">
   <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
     function onSubmit(token) {
       document.getElementById("form${widgetContext.uniqueId}").submit();

--- a/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/image-browser.jsp
@@ -258,7 +258,7 @@
     </c:forEach>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   <c:choose>
     <c:when test="${!empty inputId}">
       <%-- Directly called by a web page --%>

--- a/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
@@ -57,7 +57,7 @@
     </c:forEach>
   </tbody>
 </table>
-<script>
+<script nonce="${cspNonce}">
   document.getElementById("filter").onchange = function() {
     document.getElementById("leaderboardForm").submit();
   }

--- a/src/main/webapp/WEB-INF/jsp/cms/photo-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/photo-gallery.jsp
@@ -79,7 +79,7 @@
     </div>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   var swiper${widgetContext.uniqueId} = new Swiper('#swiper${widgetContext.uniqueId}', {
     autoplay: {
       delay: 5000

--- a/src/main/webapp/WEB-INF/jsp/cms/search-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/search-form.jsp
@@ -63,7 +63,7 @@
   </div>
 </form>
 <c:if test="${expand eq 'true'}">
-<script>
+<script nonce="${cspNonce}">
     $(document).ready(function () {
         let form = $('#form${widgetContext.uniqueId}');
         let button = $('#button${widgetContext.uniqueId}');

--- a/src/main/webapp/WEB-INF/jsp/cms/video-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/video-browser.jsp
@@ -40,7 +40,7 @@
   <small><c:out value="${number:suffix(file.fileLength)}"/></small>
   <c:if test="${!status.last}"><br /></c:if>
 </c:forEach>
-<script>
+<script nonce="${cspNonce}">
   <c:choose>
     <c:when test="${!empty inputId}">
     function mySubmit(itemUrl) {

--- a/src/main/webapp/WEB-INF/jsp/cms/web-container-xml-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-container-xml-editor.jsp
@@ -89,7 +89,7 @@
     </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   // Hook up ACE editor to all textareas with data-editor attribute
   $(function() {
     $('textarea[data-editor]').each(function() {

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-code-mirror-xml-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-code-mirror-xml-editor.jsp
@@ -68,7 +68,7 @@
         </c:choose>
       </div>
     </form>
-    <script>
+    <script nonce="${cspNonce}">
       // Hook up the editor to the textarea
       var pageXml = document.getElementById("pageXml");
       var codeMirror = CodeMirror.fromTextArea(pageXml, {

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-designer.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-designer.jsp
@@ -59,7 +59,7 @@
     </c:choose>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
 
   function widget_callback(container, btnElem) {
     // alert("The widget chooser is unavailable");

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-editor.jsp
@@ -116,7 +116,7 @@
 </form>
 
 <script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   var menuTabs = dragula([document.querySelector('#site-map-container')], {
     direction: 'horizontal',
     moves: function (el, container, handle) {

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-templates.jsp
@@ -87,7 +87,7 @@
     </c:choose>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function mySubmit(templateId, templateUniqueId) {
     <%-- Post to the url --%>
     document.getElementById("templateId").value = templateId;

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-xml-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-xml-editor.jsp
@@ -146,7 +146,7 @@
     </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   // Hook up ACE editor to all textareas with data-editor attribute
   $(function() {
     $('textarea[data-editor]').each(function() {

--- a/src/main/webapp/WEB-INF/jsp/cms/wiki-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/wiki-editor.jsp
@@ -102,7 +102,7 @@
     </div>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   // Hook up ACE editor to all textareas with data-editor attribute
   $(function() {
     $('textarea[data-editor]').each(function() {

--- a/src/main/webapp/WEB-INF/jsp/cms/wiki-page.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/wiki-page.jsp
@@ -27,7 +27,7 @@
 <script src="${ctx}/javascript/prism-1.29.0/prism.min.js"></script>
 <c:if test="${mermaid eq 'true'}">
 <script src="${ctx}/javascript/mermaid-10.9.6/mermaid.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
   document.addEventListener('DOMContentLoaded', function () {
     // The markdown renderer emits ```mermaid fences as <pre><code class="language-mermaid">;

--- a/src/main/webapp/WEB-INF/jsp/dashboard/progress-card-vertical.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/progress-card-vertical.jsp
@@ -74,7 +74,7 @@
 <%--    </div>--%>
 <%--  </c:if>--%>
 </div>
-<script>
+<script nonce="${cspNonce}">
   const data${widgetContext.uniqueId} = {
     datasets: [
       {

--- a/src/main/webapp/WEB-INF/jsp/dashboard/progress-card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/progress-card.jsp
@@ -74,7 +74,7 @@
     </div>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
   const data${widgetContext.uniqueId} = {
     datasets: [
       {

--- a/src/main/webapp/WEB-INF/jsp/dashboard/statistic-card-vertical.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/statistic-card-vertical.jsp
@@ -55,7 +55,7 @@
 <%--    </div>--%>
 <%--  </c:if>--%>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function updateFontSize${widgetContext.uniqueId}() {
     let value = Math.round($('#icon${widgetContext.uniqueId}').closest('.cell').outerWidth()*.50);
     $("#icon${widgetContext.uniqueId}").css({'font-size': value + 'px'});

--- a/src/main/webapp/WEB-INF/jsp/dashboard/statistic-card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/statistic-card.jsp
@@ -55,7 +55,7 @@
     </div>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
   function updateFontSize${widgetContext.uniqueId}() {
     let value = Math.round($('#icon${widgetContext.uniqueId}').closest('.cell').outerWidth()*.6);
     $("#icon${widgetContext.uniqueId}").css({'font-size': value + 'px'});

--- a/src/main/webapp/WEB-INF/jsp/dashboard/superset-embedded.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/superset-embedded.jsp
@@ -35,7 +35,7 @@
 <div id="superset-container${widgetContext.uniqueId}" class="superset-dashboard-container">
 </div>
 <script src="${ctx}/javascript/superset-embedded-sdk-0.1.0-alpha.7/index.js"></script>
-<script>
+<script nonce="${cspNonce}">
   function fetchGuestTokenFromBackend${widgetContext.uniqueId}() {
     return new Promise(function (resolve, reject) {
       $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/add-product-sku-to-cart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/add-product-sku-to-cart.jsp
@@ -27,7 +27,7 @@
 <jsp:useBean id="buttonName" class="java.lang.String" scope="request"/>
 <jsp:useBean id="showPrice" class="java.lang.String" scope="request"/>
 <link rel="stylesheet" href="${ctx}/css/platform-ecommerce.css?v=<%= VERSION %>" />
-<script>
+<script nonce="${cspNonce}">
   function updatePrice() {
     var qty = $('#quantity').find(":selected").text();
     $('#price').html(new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(qty * ${productSku.price}));

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/add-product-to-cart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/add-product-to-cart.jsp
@@ -27,7 +27,7 @@
 <jsp:useBean id="buttonName" class="java.lang.String" scope="request"/>
 <jsp:useBean id="showPrice" class="java.lang.String" scope="request"/>
 <link rel="stylesheet" href="${ctx}/css/platform-ecommerce.css?v=<%= VERSION %>" />
-<script>
+<script nonce="${cspNonce}">
   function updatePrice(price) {
     var qty = $('#quantity').find(":selected").text();
     $("#price").html(new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(qty * price));

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
@@ -33,7 +33,7 @@
 <jsp:useBean id="pricingRule" class="com.simisinc.platform.domain.model.ecommerce.PricingRule" scope="request"/>
 <jsp:useBean id="preventCheckout" class="java.lang.String" scope="request"/>
 <link rel="stylesheet" href="${ctx}/css/platform-ecommerce.css?v=<%= VERSION %>"/>
-<script>
+<script nonce="${cspNonce}">
   var itemIdList = [<c:forEach items="${cartEntryList}" var="cartEntry" varStatus="status">${cartEntry.cartItem.id}<c:if test="${!status.last}">, </c:if></c:forEach>];
 
   function updatePrice(itemId, price) {

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/customer-contact-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/customer-contact-form.jsp
@@ -26,7 +26,7 @@
 <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
 <input type="hidden" name="token" value="${userSession.formToken}"/>
 <%-- Form body--%>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
     if (document.getElementById("shippingCountry").value.trim() === "") {
       alert("Please choose a Country");

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form-square.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form-square.jsp
@@ -30,15 +30,15 @@
 <%-- Square --%>
 <c:choose>
   <c:when test="${testMode eq 'true'}">
-    <script type="text/javascript" src="https://sandbox.web.squarecdn.com/v1/square.js"></script>
+    <script type="text/javascript" src="https://sandbox.web.squarecdn.com/v1/square.js" nonce="${cspNonce}"></script>
   </c:when>
   <c:otherwise>
-    <script type="text/javascript" src="https://web.squarecdn.com/v1/square.js"></script>
+    <script type="text/javascript" src="https://web.squarecdn.com/v1/square.js" nonce="${cspNonce}"></script>
   </c:otherwise>
 </c:choose>
 <%-- Page Scripts --%>
 <%@include file="../page_messages.jspf" %>
-<script>
+<script nonce="${cspNonce}">
     const appId = '<c:out value="${squareAppId}" />';
     const locationId = '<c:out value="${squareLocationId}" />';
 

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form-stripe.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form-stripe.jsp
@@ -27,7 +27,7 @@
 <jsp:useBean id="stripeKey" class="java.lang.String" scope="request"/>
 <jsp:useBean id="testMode" class="java.lang.String" scope="request"/>
 <%-- Stripe --%>
-<script src="https://js.stripe.com/v3/"></script>
+<script src="https://js.stripe.com/v3/" nonce="${cspNonce}"></script>
 <%-- Page Scripts --%>
 <%@include file="../page_messages.jspf" %>
 <form method="post" id="payment-form">
@@ -59,7 +59,7 @@
     <button class="button primary" name="button" value="save">Save &amp; Continue</button>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   var stripe = Stripe('<c:out value="${stripeKey}" />');
   var elements = stripe.elements();
   var style = {

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/customer-payment-form.jsp
@@ -37,7 +37,7 @@
   }
 </style>
 <script src="${ctx}/javascript/payform-1.4.0/payform.js"></script>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
 
     var ccInput = document.getElementById('creditCardNumber');
@@ -147,7 +147,7 @@
   </div>
 </form>
 <%-- Format input for card number entry --%>
-<script>
+<script nonce="${cspNonce}">
   var ccInput = document.getElementById('creditCardNumber');
   payform.cardNumberInput(ccInput);
   var mmYYInput = document.getElementById('creditCardMMYY');

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/order-updates-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/order-updates-form.jsp
@@ -28,7 +28,7 @@
 <jsp:useBean id="allowRegistrations" class="java.lang.String" scope="request"/>
 <jsp:useBean id="subscribeToNewsletter" class="java.lang.String" scope="request"/>
 <%-- Form body--%>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
     return true;
   }

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/place-order-button.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/place-order-button.jsp
@@ -32,7 +32,7 @@
   <%-- The form --%>
   <button id="placeOrderButton" class="button primary">Place Order</button>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function placeOrder() {
     if (document.getElementById("placeOrderButton").disabled === true) {
       return false;

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
@@ -84,7 +84,7 @@
     </c:if>
   </c:if>
 </div>
-<script>
+<script nonce="${cspNonce}">
     var swiper${widgetContext.uniqueId} = new Swiper("#swiper${widgetContext.uniqueId}", {
         slidesPerView: <c:out value="${smallCardCount}" />,
         spaceBetween: 15,

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/shipping-address-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/shipping-address-form.jsp
@@ -24,7 +24,7 @@
 <jsp:useBean id="address" class="com.simisinc.platform.domain.model.ecommerce.Address" scope="request"/>
 <jsp:useBean id="shippingCountryList" class="java.util.ArrayList" scope="request"/>
 <%-- Form body--%>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
     if (document.getElementById("shippingCountry").value.trim() == "") {
       alert("Please choose a Country");
@@ -180,7 +180,7 @@
     <button class="button primary" name="button" value="save">Save &amp; Continue</button>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function updateCountry${widgetContext.uniqueId}() {
     var countryElement = document.getElementById("country");
     var country = countryElement.options[countryElement.selectedIndex].value;

--- a/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
@@ -230,7 +230,7 @@
 <%-- Javascript after content--%>
     <script src="${ctx}/javascript/foundation-6.8.1/what-input-5.2.6.min.js"></script>
     <script src="${ctx}/javascript/foundation-6.8.1/foundation.min.js"></script>
-    <script>
+    <script nonce="${cspNonce}">
       $(document).foundation();
       <%--
       $('.card-profile-stats-more-link').click(function(e){

--- a/src/main/webapp/WEB-INF/jsp/global-message.jsp
+++ b/src/main/webapp/WEB-INF/jsp/global-message.jsp
@@ -21,13 +21,13 @@
     <div class="callout radius alert" role="alert" tabindex="-1">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
-    <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
+    <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
   </c:when>
   <c:when test="${'warning' eq messageType}">
     <div class="callout radius warning" role="alert" tabindex="-1">
       <p class="text-center"><c:out value="${messageValue}" /></p>
     </div>
-    <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
+    <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
   </c:when>
   <c:when test="${'success' eq messageType}">
     <div class="callout radius success" role="status">

--- a/src/main/webapp/WEB-INF/jsp/items/activity-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/activity-list.jsp
@@ -86,7 +86,7 @@
   </c:forEach>
 </ul>
 </div>
-<script>
+<script nonce="${cspNonce}">
   // Enable notifications
   if ("Notification" in window) {
     if (Notification.permission !== 'denied') {
@@ -109,7 +109,7 @@
     }
   }
 </script>
-<script>
+<script nonce="${cspNonce}">
   // Polling
   String.prototype.toHtmlEntities = function() {
     return this.replace(/./gm, function(s) {
@@ -240,7 +240,7 @@
     }, 5000);
   })();
 </script>
-<script>
+<script nonce="${cspNonce}">
     $(document).ready(function () {
         function resizeEditor() {
             var container = document.getElementById("platform-activity-list${widgetContext.uniqueId}");

--- a/src/main/webapp/WEB-INF/jsp/items/item-business-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-business-form.jsp
@@ -24,8 +24,8 @@
 <jsp:useBean id="cancelUrl" class="java.lang.String" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-  <script>
+  <script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+  <script nonce="${cspNonce}">
     function onSubmit(token) {
       // Submit the form
       document.getElementById("form${widgetContext.uniqueId}").submit();

--- a/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
@@ -31,7 +31,7 @@
 </h4>
 </c:if>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   Dropzone.options.myDropzone = {
     autoProcessQueue: false,
     parallelUploads: 2,

--- a/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-full-form.jsp
@@ -23,7 +23,7 @@
 <jsp:useBean id="categoryList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="cancelUrl" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   tinymce.init({
     license_key: 'gpl',
     selector: '.html-field',
@@ -77,7 +77,7 @@
   }
 </script>
 <%-- Handle item image uploads --%>
-<script>
+<script nonce="${cspNonce}">
   function SavePhoto(e) {
     var file = e.files[0]; // similar to: document.getElementById("file").files[0]
     var formData = new FormData();
@@ -405,7 +405,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="expectedDate" name="expectedDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${item.expectedDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               $('#expectedDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -422,7 +422,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="expirationDate" name="expirationDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${item.expirationDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               $('#expirationDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -441,7 +441,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="startDate" name="startDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${item.startDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               $('#startDate').fdatepicker({
                 format: 'mm-dd-yyyy hh:ii',
@@ -458,7 +458,7 @@
               <input class="input-group-field" type="text" placeholder="mm-dd-yyyy time" id="endDate" name="endDate" value="<fmt:formatDate pattern="MM-dd-yyyy HH:mm" value="${item.endDate}" />">
             </div>
           </label>
-          <script>
+          <script nonce="${cspNonce}">
             $(function(){
               // yyyy-MM-dd HH:mm:ss.fffffffff
               $('#endDate').fdatepicker({
@@ -533,7 +533,7 @@
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast">
   <h3>Loading...</h3>
 </div>
-<script>
+<script nonce="${cspNonce}">
   $('#imageBrowserReveal').on('open.zf.reveal', function () {
     $('#imageBrowserReveal').html("<h3>Loading...</h3>");
     $.ajax({

--- a/src/main/webapp/WEB-INF/jsp/items/item-job-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-job-form.jsp
@@ -24,8 +24,8 @@
 <jsp:useBean id="cancelUrl" class="java.lang.String" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-  <script>
+  <script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+  <script nonce="${cspNonce}">
     function onSubmit(token) {
       // Submit the form
       document.getElementById("form${widgetContext.uniqueId}").submit();

--- a/src/main/webapp/WEB-INF/jsp/items/item-member-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-member-form.jsp
@@ -46,7 +46,7 @@
     <input type="submit" class="button radius success expanded" value="Add"/>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
     if (document.getElementById("roleId").value.trim() == "") {
       alert("Make sure to choose a role");
@@ -67,7 +67,7 @@
     return true;
   }
 </script>
-<script>
+<script nonce="${cspNonce}">
   var xhr${widgetContext.uniqueId};
   new autoComplete({
     selector: 'input[name="searchName"]',

--- a/src/main/webapp/WEB-INF/jsp/items/item-relationship-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-relationship-form.jsp
@@ -61,7 +61,7 @@
     <input type="submit" class="button radius success expanded" value="Save"/>
   </div>
 </form>
-<script>
+<script nonce="${cspNonce}">
   function checkForm${widgetContext.uniqueId}() {
     // Validate the stuff before submitting...
     if (document.getElementById("relatedCollectionId").value.trim() == "") {
@@ -79,7 +79,7 @@
     return true;
   }
 </script>
-<script>
+<script nonce="${cspNonce}">
   var xhr${widgetContext.uniqueId};
   new autoComplete({
     selector: 'input[name="relatedItemName"]',

--- a/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
@@ -26,7 +26,7 @@
 <jsp:useBean id="showRelatedCollectionName" class="java.lang.String" scope="request"/>
 <jsp:useBean id="showRemoveRelationshipButton" class="java.lang.String" scope="request"/>
 <c:if test="${showRemoveRelationshipButton eq 'true'}">
-  <script>
+  <script nonce="${cspNonce}">
     function removeRelationship${widgetContext.uniqueId}(relatedItemId) {
       if (!confirm("Are you sure you want to remove the relationship?")) {
         return;

--- a/src/main/webapp/WEB-INF/jsp/items/items-search-expanded-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-search-expanded-form.jsp
@@ -70,7 +70,7 @@
 </form>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${useLocation eq 'true'}">
-<script>
+<script nonce="${cspNonce}">
   var xhr${widgetContext.uniqueId}location;
   new autoComplete({
     selector: 'input[name="location"]',
@@ -85,7 +85,7 @@
 </c:if>
 
 <c:if test="${useAutoComplete eq 'true'}">
-<script>
+<script nonce="${cspNonce}">
   var xhr${widgetContext.uniqueId}name;
   new autoComplete({
     selector: 'input[name="name"]',

--- a/src/main/webapp/WEB-INF/jsp/items/items-search-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-search-form.jsp
@@ -66,7 +66,7 @@
   </div>
 </form>
 <c:if test="${useLocation eq 'true' or useAutoComplete eq 'true'}">
-<script>
+<script nonce="${cspNonce}">
   <c:if test="${useLocation eq 'true'}">
   <%-- Location --%>
   var xhr${widgetContext.uniqueId}location;

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
@@ -22,7 +22,7 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="sitePropertyMap" class="java.util.HashMap" scope="request"/>
-<script type="text/javascript">
+<script type="text/javascript" nonce="${cspNonce}">
     function validateEmail${widgetContext.uniqueId}(email) {
         var re = /\S+@\S+\.\S+/;
         return re.test(email);

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-simple-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-simple-form.jsp
@@ -23,8 +23,8 @@
 <jsp:useBean id="formFieldList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-  <script>
+  <script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+  <script nonce="${cspNonce}">
     function onSubmit(token) {
       document.getElementById("form${widgetContext.uniqueId}").submit();
     }

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-vertical-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-vertical-form.jsp
@@ -22,7 +22,7 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="sitePropertyMap" class="java.util.HashMap" scope="request"/>
-<script type="text/javascript">
+<script type="text/javascript" nonce="${cspNonce}">
     function validateEmail${widgetContext.uniqueId}(email) {
         let re = /\S+@\S+\.\S+/;
         return re.test(email);

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-with-name-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-with-name-form.jsp
@@ -23,8 +23,8 @@
 <jsp:useBean id="formFieldList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-<script src='https://www.google.com/recaptcha/api.js'></script>
-<script>
+<script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+<script nonce="${cspNonce}">
   function onSubmit(token) {
     document.getElementById("form${widgetContext.uniqueId}").submit();
   }

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -53,7 +53,7 @@
          override an administrator who forced light or dark. Kept inline and tiny on purpose: an
          external script would arrive too late. If script-src is ever tightened in PageServlet,
          this needs a nonce. --%>
-    <script>(function(){try{var s=window.localStorage.getItem('simis-cms-color-scheme');if(s==='light'||s==='dark'){document.documentElement.setAttribute('data-theme',s);}}catch(e){}})();</script>
+    <script nonce="${cspNonce}">(function(){try{var s=window.localStorage.getItem('simis-cms-color-scheme');if(s==='light'||s==='dark'){document.documentElement.setAttribute('data-theme',s);}}catch(e){}})();</script>
   </c:if>
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -309,7 +309,7 @@
   <%-- Javascript before content--%>
   <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin') && !fn:startsWith(pageRenderInfo.name, '/content-editor')}">
     <c:if test="${!empty analyticsPropertyMap['analytics.google.tagmanager'] && fn:startsWith(analyticsPropertyMap['analytics.google.tagmanager'], 'GTM-')}">
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      <script nonce="${cspNonce}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
@@ -565,12 +565,12 @@
     </c:otherwise>
   </c:choose>
   <%-- Javascript after content--%>
-  <script>
+  <script nonce="${cspNonce}">
     var mainToken = '${userSession.formToken}';
   </script>
     <script src="${ctx}/javascript/foundation-6.8.1/what-input-5.2.6.min.js"></script>
     <script src="${ctx}/javascript/foundation-6.8.1/foundation.min.js"></script>
-    <script>
+    <script nonce="${cspNonce}">
       $(document).foundation();
       <%--
       $('.card-profile-stats-more-link').click(function(e){
@@ -726,8 +726,8 @@
   <c:set var="doNotTrack" value="${header['DNT'] eq '1' || header['Sec-GPC'] eq '1'}"/>
   <c:if test="${!fn:startsWith(pageRenderInfo.name, '/admin') && !doNotTrack}">
     <c:if test="${!empty analyticsPropertyMap['analytics.service'] && 'google' eq analyticsPropertyMap['analytics.service'] && !empty analyticsPropertyMap['analytics.google.key']}">
-      <script async src="https://www.googletagmanager.com/gtag/js?id=${js:escape(analyticsPropertyMap['analytics.google.key'])}"></script>
-      <script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=${js:escape(analyticsPropertyMap['analytics.google.key'])}" nonce="${cspNonce}"></script>
+      <script nonce="${cspNonce}">
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
@@ -735,10 +735,10 @@
       </script>
     </c:if>
     <c:if test="${!empty analyticsPropertyMap['analytics.simplifi.value']}">
-      <script async src='https://tag.simpli.fi/sifitag/${js:escape(analyticsPropertyMap['analytics.simplifi.value'])}'></script>
+      <script async src='https://tag.simpli.fi/sifitag/${js:escape(analyticsPropertyMap['analytics.simplifi.value'])}' nonce="${cspNonce}"></script>
     </c:if>
     <c:if test="${!empty analyticsPropertyMap['analytics.brandcdn.value'] && !empty analyticsPropertyMap['analytics.brandcdn.value2']}">
-      <script type="text/javascript" src="//tag.brandcdn.com/autoscript/${js:escape(analyticsPropertyMap['analytics.brandcdn.value'])}/${js:escape(analyticsPropertyMap['analytics.brandcdn.value2'])}"></script>
+      <script type="text/javascript" src="//tag.brandcdn.com/autoscript/${js:escape(analyticsPropertyMap['analytics.brandcdn.value'])}/${js:escape(analyticsPropertyMap['analytics.brandcdn.value2'])}" nonce="${cspNonce}"></script>
     </c:if>
   </c:if>
   <c:if test="${pageEditMode eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/maps/apple_map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/apple_map.jsp
@@ -31,7 +31,7 @@ NOT IMPLEMENTED
 
 <%-- Render the widget --%>
 <div id="mapid" style="height: ${mapHeight}px;"></div>
-<script>
+<script nonce="${cspNonce}">
   var mymap = L.map('mapid').setView([${latitude}, ${longitude}], 13);
 
   <c:choose>

--- a/src/main/webapp/WEB-INF/jsp/maps/items-map-app.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/items-map-app.jsp
@@ -79,7 +79,7 @@
     <div id="mapid${widgetContext.uniqueId}" style="height:${mapHeight};"></div>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   var map${widgetContext.uniqueId} = L.map('mapid${widgetContext.uniqueId}').setView([${latitude},${longitude}],${mapZoomLevel});
   <c:choose>
     <c:when test="${mapCredentials.service eq 'mapbox'}">

--- a/src/main/webapp/WEB-INF/jsp/maps/leaflet-js_map.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/leaflet-js_map.jsp
@@ -35,7 +35,7 @@
 <script src="${ctx}/javascript/leaflet.markercluster-1.5.3/leaflet.markercluster.js"></script>
 <%-- Render the widget --%>
 <div id="mapid${widgetContext.uniqueId}" style="height: ${mapHeight}px;"></div>
-<script>
+<script nonce="${cspNonce}">
   var map${widgetContext.uniqueId} = L.map('mapid${widgetContext.uniqueId}').setView([${latitude}, ${longitude}], ${mapZoomLevel});
   <c:choose>
     <c:when test="${mapCredentials.service eq 'mapbox'}">

--- a/src/main/webapp/WEB-INF/jsp/maps/property-map-app.jsp
+++ b/src/main/webapp/WEB-INF/jsp/maps/property-map-app.jsp
@@ -160,7 +160,7 @@
     <div id="mapid${widgetContext.uniqueId}" style="height: ${mapHeight};"></div>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
   var map${widgetContext.uniqueId} = L.map('mapid${widgetContext.uniqueId}').setView([${latitude}, ${longitude}], ${mapZoomLevel});
   <c:choose>
     <c:when test="${mapCredentials.service eq 'mapbox'}">

--- a/src/main/webapp/WEB-INF/jsp/page_messages.jspf
+++ b/src/main/webapp/WEB-INF/jsp/page_messages.jspf
@@ -18,13 +18,13 @@
   <div class="callout radius alert" role="alert" tabindex="-1">
     <p class="text-center"><c:out value="${errorMessage}" /></p>
   </div>
-  <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
+  <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty warningMessage}">
   <div class="callout radius warning" role="alert" tabindex="-1">
     <p class="text-center"><c:out value="${warningMessage}" /></p>
   </div>
-  <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
+  <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty successMessage}">
   <div class="callout radius success" role="status" data-closable>

--- a/src/main/webapp/WEB-INF/jsp/register/register-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/register/register-form.jsp
@@ -19,8 +19,8 @@
 <jsp:useBean id="user" class="com.simisinc.platform.domain.model.User" scope="request"/>
 <jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
 <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-  <script>
+  <script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+  <script nonce="${cspNonce}">
     function onSubmit(token) {
       document.getElementById("form${widgetContext.uniqueId}").submit();
     }

--- a/src/main/webapp/WEB-INF/jsp/todoList/todo-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/todoList/todo-list.jsp
@@ -58,7 +58,7 @@
     </p>
   </c:otherwise>
 </c:choose>
-<script>
+<script nonce="${cspNonce}">
   var elements = document.getElementsByClassName("${widgetContext.uniqueId}todoListItem");
   var myFunction = function(ev) {
     ev.target.parentNode.classList[ ev.target.checked ? 'add' : 'remove'] ('selected');

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-email-preferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-email-preferences.jsp
@@ -53,7 +53,7 @@
         </div>
       </div>
     </form>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="${cspNonce}">
       $(document).ready(function () {
         $('[id^=mailingListCheck]').click(function () {
           var mailingListId = $(this).val();

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-profile-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-profile-form.jsp
@@ -23,7 +23,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="cancelUrl" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
-<script>
+<script nonce="${cspNonce}">
   tinymce.init({
     license_key: 'gpl',
     selector: '.html-field',
@@ -39,7 +39,7 @@
   });
 </script>
 <jsp:useBean id="fieldList" class="java.util.ArrayList" scope="request"/>
-<script>
+<script nonce="${cspNonce}">
   $(document).ready(function() {
     $('textarea').keypress(function(event) {
       if (event.keyCode === 13) {


### PR DESCRIPTION
## Summary

- **`PageServlet`**: generates a 16-byte `SecureRandom` nonce per request, stores it as the `cspNonce` request attribute, and extends the existing CSP header with `script-src 'self' 'nonce-<value>'`
  - `'self'` covers the ~25 same-origin bundled scripts (jQuery, Foundation, etc.) without per-tag changes
  - `'nonce-<value>'` is required for all inline script blocks and external CDN scripts
- **160 nonce attributes** added to 112 JSP/JSPF files:
  - All 144 inline `<script>` blocks across 110 JSP files
  - 2 inline scripts in `page_messages.jspf`
  - External CDN scripts: Google Analytics, GTM, Simpli.fi, BrandCDN (in `main.jsp`), reCAPTCHA (in 5 form JSPs), Square sandbox + production (payment form), Stripe (payment form)

**Before**: `script-src` was absent from the CSP — inline scripts were completely unrestricted.  
**After**: modern browsers enforce nonce-only for inline scripts while same-origin bundled scripts remain allowed via `'self'`.

## Test plan

- [ ] Load any page; inspect response `Content-Security-Policy` header — should contain `script-src 'self' 'nonce-<22-char-base64>'`
- [ ] Refresh the same page; verify the nonce value changes on every request
- [ ] Check browser DevTools Console — no CSP violations from inline scripts or external analytics scripts on a page with GTM/GA4 configured
- [ ] Admin pages: charts, drag-and-drop (sitemap), color pickers, file dropzone all function normally
- [ ] Forms with reCAPTCHA load and submit correctly
- [ ] Square/Stripe payment forms load correctly
- [ ] Injecting a bare `<script>alert(1)</script>` via URL param or stored XSS is blocked by the browser (CSP violation reported, script not executed)

Closes #364