### PR TITLE
P4 Slice 5: section style picker + generalize class-picker popover

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
@@ -34,13 +34,13 @@
       <%-- Determine the section container CSS --%>
       <c:choose>
         <c:when test="${empty section.cssClass && fn:startsWith(pageRenderInfo.name, '/admin')}">
-          <div id="<c:out value="${sectionId}"/>" class="grid-x grid-padding-x"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
+          <div id="<c:out value="${sectionId}"/>" class="grid-x grid-padding-x"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}" data-editor-section-class="<c:out value="${section.cssClass}"/>"</c:if>>
         </c:when>
         <c:when test="${!empty section.cssClass && (fn:contains(section.cssClass,'grid') || fn:contains(section.cssClass,'platform-no-margin'))}">
-          <div id="<c:out value="${sectionId}"/>" class="<c:out value="${section.cssClass}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
+          <div id="<c:out value="${sectionId}"/>" class="<c:out value="${section.cssClass}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}" data-editor-section-class="<c:out value="${section.cssClass}"/>"</c:if>>
         </c:when>
         <c:otherwise>
-          <div class="full-container" id="<c:out value="${sectionId}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}"</c:if>>
+          <div class="full-container" id="<c:out value="${sectionId}"/>"<c:if test="${!empty section.cssStyle}"> style="<c:out value="${section.cssStyle}" />"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-section="${sectionStatus.index}" data-editor-section-class="<c:out value="${section.cssClass}"/>"</c:if>>
 <%--          <div class="full-container"<c:if test="${!empty section.htmlId}"> id="${section.htmlId}"</c:if>>--%>
             <div class="grid-container">
               <div class="grid-x grid-margin-x<c:if test="${!empty section.cssClass}"> <c:out value="${section.cssClass}"/></c:if>">

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -558,6 +558,14 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
   background: #28a745 !important;
 }
 
+.sc-mutate-btn-style {
+  background: rgba(0, 86, 179, 0.7) !important;
+}
+
+.sc-mutate-btn-style:hover {
+  background: #0056b3 !important;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -15,7 +15,7 @@
   var inlineToolbar = null;
   var linkPrompt = null;
   var widthPicker = null;
-  var widthPickerTarget = null;
+  var classPickerApplyFn = null;
   var activeContent = null;     // the .platform-content div currently being edited
   var activeWidget = null;      // its [data-editor-widget] ancestor
   var savedSelection = null;    // Selection saved before link prompt opens
@@ -789,6 +789,24 @@
           }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
         });
       });
+      // Style trigger — references its own button for popover positioning
+      var styleTriggerBtn = document.createElement('button');
+      styleTriggerBtn.type = 'button';
+      styleTriggerBtn.className = 'sc-mutate-btn-style sc-width-trigger';
+      styleTriggerBtn.title = 'Section style';
+      styleTriggerBtn.textContent = '⊞ Style';
+      styleTriggerBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        openWidthPicker(styleTriggerBtn, SECTION_PRESETS, el.dataset.editorSectionClass || '', function (cls) {
+          closeWidthPicker();
+          setToolbarStatus('Updating section style…');
+          mutatePage('setSectionClass', {s: s, 'class': cls}).then(function () {
+            markHasDraft();
+            window.location.reload();
+          }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+        });
+      });
+      btns.appendChild(styleTriggerBtn);
     } else if (type === 'column') {
       addBtn('+ Column', 'sc-mutate-btn-add', function () {
         setToolbarStatus('Adding column…');
@@ -814,7 +832,14 @@
       widthTriggerBtn.textContent = '⇔ Width';
       widthTriggerBtn.addEventListener('click', function (e) {
         e.stopPropagation();
-        openWidthPicker(widthTriggerBtn, s, c, el.className);
+        openWidthPicker(widthTriggerBtn, COL_PRESETS, el.className, function (cls) {
+          closeWidthPicker();
+          setToolbarStatus('Updating column width…');
+          mutatePage('setColumnClass', {s: s, c: c, 'class': cls}).then(function () {
+            markHasDraft();
+            window.location.reload();
+          }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+        });
       });
       btns.appendChild(widthTriggerBtn);
     } else if (type === 'widget') {
@@ -832,39 +857,35 @@
     el.appendChild(btns);
   }
 
-  // ── Column-width picker popover ──────────────────────────────────────────────
+  // ── Class picker popover (shared by column width + section style) ─────────────
 
   var COL_PRESETS = [
-    {label: '1/1',  value: 'small-12 cell'},
-    {label: '1/2',  value: 'small-12 medium-6 cell'},
-    {label: '2/3',  value: 'small-12 medium-8 cell'},
-    {label: '1/3',  value: 'small-12 medium-4 cell'},
-    {label: '3/4',  value: 'small-12 large-9 cell'},
-    {label: '1/4',  value: 'small-12 large-3 cell'},
+    {label: '1/1', value: 'small-12 cell'},
+    {label: '1/2', value: 'small-12 medium-6 cell'},
+    {label: '2/3', value: 'small-12 medium-8 cell'},
+    {label: '1/3', value: 'small-12 medium-4 cell'},
+    {label: '3/4', value: 'small-12 large-9 cell'},
+    {label: '1/4', value: 'small-12 large-3 cell'},
+  ];
+
+  var SECTION_PRESETS = [
+    {label: 'Default',   value: ''},
+    {label: 'Centered',  value: 'align-center'},
+    {label: 'Compact',   value: 'grid-x grid-padding-x'},
+    {label: 'Cmpct Ctr', value: 'grid-x grid-padding-x align-center'},
+    {label: 'Margins',   value: 'grid-x grid-margin-x'},
+    {label: 'No Margin', value: 'platform-no-margin'},
   ];
 
   function buildWidthPicker() {
     var picker = document.createElement('div');
     picker.id = 'sc-width-picker';
     picker.setAttribute('role', 'dialog');
-    picker.setAttribute('aria-label', 'Column width');
+    picker.setAttribute('aria-label', 'Class picker');
     picker.style.display = 'none';
 
     var grid = document.createElement('div');
     grid.id = 'sc-width-presets';
-    COL_PRESETS.forEach(function (preset) {
-      var btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'sc-width-preset-btn';
-      btn.dataset.classValue = preset.value;
-      btn.title = preset.value;
-      btn.textContent = preset.label;
-      btn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        applyColumnWidth(preset.value);
-      });
-      grid.appendChild(btn);
-    });
     picker.appendChild(grid);
 
     var customRow = document.createElement('div');
@@ -873,17 +894,17 @@
     input.type = 'text';
     input.id = 'sc-width-custom-input';
     input.placeholder = 'Custom classes…';
-    input.setAttribute('aria-label', 'Custom column class');
+    input.setAttribute('aria-label', 'Custom class');
     var applyBtn = document.createElement('button');
     applyBtn.type = 'button';
     applyBtn.id = 'sc-width-custom-apply';
     applyBtn.textContent = 'Apply';
     applyBtn.addEventListener('click', function (e) {
       e.stopPropagation();
-      applyColumnWidth(input.value.trim());
+      if (classPickerApplyFn) classPickerApplyFn(input.value.trim());
     });
     input.addEventListener('keydown', function (e) {
-      if (e.key === 'Enter') { e.stopPropagation(); applyColumnWidth(input.value.trim()); }
+      if (e.key === 'Enter') { e.stopPropagation(); if (classPickerApplyFn) classPickerApplyFn(input.value.trim()); }
       if (e.key === 'Escape') closeWidthPicker();
     });
     customRow.appendChild(input);
@@ -894,8 +915,25 @@
     return picker;
   }
 
-  function openWidthPicker(triggerEl, s, c, currentClass) {
-    widthPickerTarget = {s: s, c: c};
+  function openWidthPicker(triggerEl, presets, currentClass, applyFn) {
+    classPickerApplyFn = applyFn;
+
+    // Rebuild preset buttons for this invocation's preset list
+    var grid = document.getElementById('sc-width-presets');
+    grid.innerHTML = '';
+    presets.forEach(function (preset) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sc-width-preset-btn';
+      btn.dataset.classValue = preset.value;
+      btn.title = preset.value || '(default)';
+      btn.textContent = preset.label;
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (classPickerApplyFn) classPickerApplyFn(preset.value);
+      });
+      grid.appendChild(btn);
+    });
 
     var input = document.getElementById('sc-width-custom-input');
     if (input) input.value = currentClass || '';
@@ -917,18 +955,7 @@
 
   function closeWidthPicker() {
     if (widthPicker) widthPicker.style.display = 'none';
-    widthPickerTarget = null;
-  }
-
-  function applyColumnWidth(cls) {
-    if (!cls || !widthPickerTarget) return;
-    var target = widthPickerTarget;
-    closeWidthPicker();
-    setToolbarStatus('Updating column width…');
-    mutatePage('setColumnClass', {s: target.s, c: target.c, 'class': cls}).then(function () {
-      markHasDraft();
-      window.location.reload();
-    }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+    classPickerApplyFn = null;
   }
 
   // ── Bootstrap ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a blue "⊞ Style" button to each section's mutate-button bar in layout edit mode
- Clicking it opens the shared class-picker popover (from PR #391) with six Foundation-grid section presets: Default, Centered, Compact, Compact Center, Margins, No Margin
- The picker opens pre-filled with the section's current XML class and highlights the matching preset
- Selecting a preset or typing a custom class posts `setSectionClass` (`s`, `class` params from PR #389), then `markHasDraft()` + reload

### Refactoring (Slice 4 → Slice 5)
The column-width picker is generalized into a shared "class picker":
- `openWidthPicker(triggerEl, presets, currentClass, applyFn)` — presets and apply logic are now passed by the caller instead of hard-coded
- `buildWidthPicker()` creates an empty preset grid populated on each open call
- `applyColumnWidth()` removed; column and section each provide their own inline apply closure
- `widthPickerTarget` replaced by `classPickerApplyFn`

`layout-body-renderer.jspf`: all three section-rendering branches now emit `data-editor-section-class` so JS can read the raw XML cssClass (the rendered className doesn't directly reflect it due to the full-container wrapper logic).

## Depends on
- PR #389 (`MutateLayoutCommand` + `PageServlet` dispatch)
- PR #390 (canvas overlay controls)
- PR #391 (column width picker — this PR refactors its internals)

## Test plan
- [ ] `ant compile` clean
- [ ] Column "⇔ Width" picker still works correctly after refactor
- [ ] Hover a section in layout edit mode — "⊞ Style" button appears alongside +/✕
- [ ] Opener highlights the current class if it matches a preset
- [ ] Selecting "Centered" sends `setSectionClass` with `class=align-center` and reloads
- [ ] Selecting "Default" sends empty string (removes extra class), reloads to full-container layout
- [ ] Custom input applies arbitrary class on Enter or Apply
- [ ] Escape / outside click closes without changes
- [ ] Style picker absent when `layoutMode` is false