### PR TITLE
VEX: cover CVE-2026-47178 (libheif1) so the DB image publish gate passes

### DIFF
--- a/docker/db/vex/simis-cms-db.openvex.json
+++ b/docker/db/vex/simis-cms-db.openvex.json
@@ -3,7 +3,7 @@
   "@id": "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db",
   "author": "SimIS Inc. (SimIS CMS maintainers)",
   "timestamp": "2026-07-21T12:51:42+00:00",
-  "version": 3,
+  "version": 4,
   "tooling": "tools/generate-db-vex.py",
   "statements": [
     {
@@ -1046,7 +1046,25 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Perl is present only as package-management dependency; no runtime component invokes it, the image contains no plperl library (so PL/Perl cannot be enabled), and nothing deserializes Storable blobs. The flaw is a deserialization panic (denial of service) even where reachable. Consistent with the six existing perl statements."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-47178"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libheif1"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
     }
   ],
-  "last_updated": "2026-07-24T00:00:00Z"
+  "last_updated": "2026-07-28T06:06:34Z"
 }


### PR DESCRIPTION
## Why

Checking whether the publish pipeline will actually complete once #543 (the TruffleHog fix) merges surfaced a second, independent blocker: a new \`libheif1\` CVE (\`CVE-2026-47178\`, HIGH) has appeared since \`docker/db/vex/simis-cms-db.openvex.json\` was last authored, and it isn't covered by the VEX or \`docker/db/.trivyignore\`.

Verified directly rather than assumed -- built \`docker/db/Dockerfile\` locally and ran the exact command \`.github/workflows/publish-images.yml\`'s "Enforce the database image scan gate" step uses:

\`\`\`
trivy image --scanners vuln --severity CRITICAL,HIGH --exit-code 1 \
  --vex docker/db/vex/simis-cms-db.openvex.json --ignorefile docker/db/.trivyignore \
  <image>
\`\`\`

Exit code 1, on this one finding alone.

## Why \`tools/generate-db-vex.py\` doesn't already cover this

That script sources its input from GitHub's *already-uploaded* code-scanning alerts. This CVE has never been uploaded, because every recent \`publish-images.yml\` run has died at the TruffleHog step before ever reaching the scan-and-upload steps -- so it's not a policy gap, the regenerator just can't see an alert that doesn't exist on GitHub yet. Re-running it locally reproduced the exact same 50 statements as before, confirming this.

## Fix

Added a \`not_affected\` statement for \`CVE-2026-47178\` using the identical justification already recorded for five other \`libheif1\` CVEs in this same document. The reasoning is about the package's reachability in this image, not the specific CVE -- \`libheif1\` is a transitive GDAL dependency, and \`postgis_raster\` is never created in this database, so GDAL's raster/image decoders are never loaded or reachable from SQL. Applies identically to any \`libheif1\` finding, so this isn't a new judgment call.

## Verification

Rebuilt the \`simis-cms-db\` image locally and re-ran the exact gate command above with the updated VEX -- now exits 0 (both the Debian package scan and the \`gosu\` gobinary scan report zero findings).