### PR TITLE
Fix sitemap.xml and search silently excluding every new page (#459)

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/cms/WebPage.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/WebPage.java
@@ -37,9 +37,18 @@ public class WebPage extends Entity {
   private String description = null;
   private String imageUrl = null;
   private boolean draft = false;
-  private boolean enabled = false;
-  private boolean searchable = false;
-  private boolean showInSitemap = false;
+  // enabled, searchable, and showInSitemap each match their column's own DEFAULT true
+  // (NEW_10010__new_cms.sql) -- every save path (WebPageFormWidget.post(), WebPageRepository's
+  // insert/update) writes these values explicitly, so the SQL defaults were otherwise dead code.
+  // Every page created through the app -- not the install/ seed data, which sets its own values
+  // directly in SQL -- got these silently false: enabled is never even exposed as a form field
+  // (so no page created through the CMS was ever enabled, which also gates
+  // WebPageRepository.search() -- new pages were unfindable there too, not just in the sitemap);
+  // searchable and showInSitemap are exposed as form toggles, but a blank/unchecked submission
+  // (the default state for a brand-new page's render of the form) explicitly writes false.
+  private boolean enabled = true;
+  private boolean searchable = true;
+  private boolean showInSitemap = true;
   private String sitemapChangeFrequency = null;
   private BigDecimal sitemapPriority = new BigDecimal(0);
   //  private boolean showPageHeader = false;

--- a/src/test/java/com/simisinc/platform/domain/model/cms/WebPageTest.java
+++ b/src/test/java/com/simisinc/platform/domain/model/cms/WebPageTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WebPageTest {
+
+  // enabled, searchable, and showInSitemap each match their column's own DEFAULT true
+  // (NEW_10010__new_cms.sql). WebPageFormWidget.post() writes each of these values explicitly on
+  // every save -- including a brand-new page's first save, before BeanUtils.populate ever runs --
+  // so these Java defaults are what a freshly created page actually gets whenever the field
+  // disagreed with its column. Verified live: a page created through the running app had
+  // enabled=false (never exposed as a form field at all -- no code path ever set it true) and
+  // showInSitemap=false (the create form's toggle renders unchecked for a brand-new page), and
+  // was excluded from both sitemap.xml and WebPageRepository.search() as a result.
+
+  @Test
+  void aNewPageDefaultsToEnabled() {
+    assertTrue(new WebPage().isEnabled());
+  }
+
+  @Test
+  void aNewPageDefaultsToSearchable() {
+    assertTrue(new WebPage().isSearchable());
+  }
+
+  @Test
+  void aNewPageDefaultsToShownInTheSitemap() {
+    assertTrue(new WebPage().isShowInSitemap());
+  }
+}


### PR DESCRIPTION
## What's broken

Closes #459 for real this time -- a previous PR (#482) claimed to fix sitemap.xml but didn't touch this. Confirmed live: I created a page through a real running instance and it never appeared in \`sitemap.xml\`, with no errors anywhere to explain why.

## Root cause

\`WebPage.java\` defaults \`enabled\`, \`searchable\`, and \`showInSitemap\` to \`false\`, but their columns all declare \`DEFAULT true\` (\`NEW_10010__new_cms.sql\`). \`WebPageFormWidget.post()\` writes each field's value explicitly on every save -- including a brand-new page's very first save -- so the SQL defaults have been dead code; the Java defaults are what pages actually got:

- **\`enabled\`** is never exposed as a form field at all. Grepped the whole codebase -- the only place that ever writes \`enabled = true\` is a read-side WHERE-clause fragment in \`WebPageRepository.search()\`, not a write. No code path has ever set this true for a page created through the CMS. This also silently broke full-text search for every new page, not just the sitemap (\`search()\`'s WHERE clause requires \`enabled = true AND searchable = true\`).
- **\`searchable\`** and **\`showInSitemap\`** ARE exposed as toggles on the page form, but a blank/unchecked submission explicitly writes \`false\`. A brand-new page's first render of that form shows both unchecked, matching the old default -- so unless an admin notices and flips them during creation, they stay off.

The \`install/\` seed pages (\`/legal/privacy\`, \`/legal/terms\`) were never affected -- they're inserted via raw SQL, which correctly picks up the column defaults. Only pages created through the running application ever hit this.

## Fix

Align \`WebPage.java\`'s three defaults with what their own columns already declare as the intended default.

## Verification

Live, end-to-end, twice, against a real running instance (docker-compose, real Postgres):
1. Rebuilt against \`upstream/main\` first to reproduce the bug -- created a page through the actual admin UI, confirmed \`enabled=false\` / \`show_in_sitemap=false\` in the database, confirmed it was absent from an otherwise-working \`sitemap.xml\`.
2. Rebuilt with the fix and created a second page with **zero manual intervention** -- \`enabled\`/\`searchable\`/\`show_in_sitemap\` all \`true\` by default, present in \`sitemap.xml\` immediately.

Also added \`WebPageTest\` (one assertion per field) and ran the full local suite -- no new failures beyond already-tracked local-environment noise (#534, the JaCoCo/\`java.sql.*\` instrumentation flake specific to this dev sandbox).

\`ant -lib lib/war clean compile\` and \`ant -lib lib/war compile-jsp\` both clean.