### PR TITLE
Fix fresh install: login is completely broken (missing users.account_token_expires)

### DIFF
--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -298,6 +298,7 @@ CREATE TABLE users (
   modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
   modified_by BIGINT REFERENCES users(user_id),
   account_token VARCHAR(255),
+  account_token_expires TIMESTAMP(3),
   validated TIMESTAMP(3),
   title VARCHAR(100),
   department VARCHAR(100),
@@ -398,13 +399,17 @@ CREATE TABLE sessions (
   source VARCHAR(50),
   app_id BIGINT REFERENCES apps(app_id),
   visitor_id BIGINT REFERENCES visitors(visitor_id),
-  is_bot BOOLEAN DEFAULT false
+  is_bot BOOLEAN DEFAULT false,
+  is_anonymous BOOLEAN NOT NULL DEFAULT false
 );
+
+COMMENT ON COLUMN sessions.is_anonymous IS 'True if session is from anonymous visitor (no user login)';
 
 CREATE INDEX sessions_created_idx ON sessions(created);
 CREATE INDEX sessions_sess_id_idx ON sessions(session_id);
 CREATE INDEX sessions_is_bot_idx ON sessions(is_bot);
 CREATE INDEX sessions_referer_idx ON sessions(referer);
+CREATE INDEX idx_sessions_is_anonymous_created ON sessions(is_anonymous, created DESC);
 
 -- CREATE TABLE session_country_snapshots (
 --   snapshot_id BIGSERIAL PRIMARY KEY,

--- a/src/test/java/com/simisinc/platform/infrastructure/database/DatabaseMigrationTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/database/DatabaseMigrationTest.java
@@ -198,11 +198,42 @@ class DatabaseMigrationTest {
         "flyway_history is missing - the baseline step did not run");
   }
 
+  @Test
+  void columnsThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath() throws SQLException {
+    // A table can exist (coreTablesExist passes) while still being missing a column that an
+    // upgrade/ migration added without a matching install/ counterpart -- since a fresh install
+    // never runs the upgrade/ tree, only baselines past it. Two such gaps reached this point
+    // undetected: users.account_token_expires (added by
+    // UPGRADE_20260725.1001__account_token_expires.sql) broke every login on a fresh install --
+    // UserRepository.buildRecord() unconditionally reads it -- and sessions.is_anonymous (added
+    // by UPGRADE_20260726.1002__sessions_is_anonymous.sql) broke SessionRepository's daily
+    // unique-locations report. Both are represented here, not as an exhaustive general check,
+    // but so this specific class of regression fails loudly instead of silently again.
+    assertTrue(columnExists("users", "account_token_expires"),
+        "users.account_token_expires is missing - a fresh install cannot log anyone in "
+            + "(UserRepository.buildRecord reads this column unconditionally)");
+    assertTrue(columnExists("sessions", "is_anonymous"),
+        "sessions.is_anonymous is missing - SessionRepository.findDailyUniqueLocations() "
+            + "will fail on a fresh install");
+  }
+
   private static boolean tableExists(String name) throws SQLException {
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement();
         ResultSet rs = statement.executeQuery(
             "SELECT to_regclass('public." + name + "') IS NOT NULL AS present")) {
+      assertNotNull(rs);
+      return rs.next() && rs.getBoolean("present");
+    }
+  }
+
+  private static boolean columnExists(String table, String column) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                + "WHERE table_schema = 'public' AND table_name = '" + table + "' "
+                + "AND column_name = '" + column + "') AS present")) {
       assertNotNull(rs);
       return rs.next() && rs.getBoolean("present");
     }


### PR DESCRIPTION
## What's broken

**A brand-new Azure deployment cannot log anyone in, including the admin account.** Found by actually running a local docker-compose rehearsal (fresh install path, same as what Azure will do) and trying to log in.

## Root cause

A fresh install only runs the `install/` migration tree; `upgrade/` migrations never execute against it (`DatabaseCommand.installDatabase()` baselines the upgrade Flyway instance past them instead -- intentional, documented dual-track design). Two columns were added via `upgrade/` migrations that never got a matching `install/` counterpart:

- **`users.account_token_expires`** (`UPGRADE_20260725.1001__account_token_expires.sql`) -- missing this breaks **every login**. `UserRepository.buildRecord()` unconditionally calls `rs.getTimestamp("account_token_expires")`, so any user lookup throws `PSQLException: The column name account_token_expires was not found in this ResultSet`. `AuthenticateLoginCommand.getAuthenticatedUser()` doesn't distinguish this from a real auth failure, so the user just sees "The account information provided did not match our records" -- reproduced live, including for the auto-provisioned admin account itself.
- **`sessions.is_anonymous`** (`UPGRADE_20260726.1002__sessions_is_anonymous.sql`) -- missing this breaks `SessionRepository.findDailyUniqueLocations()`, the geo-precision reporting query from #367.

Neither gap fails the migration itself (`ALTER TABLE ... ADD COLUMN` is syntactically valid whether or not anything ever runs it against a fresh DB) -- the failure only shows up later, at query time. That's why nothing in CI's existing migration checks caught this.

## Fix

Added both columns (and `is_anonymous`'s index/comment) directly to `NEW_10000__new_database.sql`, matching the upgrade migrations' final column definitions exactly.

## Verification

- Swept every `upgrade/**/*.sql` `ADD COLUMN` against the full `install/` tree to check for siblings of this exact gap -- these two were the only real misses (everything else cross-referenced correctly, once checked against all 19 install files rather than just the base one).
- Added `DatabaseMigrationTest#columnsThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath` -- real Testcontainers Postgres, `information_schema.columns` check. 6/6 `DatabaseMigrationTest` passing.
- Live end-to-end: rebuilt the WAR, `docker compose up -d --build` against a genuinely fresh Postgres volume, confirmed the login crash reproduces on unfixed `main` (real `PSQLException` in the app logs), then confirmed login succeeds cleanly after the fix (session cookie issued, no errors).
- `ant -lib lib/war clean compile`, `ant -lib lib/war compile-jsp` both clean.

## Note

Same investigation also independently reproduced the `audit_log_watermark` gap that #541 (open) already fixes -- not duplicated here, just confirms that PR is needed.