### PR TITLE
P4 Slice 7: Add widget-type picker for addWidget

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -425,6 +425,17 @@ public class PageServlet extends HttpServlet {
       // Determine the Page XML Layout for this request
       Page pageRef = WebPageXmlLayoutCommand.retrievePageForRequest(webPage, pagePath);
       Map<String, String> widgetLibrary = WebPageXmlLayoutCommand.getWidgetLibrary();
+      if (pageLayoutMode) {
+        StringBuilder wl = new StringBuilder("[");
+        boolean wlFirst = true;
+        for (String name : new TreeSet<>(widgetLibrary.keySet())) {
+          if (!wlFirst) wl.append(',');
+          wl.append('"').append(name.replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+          wlFirst = false;
+        }
+        wl.append(']');
+        request.setAttribute("widgetLibraryJson", wl.toString());
+      }
 
       // In edit mode, layout builders preview the draft layout (bypasses cache)
       if (pageEditMode && EditorPermissionCommand.canBuildLayout(userSession)

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -338,7 +338,8 @@
          data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>"
          data-ctx="${ctx}"
          data-layout-mode="<c:out value="${pageLayoutMode}"/>"
-         data-has-draft="<c:out value="${hasDraft}"/>">
+         data-has-draft="<c:out value="${hasDraft}"/>"
+         data-widget-names="<c:out value="${widgetLibraryJson}"/>">
       <span id="sc-editor-toolbar-title">Visual Editor</span>
       <a href="${ctx}/admin/web-page-designer?webPage=<c:out value="${pageRenderInfo.pagePath}"/>" class="button small hollow secondary"><i class="fa fa-fw fa-code"></i> XML</a>
       <a href="?editMode=false" id="sc-editor-exit" class="button small hollow secondary"><i class="fa fa-fw fa-times"></i> Exit</a>

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -721,3 +721,92 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
 #sc-link-prompt button.sc-cancel {
   background: #555;
 }
+
+/* ── Widget picker ─────────────────────────────────────────────────────────── */
+
+#sc-widget-picker {
+  position: fixed;
+  z-index: 10020;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  flex-direction: column;
+  width: 220px;
+  max-height: 320px;
+}
+
+#sc-widget-picker .sc-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+  font-size: 11px;
+  font-weight: 600;
+  color: #333;
+  flex-shrink: 0;
+}
+
+#sc-widget-picker .sc-picker-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #666;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+#sc-widget-search {
+  margin: 6px 8px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 12px;
+  outline: none;
+  flex-shrink: 0;
+}
+
+#sc-widget-search:focus {
+  border-color: #0056b3;
+}
+
+#sc-widget-list {
+  list-style: none;
+  margin: 0 0 4px;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+#sc-widget-list li {
+  padding: 5px 12px;
+  font-size: 12px;
+  color: #333;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#sc-widget-list li:hover {
+  background: #e8f0fe;
+  color: #0056b3;
+}
+
+.sc-mutate-btn-add-widget {
+  background: rgba(16, 141, 149, 0.75);
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sc-mutate-btn-add-widget:hover {
+  background: rgba(16, 141, 149, 1);
+}

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -18,6 +18,9 @@
   var classPickerApplyFn = null;
   var prefsPanel = null;
   var prefsPanelTarget = null;
+  var widgetPicker = null;
+  var widgetPickerTarget = null;
+  var widgetNames = [];
   var activeContent = null;     // the .platform-content div currently being edited
   var activeWidget = null;      // its [data-editor-widget] ancestor
   var savedSelection = null;    // Selection saved before link prompt opens
@@ -844,6 +847,18 @@
         });
       });
       btns.appendChild(widthTriggerBtn);
+      // Add-widget trigger for this column (appends after last existing widget)
+      var addWidgetColBtn = document.createElement('button');
+      addWidgetColBtn.type = 'button';
+      addWidgetColBtn.className = 'sc-mutate-btn-add-widget sc-widget-trigger';
+      addWidgetColBtn.title = 'Add widget to column';
+      addWidgetColBtn.textContent = '+ Widget';
+      addWidgetColBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        var widgetEls = el.querySelectorAll(':scope > [data-editor-widget]');
+        openWidgetPicker(addWidgetColBtn, s, c, widgetEls.length - 1);
+      });
+      btns.appendChild(addWidgetColBtn);
     } else if (type === 'widget') {
       // Prefs trigger — references its own button for panel positioning
       var prefsTriggerBtn = document.createElement('button');
@@ -856,6 +871,17 @@
         openPrefsPanel(prefsTriggerBtn, s, c, w, el.dataset.editorWidgetPrefs || '{}');
       });
       btns.appendChild(prefsTriggerBtn);
+      // Add-widget-after trigger for this widget position
+      var addWidgetAfterBtn = document.createElement('button');
+      addWidgetAfterBtn.type = 'button';
+      addWidgetAfterBtn.className = 'sc-mutate-btn-add-widget sc-widget-trigger';
+      addWidgetAfterBtn.title = 'Add widget after this one';
+      addWidgetAfterBtn.textContent = '+ Widget';
+      addWidgetAfterBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        openWidgetPicker(addWidgetAfterBtn, s, c, w);
+      });
+      btns.appendChild(addWidgetAfterBtn);
       addBtn('✕ Widget', 'sc-mutate-btn-remove', function () {
         showConfirm('Remove this widget?', 'Remove', true, function () {
           setToolbarStatus('Removing widget…');
@@ -1087,6 +1113,85 @@
     }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
   }
 
+  // ── Widget picker ─────────────────────────────────────────────────────────
+
+  function buildWidgetPicker() {
+    var p = document.createElement('div');
+    p.id = 'sc-widget-picker';
+    p.style.display = 'none';
+    p.innerHTML =
+      '<div class="sc-picker-header"><span>Add Widget</span>' +
+      '<button type="button" class="sc-picker-close" title="Close">&#215;</button></div>' +
+      '<input type="text" id="sc-widget-search" placeholder="Search widget…" autocomplete="off">' +
+      '<ul id="sc-widget-list"></ul>';
+    document.body.appendChild(p);
+
+    p.querySelector('.sc-picker-close').addEventListener('click', function () {
+      closeWidgetPicker();
+    });
+
+    var searchInput = p.querySelector('#sc-widget-search');
+    searchInput.addEventListener('input', function () {
+      filterWidgetList(searchInput.value);
+    });
+    searchInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') closeWidgetPicker();
+    });
+
+    return p;
+  }
+
+  function filterWidgetList(query) {
+    if (!widgetPicker) return;
+    var list = widgetPicker.querySelector('#sc-widget-list');
+    if (!list) return;
+    var q = query.trim().toLowerCase();
+    list.querySelectorAll('li').forEach(function (li) {
+      li.style.display = (!q || li.dataset.name.indexOf(q) !== -1) ? '' : 'none';
+    });
+  }
+
+  function openWidgetPicker(triggerEl, s, c, after) {
+    if (!widgetPicker) return;
+    widgetPickerTarget = {s: s, c: c, after: after};
+
+    var list = widgetPicker.querySelector('#sc-widget-list');
+    list.innerHTML = '';
+    widgetNames.forEach(function (name) {
+      var li = document.createElement('li');
+      li.dataset.name = name;
+      li.textContent = name;
+      li.addEventListener('click', function () {
+        var target = widgetPickerTarget;
+        closeWidgetPicker();
+        setToolbarStatus('Adding widget…');
+        mutatePage('addWidget', {s: target.s, c: target.c, after: target.after, widgetName: name}).then(function () {
+          markHasDraft();
+          window.location.reload();
+        }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
+      });
+      list.appendChild(li);
+    });
+
+    var searchInput = widgetPicker.querySelector('#sc-widget-search');
+    searchInput.value = '';
+    filterWidgetList('');
+
+    var rect = triggerEl.getBoundingClientRect();
+    var pw = 220;
+    var left = Math.min(rect.left, window.innerWidth - pw - 8);
+    widgetPicker.style.left = Math.max(8, left) + 'px';
+    widgetPicker.style.top = (rect.bottom + 4) + 'px';
+    widgetPicker.style.display = 'flex';
+
+    setTimeout(function () { searchInput.focus(); }, 0);
+  }
+
+  function closeWidgetPicker() {
+    if (widgetPicker) widgetPicker.style.display = 'none';
+    widgetPickerTarget = null;
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────────
 
   inlineToolbar = buildInlineToolbar();
@@ -1094,6 +1199,8 @@
   buildConfirmModal();
   widthPicker = buildWidthPicker();
   prefsPanel = buildPrefsPanel();
+  widgetPicker = buildWidgetPicker();
+  widgetNames = JSON.parse((toolbar && toolbar.dataset.widgetNames) || '[]');
 
   // Close width picker on outside click
   document.addEventListener('click', function (e) {
@@ -1105,6 +1212,11 @@
     if (prefsPanel && prefsPanel.style.display !== 'none') {
       if (!prefsPanel.contains(e.target) && !e.target.closest('.sc-prefs-trigger')) {
         closePrefsPanel();
+      }
+    }
+    if (widgetPicker && widgetPicker.style.display !== 'none') {
+      if (!widgetPicker.contains(e.target) && !e.target.closest('.sc-widget-trigger')) {
+        closeWidgetPicker();
       }
     }
   });
@@ -1186,6 +1298,7 @@
   // Keyboard shortcut: Escape exits editor or closes open panels
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
+      if (widgetPicker && widgetPicker.style.display !== 'none') { closeWidgetPicker(); return; }
       if (prefsPanel && prefsPanel.style.display !== 'none') { closePrefsPanel(); return; }
       if (widthPicker && widthPicker.style.display !== 'none') { closeWidthPicker(); return; }
       if (activeContent) deactivateEdit(true);


### PR DESCRIPTION
## Summary

- Exposes the widget library as a sorted JSON array on the editor toolbar (`data-widget-names`) via a new `widgetLibraryJson` request attribute set in `PageServlet` — only populated when the user has layout-builder permission
- Adds a searchable `#sc-widget-picker` popover with a search input and scrollable list of widget names
- Wires in two entry points for the picker:
  - **Column mutate bar**: `+ Widget` button appends after the last existing widget (or prepends to empty columns)
  - **Widget mutate bar**: `+ Widget` button inserts a new widget directly after the hovered one
- Selecting a name POSTs `addWidget` with `{s, c, after, widgetName}` then reloads the page to show the new widget
- Picker closes on outside click, Escape key, or after selection

## Test plan

- [ ] Enter layout mode on a page with at least two columns — one empty, one with widgets
- [ ] Hover a column → mutate bar shows `+ Widget`; click it → picker opens listing all widget types
- [ ] Type a partial name in the search box → list filters live; Escape closes the picker
- [ ] Select a widget → page reloads with the new widget appended at the end of that column
- [ ] Hover an existing widget → mutate bar shows `+ Widget`; selecting inserts after that specific widget
- [ ] Verify empty-column `after=-1` sends the widget to position 0
- [ ] Verify that non-layout-mode users (content editors only) do NOT see the `+ Widget` buttons