### PR TITLE
Fix PageServlet's action() dispatch to actually validate the CSRF token

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -868,10 +868,10 @@ public class PageServlet extends HttpServlet {
         }
         pageRenderInfo.setTargetWidget(targetWidget);
 
-        // Verify a token exists
+        // Verify the token matches this session's form token
         String formToken = request.getParameter("token");
-        if (StringUtils.isEmpty(formToken)) {
-          LOG.error("DEVELOPER: A FORM TOKEN IS REQUIRED " + pagePath + " " + request.getRemoteAddr());
+        if (!isFormTokenValid(formToken, userSession.getFormToken())) {
+          LOG.error("DEVELOPER: A VALID FORM TOKEN IS REQUIRED " + pagePath + " " + request.getRemoteAddr());
           controllerSession.clearAllWidgetData();
           response.sendError(HttpServletResponse.SC_NOT_FOUND);
           return;
@@ -1081,6 +1081,19 @@ public class PageServlet extends HttpServlet {
       return null;
     }
     return json.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026");
+  }
+
+  /**
+   * Validates the "token" request parameter against this session's real form token before a
+   * POST/DELETE/action() widget dispatch is allowed past this fail-fast gate. WebContainerCommand
+   * independently re-validates the same token against the specific target widget before invoking
+   * it, so this check being wrong would not by itself open a bypass today -- but it should still
+   * reject what it claims to reject, both to fail fast (before the page-render work downstream)
+   * and so a future change to that later check can't silently lose CSRF coverage this one already
+   * appeared to provide.
+   */
+  static boolean isFormTokenValid(String requestToken, String sessionToken) {
+    return StringUtils.isNotEmpty(requestToken) && sessionToken != null && sessionToken.equals(requestToken);
   }
 
   private static int intParam(HttpServletRequest request, String name, int defaultValue) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -88,4 +88,25 @@ class PageServletTest {
     assertEquals("Product", product.get("@type").asText());
     assertTrue(product.get("name").asText().contains("</script><script>"));
   }
+
+  @Test
+  void isFormTokenValidAcceptsAMatchingToken() {
+    assertTrue(PageServlet.isFormTokenValid("abc-123", "abc-123"));
+  }
+
+  @Test
+  void isFormTokenValidRejectsAMismatchedToken() {
+    assertFalse(PageServlet.isFormTokenValid("wrong-token", "abc-123"));
+  }
+
+  @Test
+  void isFormTokenValidRejectsABlankOrMissingRequestToken() {
+    assertFalse(PageServlet.isFormTokenValid("", "abc-123"));
+    assertFalse(PageServlet.isFormTokenValid(null, "abc-123"));
+  }
+
+  @Test
+  void isFormTokenValidRejectsANullSessionToken() {
+    assertFalse(PageServlet.isFormTokenValid("abc-123", null));
+  }
 }


### PR DESCRIPTION
## What's broken

Flagged as a known follow-up in #539's description. `PageServlet.service()`'s gate on every POST/DELETE/GET+`action=` widget dispatch (`webContainerContext.isTargeted()`, ~line 872) only checked that the `token` request parameter was non-blank:

```java
String formToken = request.getParameter("token");
if (StringUtils.isEmpty(formToken)) {
  ...sendError(404); return;
}
```

It never compared `formToken` against the session's real form token (`userSession.getFormToken()`). Any non-empty string satisfied the check.

## Corrected scope (important -- please read before judging severity)

Before writing a fix I had this investigated properly, since "every widget's action() dispatch" is a large blast radius to touch on assumption alone. That surfaced something #539's note didn't have: **`WebContainerCommand.processWidgets()` already performs a real `userSession.getFormToken().equals(formToken)` comparison** for the specific target widget, before `action()`/`post()`/`delete()` is invoked via reflection -- and has since 2022 (commit `595572b3f`), long predating #539.

So today, a request with a non-blank-but-wrong token gets past `PageServlet.java`'s check, but is still blocked by `WebContainerCommand`'s real check one call deeper, before any widget code runs. This is a **missing fail-fast / defense-in-depth gap**, not an unconditional bypass letting a forged token reach a widget's action method -- correcting that here since #539 described it as a live sitewide bypass, and that framing turned out to be wrong on inspection.

I'm fixing it anyway, for two reasons:
- A check whose name and log message (`"A FORM TOKEN IS REQUIRED"`) claim to validate the token should actually validate it -- not just check it's non-empty.
- If `WebContainerCommand`'s check is ever refactored or removed, this one silently stops being a compensating control unless it's already doing real work.

## Fix

Extracted the comparison into `PageServlet.isFormTokenValid(requestToken, sessionToken)`, mirroring the same real-comparison pattern already used seven other places in this exact file (the `saveDraftLayout` / `publishDraft` / `discardDraft` / `saveWidgetContent` / `reorderCollectionItem` / `deactivateCollectionItem` / `saveCollectionItem` ad hoc handlers), plus `WebContainerCommand.processWidgets()` and `WebRequestFilter`'s `/logout` guard.

Checked every legitimate caller in the app before tightening this -- roughly 140+ JSP/JS call sites across `src/main/webapp` that build a `token=` parameter alongside `action=`/`command=delete`/a POST form. Every one of them already resolves to `userSession.getFormToken()` (directly via EL, or via the `mainToken` JS relay set once per page render in `main.jsp`). Zero legitimate-flow breakage. The one caller that doesn't send a real token (`overlay-editor-pane.js`'s in-place Quill editor defaults to reading a `formToken`-named field that no JSP renders -- everything else is named `token`) is already non-functional under the current weak check, so tightening it changes nothing there; that's a separate, unrelated bug worth its own report.

## Tests

`PageServlet.service()` isn't unit-testable in isolation (nothing in this codebase drives it directly -- confirmed by checking `WebContainerCommandTest`, which has the same gap for `processWidgets()`), so following the same extraction-for-testability pattern this file already uses for `escapeForInlineScript`/`generateJsonLdData` (added for #403). Added 4 plain-JUnit cases to `PageServletTest.java`: matching token, mismatched token, blank/missing request token, null session token. All pass locally, along with the 3 existing `PageServletTest` cases (7/7).

Also ran the full local suite (`ant -lib lib/tests ci-test`). Failures observed are all pre-existing and unrelated:
- `ContentWidgetTest`'s batch-only flake (#534) -- passes 4/4 in isolation; structurally can't be touched by this change since it calls `widget.action()` directly, never through `PageServlet`/`WebContainerCommand`.
- `TrustedProxyIpFilterTest` (#535) -- separately filed, unrelated subsystem.
- The known local-sandbox-only JaCoCo instrumentation crash (`BlockedIPListCommandTest`, `CaptchaCommandTest`, etc.) that's never once reproduced in real GitHub Actions.

`ant -lib lib/war clean compile` and `ant -lib lib/war compile-jsp` both pass clean.