### PR TITLE
Fix Mail Test panel to actually test SMTP configuration

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidget.java
@@ -16,12 +16,14 @@
 
 package com.simisinc.platform.presentation.widgets.admin;
 
-import com.simisinc.platform.domain.events.cms.UserInvitedEvent;
-import com.simisinc.platform.domain.events.cms.UserRegisteredEvent;
-import com.simisinc.platform.domain.events.cms.UserSignedUpEvent;
-import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.application.email.EmailCommand;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.mail.ImageHtmlEmail;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -34,6 +36,8 @@ import java.lang.reflect.InvocationTargetException;
 public class SendMailWidget extends GenericWidget {
 
   static final long serialVersionUID = -8484048371911908893L;
+
+  private static Log LOG = LogFactory.getLog(SendMailWidget.class);
 
   static String JSP = "/admin/send-mail-form.jsp";
 
@@ -50,13 +54,23 @@ public class SendMailWidget extends GenericWidget {
 
   public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
 
-    // Trigger event to test the email
-    WorkflowManager.triggerWorkflowForEvent(new UserSignedUpEvent(context.getUserSession().getUser()));
-    WorkflowManager.triggerWorkflowForEvent(new UserInvitedEvent(context.getUserSession().getUser(), context.getUserSession().getUser()));
-    WorkflowManager.triggerWorkflowForEvent(new UserRegisteredEvent(context.getUserSession().getUser(), context.getRequest().getRemoteAddr()));
+    // Test the configured SMTP settings by sending a single message to the current admin
+    User user = context.getUserSession().getUser();
+    try {
+      ImageHtmlEmail email = EmailCommand.prepareNewEmail();
+      email.addTo(user.getEmail(), user.getFullName());
+      email.setSubject("SimIS CMS Mail Test");
+      email.setMsg("This is a test message sent from the Mail Server Settings page to confirm the configured SMTP settings are working.");
+      email.send();
+    } catch (Exception e) {
+      LOG.warn("Mail test failed to send", e);
+      context.setErrorMessage("Mail test failed: " + e.getMessage());
+      context.setRedirect("/admin/mail-properties");
+      return context;
+    }
 
     // Determine the page to return to (if other than this one)
-    context.setSuccessMessage("Mail was sent");
+    context.setSuccessMessage("A test email was sent to " + user.getEmail());
     context.setRedirect("/admin/mail-properties");
     return context;
   }

--- a/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/send-mail-form.jsp
@@ -28,15 +28,14 @@
   </c:if>
   <%@include file="../page_messages.jspf" %>
   <%-- Form Content --%>
+  <p>Sends a test email to your own address using the SMTP settings configured to the left, to confirm they work.</p>
   <label>To
     <p>${userSession.user.email}</p>
   </label>
   <label>Subject
-    <p>Site Invitation Message</p>
+    <p>SimIS CMS Mail Test</p>
   </label>
-  <%-- TODO: This form is a stub — needs customizable recipient, subject, and body fields --%>
   <div class="button-container">
-    <input type="submit" class="button radius secondary expanded" value="Send Mail"/>
-    <input type="submit" class="button radius success expanded" value="Send Mail" data-disable-on-submit="Sending..."/>
+    <input type="submit" class="button radius success expanded" value="Send Test Email" data-disable-on-submit="Sending..."/>
   </div>
 </form>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -359,7 +359,7 @@
         </widget>
       </column>
       <column class="small-12 medium-5 cell">
-        <widget name="sendMail" class="callout primary radius" sticky="true">
+        <widget name="sendMail" class="callout primary radius">
           <icon>mail</icon>
           <title>Mail Test</title>
         </widget>


### PR DESCRIPTION
## Summary

The "Mail Test" panel on `/admin/mail-properties` was supposed to test the site's configured SMTP settings, but `SendMailWidget.post()` instead fired three unrelated user-lifecycle workflow events (`UserSignedUpEvent`, `UserInvitedEvent`, `UserRegisteredEvent`), each sending its own templated email to the admin, ignoring `mail.host_name`/`mail.port`/`mail.username`/`mail.password` entirely and always reporting success.

- `SendMailWidget.post()` now sends a single test email via `EmailCommand.prepareNewEmail()` (the same SMTP infrastructure `SendAdminEmailCommand` uses), and reports the real outcome with `setSuccessMessage()`/`setErrorMessage()`.
- Removed the three `WorkflowManager.triggerWorkflowForEvent(...)` calls.
- Updated `send-mail-form.jsp`: removed the "This form is a stub" TODO and the duplicate submit button, fixed the stale "Site Invitation Message" subject text to match actual behavior.
- Removed `sticky="true"` from the `sendMail` widget in `admin-layout.xml`. Root cause of the reported browser console error (`TypeError: Cannot read properties of undefined (reading 'top')`, which was blocking the success/error message from displaying): Foundation's Sticky JS needs a `data-btm-anchor="platform-footer"` element, but the footer is only rendered on non-admin pages (`layout.jsp`), so on `/admin/mail-properties` Foundation's `_parsePoints()` (`foundation.js`) does `$('#platform-footer').offset().top` against an empty selection and throws.

## Scope note

Issue #522 bundles three distinct bugs. This PR addresses **Bug #1** (the broken mail test) and the console-error part of the JSP notes. It does **not** address Bug #2 (SMTP password field not masked — a systemic issue across four+ settings pages) or Bug #3 (question about whether the localhost SMTP config is intentional pre-Azure-migration); leaving #522 open for those.

## Test plan

- [x] `ant -lib lib/war clean compile` — passes
- [x] `ant -lib lib/war compile-jsp` — passes (JSP syntax gate)
- [x] `ant -lib lib/tests ci-test` — passes, 133 test classes, 0 failures
- [ ] Manual verification of the SMTP test against a real mail server (not exercised locally — no SMTP server available in this environment)
