### PR TITLE
P4 Slice 4: column-width picker popover

### DIFF
--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -465,6 +465,99 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
   background: #c0392b;
 }
 
+/* ── Column-width picker popover ── */
+
+#sc-width-picker {
+  position: absolute;
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 8px;
+  z-index: 10001;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  font-family: sans-serif;
+  width: 216px;
+}
+
+#sc-width-presets {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.sc-width-preset-btn {
+  background: #2a2a3e;
+  border: 1px solid #555;
+  color: #ccc;
+  padding: 5px 4px;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 12px;
+  text-align: center;
+  font-family: sans-serif;
+  line-height: 1.2;
+}
+
+.sc-width-preset-btn:hover {
+  border-color: #0056b3;
+  color: #fff;
+  background: #2a2a4e;
+}
+
+.sc-width-preset-btn.sc-active {
+  background: #0056b3;
+  border-color: #0056b3;
+  color: #fff;
+}
+
+#sc-width-custom-row {
+  display: flex;
+  gap: 4px;
+}
+
+#sc-width-custom-input {
+  flex: 1;
+  background: #2a2a3e;
+  border: 1px solid #555;
+  color: #eee;
+  padding: 3px 6px;
+  font-size: 11px;
+  border-radius: 3px;
+  font-family: sans-serif;
+  min-width: 0;
+}
+
+#sc-width-custom-input:focus {
+  outline: none;
+  border-color: #0056b3;
+}
+
+#sc-width-custom-apply {
+  background: #0056b3;
+  border: none;
+  color: #fff;
+  padding: 3px 8px;
+  font-size: 11px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: sans-serif;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+#sc-width-custom-apply:hover {
+  opacity: 0.9;
+}
+
+.sc-mutate-btn-width {
+  background: rgba(40, 167, 69, 0.7) !important;
+}
+
+.sc-mutate-btn-width:hover {
+  background: #28a745 !important;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -14,6 +14,8 @@
 
   var inlineToolbar = null;
   var linkPrompt = null;
+  var widthPicker = null;
+  var widthPickerTarget = null;
   var activeContent = null;     // the .platform-content div currently being edited
   var activeWidget = null;      // its [data-editor-widget] ancestor
   var savedSelection = null;    // Selection saved before link prompt opens
@@ -804,6 +806,17 @@
           }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
         });
       });
+      // Width trigger — references its own button for popover positioning
+      var widthTriggerBtn = document.createElement('button');
+      widthTriggerBtn.type = 'button';
+      widthTriggerBtn.className = 'sc-mutate-btn-width sc-width-trigger';
+      widthTriggerBtn.title = 'Column width';
+      widthTriggerBtn.textContent = '⇔ Width';
+      widthTriggerBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        openWidthPicker(widthTriggerBtn, s, c, el.className);
+      });
+      btns.appendChild(widthTriggerBtn);
     } else if (type === 'widget') {
       addBtn('✕ Widget', 'sc-mutate-btn-remove', function () {
         showConfirm('Remove this widget?', 'Remove', true, function () {
@@ -819,11 +832,120 @@
     el.appendChild(btns);
   }
 
+  // ── Column-width picker popover ──────────────────────────────────────────────
+
+  var COL_PRESETS = [
+    {label: '1/1',  value: 'small-12 cell'},
+    {label: '1/2',  value: 'small-12 medium-6 cell'},
+    {label: '2/3',  value: 'small-12 medium-8 cell'},
+    {label: '1/3',  value: 'small-12 medium-4 cell'},
+    {label: '3/4',  value: 'small-12 large-9 cell'},
+    {label: '1/4',  value: 'small-12 large-3 cell'},
+  ];
+
+  function buildWidthPicker() {
+    var picker = document.createElement('div');
+    picker.id = 'sc-width-picker';
+    picker.setAttribute('role', 'dialog');
+    picker.setAttribute('aria-label', 'Column width');
+    picker.style.display = 'none';
+
+    var grid = document.createElement('div');
+    grid.id = 'sc-width-presets';
+    COL_PRESETS.forEach(function (preset) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sc-width-preset-btn';
+      btn.dataset.classValue = preset.value;
+      btn.title = preset.value;
+      btn.textContent = preset.label;
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        applyColumnWidth(preset.value);
+      });
+      grid.appendChild(btn);
+    });
+    picker.appendChild(grid);
+
+    var customRow = document.createElement('div');
+    customRow.id = 'sc-width-custom-row';
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'sc-width-custom-input';
+    input.placeholder = 'Custom classes…';
+    input.setAttribute('aria-label', 'Custom column class');
+    var applyBtn = document.createElement('button');
+    applyBtn.type = 'button';
+    applyBtn.id = 'sc-width-custom-apply';
+    applyBtn.textContent = 'Apply';
+    applyBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      applyColumnWidth(input.value.trim());
+    });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.stopPropagation(); applyColumnWidth(input.value.trim()); }
+      if (e.key === 'Escape') closeWidthPicker();
+    });
+    customRow.appendChild(input);
+    customRow.appendChild(applyBtn);
+    picker.appendChild(customRow);
+
+    document.body.appendChild(picker);
+    return picker;
+  }
+
+  function openWidthPicker(triggerEl, s, c, currentClass) {
+    widthPickerTarget = {s: s, c: c};
+
+    var input = document.getElementById('sc-width-custom-input');
+    if (input) input.value = currentClass || '';
+
+    document.querySelectorAll('.sc-width-preset-btn').forEach(function (btn) {
+      btn.classList.toggle('sc-active', btn.dataset.classValue === currentClass);
+    });
+
+    widthPicker.style.display = 'block';
+
+    // Position below the trigger, clamped to viewport
+    var rect = triggerEl.getBoundingClientRect();
+    var pw = 216;
+    var left = window.scrollX + rect.left;
+    if (left + pw > window.innerWidth - 8) left = window.innerWidth - pw - 8;
+    widthPicker.style.top = (window.scrollY + rect.bottom + 4) + 'px';
+    widthPicker.style.left = Math.max(8, left) + 'px';
+  }
+
+  function closeWidthPicker() {
+    if (widthPicker) widthPicker.style.display = 'none';
+    widthPickerTarget = null;
+  }
+
+  function applyColumnWidth(cls) {
+    if (!cls || !widthPickerTarget) return;
+    var target = widthPickerTarget;
+    closeWidthPicker();
+    setToolbarStatus('Updating column width…');
+    mutatePage('setColumnClass', {s: target.s, c: target.c, 'class': cls}).then(function () {
+      markHasDraft();
+      window.location.reload();
+    }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────────
 
   inlineToolbar = buildInlineToolbar();
   linkPrompt = buildLinkPrompt();
   buildConfirmModal();
+  widthPicker = buildWidthPicker();
+
+  // Close width picker on outside click
+  document.addEventListener('click', function (e) {
+    if (widthPicker && widthPicker.style.display !== 'none') {
+      if (!widthPicker.contains(e.target) && !e.target.closest('.sc-width-trigger')) {
+        closeWidthPicker();
+      }
+    }
+  });
 
   if (layoutMode) {
     buildSaveLayoutButton();      // inserts before Exit


### PR DESCRIPTION
## Summary

- Hovering a column in layout edit mode now shows a green "⇔ Width" button in the mutate-button bar
- Clicking it opens a popover with Foundation grid width presets (1/1, 1/2, 2/3, 1/3, 3/4, 1/4) in a 3-column grid, plus a free-text custom input
- Current column class is pre-filled in the custom input; the matching preset is highlighted
- Selection posts `setColumnClass` to PageServlet (`s`, `c`, `class` params from PR #389), then calls `markHasDraft()` + `window.location.reload()`
- Popover closes on outside click or Escape without making changes

## Depends on
- PR #389 (`MutateLayoutCommand` + `PageServlet` dispatch)
- PR #390 (canvas overlay controls — provides `mutatePage()`, `insertMutateButtons()`)

## Test plan
- [ ] Build compiles clean (`ant compile`)
- [ ] Hover a column in layout edit mode — "⇔ Width" button appears alongside +/✕ buttons
- [ ] Clicking "⇔ Width" opens the popover below the button, clamped to viewport
- [ ] Active preset highlighted matches the column's current class
- [ ] Clicking a preset (e.g., 1/2) sends `setColumnClass` and reloads; column has `small-12 medium-6 cell`
- [ ] Custom input accepts arbitrary class string and applies on "Apply" or Enter
- [ ] Pressing Escape closes the picker without changes
- [ ] Clicking outside the picker closes it
- [ ] Width picker does not appear when `layoutMode` is false