### PR TITLE
Remove leaked token value flagged by secret scanning

### DIFF
--- a/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/RestRequestFilter.java
@@ -378,7 +378,6 @@ public class RestRequestFilter implements Filter {
         "\"access_token\":\"" + loginToken + "\",\n" +
         "\"token_type\":\"bearer\",\n" +
         "\"expires_in\":" + tokenExpirationInSeconds + ",\n" +
-        //        "\"refresh_token\":\"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk\",\n" +
         "\"name\":\"" + JsonCommand.toJson(UserCommand.name(user)) + "\",\n" +
         "\"first_name\":\"" + JsonCommand.toJson(user.getFirstName()) + "\",\n" +
         "\"last_name\":\"" + JsonCommand.toJson(user.getLastName()) + "\",\n" +


### PR DESCRIPTION
## What's exposed

GitHub secret scanning flagged https://github.com/SimisRnD/simis-cms/security/secret-scanning/4 -- a credential-shaped string hardcoded in `RestRequestFilter.java:381`, inside a commented-out example `refresh_token` JSON field:

\`\`\`java
//        "\"refresh_token\":\"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk\",\n" +
\`\`\`

Still present on current `main` (landed via #375, merged 2026-07-26).

## Fix

Removed the dead line. The field it belonged to is already commented out and unused -- this is a pure deletion of inert code, no behavior change.

## Note

Whether the token value itself is/was a real, still-valid credential isn't something I can determine from the repo -- that's a question for whoever owns the relevant identity/OAuth provider, not a code question. Flagging that explicitly rather than guessing at severity.