### PR TITLE
Fix PR #440's broken JSP edits (file upload, order modals, form validation)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/cancel-order.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/cancel-order.jsp
@@ -48,18 +48,8 @@
   </form>
 </div>
 
-<script>
-  function openCancelConfirm() {
-<form method="post" onsubmit="return cancelOrder()">
-  <%-- Required by controller --%>
-  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
-  <input type="hidden" name="token" value="${userSession.formToken}"/>
-  <%-- The form --%>
-  <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
-  <button id="cancelOrderButton" class="button alert expanded">Cancel Order</button>
-</form>
 <script nonce="${cspNonce}">
-  function cancelOrder() {
+  function openCancelConfirm() {
     if (document.getElementById("cancelOrderButton").disabled === true) {
       return;
     }

--- a/src/main/webapp/WEB-INF/jsp/admin/dataset-upload-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/dataset-upload-form.jsp
@@ -56,7 +56,6 @@
     </select>
   </label>
   <div class="button-container">
-    <input type="submit" class="button radius primary" value="Add Dataset"/>
     <input type="submit" class="button radius success" value="Add Dataset" data-disable-on-submit="Uploading..."/>
     <a class="button radius secondary" href="${ctx}/admin/datasets">Cancel</a>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-file-drop-zone.jsp
@@ -36,70 +36,8 @@
 </h4>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script src="${ctx}/javascript/dropzone-setup.js"></script>
-<script>
-  initializeDropzone('myDropzone', 55);
 <script nonce="${cspNonce}">
-  Dropzone.options.myDropzone = {
-    autoProcessQueue: false,
-    parallelUploads: 2,
-    maxFilesize: 55,
-    clickable: '#dz-browse',
-    dictDefaultMessage: 'Drag and drop files here (max 55 MB)<br/><br/>or use the Browse button below',
-    init: function() {
-      var submitButton = document.querySelector("#submit-all");
-      var errorRegion  = document.querySelector("#upload-errors");
-      var statusRegion = document.querySelector("#upload-status");
-      var errorCount   = 0;
-      var successCount = 0;
-      myDropzone = this;
-
-      submitButton.addEventListener("click", function() {
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        myDropzone.processQueue();
-      });
-
-      this.on("addedfile", function() {
-        if (submitButton.classList.contains('primary')) {
-          submitButton.classList.add('success');
-          submitButton.classList.remove('primary');
-        }
-      });
-
-      this.on("success", function() {
-        successCount++;
-        myDropzone.processQueue();
-      });
-
-      this.on("error", function(file, message) {
-        errorCount++;
-        var msg = document.createElement('p');
-        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
-        errorRegion.appendChild(msg);
-      });
-
-      this.on("queuecomplete", function() {
-        if (errorCount === 0 && successCount > 0) {
-          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
-          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
-        }
-      });
-
-      document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        myDropzone.removeAllFiles(true);
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        if (submitButton.classList.contains('success')) {
-          submitButton.classList.add('primary');
-          submitButton.classList.remove('success');
-        }
-      });
-    }
-  };
+  initializeDropzone('myDropzone', 55);
 </script>
 <p>Drag files here or use "Browse Files" to select them, then click "Upload All Files". Use "Reset" to clear your selections.</p>
 <form action="${widgetContext.uri}?widget=${widgetContext.uniqueId}" class="dropzone" id="my-dropzone">

--- a/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
@@ -36,7 +36,6 @@
   </label>
   <%-- TODO: This form is a stub — needs customizable recipient, subject, and body fields --%>
   <div class="button-container">
-    <input type="submit" class="button radius secondary expanded" value="Send Mail"/>
     <input type="submit" class="button radius success expanded" value="Send Mail" data-disable-on-submit="Sending..."/>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/jsp/admin/ship-order.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/ship-order.jsp
@@ -48,18 +48,8 @@
   </form>
 </div>
 
-<script>
-  function openShipConfirm() {
-<form method="post" onsubmit="return shipOrder()">
-  <%-- Required by controller --%>
-  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
-  <input type="hidden" name="token" value="${userSession.formToken}"/>
-  <%-- The form --%>
-  <input type="hidden" name="uniqueId" value="${order.uniqueId}"/>
-  <button id="shipOrderButton" class="button primary expanded">Send Order to Shipping</button>
-</form>
 <script nonce="${cspNonce}">
-  function shipOrder() {
+  function openShipConfirm() {
     if (document.getElementById("shipOrderButton").disabled === true) {
       return;
     }

--- a/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/file-drop-zone.jsp
@@ -31,71 +31,10 @@
 </h4>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script src="${ctx}/javascript/dropzone-setup.js"></script>
-<script>
-  initializeDropzone('myDropzone', 20);
 <script nonce="${cspNonce}">
-  Dropzone.options.myDropzone = {
-    autoProcessQueue: false,
-    parallelUploads: 2,
-    maxFilesize: 20,
-    clickable: '#dz-browse',
-    dictDefaultMessage: 'Drag and drop files here (max 20 MB)<br/><br/>or use the Browse button below',
-    init: function() {
-      var submitButton = document.querySelector("#submit-all");
-      var errorRegion  = document.querySelector("#upload-errors");
-      var statusRegion = document.querySelector("#upload-status");
-      var errorCount   = 0;
-      var successCount = 0;
-      myDropzone = this;
-
-      submitButton.addEventListener("click", function() {
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        myDropzone.processQueue();
-      });
-
-      this.on("addedfile", function() {
-        if (submitButton.classList.contains('primary')) {
-          submitButton.classList.add('success');
-          submitButton.classList.remove('primary');
-        }
-      });
-
-      this.on("success", function() {
-        successCount++;
-        myDropzone.processQueue();
-      });
-
-      this.on("error", function(file, message) {
-        errorCount++;
-        var msg = document.createElement('p');
-        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
-        errorRegion.appendChild(msg);
-      });
-
-      this.on("queuecomplete", function() {
-        if (errorCount === 0 && successCount > 0) {
-          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
-          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
-        }
-      });
-
-      document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        myDropzone.removeAllFiles(true);
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        if (submitButton.classList.contains('success')) {
-          submitButton.classList.add('primary');
-          submitButton.classList.remove('success');
-        }
-      });
-    }
-  };
+  initializeDropzone('myDropzone', 20);
 </script>
+
 <p>Drag files here or use "Browse Files" to select them, then click "Upload All Files". Use "Reset" to clear your selections.</p>
 <form action="${widgetContext.uri}?widget=${widgetContext.uniqueId}" class="dropzone" id="my-dropzone">
   <%-- Required by controller --%>

--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -46,7 +46,6 @@
   }
 </style>
 
-<script>
 <script nonce="${cspNonce}">
   <c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
     function onSubmit(token) {

--- a/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-file-drop-zone.jsp
@@ -33,71 +33,10 @@
 </c:if>
 <script src="${ctx}/javascript/dropzone-5.9.3/dropzone.min.js"></script>
 <script src="${ctx}/javascript/dropzone-setup.js"></script>
-<script>
-  initializeDropzone('myDropzone', 100);
 <script nonce="${cspNonce}">
-  Dropzone.options.myDropzone = {
-    autoProcessQueue: false,
-    parallelUploads: 2,
-    maxFilesize: 100,
-    clickable: '#dz-browse',
-    dictDefaultMessage: 'Drag and drop files here (max 100 MB)<br/><br/>or use the Browse button below',
-    init: function() {
-      var submitButton = document.querySelector("#submit-all");
-      var errorRegion  = document.querySelector("#upload-errors");
-      var statusRegion = document.querySelector("#upload-status");
-      var errorCount   = 0;
-      var successCount = 0;
-      myDropzone = this;
-
-      submitButton.addEventListener("click", function() {
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        myDropzone.processQueue();
-      });
-
-      this.on("addedfile", function() {
-        if (submitButton.classList.contains('primary')) {
-          submitButton.classList.add('success');
-          submitButton.classList.remove('primary');
-        }
-      });
-
-      this.on("success", function() {
-        successCount++;
-        myDropzone.processQueue();
-      });
-
-      this.on("error", function(file, message) {
-        errorCount++;
-        var msg = document.createElement('p');
-        msg.textContent = file.name + ': ' + (typeof message === 'string' ? message : (message.error || 'Upload failed'));
-        errorRegion.appendChild(msg);
-      });
-
-      this.on("queuecomplete", function() {
-        if (errorCount === 0 && successCount > 0) {
-          statusRegion.textContent = successCount + (successCount === 1 ? ' file' : ' files') + ' uploaded. Refreshing…';
-          setTimeout(function() { window.location.href = '' + window.location.href; }, 1200);
-        }
-      });
-
-      document.querySelector("#clear-dropzone").addEventListener("click", function() {
-        myDropzone.removeAllFiles(true);
-        errorCount = 0;
-        successCount = 0;
-        errorRegion.innerHTML = '';
-        statusRegion.textContent = '';
-        if (submitButton.classList.contains('success')) {
-          submitButton.classList.add('primary');
-          submitButton.classList.remove('success');
-        }
-      });
-    }
-  };
+  initializeDropzone('myDropzone', 100);
 </script>
+
 <p>Drag files here or use "Browse Files" to select them, then click "Upload All Files". Use "Reset" to clear your selections.</p>
 <form action="${widgetContext.uri}?widget=${widgetContext.uniqueId}" class="dropzone" id="my-dropzone">
   <%-- Required by controller --%>

--- a/src/main/webapp/WEB-INF/jsp/login/forgot-password-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/forgot-password-form.jsp
@@ -23,7 +23,6 @@
   <input type="hidden" name="token" value="${userSession.formToken}" />
   <%-- Form Content --%>
   <c:if test="${!empty title}">
-    <h1><c:if test="${!empty icon}"><i class="fa ${icon}"></i> </c:if><c:out value="${title}"/></h1>
     <h1 ><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h1>
   </c:if>
   <%@include file="../page_messages.jspf" %>

--- a/src/main/webapp/WEB-INF/jsp/page_messages.jspf
+++ b/src/main/webapp/WEB-INF/jsp/page_messages.jspf
@@ -18,7 +18,6 @@
   <div class="callout radius alert" role="alert" tabindex="-1">
     <p class="text-center"><c:out value="${errorMessage}" /></p>
   </div>
-  <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty warningMessage}">
   <div class="callout radius warning" role="alert" tabindex="-1">
@@ -26,7 +25,6 @@
   </div>
 </c:if>
 <c:if test="${!empty errorMessage || !empty warningMessage}">
-  <script>document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
   <script nonce="${cspNonce}">document.addEventListener('DOMContentLoaded',function(){var el=document.querySelector('[role="alert"]');if(el)el.focus();});</script>
 </c:if>
 <c:if test="${!empty successMessage}">

--- a/src/main/webapp/WEB-INF/jsp/userProfile/my-profile-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/my-profile-form.jsp
@@ -39,26 +39,25 @@
   });
 </script>
 <jsp:useBean id="fieldList" class="java.util.ArrayList" scope="request"/>
-<script>
-  <style>
-    .form-field-error {
-      border-left: 4px solid #cc4c28 !important;
-      background-color: rgba(204, 76, 40, 0.02);
-    }
-    .error-message {
-      display: none;
-      color: #cc4c28;
-      font-weight: 500;
-      margin-top: 0.5rem;
-      font-size: 0.9rem;
-    }
-    .error-message i {
-      margin-right: 0.5rem;
-    }
-    .error-message.show {
-      display: block;
-    }
-  </style>
+<style>
+  .form-field-error {
+    border-left: 4px solid #cc4c28 !important;
+    background-color: rgba(204, 76, 40, 0.02);
+  }
+  .error-message {
+    display: none;
+    color: #cc4c28;
+    font-weight: 500;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+  }
+  .error-message i {
+    margin-right: 0.5rem;
+  }
+  .error-message.show {
+    display: block;
+  }
+</style>
 
 <script nonce="${cspNonce}">
   $(document).ready(function() {
@@ -88,42 +87,42 @@
           return false;
       }
     });
-
-    function checkForm${widgetContext.uniqueId}() {
-      var hasErrors = false;
-      var firstErrorField = null;
-      <c:forEach items="${fieldList}" var="formField" varStatus="status">
-      <c:if test="${formField.required}">
-      <c:choose>
-      <c:when test="${!empty formField.listOfOptions}">
-
-      </c:when>
-      <c:otherwise>
-      var field = document.getElementById("${widgetContext.uniqueId}${js:escape(formField.name)}");
-      var errorEl = document.getElementById("error-${widgetContext.uniqueId}${js:escape(formField.name)}");
-      if (field.value.trim() === "") {
-        if (errorEl) {
-          errorEl.classList.add("show");
-        }
-        field.classList.add("form-field-error");
-        field.setAttribute("aria-invalid", "true");
-        hasErrors = true;
-        if (!firstErrorField) firstErrorField = field;
-      } else if (errorEl) {
-        errorEl.classList.remove("show");
-        field.classList.remove("form-field-error");
-        field.setAttribute("aria-invalid", "false");
-      }
-      </c:otherwise>
-      </c:choose>
-      </c:if>
-      </c:forEach>
-      if (hasErrors && firstErrorField) {
-        firstErrorField.focus();
-      }
-      return !hasErrors;
-    }
   });
+
+  function checkForm${widgetContext.uniqueId}() {
+    var hasErrors = false;
+    var firstErrorField = null;
+    <c:forEach items="${fieldList}" var="formField" varStatus="status">
+    <c:if test="${formField.required}">
+    <c:choose>
+    <c:when test="${!empty formField.listOfOptions}">
+
+    </c:when>
+    <c:otherwise>
+    var field = document.getElementById("${widgetContext.uniqueId}${js:escape(formField.name)}");
+    var errorEl = document.getElementById("error-${widgetContext.uniqueId}${js:escape(formField.name)}");
+    if (field.value.trim() === "") {
+      if (errorEl) {
+        errorEl.classList.add("show");
+      }
+      field.classList.add("form-field-error");
+      field.setAttribute("aria-invalid", "true");
+      hasErrors = true;
+      if (!firstErrorField) firstErrorField = field;
+    } else if (errorEl) {
+      errorEl.classList.remove("show");
+      field.classList.remove("form-field-error");
+      field.setAttribute("aria-invalid", "false");
+    }
+    </c:otherwise>
+    </c:choose>
+    </c:if>
+    </c:forEach>
+    if (hasErrors && firstErrorField) {
+      firstErrorField.focus();
+    }
+    return !hasErrors;
+  }
 </script>
 <form id="form${widgetContext.uniqueId}" method="post" onsubmit="return checkForm${widgetContext.uniqueId}()">
   <%-- Required by controller --%>


### PR DESCRIPTION
## Summary

Follow-up to the security-PR audit. #440 claimed "ALL 29 of 29 issues resolved (100%)" with every test-plan checkbox checked, but shipped 7 JSPs with an unclosed \`<script>\` tag that spliced leftover code from the edit into the next, correctly-nonced \`<script>\` tag. Per HTML5 tokenizer rules, an unclosed \`<script>\` swallows everything up to the next literal \`</script>\` as raw script text -- so all of the following silently failed to parse or execute, not just render slightly wrong:

- **\`admin/cancel-order.jsp\`, \`admin/ship-order.jsp\`**: the confirmation modals never opened -- the button's \`onclick\` called a function that was never actually defined
- **\`admin/folder-file-drop-zone.jsp\`, \`cms/file-drop-zone.jsp\`, \`items/item-file-drop-zone.jsp\`**: all 3 file-upload dropzones never got their config applied (Browse button, size limits, upload behavior)
- **\`cms/form.jsp\`, \`userProfile/my-profile-form.jsp\`**: the client-side form-validation refactor was dead code -- both forms submitted with **zero** validation, the opposite of what was claimed

\`userProfile/my-profile-form.jsp\` had a second, independent bug on top of the unclosed tag: a \`<style>\` block nested inside \`<script>\`, and the validation function defined inside the \`$(document).ready()\` closure instead of at top level -- so even with the tag fixed, it would still have been unreachable from the form's \`onsubmit\` attribute. Restructured to match the working pattern already used in \`cms/form.jsp\`.

Three smaller regressions from the same PR:
- **\`admin/dataset-upload-form.jsp\`, \`admin/send-mail-form.jsp\`**: the "uniform primary button" pass inserted a new button above the old one instead of replacing it -- both forms rendered two submit buttons
- **\`login/forgot-password-form.jsp\`**: the title fix duplicated the \`<h1>\` instead of replacing it, and the newly-added copy dropped \`fn:escapeXml()\` around \`${icon}\` -- an escaping regression. Removed the unescaped duplicate, kept the original escaped line.
- **\`page_messages.jspf\`**: a new, redundant, partially-unnonced focus-on-load script was added instead of extending the existing one -- which itself only covered \`errorMessage\`, never \`warningMessage\`. Consolidated into one correctly-nonced script covering both, which is a genuine (if botched in the original attempt) accessibility fix.

## Why this wasn't caught

\`compile-jsp\` cannot catch this class of bug -- Jasper only validates JSP/JSTL tag syntax, it doesn't parse embedded \`<script>\` content as HTML. That's exactly why this shipped broken without CI flagging it, and why the PR's own checked-off test plan didn't reflect reality.

## Test plan
- [x] Structural check: \`<script\`/\`</script>\` counts now balanced in every touched file (previously mismatched in all 7 broken files)
- [x] Repo-wide sweep confirms no other JSP has the same unclosed-then-reopened \`<script>\` pattern
- [x] \`ant -lib lib/war clean compile\` -- clean
- [x] \`ant -lib lib/war compile-jsp\` -- clean
- [x] \`ant -lib lib/tests ci-test\` -- no new failures. Two pre-existing/unrelated: \`ContentWidgetTest\` (tracked as #534) and \`CaptchaCommandTest\` (passes 2/2 in isolation, flaky only under the full batch run -- not something this PR touches)