### PR TITLE
Close the step-up re-authentication bypass in PR #352 (issue #298)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -424,14 +424,15 @@ public class ContentHtmlCommand {
 
     // Determine the action. Governed publishing (Project #6, Phase 1) adds the review workflow; the
     // gate is enforced only when the site has opted in via content.review.required.
+    // Note: "approve" is intentionally NOT handled here -- it requires step-up re-authentication
+    // (see performContentApproval(), reached via ContentWidget.post()) and must only be reachable
+    // through that gated path.
     String action = context.getParameter("action");
     boolean reviewRequired = LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required");
     if ("publish".equals(action)) {
       return publishContent(context, content, reviewRequired);
     } else if ("submitForReview".equals(action)) {
       return submitForReview(context, content);
-    } else if ("approve".equals(action)) {
-      return approveContent(context, content);
     } else if ("reject".equals(action)) {
       return rejectContent(context, content);
     } else if ("deleteContent".equals(action)) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -121,11 +121,11 @@ public class UserDetailsWidget extends GenericWidget {
       return context;
     }
     // Execute the action
+    // Note: resetPassword is intentionally NOT handled here -- it requires step-up
+    // re-authentication (see post()) and must only be reachable through that gated path.
     context.setRedirect("/admin/user-details?userId=" + userId);
     String action = context.getParameter("action");
-    if ("resetPassword".equals(action)) {
-      return resetPassword(context, user);
-    } else if ("suspendAccount".equals(action)) {
+    if ("suspendAccount".equals(action)) {
       return suspendAccount(context, user);
     } else if ("restoreAccount".equals(action)) {
       return restoreAccount(context, user);

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
@@ -95,4 +95,25 @@ class UserDetailsWidgetTest extends WidgetBase {
       audit.verifyNoInteractions();
     }
   }
+
+  @Test
+  void actionResetPasswordIsNotHandledByTheGetActionPath() throws Exception {
+    // Password reset requires step-up re-authentication (see post()). The GET/action() path must
+    // never reset a password directly -- that would bypass step-up entirely, reachable via a plain
+    // GET request carrying the same parameters the old pre-step-up UI link used to build.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetPassword");
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(lockedUser());
+
+      new UserDetailsWidget().action(widgetContext);
+
+      userRepo.verify(() -> UserRepository.createAccountToken(any()), never());
+      audit.verifyNoInteractions();
+    }
+  }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -16,9 +16,13 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 import java.sql.Connection;
 
@@ -27,6 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.database.DB;
@@ -118,6 +125,34 @@ class ContentWidgetTest extends WidgetBase {
         ContentWidget contentWidget = new ContentWidget();
         widgetContext = contentWidget.action(widgetContext);
       }
+    }
+  }
+
+  @Test
+  void actionApproveIsNotHandledByTheGetActionPath() {
+    // Content approval requires step-up re-authentication (see ContentWidget.post(), which routes
+    // through ContentHtmlCommand.performContentApproval()). The GET/action() path must never approve
+    // content directly -- that would bypass step-up entirely, reachable via a plain GET request.
+    preferences.put("uniqueId", "hello-content");
+    widgetContext.getParameterMap().put("action", new String[] { "approve" });
+
+    Content content = new Content();
+    content.setUniqueId("hello-content");
+    content.setDraftContent("<p>Draft</p>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<ContentReviewCommand> contentReview = mockStatic(ContentReviewCommand.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
+      // Grant edit permission so the test proves the dispatch itself doesn't approve, not just that
+      // permission was denied first.
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+
+      new ContentWidget().action(widgetContext);
+
+      contentReview.verify(() -> ContentReviewCommand.approve(any(), anyLong(), anyString()), never());
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the security-PR audit. #352 added step-up re-authentication to four sensitive admin actions (role/group changes, password reset, MFA disable, content approval), but for two of them the protection was incomplete.

**The bug:** for password reset and content approval, #352 added a new step-up-gated \`post()\` path, but the pre-existing GET-triggered \`action()\` handler for the *same operation* was left completely unmodified -- still reachable, with zero step-up check:

- \`UserDetailsWidget.action()\` still had \`if ("resetPassword".equals(action)) { return resetPassword(context, user); }\`, reachable via a plain GET to \`.../admin/user-details?userId=X&action=resetPassword&token=<anything>\` -- the exact URL shape the pre-#352 UI used to generate.
- \`ContentHtmlCommand.performWebAction()\` (reached via \`ContentWidget.action()\`) still had \`"approve".equals(action) -> approveContent(...)\`, same story.

Neither path requires re-authentication or a real CSRF token (see note below) -- so a hijacked or idle session, or anyone who could get an admin to click a crafted link, could reset another user's password or approve/publish governed content with zero step-up, defeating the entire point of #352.

Not related to the confirmed auth-backdoor pattern from the same compromised window (#526/#528/#529) -- this is a missed-the-other-code-path regression, not anything malicious.

## Fix

Both old GET-triggered UI links were already replaced by the new modal+POST forms as part of #352 itself (confirmed directly against the JSPs -- nothing generates the old link shape anymore), so this removes the dead-but-reachable code path outright rather than duplicating the step-up check in two places:

- \`UserDetailsWidget.action()\` no longer handles \`resetPassword\` -- \`post()\` is now the only entry point
- \`ContentHtmlCommand.performWebAction()\` no longer handles \`approve\` -- \`performContentApproval()\` (reached via \`ContentWidget.post()\`) is now the only entry point

Added regression tests for both, sending the exact same parameters an attacker would and asserting the operation does not fire.

## Known follow-up, not fixed here

While tracing the dispatch path I confirmed a separate, pre-existing issue: the GET/action() dispatch's token check in \`PageServlet.java\` (\`service()\`, around line 872) only verifies the \`token\` parameter is *non-blank* -- it doesn't compare it against \`userSession.getFormToken()\` the way the JSON mutate-action paths do. This isn't introduced by #352 and isn't specific to these two actions -- it affects the GET/action() dispatch pattern sitewide. Didn't fix it here given the blast radius (every widget's \`action()\` method); flagging it as its own follow-up rather than scope-creeping this PR.

## Test plan
- [x] New tests: \`UserDetailsWidgetTest#actionResetPasswordIsNotHandledByTheGetActionPath\`, \`ContentWidgetTest#actionApproveIsNotHandledByTheGetActionPath\` -- both grant permission first (so the test proves the dispatch itself doesn't act, not just that permission was denied), then assert the underlying repository/command call never fires
- [x] `ant -lib lib/war clean compile` -- clean
- [x] `ant -lib lib/war compile-jsp` -- clean
- [x] Both new tests + existing tests in both files pass (7/7)