### PR TITLE
JSON-LD structured data for Organization, WebPage, and Product (#403)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageRenderInfo.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageRenderInfo.java
@@ -45,6 +45,7 @@ public class PageRenderInfo implements ContainerRenderInfo, Serializable {
   private String pageType = "website";
   private String pageUrl;
   private String cssClass = null;
+  private String jsonLdData;
 
   public PageRenderInfo() {
   }
@@ -156,6 +157,14 @@ public class PageRenderInfo implements ContainerRenderInfo, Serializable {
 
   public void setPageUrl(String pageUrl) {
     this.pageUrl = pageUrl;
+  }
+
+  public String getJsonLdData() {
+    return jsonLdData;
+  }
+
+  public void setJsonLdData(String jsonLdData) {
+    this.jsonLdData = jsonLdData;
   }
 
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -736,6 +736,14 @@ public class PageServlet extends HttpServlet {
         }
       }
 
+      // Generate JSON-LD structured data for search engines and AI (issue #403)
+      if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
+        if (StringUtils.isNotBlank(jsonLd)) {
+          pageRenderInfo.setJsonLdData(jsonLd);
+        }
+      }
+
       // Finally... we have a page ready to be processed...
       if (LOG.isDebugEnabled()) {
         LOG.debug(request.getMethod() + " page " + pageRef.getName());
@@ -873,6 +881,85 @@ public class PageServlet extends HttpServlet {
 
     } catch (Exception e) {
       LOG.error("Page error caught: " + e.getMessage(), e);
+    }
+  }
+
+  private static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl,
+                                            Map<String, String> sitePropertyMap,
+                                            Item item, Collection collection) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      Map<String, Object> jsonLd = new LinkedHashMap<>();
+      jsonLd.put("@context", "https://schema.org");
+
+      List<Map<String, Object>> graph = new ArrayList<>();
+
+      // Add Organization schema (for homepage) - include on every page for consistency
+      if (StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
+        Map<String, Object> organization = new LinkedHashMap<>();
+        organization.put("@type", "Organization");
+        organization.put("@id", siteUrl + "#organization");
+        organization.put("name", sitePropertyMap.get("site.name"));
+        organization.put("url", siteUrl);
+
+        String siteLogo = sitePropertyMap.get("site.image");
+        if (StringUtils.isNotBlank(siteLogo)) {
+          if (siteLogo.startsWith("/")) {
+            organization.put("logo", siteUrl + siteLogo);
+          } else {
+            organization.put("logo", siteLogo);
+          }
+        }
+        graph.add(organization);
+      }
+
+      // Add WebPage schema for all pages
+      Map<String, Object> webPage = new LinkedHashMap<>();
+      webPage.put("@type", "WebPage");
+      if (StringUtils.isNotBlank(pageRenderInfo.getPageUrl())) {
+        webPage.put("url", pageRenderInfo.getPageUrl());
+      }
+      if (StringUtils.isNotBlank(pageRenderInfo.getTitle())) {
+        webPage.put("name", pageRenderInfo.getTitle());
+      }
+      if (StringUtils.isNotBlank(pageRenderInfo.getDescription())) {
+        webPage.put("description", pageRenderInfo.getDescription());
+      }
+      webPage.put("isPartOf", Collections.singletonMap("@id", siteUrl + "#organization"));
+
+      // Add image if available
+      if (StringUtils.isNotBlank(pageRenderInfo.getImageUrl())) {
+        String imageUrl = pageRenderInfo.getImageUrl();
+        if (imageUrl.startsWith("/")) {
+          imageUrl = siteUrl + imageUrl;
+        }
+        webPage.put("image", imageUrl);
+      }
+      graph.add(webPage);
+
+      // Add Product schema if this is an item (catalog product)
+      if (item != null && StringUtils.isNotBlank(item.getName())) {
+        Map<String, Object> product = new LinkedHashMap<>();
+        product.put("@type", "Product");
+        product.put("name", item.getName());
+        if (StringUtils.isNotBlank(item.getDescription())) {
+          product.put("description", item.getDescription());
+        }
+        if (StringUtils.isNotBlank(pageRenderInfo.getImageUrl())) {
+          String imageUrl = pageRenderInfo.getImageUrl();
+          if (imageUrl.startsWith("/")) {
+            imageUrl = siteUrl + imageUrl;
+          }
+          product.put("image", imageUrl);
+        }
+        graph.add(product);
+      }
+
+      jsonLd.put("@graph", graph);
+      return mapper.writeValueAsString(jsonLd);
+    } catch (Exception e) {
+      LOG.warn("Error generating JSON-LD data: " + e.getMessage());
+      return null;
     }
   }
 

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -138,6 +138,10 @@
   <c:if test="${!empty pageRenderInfo.canonicalUrl}">
     <link rel="canonical" href="<c:out value="${pageRenderInfo.canonicalUrl}"/>" />
   </c:if>
+  <%-- JSON-LD structured data for search engines and AI (issue #403) --%>
+  <c:if test="${!empty pageRenderInfo.jsonLdData}">
+    <script type="application/ld+json"><c:out value="${pageRenderInfo.jsonLdData}" escapeXml="false" /></script>
+  </c:if>
   <%-- CSS --%>
     <c:if test="${!empty themePropertyMap['theme.fonts.body']}">
       <link rel="stylesheet" href="${ctx}/css/google-fonts/<c:out value="${themePropertyMap['theme.fonts.body']}"/>.css">


### PR DESCRIPTION
## Summary
Implement JSON-LD structured data schema markup for improved search engine understanding and rich snippet generation (issue #403).

### Changes
- **PageRenderInfo**: Added `jsonLdData` field to carry serialized JSON-LD
- **PageServlet**: Implemented `generateJsonLdData()` method that builds schema.org markup using Jackson ObjectMapper
  - Organization schema (company name, URL, logo) on all pages
  - WebPage schema (title, description, URL, image) on all pages  
  - Product schema (name, description, image) on item/catalog pages
- **main.jsp**: Added `<script type="application/ld+json">` block to render the structured data

### Design Decisions
- **Server-side generation**: JSON-LD is built in PageServlet using same data sources as canonical URLs and Open Graph tags (PageRenderInfo, sitePropertyMap)
- **Jackson ObjectMapper**: Used for clean JSON serialization instead of string concatenation; helps avoid escaping issues
- **@graph pattern**: Entities are linked via @id/@context to enable cross-references and consistency
- **All-page coverage**: Organization and WebPage schemas appear on every page for consistent semantic metadata

### Validation
Structured data can be validated using [Google Rich Results Test](https://search.google.com/test/rich-results) or schema.org validator. The implementation follows Google's JSON-LD embedding recommendations.

### Testing
- Compiles successfully against Java 21
- Unit tests execute (pre-existing failures in unrelated test classes are pre-existing)
- JSON-LD generation gracefully handles missing data (optional fields)

Closes issue #403 in the SEO & Discoverability milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)