### PR TITLE
P4 Slice 3: canvas overlay controls for structural mutations

### DIFF
--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -419,6 +419,52 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-move-btns {
   color: #fff;
 }
 
+/* ── Structural mutation buttons (add / remove section, column, widget) ── */
+
+.sc-mutate-btns {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: none;
+  gap: 2px;
+  z-index: 101;
+  padding: 2px;
+}
+
+body.page-edit-mode [data-editor-section]:hover > .sc-mutate-btns,
+body.page-edit-mode [data-editor-column]:hover > .sc-mutate-btns,
+body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
+  display: flex;
+}
+
+.sc-mutate-btns button {
+  border: none;
+  color: #fff;
+  font-size: 10px;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 2px;
+  line-height: 1.4;
+  font-family: sans-serif;
+  white-space: nowrap;
+}
+
+.sc-mutate-btn-add {
+  background: rgba(0, 86, 179, 0.75);
+}
+
+.sc-mutate-btn-add:hover {
+  background: #0056b3;
+}
+
+.sc-mutate-btn-remove {
+  background: rgba(192, 57, 43, 0.75);
+}
+
+.sc-mutate-btn-remove:hover {
+  background: #c0392b;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -728,6 +728,97 @@
     });
   }
 
+  // ── Structural mutations (add / remove section, column, widget) ─────────────
+
+  function mutatePage(action, params) {
+    var qs = new URLSearchParams();
+    qs.append('action', action);
+    qs.append('token', getToken());
+    if (params) {
+      Object.keys(params).forEach(function (k) {
+        if (params[k] !== undefined) qs.append(k, String(params[k]));
+      });
+    }
+    return fetch(window.location.pathname + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (!data.success) throw new Error(data.error || 'Mutation failed');
+      return data;
+    });
+  }
+
+  function insertMutateButtons(el, type, s, c, w) {
+    var btns = document.createElement('div');
+    btns.className = 'sc-mutate-btns';
+
+    function addBtn(label, cls, onClick) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = cls;
+      btn.title = label;
+      btn.textContent = label;
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        onClick();
+      });
+      btns.appendChild(btn);
+    }
+
+    if (type === 'section') {
+      addBtn('+ Section', 'sc-mutate-btn-add', function () {
+        setToolbarStatus('Adding section…');
+        mutatePage('addSection', {after: s}).then(function () {
+          markHasDraft();
+          window.location.reload();
+        }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+      });
+      addBtn('✕ Section', 'sc-mutate-btn-remove', function () {
+        showConfirm('Remove this section and all its content?', 'Remove', true, function () {
+          setToolbarStatus('Removing section…');
+          mutatePage('removeSection', {s: s}).then(function () {
+            markHasDraft();
+            window.location.reload();
+          }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+        });
+      });
+    } else if (type === 'column') {
+      addBtn('+ Column', 'sc-mutate-btn-add', function () {
+        setToolbarStatus('Adding column…');
+        mutatePage('addColumn', {s: s, after: c}).then(function () {
+          markHasDraft();
+          window.location.reload();
+        }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+      });
+      addBtn('✕ Column', 'sc-mutate-btn-remove', function () {
+        showConfirm('Remove this column and all its widgets?', 'Remove', true, function () {
+          setToolbarStatus('Removing column…');
+          mutatePage('removeColumn', {s: s, c: c}).then(function () {
+            markHasDraft();
+            window.location.reload();
+          }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+        });
+      });
+    } else if (type === 'widget') {
+      addBtn('✕ Widget', 'sc-mutate-btn-remove', function () {
+        showConfirm('Remove this widget?', 'Remove', true, function () {
+          setToolbarStatus('Removing widget…');
+          mutatePage('removeWidget', {s: s, c: c, w: w}).then(function () {
+            markHasDraft();
+            window.location.reload();
+          }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+        });
+      });
+    }
+
+    el.appendChild(btns);
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────────
 
   inlineToolbar = buildInlineToolbar();
@@ -748,18 +839,27 @@
       insertDragHandle(el, 'section');
       insertMoveButtons(el, 'section');
       makeDraggable(el, 'section');
+      insertMutateButtons(el, 'section', idx, -1, -1);
     }
   });
 
   // Columns
   document.querySelectorAll('[data-editor-column]').forEach(function (el) {
     var parts = el.dataset.editorColumn.split('-');
+    var colSectionIdx = parseInt(parts[0], 10);
     var colIdx = parseInt(parts[1], 10);
     insertHandle(el, 'column', 'Col ' + (colIdx + 1));
+    if (layoutMode) {
+      insertMutateButtons(el, 'column', colSectionIdx, colIdx, -1);
+    }
   });
 
   // Widgets
   document.querySelectorAll('[data-editor-widget]').forEach(function (el) {
+    var wParts = el.dataset.editorWidget.split('-');
+    var wSIdx = parseInt(wParts[0], 10);
+    var wCIdx = parseInt(wParts[1], 10);
+    var wIdx = parseInt(wParts[2], 10);
     var isContentWidget = !!el.querySelector('[data-content-unique-id]');
     var href = isContentWidget ? null : (ctx + '/admin/web-page-designer?webPage=' + encodeURIComponent(pagePath));
     insertHandle(el, 'widget', isContentWidget ? 'Content' : 'Widget', href);
@@ -767,12 +867,13 @@
       insertDragHandle(el, 'widget');
       insertMoveButtons(el, 'widget');
       makeDraggable(el, 'widget');
+      insertMutateButtons(el, 'widget', wSIdx, wCIdx, wIdx);
     }
   });
 
   // Click on a content block → activate inline editor
   document.addEventListener('click', function (e) {
-    if (e.target.closest('.sc-editor-drag-handle, .sc-move-btns, .sc-editor-handle')) return;
+    if (e.target.closest('.sc-editor-drag-handle, .sc-move-btns, .sc-mutate-btns, .sc-editor-handle')) return;
 
     var contentEl = e.target.closest('.platform-content[data-content-unique-id]');
     if (contentEl) {


### PR DESCRIPTION
## Summary

- Adds hover-revealed mutation buttons to sections, columns, and widgets in layout edit mode
- Sections get "+ Section" (insert after) and "✕ Section" (remove) at bottom-right
- Columns get "+ Column" (insert after) and "✕ Column" (remove) at bottom-right
- Widgets get "✕ Widget" (remove) at bottom-right
- All destructive actions gated behind the confirm modal (red button)
- Successful mutation posts to `PageServlet` via the `mutatePage()` helper using the `s`/`c`/`w`/`after` params from PR #389, then calls `markHasDraft()` + `window.location.reload()` to reflect the updated XML in the DOM

## Depends on
PR #389 (`MutateLayoutCommand` + `PageServlet` dispatch) must be merged first.

## Test plan
- [ ] Build compiles clean (`ant compile`)
- [ ] In layout edit mode, hover a section — "+ Section" and "✕ Section" buttons appear at bottom-right
- [ ] Clicking "+ Section" adds a new empty section after the hovered one and reloads; draft indicator activates
- [ ] Clicking "✕ Section" on a section with content shows the confirm modal; confirming removes it and reloads
- [ ] Hover a column — "+ Column" and "✕ Column" buttons appear; both work correctly
- [ ] Hover a widget — "✕ Widget" button appears; confirming removes it and reloads
- [ ] Clicking a mutate button while inline editing is active does not accidentally deactivate the inline editor
- [ ] No mutate buttons appear when `layoutMode` is false (content-only edit mode)