### PR TITLE
P4 Slice 6: inline widget preferences editor

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WidgetRenderInfo.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WidgetRenderInfo.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.controller;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Description
@@ -35,6 +36,7 @@ public class WidgetRenderInfo implements Serializable {
   private boolean sticky = false;
   private boolean hr = false;
   private String content = null;
+  private String prefsJson = "{}";
 
   public WidgetRenderInfo() {
   }
@@ -46,6 +48,28 @@ public class WidgetRenderInfo implements Serializable {
     this.sticky = widget.isSticky();
     this.hr = widget.hasHr();
     this.content = content;
+    Map<String, String> prefs = widget.getPreferences();
+    if (prefs != null && !prefs.isEmpty()) {
+      this.prefsJson = prefsToJson(prefs);
+    }
+  }
+
+  private static String prefsToJson(Map<String, String> prefs) {
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<String, String> e : prefs.entrySet()) {
+      if (!first) sb.append(',');
+      sb.append('"').append(e.getKey()).append("\":\"");
+      String v = e.getValue();
+      if (v != null) {
+        sb.append(v.replace("\\", "\\\\").replace("\"", "\\\"")
+            .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t"));
+      }
+      sb.append('"');
+      first = false;
+    }
+    sb.append('}');
+    return sb.toString();
   }
 
   public String getHtmlId() {
@@ -68,5 +92,9 @@ public class WidgetRenderInfo implements Serializable {
 
   public String getContent() {
     return content;
+  }
+
+  public String getPrefsJson() {
+    return prefsJson;
   }
 }

--- a/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
@@ -81,12 +81,12 @@
               ${widget.content}
             </c:when>
             <c:when test="${!empty widget.cssClass}">
-              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}"</c:if>>
+              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>"</c:if>>
                 ${widget.content}
               </div>
             </c:when>
             <c:otherwise>
-              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}"</c:if>>
+              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>"</c:if>>
                 ${widget.content}
               </div>
             </c:otherwise>

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -566,6 +566,124 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
   background: #0056b3 !important;
 }
 
+.sc-mutate-btn-prefs {
+  background: rgba(108, 117, 125, 0.75);
+}
+
+.sc-mutate-btn-prefs:hover {
+  background: #6c757d;
+}
+
+/* ── Widget preferences panel ── */
+
+#sc-prefs-panel {
+  position: absolute;
+  background: #1a1a2e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 8px;
+  z-index: 10001;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  font-family: sans-serif;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#sc-prefs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#sc-prefs-header span {
+  color: #ccc;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+#sc-prefs-close {
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+#sc-prefs-close:hover {
+  color: #fff;
+}
+
+#sc-prefs-textarea {
+  background: #2a2a3e;
+  border: 1px solid #555;
+  color: #eee;
+  padding: 6px;
+  font-size: 11px;
+  border-radius: 3px;
+  font-family: monospace;
+  resize: vertical;
+  min-height: 80px;
+  max-height: 200px;
+  width: 100%;
+  box-sizing: border-box;
+  line-height: 1.5;
+}
+
+#sc-prefs-textarea:focus {
+  outline: none;
+  border-color: #0056b3;
+}
+
+#sc-prefs-error {
+  color: #dc3545;
+  font-size: 11px;
+  min-height: 0;
+  line-height: 1.3;
+}
+
+#sc-prefs-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+#sc-prefs-reset {
+  background: #3a3a4e;
+  border: 1px solid #555;
+  color: #ccc;
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: sans-serif;
+}
+
+#sc-prefs-reset:hover {
+  color: #fff;
+  background: #4a4a5e;
+}
+
+#sc-prefs-apply {
+  background: #0056b3;
+  border: none;
+  color: #fff;
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: sans-serif;
+}
+
+#sc-prefs-apply:hover {
+  opacity: 0.9;
+}
+
 /* Link prompt overlay */
 #sc-link-prompt {
   position: absolute;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -16,6 +16,8 @@
   var linkPrompt = null;
   var widthPicker = null;
   var classPickerApplyFn = null;
+  var prefsPanel = null;
+  var prefsPanelTarget = null;
   var activeContent = null;     // the .platform-content div currently being edited
   var activeWidget = null;      // its [data-editor-widget] ancestor
   var savedSelection = null;    // Selection saved before link prompt opens
@@ -843,6 +845,17 @@
       });
       btns.appendChild(widthTriggerBtn);
     } else if (type === 'widget') {
+      // Prefs trigger — references its own button for panel positioning
+      var prefsTriggerBtn = document.createElement('button');
+      prefsTriggerBtn.type = 'button';
+      prefsTriggerBtn.className = 'sc-mutate-btn-prefs sc-prefs-trigger';
+      prefsTriggerBtn.title = 'Widget preferences';
+      prefsTriggerBtn.textContent = '⚙ Prefs';
+      prefsTriggerBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        openPrefsPanel(prefsTriggerBtn, s, c, w, el.dataset.editorWidgetPrefs || '{}');
+      });
+      btns.appendChild(prefsTriggerBtn);
       addBtn('✕ Widget', 'sc-mutate-btn-remove', function () {
         showConfirm('Remove this widget?', 'Remove', true, function () {
           setToolbarStatus('Removing widget…');
@@ -958,18 +971,140 @@
     classPickerApplyFn = null;
   }
 
+  // ── Widget preferences panel ──────────────────────────────────────────────
+
+  function buildPrefsPanel() {
+    var panel = document.createElement('div');
+    panel.id = 'sc-prefs-panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', 'Widget preferences');
+    panel.style.display = 'none';
+
+    var header = document.createElement('div');
+    header.id = 'sc-prefs-header';
+    var title = document.createElement('span');
+    title.textContent = 'Widget Prefs';
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.id = 'sc-prefs-close';
+    closeBtn.textContent = '×';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      closePrefsPanel();
+    });
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+    panel.appendChild(header);
+
+    var textarea = document.createElement('textarea');
+    textarea.id = 'sc-prefs-textarea';
+    textarea.setAttribute('aria-label', 'Preferences JSON');
+    textarea.setAttribute('spellcheck', 'false');
+    textarea.setAttribute('autocomplete', 'off');
+    panel.appendChild(textarea);
+
+    var error = document.createElement('div');
+    error.id = 'sc-prefs-error';
+    error.setAttribute('aria-live', 'polite');
+    panel.appendChild(error);
+
+    var footer = document.createElement('div');
+    footer.id = 'sc-prefs-footer';
+    var resetBtn = document.createElement('button');
+    resetBtn.type = 'button';
+    resetBtn.id = 'sc-prefs-reset';
+    resetBtn.textContent = 'Reset';
+    resetBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (prefsPanelTarget) textarea.value = prefsPanelTarget.original;
+      error.textContent = '';
+    });
+    var applyBtn = document.createElement('button');
+    applyBtn.type = 'button';
+    applyBtn.id = 'sc-prefs-apply';
+    applyBtn.textContent = 'Apply';
+    applyBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      applyPrefs();
+    });
+    footer.appendChild(resetBtn);
+    footer.appendChild(applyBtn);
+    panel.appendChild(footer);
+
+    panel.addEventListener('click', function (e) { e.stopPropagation(); });
+    document.body.appendChild(panel);
+    return panel;
+  }
+
+  function openPrefsPanel(triggerEl, s, c, w, currentPrefsJson) {
+    prefsPanelTarget = {s: s, c: c, w: w, original: currentPrefsJson};
+
+    var textarea = document.getElementById('sc-prefs-textarea');
+    var error = document.getElementById('sc-prefs-error');
+    try {
+      textarea.value = JSON.stringify(JSON.parse(currentPrefsJson), null, 2);
+    } catch (e) {
+      textarea.value = currentPrefsJson;
+    }
+    if (error) error.textContent = '';
+
+    prefsPanel.style.display = 'flex';
+
+    var rect = triggerEl.getBoundingClientRect();
+    var pw = 300;
+    var left = window.scrollX + rect.left;
+    if (left + pw > window.innerWidth - 8) left = window.innerWidth - pw - 8;
+    prefsPanel.style.top = (window.scrollY + rect.bottom + 4) + 'px';
+    prefsPanel.style.left = Math.max(8, left) + 'px';
+
+    textarea.focus();
+  }
+
+  function closePrefsPanel() {
+    if (prefsPanel) prefsPanel.style.display = 'none';
+    prefsPanelTarget = null;
+  }
+
+  function applyPrefs() {
+    if (!prefsPanelTarget) return;
+    var textarea = document.getElementById('sc-prefs-textarea');
+    var error = document.getElementById('sc-prefs-error');
+    var raw = textarea.value.trim();
+    if (!raw) { if (error) error.textContent = 'Enter at least one key/value pair.'; return; }
+    try {
+      JSON.parse(raw);
+    } catch (e) {
+      if (error) error.textContent = 'Invalid JSON: ' + e.message;
+      return;
+    }
+    var target = prefsPanelTarget;
+    closePrefsPanel();
+    setToolbarStatus('Saving preferences…');
+    mutatePage('setWidgetPreferences', {s: target.s, c: target.c, w: target.w, prefs: raw}).then(function () {
+      markHasDraft();
+      window.location.reload();
+    }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────────
 
   inlineToolbar = buildInlineToolbar();
   linkPrompt = buildLinkPrompt();
   buildConfirmModal();
   widthPicker = buildWidthPicker();
+  prefsPanel = buildPrefsPanel();
 
   // Close width picker on outside click
   document.addEventListener('click', function (e) {
     if (widthPicker && widthPicker.style.display !== 'none') {
       if (!widthPicker.contains(e.target) && !e.target.closest('.sc-width-trigger')) {
         closeWidthPicker();
+      }
+    }
+    if (prefsPanel && prefsPanel.style.display !== 'none') {
+      if (!prefsPanel.contains(e.target) && !e.target.closest('.sc-prefs-trigger')) {
+        closePrefsPanel();
       }
     }
   });
@@ -1048,10 +1183,12 @@
     showInlineToolbar();
   });
 
-  // Keyboard shortcut: Escape exits editor
+  // Keyboard shortcut: Escape exits editor or closes open panels
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape' && activeContent) {
-      deactivateEdit(true);
+    if (e.key === 'Escape') {
+      if (prefsPanel && prefsPanel.style.display !== 'none') { closePrefsPanel(); return; }
+      if (widthPicker && widthPicker.style.display !== 'none') { closeWidthPicker(); return; }
+      if (activeContent) deactivateEdit(true);
     }
   });
 


### PR DESCRIPTION
## Summary

- Hovering a widget in layout edit mode shows a grey "⚙ Prefs" button alongside "✕ Widget"
- Clicking it opens a floating panel pre-filled with the widget's current preferences as pretty-printed JSON
- Client-side JSON validation on Apply; invalid JSON shows an error message without submitting
- Valid JSON posts `setWidgetPreferences` (`s`, `c`, `w`, `prefs` params from PR #389) then `markHasDraft()` + reload
- Reset button restores the textarea to its original value
- Escape and outside-click close without changes; Escape now closes prefs panel → class picker → content editor in priority order

### Backend — `WidgetRenderInfo.java`
- Added `prefsJson` field (defaults to `{}`)
- Constructor serializes `widget.getPreferences()` to compact JSON using a hand-rolled writer; keys are pre-validated to `[a-zA-Z][a-zA-Z0-9]*` so they never need escaping
- `getPrefsJson()` getter

### JSP — `layout-body-renderer.jspf`
- Both widget div branches now emit `data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>"` so the JS can read current prefs from the DOM

## Depends on
- PR #389 (`MutateLayoutCommand` + `PageServlet` dispatch)
- PR #390 (canvas overlay controls)
- PR #391 (column width picker)
- PR #392 (section style picker — this PR builds on that branch)

## Test plan
- [ ] `ant compile` clean, no warnings on `WidgetRenderInfo`
- [ ] Hover a widget with known preferences — "⚙ Prefs" button appears; clicking shows panel pre-filled with correct JSON (pretty-printed)
- [ ] Hover a widget with no preferences — panel opens showing `{}`
- [ ] Edit a value and click Apply → `setWidgetPreferences` posted, draft indicator activates, page reloads with updated prefs
- [ ] Enter invalid JSON → error message shown, no POST fired
- [ ] Click Reset → textarea restored to original value
- [ ] Escape closes the panel; pressing again closes class picker if open; pressing again exits inline editing
- [ ] Outside click closes panel
- [ ] No "⚙ Prefs" button when `layoutMode` is false