### PR TITLE
Fix newsletter signup form's missing bot protection

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjax.java
@@ -22,6 +22,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.sanctionco.jmail.JMail;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.cms.CaptchaCommand;
 import com.simisinc.platform.application.mailinglists.SaveEmailCommand;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -57,6 +59,21 @@ public class EmailSubscribeAjax extends GenericWidget {
     }
     if (!JMail.isValid(emailValue)) {
       context.setJson("[]");
+      return context;
+    }
+
+    // Validate the captcha (issue #484 -- this endpoint had no bot protection at all, unlike the
+    // sibling EmailSubscribeWidget/FormWidget paths which already call this same check). Always
+    // required here: unlike a page-embedded widget instance, this JSON-service endpoint has no
+    // per-page preferences to make it optional, and the rendering JSP always shows a challenge.
+    if (!CaptchaCommand.validateRequest(context)) {
+      context.setJson("{\"status\":\"1\",\"message\":\"Please verify you're human before subscribing\"}");
+      return context;
+    }
+
+    // Rate limit by IP to prevent bot signup floods
+    if (!RateLimitCommand.isIpAllowedRightNow(context.getRequest().getRemoteAddr(), true)) {
+      context.setJson("{\"status\":\"1\",\"message\":\"" + RateLimitCommand.INVALID_ATTEMPTS + "\"}");
       return context;
     }
 

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
@@ -22,37 +22,92 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="sitePropertyMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="useCaptcha" class="java.lang.String" scope="request"/>
+<%-- issue #484: this form previously submitted straight to EmailSubscribeAjax with no CAPTCHA or
+     rate limiting at all -- the sibling EmailSubscribeWidget/FormWidget paths already had both.
+     Mirrors the same three-way captcha branch form.jsp already uses (Google invisible reCAPTCHA,
+     the image+text fallback, or none), adapted for this widget's AJAX (not native POST) submit. --%>
+<c:if test="${useCaptcha eq 'true' && !empty googleSiteKey}">
+<script src='https://www.google.com/recaptcha/api.js' nonce="${cspNonce}"></script>
+</c:if>
 <script type="text/javascript" nonce="${cspNonce}">
     function validateEmail${widgetContext.uniqueId}(email) {
         var re = /\S+@\S+\.\S+/;
         return re.test(email);
     }
-    function emailSignUp${widgetContext.uniqueId}() {
+    function submitEmailSignUp${widgetContext.uniqueId}(extraParams) {
         var email = document.getElementById("email${widgetContext.uniqueId}").value;
         if (email === undefined || email.length === 0) {
             document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Please enter your email address";
-            return false;
+            return;
         }
         if (!validateEmail${widgetContext.uniqueId}(email)) {
             document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Please re-enter your email address using a proper format.";
-            return false;
+            return;
         }
-        $.getJSON("${ctx}/json/emailSubscribe?token=${userSession.formToken}&email=" + encodeURIComponent(email), function(data) {
+        $.getJSON("${ctx}/json/emailSubscribe?token=${userSession.formToken}&email=" + encodeURIComponent(email) + extraParams, function(data) {
             if (data.status === undefined || data.status !== '0') {
-                document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Please re-enter your email address using a proper format.";
-                return false;
+                document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML =
+                    (data.message ? data.message : "Please re-enter your email address using a proper format.");
+                return;
             }
             document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Thanks for signing up for <c:out value="${js:escape(sitePropertyMap['site.name'])}"/> emails";
         });
+    }
+    <c:choose>
+    <c:when test="${useCaptcha eq 'true' && !empty googleSiteKey}">
+    // The g-recaptcha-bound submit button (below) intercepts the click itself and calls this
+    // callback with the verified token once the invisible check passes -- Google's own script
+    // prevents the native form submission, so this is only a harmless fallback for any other path
+    // that might fire the form's submit event (e.g. pressing Enter before the script has loaded).
+    function emailSignUp${widgetContext.uniqueId}() {
         return false;
     }
+    function emailSignUpCaptchaCallback${widgetContext.uniqueId}(token) {
+        submitEmailSignUp${widgetContext.uniqueId}("&g-recaptcha-response=" + encodeURIComponent(token));
+    }
+    </c:when>
+    <c:when test="${useCaptcha eq 'true'}">
+    function emailSignUp${widgetContext.uniqueId}() {
+        var captchaValue = document.getElementById("captcha${widgetContext.uniqueId}").value;
+        if (!captchaValue) {
+            document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Please enter the text shown in the image";
+            return false;
+        }
+        submitEmailSignUp${widgetContext.uniqueId}("&captcha=" + encodeURIComponent(captchaValue));
+        return false;
+    }
+    </c:when>
+    <c:otherwise>
+    function emailSignUp${widgetContext.uniqueId}() {
+        submitEmailSignUp${widgetContext.uniqueId}("");
+        return false;
+    }
+    </c:otherwise>
+    </c:choose>
 </script>
 <form method="get" onsubmit="return emailSignUp${widgetContext.uniqueId}()">
   <div class="input-group">
     <input class="input-group-field" type="text" id="email${widgetContext.uniqueId}" name="email${widgetContext.uniqueId}" placeholder="name@email.com" required>
     <div class="input-group-button">
-      <button type="submit" class="button call-to-action"><c:out value="${buttonName}" /></button>
+      <c:choose>
+        <c:when test="${useCaptcha eq 'true' && !empty googleSiteKey}">
+          <button type="submit" class="g-recaptcha button call-to-action"
+                  data-sitekey="<c:out value="${googleSiteKey}" />"
+                  data-callback="emailSignUpCaptchaCallback${widgetContext.uniqueId}"
+                  data-action="subscribe"><c:out value="${buttonName}" /></button>
+        </c:when>
+        <c:otherwise>
+          <button type="submit" class="button call-to-action"><c:out value="${buttonName}" /></button>
+        </c:otherwise>
+      </c:choose>
     </div>
   </div>
+  <c:if test="${useCaptcha eq 'true' && empty googleSiteKey}">
+    <p class="help-text">
+      Enter the text shown: <img src="/assets/captcha" alt="captcha" style="vertical-align: middle;" />
+      <input type="text" id="captcha${widgetContext.uniqueId}" required/>
+    </p>
+  </c:if>
   <p class="help-text" id="emailHelpText${widgetContext.uniqueId}"></p>
 </form>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjaxTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.ecommerce;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.cms.CaptchaCommand;
+import com.simisinc.platform.application.mailinglists.SaveEmailCommand;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+
+/**
+ * Issue #484 -- this endpoint (the real target of the footer newsletter signup form's AJAX call,
+ * distinct from EmailSubscribeWidget.post()) previously had no CAPTCHA or rate-limit check at all.
+ *
+ * @author Elizabeth Houser
+ */
+class EmailSubscribeAjaxTest extends WidgetBase {
+
+  private void addValidParams() {
+    addQueryParameter(widgetContext, "token", widgetContext.getUserSession().getFormToken());
+    addQueryParameter(widgetContext, "email", "subscriber@example.com");
+  }
+
+  @Test
+  void validSubmissionIsSavedWhenCaptchaAndRateLimitPass() {
+    addValidParams();
+
+    try (MockedStatic<CaptchaCommand> captcha = mockStatic(CaptchaCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<SaveEmailCommand> saveEmail = mockStatic(SaveEmailCommand.class)) {
+      captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
+      saveEmail.when(() -> SaveEmailCommand.saveEmail(any())).thenReturn(new Email());
+
+      new EmailSubscribeAjax().execute(widgetContext);
+
+      Assertions.assertEquals("{\"status\":\"0\"}", widgetContext.getJson());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()));
+    }
+  }
+
+  @Test
+  void captchaFailureRejectsWithoutSaving() {
+    addValidParams();
+
+    try (MockedStatic<CaptchaCommand> captcha = mockStatic(CaptchaCommand.class);
+        MockedStatic<SaveEmailCommand> saveEmail = mockStatic(SaveEmailCommand.class)) {
+      captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(false);
+
+      new EmailSubscribeAjax().execute(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertTrue(json.contains("\"status\":\"1\""), json);
+      Assertions.assertTrue(json.contains("verify you're human"), json);
+      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()), never());
+    }
+  }
+
+  @Test
+  void rateLimitFailureRejectsWithoutSaving() {
+    addValidParams();
+
+    try (MockedStatic<CaptchaCommand> captcha = mockStatic(CaptchaCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<SaveEmailCommand> saveEmail = mockStatic(SaveEmailCommand.class)) {
+      captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(false);
+
+      new EmailSubscribeAjax().execute(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertTrue(json.contains("\"status\":\"1\""), json);
+      Assertions.assertTrue(json.contains(RateLimitCommand.INVALID_ATTEMPTS), json);
+      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()), never());
+    }
+  }
+
+  @Test
+  void captchaIsCheckedBeforeRateLimit() {
+    // Order matters for the "first rejection reason wins" style used elsewhere in this codebase --
+    // confirm rate limiting isn't even consulted when the captcha already failed.
+    addValidParams();
+
+    try (MockedStatic<CaptchaCommand> captcha = mockStatic(CaptchaCommand.class);
+        MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class)) {
+      captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(false);
+
+      new EmailSubscribeAjax().execute(widgetContext);
+
+      rateLimit.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void invalidEmailIsRejectedBeforeCaptchaIsEvenChecked() {
+    // Pre-existing behavior must survive: malformed input shouldn't burn a captcha/rate-limit check.
+    addQueryParameter(widgetContext, "token", widgetContext.getUserSession().getFormToken());
+    addQueryParameter(widgetContext, "email", "not-an-email");
+
+    try (MockedStatic<CaptchaCommand> captcha = mockStatic(CaptchaCommand.class)) {
+      new EmailSubscribeAjax().execute(widgetContext);
+
+      Assertions.assertEquals("[]", widgetContext.getJson());
+      captcha.verifyNoInteractions();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #484.

The footer newsletter signup form doesn't actually submit through `EmailSubscribeWidget.post()` -- despite that widget's own captcha/rate-limit protection, its `inline` view (what the footer actually uses, per `footer-layout.xml`) renders a client-side AJAX call straight to `EmailSubscribeAjax`, a completely separate class registered at `/json/emailSubscribe`. That class had zero CAPTCHA validation and zero rate limiting -- only a CSRF token check, a blank check, and an email-format check. A bot only needs to load any page once to obtain a valid token, then can hit that endpoint freely. This is very likely the real source of the spam-heavy mailing list volume.

The original ticket's technical write-up (and its `tailspin-artifact` label) both undersold/misread this -- the label's own claim that the issue "misdescribes actual state" doesn't hold up once you trace the actual submission path the footer form uses; it just isn't the code path the original diagnosis or the automated review both happened to check.

**Fix**: wires the existing, already-proven `CaptchaCommand.validateRequest()` and `RateLimitCommand.isIpAllowedRightNow()` checks into `EmailSubscribeAjax`, matching the exact pattern already used by `EmailSubscribeWidget`/`FormWidget`. Updates the inline form's JSP and client-side JS to actually render and submit a real challenge:
- Google invisible reCAPTCHA when configured (mirrors `form.jsp`'s working button-bound pattern)
- The image+text fallback CAPTCHA otherwise
- No changes to `CaptchaCommand` itself -- the site's real client-side integration is invisible reCAPTCHA v2 (script loaded without `?render=`, bound via `class="g-recaptcha"` + `data-callback`), not v3, so there's no score field to validate; v2's existing success-only check is already correct for what's actually deployed.

Deliberately out of scope: switching CAPTCHA providers or adding a multi-provider selector (that's #519, a separate `needs-elizabeth`-flagged redesign with its own real open questions).

## Test plan

- `ant -lib lib/war clean compile` / `compile-jsp`: clean
- `ant -lib lib/tests ci-test`: only the known pre-existing flakes failed (`HealthCommandTest` 3, `BlockedIPListCommandTest` 2, `CaptchaCommandTest` 1 -- JaCoCo instrumentation crash unrelated to this change; `ContentWidgetTest` 1 -- tracked flake, issue #534)
- New `EmailSubscribeAjaxTest`: valid submission with captcha+rate-limit passing saves correctly; captcha failure and rate-limit failure both reject without saving and return an accurate message; captcha is checked before rate limiting; pre-existing invalid-email rejection still short-circuits before either check runs (doesn't burn a captcha/rate-limit check on malformed input)
- `check-unescaped-el.py --strict`: zero findings tied to the modified JSP (all new EL usage is either non-output `<c:if>`/`<c:choose>` test conditions, or wrapped in `<c:out>`/the existing `js:escape()` helper, matching the file's own established pattern)