### PR TITLE
Fix the audit-log tamper detection PR #354 claimed to add (#296, AU-9)

### DIFF
--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -465,6 +465,17 @@ CREATE INDEX audit_log_occurred_idx ON audit_log(occurred);
 CREATE INDEX audit_log_category_type_idx ON audit_log(event_category, event_type);
 CREATE INDEX audit_log_actor_idx ON audit_log(actor_user_id);
 
+-- Audit log prefix-deletion watermark (#296, AU-9; mirrored by UPGRADE_20260725.1002 for existing
+-- installs). Left empty on a fresh install -- there is no audit history yet to backfill from, and
+-- the application sets row id=1 atomically on the very first hashed insert (see
+-- AuditLogRepository.add()). Pre-seeding a placeholder row here would permanently block that
+-- INSERT ... ON CONFLICT DO NOTHING from ever recording the real value. See
+-- AuditLogIntegrityCommand for how the watermark is used to detect oldest-prefix deletion.
+CREATE TABLE audit_log_watermark (
+  id                     INTEGER PRIMARY KEY DEFAULT 1,
+  lowest_hashed_audit_id BIGINT  NOT NULL DEFAULT 0
+);
+
 -- Multi-factor authentication recovery codes: one-time backup codes, stored as SHA-256 hashes
 CREATE TABLE user_mfa_recovery_codes (
   recovery_code_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__audit_watermark.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260725.1002__audit_watermark.sql
@@ -13,7 +13,12 @@ CREATE TABLE IF NOT EXISTS audit_log_watermark (
   lowest_hashed_audit_id BIGINT  NOT NULL DEFAULT 0
 );
 
--- Backfill: initialise the watermark from the current chain (0 if no hashed records exist yet).
+-- Backfill: initialise the watermark from the current chain, but ONLY when a hashed record already
+-- exists. If none do yet, leave the table empty rather than seeding a placeholder 0 -- the
+-- application's own ON CONFLICT DO NOTHING insert (see AuditLogRepository.add()) can only ever set
+-- the watermark once, on the row's first appearance; a pre-seeded 0 row would permanently block it
+-- from ever recording the true first hashed audit_id once one is actually written.
 INSERT INTO audit_log_watermark (id, lowest_hashed_audit_id)
-SELECT 1, COALESCE(MIN(audit_id), 0) FROM audit_log WHERE record_hash IS NOT NULL
+SELECT 1, MIN(audit_id) FROM audit_log WHERE record_hash IS NOT NULL
+HAVING MIN(audit_id) IS NOT NULL
 ON CONFLICT (id) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogChainIntegrationTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/audit/AuditLogChainIntegrationTest.java
@@ -156,17 +156,28 @@ class AuditLogChainIntegrationTest {
   }
 
   @Test
-  void toleratesARetentionPurgeOfTheOldestRecords() {
+  void detectsUnauthorizedDeletionOfTheOldestPrefix() {
     save(nanosecondEvent(1));
     save(nanosecondEvent(2));
     save(nanosecondEvent(3));
 
-    // Deleting the oldest record (as retention does) leaves the chain verifiable from the new oldest record.
+    // Confirm the watermark actually recorded the true first hashed audit_id -- the exact condition
+    // the fresh-install/backfill fix exists to guarantee (a stale pre-seeded 0 would silently defeat
+    // the check below instead of catching it).
+    assertTrue(AuditLogRepository.loadWatermarkLowestId() > 0L,
+        "the watermark must be set once a hashed record has been written");
+
+    // A raw delete of the oldest hashed record, bypassing deleteOlderThan() entirely -- this is
+    // exactly the "deleted outside of the normal retention job" case the watermark exists to catch;
+    // only deleteOlderThan() legitimately advances it afterward (see
+    // deleteOlderThanRemovesTheAgedPrefixAndLeavesTheChainIntact for the legitimate-purge case).
     execute("DELETE FROM audit_log WHERE audit_id = 1");
 
     AuditIntegrityResult result = AuditLogIntegrityCommand.verify();
-    assertTrue(result.isIntact(), "the surviving records must still verify after an oldest-first purge");
-    assertEquals(2, result.getCheckedCount());
+    assertFalse(result.isIntact(), "an oldest-prefix deletion outside the retention job must be flagged as tampering");
+    // The reported id is the new minimum hashed record (2), not the deleted one (1) -- it identifies
+    // where the chain now starts, which no longer matches the watermark.
+    assertEquals(2L, result.getFirstInvalidAuditId());
   }
 
   @Test
@@ -261,8 +272,7 @@ class AuditLogChainIntegrationTest {
     execute("CREATE TABLE audit_log_watermark ("
         + "id INTEGER PRIMARY KEY DEFAULT 1, "
         + "lowest_hashed_audit_id BIGINT NOT NULL DEFAULT 0)");
-    execute("INSERT INTO audit_log_watermark (id, lowest_hashed_audit_id) "
-        + "SELECT 1, COALESCE(MIN(audit_id), 0) FROM audit_log WHERE record_hash IS NOT NULL "
-        + "ON CONFLICT (id) DO NOTHING");
+    // Matches the fixed migration: left empty here (audit_log is empty at this point), so the
+    // application's own first hashed insert sets the true watermark -- see AuditLogRepository.add().
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the security-PR audit. #354 added an \`audit_log_watermark\` table and a \`verify()\`-time check meant to detect deletion of the oldest audit-log records outside the retention job -- but the detection was structurally inert in exactly the scenarios it exists to protect.

## The two bugs

**1. Fresh installs never got the table at all.** \`DatabaseCommand.installDatabase()\` deliberately baselines the \`upgrade/\` Flyway instance to \`ApplicationInfo.VERSION\` on a new install ("New installs don't need UPGRADE migrations since they start with the latest schema from NEW_* migrations") -- so \`UPGRADE_20260725.1002__audit_watermark.sql\`, dated before that baseline, was silently skipped forever on any fresh install. \`loadWatermarkLowestId()\` then caught the resulting "table not found" and returned 0, and \`verify()\` gates the whole check behind \`watermark > 0L\`. This isn't a bug in the baselining itself -- that's this project's real, intentional dual-track schema design (fresh installs get their schema from \`NEW_*.sql\`, not by replaying every historical upgrade migration) -- #354 just forgot the \`install/\` side of it. Added the table to \`NEW_10000__new_database.sql\` to match.

**2. Even on upgraded/existing databases, the watermark could get permanently stuck at 0.** The migration's own backfill pre-seeded row id=1 with \`0\` whenever no hashed record existed yet at migration time. \`AuditLogRepository.add()\`'s watermark-set is \`INSERT ... ON CONFLICT (id) DO NOTHING\` -- correct in principle (never regress an already-set watermark) -- but since the migration had already created that row, the real first hashed insert could never write into it. Changed the backfill to only produce a row when a hashed record genuinely already exists (\`HAVING MIN(audit_id) IS NOT NULL\`), leaving the table empty otherwise so the application's own first hashed insert sets the true value, exactly as the design intends.

**3. The PR's own test never exercised the actual attack case.** \`AuditLogChainIntegrationTest#toleratesARetentionPurgeOfTheOldestRecords\` performed a raw \`DELETE\` of the oldest hashed record -- bypassing \`deleteOlderThan()\` entirely, which is exactly the "deleted outside the normal retention job" case the watermark exists to catch -- and asserted the chain still verified intact. It passed only because of bug #2 (watermark permanently 0 in that test's schema setup, so the new check never fired). Renamed and flipped it to \`detectsUnauthorizedDeletionOfTheOldestPrefix\`, asserting \`verify()\` correctly reports \`broken()\` for that scenario now that the watermark is actually populated. The genuinely-legitimate purge case remains covered separately by \`deleteOlderThanRemovesTheAgedPrefixAndLeavesTheChainIntact\`, which calls the real \`deleteOlderThan()\` method.

## Test plan
- [x] \`ant -lib lib/war clean compile\` -- clean
- [x] \`ant -lib lib/war compile-jsp\` -- clean
- [x] **Verified against real PostgreSQL (Testcontainers), not just reasoned about:**
  - \`AuditLogChainIntegrationTest\` -- full suite (5/5) passes, including the new positive-detection case actually catching a simulated unauthorized deletion
  - \`DatabaseMigrationTest\` -- full suite (5/5) passes, confirming the new table creates cleanly as part of a real fresh install via the actual Flyway install path (not just SQL review)
- [x] \`ant -lib lib/tests ci-test\` -- no new failures beyond already-tracked local-environment noise (#534 and a JaCoCo/\`java.sql.*\` instrumentation flake specific to this dev sandbox, unrelated to anything touched here)