### PR TITLE
Fix publish-images.yml TruffleHog step failing every run

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -52,14 +52,20 @@ jobs:
       # Secret scanning: detect hardcoded credentials (passwords, API keys, tokens)
       # before they reach the image. TruffleHog scans git history and the checked-out
       # code; a finding blocks the workflow to prevent secret leaks.
+      #
+      # base/head are deliberately left unset: this step runs on push/release/schedule/
+      # workflow_dispatch, not just PRs, and at scan time HEAD *is* the default branch
+      # (this workflow only runs against main), so an explicit base/head pins them to the
+      # same commit and TruffleHog refuses to scan ("BASE and HEAD commits are the same").
+      # Leaving them unset lets the action fall back to its own event-aware detection,
+      # which correctly derives the commit range from the triggering event instead.
       - name: Scan for secrets in code and history
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          # Exit on any findings to prevent secrets from reaching images
-          extra_args: --fail --json
+          # The action already runs with --fail internally; adding it again in
+          # extra_args trips its "flag 'fail' cannot be repeated" error.
+          extra_args: --json
 
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5


### PR DESCRIPTION
## What's broken

Every run of `publish-images.yml` (push to main, release, monthly schedule) fails at the "Scan for secrets in code and history" step with:

```
BASE and HEAD commits are the same. TruffleHog won't scan anything.
```

This is the pipeline the #530 azure/login fix got past checkout and Azure sign-in for -- this is a separate, pre-existing bug in the same workflow that still blocks every run downstream of it.

## Root cause

The step pins:

```yaml
base: ${{ github.event.repository.default_branch }}
head: HEAD
```

TruffleHog's own entrypoint script checks for explicit `base`/`head` inputs *before* it looks at the triggering event at all. Since this workflow only ever runs against `main`, at scan time `HEAD` **is** `main` -- they resolve to the literal same commit every time, so the action's own same-commit guard trips before it ever scans anything. Confirmed directly from the job log: `git rev-parse main` and `git rev-parse HEAD` both resolved to `3c171ae1...` on the failing run.

Explicit `base`/`head` are the right call for a PR diff (that's genuinely two different commits, which is exactly how `secret-scan-pr.yml` from #537 uses them) -- they don't make sense for a push-to-branch trigger.

There's a second, latent bug hiding behind this one: `extra_args: --fail --json` duplicates a `--fail` the action already passes internally, which trips a separate `"flag 'fail' cannot be repeated"` error -- currently masked because the base/head check fails first.

## Fix

Drop both explicit inputs and the redundant `--fail`. With `base`/`head` unset, the action falls through to its own event-aware detection, which I traced through against the actual run's environment:

- **push**: derives an incremental range from the push's own before/after commit ids (`COMMIT_IDS`) -- scans just what was pushed.
- **workflow_dispatch / schedule / release**: falls back to a full-repo scan.

## Verification

Read the action's script source directly from the job log (it's echoed verbatim by Actions regardless of which branch executes) and hand-traced it against this run's actual `COMMIT_IDS` env value to confirm the push-event path produces a sane, non-empty scan range. Not yet verified against a live run -- this workflow only triggers on push to `main` / release / schedule, so a genuine end-to-end test needs either a manual `workflow_dispatch` against this branch (which would push real images to the registry) or merging. Flagging for a manual dispatch or post-merge check rather than doing that unilaterally.