### PR TITLE
Add ZeroBounce email validation integration

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
@@ -45,6 +45,7 @@ public class SecretSitePropertiesCommand {
       "captcha.google.secretkey",
       // Server-side integration keys and tokens
       "mailing-list.mailchimp.apiKey",
+      "mailing-list.zerobounce.apiKey",
       "bi.superset.secret",
       "social.instagram.accessToken",
       "elearning.lrs.key",

--- a/src/main/java/com/simisinc/platform/application/mailinglists/ZeroBounceApiClientCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/ZeroBounceApiClientCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jackson.JsonLoader;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+
+/**
+ * Real-time, single-address email deliverability validation with ZeroBounce (v2 API).
+ * <p>
+ * On a successful call the result is persisted via {@link EmailRepository#markValidated}, so
+ * callers do not need to handle storage themselves -- they only need the returned JsonNode if
+ * they want to inspect the full ZeroBounce response (free_email, did_you_mean, etc.).
+ *
+ * @author SimIS Inc.
+ * @created 7/28/26
+ */
+public class ZeroBounceApiClientCommand {
+
+  private static Log LOG = LogFactory.getLog(ZeroBounceApiClientCommand.class);
+
+  private static String BASE_URL = "https://api.zerobounce.net/v2/validate";
+
+  /**
+   * Validates a single email address with ZeroBounce and records the classification on the
+   * emails record (validation_status/validation_sub_status/validated_at).
+   *
+   * @param emailAddress the email to validate; must already be persisted (a valid id is required
+   *                      to store the result)
+   * @return the ZeroBounce response as JSON, or null if the API is not configured, the address is
+   *         invalid, or the call failed for any reason (never throws)
+   */
+  public static JsonNode validateEmail(Email emailAddress) {
+    if (emailAddress == null || StringUtils.isBlank(emailAddress.getEmail()) || emailAddress.getId() == -1) {
+      return null;
+    }
+
+    String apiKey = getApiKey();
+    if (apiKey == null) {
+      return null;
+    }
+
+    try {
+      // GET https://api.zerobounce.net/v2/validate?email=...&api_key=...&ip_address=...
+      StringBuilder url = new StringBuilder(BASE_URL)
+          .append("?email=").append(URLEncoder.encode(emailAddress.getEmail().trim(), StandardCharsets.UTF_8))
+          .append("&api_key=").append(URLEncoder.encode(apiKey, StandardCharsets.UTF_8));
+      if (StringUtils.isNotBlank(emailAddress.getIpAddress())) {
+        url.append("&ip_address=").append(URLEncoder.encode(emailAddress.getIpAddress().trim(), StandardCharsets.UTF_8));
+      }
+
+      Map<String, String> headers = new HashMap<>();
+      headers.put("Accept", "application/json");
+
+      String remoteContent = HttpGetCommand.execute(url.toString(), headers);
+
+      // Check for content
+      if (StringUtils.isBlank(remoteContent)) {
+        LOG.debug("HttpGet Remote content is empty");
+        return null;
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("REMOTE TEXT: " + remoteContent);
+      }
+
+      JsonNode json = JsonLoader.fromString(remoteContent);
+
+      // Errors have no "status" field at all: {"error": "Invalid API Key or your account ran out of credits"}
+      if (json.has("error")) {
+        LOG.warn("ZeroBounce returned an error: " + json.get("error").asText());
+        return null;
+      }
+      if (!json.has("status")) {
+        LOG.warn("ZeroBounce response did not include a status");
+        return null;
+      }
+
+      // Persist the classification result. Guard against JsonNode's well-known asText() gotcha:
+      // a JSON null value (as opposed to an absent key) is a NullNode, and NullNode.asText()
+      // returns the literal string "null" rather than a real null -- checked explicitly here so
+      // an absent, blank, or JSON-null sub_status all consistently persist as a real SQL NULL.
+      String status = json.get("status").asText();
+      JsonNode subStatusNode = json.get("sub_status");
+      String subStatus = (subStatusNode != null && !subStatusNode.isNull()) ? subStatusNode.asText() : null;
+      EmailRepository.markValidated(emailAddress, status, subStatus);
+
+      return json;
+    } catch (Exception e) {
+      // Anything could have gone wrong - limits exceeded, bad key, communication issue
+      LOG.warn("ZeroBounce validateEmail issue: " + e.getMessage());
+    }
+    return null;
+  }
+
+  private static String getApiKey() {
+    String apiKey = LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey");
+    if (StringUtils.isBlank(apiKey)) {
+      LOG.debug("ZeroBounce API is not configured");
+      return null;
+    }
+    return apiKey;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/Email.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/Email.java
@@ -59,6 +59,10 @@ public class Email extends Entity {
   private Timestamp lastEmailed = null;
   private Timestamp syncDate = null;
 
+  private String validationStatus = null;
+  private String validationSubStatus = null;
+  private Timestamp validatedAt = null;
+
   private Timestamp subscribed = null;
   private Timestamp unsubscribed = null;
   private String unsubscribeReason = null;
@@ -287,6 +291,30 @@ public class Email extends Entity {
 
   public void setSyncDate(Timestamp syncDate) {
     this.syncDate = syncDate;
+  }
+
+  public String getValidationStatus() {
+    return validationStatus;
+  }
+
+  public void setValidationStatus(String validationStatus) {
+    this.validationStatus = validationStatus;
+  }
+
+  public String getValidationSubStatus() {
+    return validationSubStatus;
+  }
+
+  public void setValidationSubStatus(String validationSubStatus) {
+    this.validationSubStatus = validationSubStatus;
+  }
+
+  public Timestamp getValidatedAt() {
+    return validatedAt;
+  }
+
+  public void setValidatedAt(Timestamp validatedAt) {
+    this.validatedAt = validatedAt;
   }
 
   public Timestamp getSubscribed() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/EmailRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/EmailRepository.java
@@ -215,6 +215,48 @@ public class EmailRepository {
     DB.update(TABLE_NAME, set, where);
   }
 
+  /**
+   * Records the result of a deliverability validation (e.g. ZeroBounce) for this address.
+   * Overwrites any previous classification and stamps validated_at with the current time.
+   *
+   * @param record the email record to update (must already be persisted)
+   * @param validationStatus the vendor's primary classification (e.g. "valid", "invalid", "catch-all")
+   * @param validationSubStatus the vendor's finer-grained reason code; may be blank or null
+   */
+  public static void markValidated(Email record, String validationStatus, String validationSubStatus) {
+    if (record == null || record.getId() == -1) {
+      return;
+    }
+    SqlUtils updateValues = new SqlUtils()
+        .add("validation_status", validationStatus, 20)
+        .add("validation_sub_status", validationSubStatus, 50)
+        .add("validated_at", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("email_id = ?", record.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  /**
+   * Finds emails that have never been run through deliverability validation (validated_at IS NULL),
+   * oldest record first, so a scheduled classification job can work through the backlog in order.
+   *
+   * @param constraints paging/sort context; set a page size to bound the batch, e.g. new DataConstraints(1, 100)
+   * @return a page of unvalidated emails, or null if there are none
+   */
+  public static List<Email> findUnvalidatedEmails(DataConstraints constraints) {
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("email_id");
+    SqlUtils where = new SqlUtils()
+        .add("validated_at IS NULL");
+    DataResult result = DB.selectAllFrom(TABLE_NAME, where, constraints, EmailRepository::buildRecord);
+    if (result.hasRecords()) {
+      return (List<Email>) result.getRecords();
+    }
+    return null;
+  }
+
   private static Email buildRecord(ResultSet rs) {
     try {
       Email record = new Email();
@@ -252,6 +294,9 @@ public class EmailRepository {
       record.setTotalSpent(rs.getBigDecimal("total_spent"));
       // @todo tags
       record.setSyncDate(rs.getTimestamp("sync_date"));
+      record.setValidationStatus(rs.getString("validation_status"));
+      record.setValidationSubStatus(rs.getString("validation_sub_status"));
+      record.setValidatedAt(rs.getTimestamp("validated_at"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -32,6 +32,7 @@ import com.simisinc.platform.infrastructure.scheduler.cms.WebVitalsCleanupJob;
 import com.simisinc.platform.infrastructure.scheduler.ecommerce.OrderManagementProcessNewOrders;
 import com.simisinc.platform.infrastructure.scheduler.ecommerce.OrderManagementProcessShippingUpdates;
 import com.simisinc.platform.infrastructure.scheduler.login.UserTokensCleanupJob;
+import com.simisinc.platform.infrastructure.scheduler.mailinglists.EmailClassificationJob;
 import com.simisinc.platform.infrastructure.scheduler.medicine.ProcessMedicineSchedulesJob;
 import com.simisinc.platform.infrastructure.scheduler.socialmedia.InstagramMediaSnapshotJob;
 import org.apache.commons.logging.Log;
@@ -82,6 +83,7 @@ public class SchedulerManager {
   public static final String SESSIONS_PII_SCRUB_JOB = "SessionsPiiScrub";
   public static final String AUDIT_LOG_RETENTION_JOB = "AuditLogRetention";
   public static final String AUDIT_LOG_INTEGRITY_JOB = "AuditLogIntegrity";
+  public static final String EMAIL_CLASSIFICATION_JOB = "EmailClassification";
 
   // Jobs which can be run by multiple clients
   public static final String DATASETS_DOWNLOAD_AND_SYNC_JOB = "DatasetsDownloadAndSync";
@@ -163,6 +165,10 @@ public class SchedulerManager {
         BackgroundJob.scheduleRecurrently(SESSIONS_PII_SCRUB_JOB, Cron.daily(4, 45), SessionsPiiScrubJob::execute);
         BackgroundJob.scheduleRecurrently(AUDIT_LOG_RETENTION_JOB, Cron.daily(4, 15), AuditLogRetentionJob::execute);
         BackgroundJob.scheduleRecurrently(AUDIT_LOG_INTEGRITY_JOB, Cron.daily(4, 30), AuditLogIntegrityJob::execute);
+        // Once daily is plenty for a backlog job, and keeps it off ZeroBounce's real per-lookup API
+        // billing except when there's actually unvalidated backlog; runs ahead of the 4am cluster above
+        // so it isn't competing with those jobs for DB/API time.
+        BackgroundJob.scheduleRecurrently(EMAIL_CLASSIFICATION_JOB, Cron.daily(3), EmailClassificationJob::execute);
       }
     } catch (Exception se) {
       LOG.error("Error starting jobrunr: ", se);

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/EmailClassificationJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/EmailClassificationJob.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.mailinglists;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jobrunr.jobs.annotations.Job;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.mailinglists.ZeroBounceApiClientCommand;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Classifies emails that have never been run through deliverability validation
+ * (see {@link EmailRepository#findUnvalidatedEmails}), using whichever vendor is configured
+ * (currently {@link ZeroBounceApiClientCommand}). A no-op, not an error, when that vendor's API
+ * key site property is blank -- this integration is optional, matching how
+ * ProcessEmailSubscriptionJob bails out when MailChimp isn't configured.
+ * <p>
+ * Each run is capped to a bounded batch so a single execution can never exhaust the vendor's
+ * per-lookup API credits or run long enough to bump into the next scheduled run. A single
+ * address's failure (network error, vendor error) is logged and does not abort the rest of the
+ * batch -- since a failed lookup leaves validated_at NULL, that address is simply picked up again
+ * on the next run.
+ *
+ * @author SimIS Inc.
+ */
+public class EmailClassificationJob {
+
+  private static Log LOG = LogFactory.getLog(EmailClassificationJob.class);
+
+  // Bounds a single run to respect the vendor's real-time API rate limits and keep the job's
+  // wall-clock time reasonable; the backlog is worked down over subsequent daily runs.
+  private static final int BATCH_SIZE = 200;
+
+  @Job(name = "Classify unvalidated emails for deliverability")
+  public static void execute() {
+    // This integration is optional -- skip cleanly (not an error) when it isn't configured, so an
+    // unconfigured install doesn't spend a lock/DB round-trip on a batch that would just fail
+    String apiKey = LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey");
+    if (StringUtils.isBlank(apiKey)) {
+      LOG.debug("ZeroBounce is not configured, skipping email classification");
+      return;
+    }
+
+    // Distributed lock so only one node classifies at a time
+    String lock = LockManager.lock(SchedulerManager.EMAIL_CLASSIFICATION_JOB, Duration.ofHours(2));
+    if (lock == null) {
+      return;
+    }
+
+    List<Email> emailList = EmailRepository.findUnvalidatedEmails(new DataConstraints(1, BATCH_SIZE));
+    if (emailList == null || emailList.isEmpty()) {
+      LOG.debug("No unvalidated emails found");
+      return;
+    }
+
+    int successCount = 0;
+    int failureCount = 0;
+    for (Email email : emailList) {
+      try {
+        if (ZeroBounceApiClientCommand.validateEmail(email) != null) {
+          ++successCount;
+        } else {
+          ++failureCount;
+        }
+      } catch (Exception e) {
+        // A single address must never abort the rest of the batch
+        ++failureCount;
+        LOG.warn("Email classification failed for email_id=" + email.getId() + ": " + e.getMessage());
+      }
+    }
+    LOG.info("Email classification: " + successCount + " succeeded, " + failureCount + " failed, out of "
+        + emailList.size() + " checked");
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -140,6 +140,7 @@ INSERT INTO site_properties (property_label, property_name, property_value, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (10, 'Mailing List Service', 'mailing-list.service', 'None', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'MailChimp API Key', 'mailing-list.mailchimp.apiKey', '', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (22, 'MailChimp List Id', 'mailing-list.mailchimp.listId', '', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (24, 'ZeroBounce API Key', 'mailing-list.zerobounce.apiKey', '', 'text');
 
 -- Maps
 

--- a/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
+++ b/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
@@ -41,7 +41,10 @@ CREATE TABLE emails (
   number_of_orders INTEGER DEFAULT 0,
   total_spent NUMERIC(15,6) DEFAULT 0,
   tags JSONB,
-  sync_date TIMESTAMP(3)
+  sync_date TIMESTAMP(3),
+  validation_status VARCHAR(20),
+  validation_sub_status VARCHAR(50),
+  validated_at TIMESTAMP(3)
 );
 
 CREATE INDEX emails_created_idx ON emails(created);
@@ -52,6 +55,7 @@ CREATE INDEX emails_last_ord_idx ON emails(last_order);
 CREATE INDEX emails_num_ord_idx ON emails(number_of_orders);
 CREATE INDEX emails_total_sp_idx ON emails(total_spent);
 CREATE INDEX emails_sync_date_idx ON emails(sync_date);
+CREATE INDEX emails_validation_status_idx ON emails(validation_status);
 
 CREATE TABLE mailing_lists (
   list_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260728.2000__email_classification.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260728.2000__email_classification.sql
@@ -1,0 +1,31 @@
+-- Email deliverability classification (#574): stores the result of a per-address validation
+-- call (e.g. ZeroBounce) directly on emails, not on mailing_list_members, because deliverability
+-- is a property of the address itself, not of any one list membership -- emails.email is already
+-- UNIQUE, giving exactly the granularity a vendor classifies at.
+--
+-- validation_status:     the vendor's primary classification, stored verbatim
+--                         (e.g. valid, invalid, catch-all, unknown, spamtrap, abuse, do_not_mail).
+-- validation_sub_status: the vendor's finer-grained reason code, stored verbatim, blank when the
+--                         vendor has none to report.
+-- validated_at:          when the address was last run through validation -- a "last checked"
+--                         marker, not a "last known-good" marker. NULL means never validated,
+--                         which is how the classification job finds its backlog.
+--
+-- Deliberately vendor-neutral column names (not "zerobounce_status") to match sync_date's own
+-- precedent on this table, which stayed generic despite only serving MailChimp so far.
+--
+-- Feeds #562 (flagged as spam/bounced breakdown) and unblocks #564 (mailing list hygiene).
+-- Idempotent so it is safe to re-run; fresh installs get the identical columns from NEW_10070
+-- instead.
+ALTER TABLE emails ADD COLUMN IF NOT EXISTS validation_status VARCHAR(20);
+ALTER TABLE emails ADD COLUMN IF NOT EXISTS validation_sub_status VARCHAR(50);
+ALTER TABLE emails ADD COLUMN IF NOT EXISTS validated_at TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS emails_validation_status_idx ON emails(validation_status);
+
+-- ZeroBounce API key, following the exact shape of the MailChimp API key row it sits beside in
+-- NEW_10000. Encrypted at rest -- see SecretSitePropertiesCommand.SECRET_PROPERTY_NAMES, which
+-- gets the matching 'mailing-list.zerobounce.apiKey' entry in this same change.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (24, 'ZeroBounce API Key', 'mailing-list.zerobounce.apiKey', '', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/application/mailinglists/ZeroBounceApiClientCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/ZeroBounceApiClientCommandTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.http.HttpGetCommand;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+
+/**
+ * Verifies {@link ZeroBounceApiClientCommand#validateEmail} against realistic ZeroBounce v2
+ * {@code /validate} response payloads, without ever making a real network call:
+ * {@link HttpGetCommand}, {@link LoadSitePropertyCommand}, and {@link EmailRepository} are all
+ * statically mocked, so the only thing exercised for real is the client's own parsing/branching
+ * logic (and the real {@code JsonLoader} parse of the mocked response body).
+ *
+ * @author SimIS Inc.
+ */
+class ZeroBounceApiClientCommandTest {
+
+  private static final String API_KEY = "test-api-key-123";
+
+  // A realistic ZeroBounce v2 /validate success response (field shape per ZeroBounce's public
+  // API docs) for an address with a reason code attached.
+  private static final String INVALID_WITH_SUB_STATUS_RESPONSE = """
+      {
+        "address": "invalid@example.com",
+        "status": "invalid",
+        "sub_status": "mailbox_not_found",
+        "account": null,
+        "domain": null,
+        "did_you_mean": null,
+        "domain_age_days": "9855",
+        "free_email": false,
+        "mx_found": "true",
+        "mx_record": "aspmx.l.google.com",
+        "smtp_provider": "google",
+        "firstname": "",
+        "lastname": "",
+        "gender": "",
+        "country": null,
+        "region": null,
+        "city": null,
+        "zipcode": null,
+        "processed_at": "2026-07-28 10:00:00.000"
+      }
+      """;
+
+  // Same shape, but the vendor omits sub_status entirely (as it does for a clean "valid" result).
+  private static final String VALID_WITHOUT_SUB_STATUS_RESPONSE = """
+      {
+        "address": "valid@example.com",
+        "status": "valid",
+        "free_email": false,
+        "mx_found": "true",
+        "mx_record": "aspmx.l.google.com",
+        "smtp_provider": "google",
+        "processed_at": "2026-07-28 10:00:00.000"
+      }
+      """;
+
+  // A defensive case ZeroBounce's documented v2 shape does not currently produce (their sub_status
+  // is always a string, empty or not) but the parser must not mishandle if a vendor ever does this:
+  // sub_status present as an explicit JSON null rather than omitted or an empty string.
+  private static final String VALID_WITH_EXPLICIT_NULL_SUB_STATUS_RESPONSE = """
+      {
+        "address": "valid@example.com",
+        "status": "valid",
+        "sub_status": null,
+        "free_email": false,
+        "mx_found": "true",
+        "mx_record": "aspmx.l.google.com",
+        "smtp_provider": "google",
+        "processed_at": "2026-07-28 10:00:00.000"
+      }
+      """;
+
+  // ZeroBounce's error shape has no "status" field at all.
+  private static final String VENDOR_ERROR_RESPONSE = """
+      {"error": "Invalid API Key or your account ran out of credits"}
+      """;
+
+  @Test
+  void validateEmailParsesSuccessResponseAndPersistsClassification() {
+    Email email = persistedEmail(101L, "invalid@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn(INVALID_WITH_SUB_STATUS_RESPONSE);
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertTrue(result != null, "a successful response should be returned");
+      assertEquals("invalid", result.get("status").asText());
+      assertEquals("mailbox_not_found", result.get("sub_status").asText());
+      assertEquals("google", result.get("smtp_provider").asText());
+
+      // The classification was persisted with the vendor's exact status/sub_status
+      emailRepository.verify(() -> EmailRepository.markValidated(email, "invalid", "mailbox_not_found"));
+
+      // The request itself: fixed base URL, email + api_key url-encoded onto the query string
+      ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+      httpGet.verify(() -> HttpGetCommand.execute(urlCaptor.capture(), anyMap()));
+      String url = urlCaptor.getValue();
+      assertTrue(url.startsWith("https://api.zerobounce.net/v2/validate?"), "unexpected base url: " + url);
+      assertTrue(url.contains("email=invalid%40example.com"), "email should be url-encoded: " + url);
+      assertTrue(url.contains("api_key=" + API_KEY), "api key should be present: " + url);
+      assertFalse(url.contains("ip_address="), "ip_address should be omitted when blank: " + url);
+    }
+  }
+
+  @Test
+  void validateEmailIncludesUrlEncodedIpAddressWhenPresent() {
+    Email email = persistedEmail(102L, "geo@example.com");
+    email.setIpAddress("203.0.113.5");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn(VALID_WITHOUT_SUB_STATUS_RESPONSE);
+
+      ZeroBounceApiClientCommand.validateEmail(email);
+
+      ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+      httpGet.verify(() -> HttpGetCommand.execute(urlCaptor.capture(), anyMap()));
+      assertTrue(urlCaptor.getValue().contains("ip_address=203.0.113.5"));
+    }
+  }
+
+  @Test
+  void validateEmailPassesNullSubStatusWhenVendorOmitsIt() {
+    Email email = persistedEmail(103L, "valid@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn(VALID_WITHOUT_SUB_STATUS_RESPONSE);
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertTrue(result != null);
+      assertEquals("valid", result.get("status").asText());
+      emailRepository.verify(() -> EmailRepository.markValidated(email, "valid", null));
+    }
+  }
+
+  @Test
+  void validateEmailPassesNullSubStatusWhenVendorSendsAnExplicitJsonNull() {
+    // Regression guard for a Jackson footgun: NullNode.asText() returns the literal string "null",
+    // not a real null, so this must be checked explicitly rather than relying on json.has().
+    Email email = persistedEmail(108L, "valid@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap()))
+          .thenReturn(VALID_WITH_EXPLICIT_NULL_SUB_STATUS_RESPONSE);
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertTrue(result != null);
+      emailRepository.verify(() -> EmailRepository.markValidated(email, "valid", null));
+    }
+  }
+
+  @Test
+  void validateEmailReturnsNullAndDoesNotPersistOnVendorErrorResponse() {
+    Email email = persistedEmail(104L, "whatever@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn(VENDOR_ERROR_RESPONSE);
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertNull(result, "a vendor error response must not be treated as a classification");
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void validateEmailReturnsNullAndDoesNotPersistWhenStatusFieldIsMissing() {
+    Email email = persistedEmail(105L, "weird@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      // Neither "error" nor "status" - a shape ZeroBounce should never send, but the client must
+      // not assume "status" is present just because "error" is absent.
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn("{\"address\":\"weird@example.com\"}");
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertNull(result);
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void validateEmailReturnsNullWithoutPersistingWhenHttpCallFails() {
+    Email email = persistedEmail(106L, "unreachable@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey"))
+          .thenReturn(API_KEY);
+      // HttpGetCommand.execute's own contract: null on any failure (bad status, timeout, empty body)
+      httpGet.when(() -> HttpGetCommand.execute(anyString(), anyMap())).thenReturn(null);
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertNull(result);
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void validateEmailReturnsNullWithoutAnyHttpCallWhenApiKeyIsNotConfigured() {
+    Email email = persistedEmail(107L, "someone@example.com");
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.zerobounce.apiKey")).thenReturn("");
+
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertNull(result);
+      httpGet.verify(() -> HttpGetCommand.execute(anyString(), anyMap()), never());
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void validateEmailReturnsNullWithoutAnyHttpCallForAnUnpersistedEmail() {
+    Email email = new Email();
+    email.setEmail("never-saved@example.com");
+    // Default id is -1 (never persisted) - there is nowhere to store the classification
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      JsonNode result = ZeroBounceApiClientCommand.validateEmail(email);
+
+      assertNull(result);
+      httpGet.verify(() -> HttpGetCommand.execute(anyString(), anyMap()), never());
+      // The guard clause returns before even looking at site properties
+      siteProperty.verify(() -> LoadSitePropertyCommand.loadByName(anyString()), never());
+    }
+  }
+
+  private static Email persistedEmail(long id, String address) {
+    Email email = new Email();
+    email.setId(id);
+    email.setEmail(address);
+    return email;
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/database/WebVitalsMigrationTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/database/WebVitalsMigrationTest.java
@@ -120,15 +120,25 @@ class WebVitalsMigrationTest {
     // web_pages: referenced by FK from the web_vitals migrations under test. sessions: altered by
     // UPGRADE_20260727.1000__sessions_ip_address_nullable.sql, an unrelated migration that now
     // sorts between the baseline and the web_vitals migrations' versions -- Flyway applies
-    // everything in range, not just the two under test, so it runs here too. distributed_lock:
-    // not touched by any migration under test, but WebVitalsAggregationJob/WebVitalsCleanupJob
-    // both take a LockManager lock before running, and this test drives those jobs through their
-    // real execute() methods rather than re-implementing their SQL inline. Everything else in the
-    // real install schema is irrelevant to this conflict.
+    // everything in range, not just the two under test, so it runs here too. emails and
+    // site_properties: both touched by UPGRADE_20260728.2000__email_classification.sql (#574),
+    // another unrelated migration that lands in this same range for the same reason -- it ALTERs
+    // emails and does an INSERT ... ON CONFLICT (property_name) into site_properties, so
+    // property_name needs the real table's UNIQUE constraint or the ON CONFLICT clause itself
+    // fails. Expect this list to keep growing by a line or two every time a later migration's
+    // version happens to sort after this baseline. distributed_lock: not touched by any migration
+    // under test, but WebVitalsAggregationJob/WebVitalsCleanupJob both take a LockManager lock
+    // before running, and this test drives those jobs through their real execute() methods rather
+    // than re-implementing their SQL inline. Everything else in the real install schema is
+    // irrelevant to this conflict.
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("CREATE TABLE web_pages (web_page_id BIGSERIAL PRIMARY KEY, link VARCHAR(255))");
       statement.execute("CREATE TABLE sessions (session_id BIGSERIAL PRIMARY KEY, ip_address VARCHAR(64) NOT NULL)");
+      statement.execute("CREATE TABLE emails (email_id BIGSERIAL PRIMARY KEY)");
+      statement.execute("CREATE TABLE site_properties (property_id SERIAL PRIMARY KEY, "
+          + "property_order INTEGER DEFAULT 100, property_label VARCHAR(50), "
+          + "property_name VARCHAR(50) UNIQUE NOT NULL, property_value TEXT NOT NULL, property_type VARCHAR(100))");
       statement.execute("CREATE TABLE distributed_lock (name VARCHAR(64) PRIMARY KEY NOT NULL, "
           + "locked_at TIMESTAMP(3) NOT NULL, lock_until TIMESTAMP(3) NOT NULL, uuid VARCHAR(255) NOT NULL)");
     } catch (SQLException se) {

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/EmailRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/EmailRepositoryTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies the email deliverability classification path (#574) against a real PostgreSQL
+ * instance: {@link EmailRepository#markValidated} and {@link EmailRepository#findUnvalidatedEmails}.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available, so it does not break the build on hosts without a Docker daemon.
+ * </p>
+ *
+ * <p>
+ * The test creates a focused subset of the real {@code emails} schema. It is not the full column
+ * list from the install script: {@code tags} and {@code last_interaction} are omitted because
+ * nothing under test reads or writes them. Every other column is kept, including the ones that
+ * look unrelated to classification (name, geo, order history, etc.) -- {@link
+ * EmailRepository#buildRecord} selects the full row and reads every one of those columns by name,
+ * so a schema that were any narrower would turn each row into a swallowed SQLException and a null
+ * record instead of a real assertion failure. The {@code created_by}/{@code modified_by} foreign
+ * keys to {@code users} are dropped since there is no users table here, matching
+ * ContentRepositoryTest's precedent.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+class EmailRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    // Only run when a Docker daemon is reachable; otherwise mark the whole class as skipped
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping EmailRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    // Point the application's shared DataSource at the container
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE emails RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset emails table", se);
+    }
+  }
+
+  @Test
+  void markValidatedPersistsTheClassification() {
+    Email email = addEmail("valid@example.com");
+
+    EmailRepository.markValidated(email, "valid", "");
+
+    Email reloaded = EmailRepository.findById(email.getId());
+    assertNotNull(reloaded);
+    assertEquals("valid", reloaded.getValidationStatus());
+    assertEquals("", reloaded.getValidationSubStatus());
+    assertNotNull(reloaded.getValidatedAt(), "validated_at should be stamped once classified");
+  }
+
+  @Test
+  void markValidatedOverwritesAPreviousClassification() {
+    Email email = addEmail("recheck@example.com");
+    EmailRepository.markValidated(email, "invalid", "mailbox_not_found");
+
+    EmailRepository.markValidated(email, "valid", null);
+
+    Email reloaded = EmailRepository.findById(email.getId());
+    assertEquals("valid", reloaded.getValidationStatus());
+    assertNull(reloaded.getValidationSubStatus());
+  }
+
+  @Test
+  void markValidatedIsSafeOnNullOrUnpersistedRecord() {
+    // Neither call should throw, and neither should touch the table
+    EmailRepository.markValidated(null, "valid", null);
+    EmailRepository.markValidated(new Email(), "valid", null);
+
+    assertEquals(0, DB.selectCountFrom("emails"), "no row should have been created or modified");
+  }
+
+  @Test
+  void findUnvalidatedEmailsOnlyReturnsEmailsNeverClassified() {
+    Email classified = addEmail("classified@example.com");
+    EmailRepository.markValidated(classified, "valid", "");
+    Email unvalidated = addEmail("pending@example.com");
+
+    List<Email> results = EmailRepository.findUnvalidatedEmails(new DataConstraints(1, 100));
+
+    assertNotNull(results);
+    assertEquals(1, results.size(), "only the never-classified address should come back");
+    assertEquals(unvalidated.getId(), results.get(0).getId());
+    assertEquals("pending@example.com", results.get(0).getEmail());
+    assertNull(results.get(0).getValidatedAt());
+  }
+
+  @Test
+  void findUnvalidatedEmailsReturnsNullWhenNoneArePending() {
+    Email onlyEmail = addEmail("already-checked@example.com");
+    EmailRepository.markValidated(onlyEmail, "valid", "");
+
+    assertNull(EmailRepository.findUnvalidatedEmails(new DataConstraints(1, 100)),
+        "matches findAll()'s null-vs-empty-list convention, which EmailClassificationJob relies on");
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS emails CASCADE");
+      statement.execute("CREATE TABLE emails ("
+          + "email_id BIGSERIAL PRIMARY KEY, "
+          + "email VARCHAR(255) UNIQUE NOT NULL, "
+          + "first_name VARCHAR(100), "
+          + "last_name VARCHAR(100), "
+          + "organization VARCHAR(100), "
+          + "source VARCHAR(50), "
+          + "ip_address VARCHAR(200), "
+          + "session_id VARCHAR(255), "
+          + "user_agent VARCHAR(500), "
+          + "referer VARCHAR(255), "
+          + "continent VARCHAR(20), "
+          + "country_iso VARCHAR(2), "
+          + "country VARCHAR(100), "
+          + "city VARCHAR(100), "
+          + "state_iso VARCHAR(3), "
+          + "state VARCHAR(100), "
+          + "postal_code VARCHAR(50), "
+          + "timezone VARCHAR(50), "
+          + "latitude float, "
+          + "longitude float, "
+          + "metro_code INTEGER, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "created_by BIGINT, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT, "
+          + "subscribed TIMESTAMP(3), "
+          + "unsubscribed TIMESTAMP(3), "
+          + "unsubscribe_reason VARCHAR(100), "
+          + "last_emailed TIMESTAMP(3), "
+          + "last_order TIMESTAMP(3), "
+          + "number_of_orders INTEGER DEFAULT 0, "
+          + "total_spent NUMERIC(15,6) DEFAULT 0, "
+          + "sync_date TIMESTAMP(3), "
+          + "validation_status VARCHAR(20), "
+          + "validation_sub_status VARCHAR(50), "
+          + "validated_at TIMESTAMP(3))");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the emails schema", se);
+    }
+  }
+
+  private static Email addEmail(String address) {
+    Email email = new Email();
+    email.setEmail(address);
+    return EmailRepository.add(email);
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/EmailClassificationJobTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/EmailClassificationJobTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.mailinglists.ZeroBounceApiClientCommand;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Verifies {@link EmailClassificationJob#execute}'s control flow: the configuration/lock/backlog
+ * guard clauses, and -- the main point of this test -- that a single address failing
+ * classification (whether {@link ZeroBounceApiClientCommand#validateEmail} returns null or
+ * throws) does not stop the rest of the batch from being processed.
+ * <p>
+ * {@link LoadSitePropertyCommand}, {@link LockManager}, {@link EmailRepository}, and {@link
+ * ZeroBounceApiClientCommand} are all statically mocked, so nothing here touches a database or
+ * the network -- this is purely the job's own orchestration logic.
+ *
+ * @author SimIS Inc.
+ */
+class EmailClassificationJobTest {
+
+  private static final String API_KEY_PROPERTY = "mailing-list.zerobounce.apiKey";
+
+  @Test
+  void executeProcessesTheWholeBatchDespiteAPerEmailFailure() {
+    Email succeeds1 = email(1L, "succeeds1@example.com");
+    Email failsReturnsNull = email(2L, "fails-null@example.com");
+    Email failsThrows = email(3L, "fails-throws@example.com");
+    Email succeeds2 = email(4L, "succeeds2@example.com");
+    List<Email> batch = Arrays.asList(succeeds1, failsReturnsNull, failsThrows, succeeds2);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class);
+        MockedStatic<ZeroBounceApiClientCommand> zeroBounce = mockStatic(ZeroBounceApiClientCommand.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(API_KEY_PROPERTY)).thenReturn("configured-key");
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.EMAIL_CLASSIFICATION_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      emailRepository.when(() -> EmailRepository.findUnvalidatedEmails(any(DataConstraints.class))).thenReturn(batch);
+
+      JsonNode ok = JsonNodeFactory.instance.objectNode().put("status", "valid");
+      zeroBounce.when(() -> ZeroBounceApiClientCommand.validateEmail(succeeds1)).thenReturn(ok);
+      zeroBounce.when(() -> ZeroBounceApiClientCommand.validateEmail(failsReturnsNull)).thenReturn(null);
+      zeroBounce.when(() -> ZeroBounceApiClientCommand.validateEmail(failsThrows))
+          .thenThrow(new RuntimeException("simulated ZeroBounce failure"));
+      zeroBounce.when(() -> ZeroBounceApiClientCommand.validateEmail(succeeds2)).thenReturn(ok);
+
+      EmailClassificationJob.execute();
+
+      // Every address in the batch was attempted, in particular succeeds2 - which comes after
+      // both failure modes - proving neither a null return nor a thrown exception aborts the loop.
+      zeroBounce.verify(() -> ZeroBounceApiClientCommand.validateEmail(succeeds1), times(1));
+      zeroBounce.verify(() -> ZeroBounceApiClientCommand.validateEmail(failsReturnsNull), times(1));
+      zeroBounce.verify(() -> ZeroBounceApiClientCommand.validateEmail(failsThrows), times(1));
+      zeroBounce.verify(() -> ZeroBounceApiClientCommand.validateEmail(succeeds2), times(1));
+
+      // The batch was pulled as a single bounded page (BATCH_SIZE = 200), oldest first
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      emailRepository.verify(() -> EmailRepository.findUnvalidatedEmails(constraintsCaptor.capture()));
+      assertEquals(1, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(200, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void executeSkipsCleanlyWhenApiKeyIsNotConfigured() {
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(API_KEY_PROPERTY)).thenReturn("");
+
+      EmailClassificationJob.execute();
+
+      // An unconfigured install must not touch the lock or the database at all
+      lockManager.verifyNoInteractions();
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeSkipsTheBatchWhenTheLockIsHeldByAnotherNode() {
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(API_KEY_PROPERTY)).thenReturn("configured-key");
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.EMAIL_CLASSIFICATION_JOB), any(Duration.class)))
+          .thenReturn(null);
+
+      EmailClassificationJob.execute();
+
+      emailRepository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeSkipsCleanlyWhenThereIsNoBacklog() {
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<EmailRepository> emailRepository = mockStatic(EmailRepository.class);
+        MockedStatic<ZeroBounceApiClientCommand> zeroBounce = mockStatic(ZeroBounceApiClientCommand.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(API_KEY_PROPERTY)).thenReturn("configured-key");
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.EMAIL_CLASSIFICATION_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      emailRepository.when(() -> EmailRepository.findUnvalidatedEmails(any(DataConstraints.class))).thenReturn(null);
+
+      EmailClassificationJob.execute();
+
+      zeroBounce.verifyNoInteractions();
+    }
+  }
+
+  private static Email email(long id, String address) {
+    Email email = new Email();
+    email.setId(id);
+    email.setEmail(address);
+    return email;
+  }
+}


### PR DESCRIPTION
## Summary

Adds real-time, single-address email deliverability validation via ZeroBounce's v2 API, following the exact per-vendor-class pattern the existing MailChimp/Square/Superset/etc. integrations already use, rather than introducing any new generic integration infrastructure.

- `ZeroBounceApiClientCommand` calls ZeroBounce's `/v2/validate` endpoint through the existing `HttpGetCommand` transport and persists the result via `EmailRepository.markValidated`. Never throws -- a missing API key, a vendor error payload, a response missing `status`, or any network failure all just result in a `null` return, so callers don't need special-case handling.
- `Email`/`EmailRepository` gain `validation_status`, `validation_sub_status`, and `validated_at`, plus `findUnvalidatedEmails()` so a backlog can be queried and worked through oldest-first. Columns are vendor-neutral (not `zerobounce_status`) to match the precedent already set by the existing `sync_date` column.
- `EmailClassificationJob` is a new daily JobRunr job (3am, ahead of the existing 4am maintenance cluster) that pulls a bounded batch (200) of never-validated emails and classifies them. It's a clean no-op when the API key site property isn't configured, uses the existing distributed lock so only one node runs it, and one address failing (null return or thrown exception) never aborts the rest of the batch.
- API key is stored via the existing `site_properties` mechanism and added to `SecretSitePropertiesCommand`'s encryption allowlist. It shows up in the existing "Mailing List Settings" admin page for free, since that page is already driven generically off the `mailing-list` property prefix -- no new UI code needed.

Also includes a small fixture fix to `WebVitalsMigrationTest` -- see Test plan below for why it was necessary.

## What was not built

- **ZeroBounce's bulk/batch API** (CSV upload → poll → download result). The issue's own scoping called this out as the one genuine gap in the HTTP layer today (no outbound multipart support yet) *if* a batch workflow turns out to be the actual target. It isn't needed here: none of the four acceptance criteria call for it, and real-time single-address validation satisfies all of them as written. Left for a follow-up if an actual bulk import/export workflow (see #462) ends up needing it.
- **No new generic integration framework.** This deliberately follows the existing per-vendor-class shape instead of anything from #454 (secrets manager), #455 (integration registry/marketplace), or #452 (webhook event system) -- consistent with the issue's own explicit scoping decision not to block on or bundle with that larger vision.

## Test plan

- `ant -lib lib/war clean compile` -- clean
- `ant -lib lib/war compile-jsp` -- clean (this change touches no JSP)
- `ant -lib lib/tests ci-test` -- 634 tests run, only the known pre-existing flakes: `HealthCommandTest` (3), `BlockedIPListCommandTest` (2), `CaptchaCommandTest` (1), `ContentWidgetTest` (1, tracked as #534) -- the JaCoCo `java.sql.*` instrumentation crash cascade and the batch-order-dependent flake, both confirmed present on a clean `upstream/main` checkout and unrelated to this change.
- New coverage:
  - `ZeroBounceApiClientCommandTest` (9 tests): the v2 `/validate` response parsing against realistic payloads -- success with/without `sub_status`, the explicit-JSON-null `sub_status` footgun (Jackson's `NullNode.asText()` returns the literal string `"null"`), vendor error responses, a response missing `status` entirely, HTTP failures, an unconfigured API key, and an unpersisted email -- all via `mockStatic` on `HttpGetCommand`/`LoadSitePropertyCommand`/`EmailRepository`, no real network calls.
  - `EmailClassificationJobTest` (4 tests): the job's own orchestration -- config/lock/backlog guard clauses, and, the main point of this test, that one address failing (whether `validateEmail` returns null or throws) never stops the rest of the batch from being processed.
  - `EmailRepositoryTest` (5 tests): a real Testcontainers/PostgreSQL integration test (no mocked DB access) covering `markValidated` and `findUnvalidatedEmails` against the actual schema shape.
- This branch was cut before the web-vitals work (#548) landed on `main`. After rebasing onto the current `main`, `WebVitalsMigrationTest` -- a regression test that baselines Flyway just below two specific migrations and then migrates with production's real (whole-directory, out-of-order) config -- started picking up `UPGRADE_20260728.2000__email_classification.sql` too, since its version now legitimately sorts into that test's baseline range. The test already has this exact problem once already, for an unrelated `sessions` migration, and already works around it with a minimal stand-in table; this just extends that same established pattern with `emails` and `site_properties` stand-ins (the latter needs the real `UNIQUE` constraint on `property_name`, since this migration's `INSERT ... ON CONFLICT (property_name)` isn't valid SQL without it). Confirmed this was a real, 100%-reproducible failure before the fix (not a flake) and that it's fully resolved after.

Closes #574. Feeds #562 (spam/bounced breakdown), unblocks #564 (mailing list hygiene).
