### PR TITLE
Fix invalid azure/login action version blocking every image publish

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -96,7 +96,7 @@ jobs:
       # Skip when ACR_REGISTRY is not set (forks, local branches).
       - name: Sign in to Azure (OIDC)
         if: env.ACR_REGISTRY != ''
-        uses: azure/login@v2.5.0
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
## The problem

`publish-images.yml` references `azure/login@v2.5.0` — a version that was never released. Every run since at least **2026-07-27T01:30** has failed before the Docker build even starts:

```
Unable to resolve action `azure/login@v2.5.0`, unable to find version `v2.5.0`
```

This workflow runs on every push to `main`, on release, and monthly (Debian security-fix rebuild). **No container images have published today.**

## The fix

One line: pin to the resolved commit SHA for the `v2` tag, matching how every other action in this file is already pinned (#269's digest-pinning work):

```diff
-        uses: azure/login@v2.5.0
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
```

Resolved via `gh api repos/Azure/login/commits/v2`, verified against the existing `actions/checkout` pin in this same file using the identical method (both resolve correctly).

## Verified before opening

- YAML parses (`ruby -ryaml`)
- All 8 digest-pinned actions in the file — including this one — resolve via the GitHub API; no other landmines
- Diff is exactly this one line

## Note on #529

PR #529 independently contains this same fix (bundled with 10 other build-safety commits) but is still awaiting review. This is a minimal, standalone version so image publishing is unblocked without waiting on that larger review — once #529 merges, the identical line is a no-op.