### PR TITLE
Guard CSV exports against formula injection in DB.exportToCsvAllFrom

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/database/DB.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/database/DB.java
@@ -33,6 +33,8 @@ import org.apache.commons.logging.LogFactory;
 import org.postgresql.util.PGInterval;
 
 import com.simisinc.platform.domain.model.Entity;
+import com.univocity.parsers.common.NormalizedString;
+import com.univocity.parsers.common.processor.RowWriterProcessor;
 import com.univocity.parsers.csv.CsvRoutines;
 import com.univocity.parsers.csv.CsvWriterSettings;
 
@@ -872,6 +874,9 @@ public class DB {
     writerSettings.setQuoteAllFields(true);
     writerSettings.setHeaderWritingEnabled(true);
     //    writerSettings.setHeaders("email", "created", "master_unsub", "unsubscribed", "is_valid");
+    // Quoting (above) only prevents CSV structural injection; a spreadsheet app still evaluates a
+    // cell as a formula based on its first character regardless of quoting, so guard against that too
+    writerSettings.setRowWriterProcessor((RowWriterProcessor<Object[]>) DB::sanitizeRowForCsvFormulaInjection);
     CsvRoutines routines = new CsvRoutines(writerSettings);
 
     // Get a connection, execute the query, return the data
@@ -893,6 +898,40 @@ public class DB {
         LOG.debug("Query took " + totalTime + "ms");
       }
     }
+  }
+
+  /**
+   * Characters that Excel/Google Sheets treat as the start of a formula when a CSV cell is opened,
+   * regardless of whether the field is quoted -- quoting only protects CSV structure, not formula
+   * evaluation.
+   */
+  private static final char[] CSV_FORMULA_INJECTION_PREFIXES = { '=', '+', '-', '@', '\t' };
+
+  static Object[] sanitizeRowForCsvFormulaInjection(Object[] row, NormalizedString[] headers, int[] indexesToWrite) {
+    for (int i = 0; i < row.length; i++) {
+      if (row[i] instanceof String value) {
+        row[i] = sanitizeCsvFormulaInjectionValue(value);
+      }
+    }
+    return row;
+  }
+
+  /**
+   * Prefixes a value with a single quote if it would otherwise be interpreted as a formula when the
+   * exported CSV is opened in a spreadsheet application (the standard mitigation for CSV formula
+   * injection, since the spreadsheet app then treats the cell as literal text).
+   */
+  static String sanitizeCsvFormulaInjectionValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    char firstChar = value.charAt(0);
+    for (char prefix : CSV_FORMULA_INJECTION_PREFIXES) {
+      if (firstChar == prefix) {
+        return "'" + value;
+      }
+    }
+    return value;
   }
 
   public static boolean hasColumn(ResultSet rs, String column) {

--- a/src/test/java/com/simisinc/platform/infrastructure/database/DBTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/database/DBTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.database;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.StringWriter;
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+
+import com.univocity.parsers.common.processor.RowWriterProcessor;
+import com.univocity.parsers.csv.CsvWriter;
+import com.univocity.parsers.csv.CsvWriterSettings;
+
+/**
+ * Covers the CSV formula-injection guard used by {@link DB#exportToCsvAllFrom}. Quoting (via
+ * {@code setQuoteAllFields}) stops CSV *structural* injection, but a spreadsheet application still
+ * evaluates a cell as a formula based on its first character regardless of quoting, so exported text
+ * needs its own guard on top of that.
+ */
+class DBTest {
+
+  @Test
+  void valuesStartingWithAFormulaTriggerArePrefixedWithASingleQuote() {
+    assertEquals("'=SUM(A1:A1)", DB.sanitizeCsvFormulaInjectionValue("=SUM(A1:A1)"));
+    assertEquals("'+1+1", DB.sanitizeCsvFormulaInjectionValue("+1+1"));
+    assertEquals("'-1+1", DB.sanitizeCsvFormulaInjectionValue("-1+1"));
+    assertEquals("'@SUM(A1:A1)", DB.sanitizeCsvFormulaInjectionValue("@SUM(A1:A1)"));
+    assertEquals("'\tSUM(A1:A1)", DB.sanitizeCsvFormulaInjectionValue("\tSUM(A1:A1)"));
+  }
+
+  @Test
+  void ordinaryValuesAreReturnedUnchanged() {
+    assertEquals("Acme Corp", DB.sanitizeCsvFormulaInjectionValue("Acme Corp"));
+    assertEquals("192.168.1.1", DB.sanitizeCsvFormulaInjectionValue("192.168.1.1"));
+    // A trigger character is present, but not in the leading position
+    assertEquals("total-1", DB.sanitizeCsvFormulaInjectionValue("total-1"));
+  }
+
+  @Test
+  void blankAndNullValuesAreUnchanged() {
+    assertEquals("", DB.sanitizeCsvFormulaInjectionValue(""));
+    assertNull(DB.sanitizeCsvFormulaInjectionValue(null));
+  }
+
+  @Test
+  void rowSanitizationOnlyTouchesStringCells() {
+    Timestamp created = new Timestamp(0);
+    Object[] row = { "=cmd|' /c calc'!A1", "Acme Corp", 42, true, created, null };
+
+    Object[] result = DB.sanitizeRowForCsvFormulaInjection(row, null, null);
+
+    assertSame(row, result);
+    assertArrayEquals(new Object[] { "'=cmd|' /c calc'!A1", "Acme Corp", 42, true, created, null }, result);
+  }
+
+  @Test
+  void csvWriterPipelineAppliesTheGuardBeforeQuoting() {
+    // Builds settings the same way exportToCsvAllFrom does, to prove univocity's CsvWriter really
+    // invokes DB.sanitizeRowForCsvFormulaInjection per row -- not just that the method is callable.
+    // Must go through processRecord(), not writeRow(): AbstractRoutines.write(ResultSet, Writer) --
+    // what exportToCsvAllFrom actually calls via CsvRoutines -- only routes rows through the
+    // configured RowWriterProcessor when writing via processRecord(); writeRow() bypasses it.
+    CsvWriterSettings writerSettings = new CsvWriterSettings();
+    writerSettings.getFormat().setLineSeparator("\n");
+    writerSettings.setQuoteAllFields(true);
+    writerSettings.setRowWriterProcessor((RowWriterProcessor<Object[]>) DB::sanitizeRowForCsvFormulaInjection);
+
+    StringWriter out = new StringWriter();
+    CsvWriter writer = new CsvWriter(out, writerSettings);
+    writer.processRecord(new Object[] { "=SUM(A1:A1)" });
+    writer.processRecord(new Object[] { "Acme Corp" });
+    writer.close();
+
+    assertEquals("\"'=SUM(A1:A1)\"\n\"Acme Corp\"\n", out.toString());
+  }
+}


### PR DESCRIPTION
## Summary

`DB.exportToCsvAllFrom()` uses univocity's `CsvWriterSettings` with `setQuoteAllFields(true)`, which prevents CSV *structural* injection (commas/newlines/quotes breaking column alignment) but does nothing about CSV *formula* injection: a cell whose value starts with `=`, `+`, `-`, `@`, or a tab is evaluated as a formula by Excel/Google Sheets when the exported file is opened, regardless of CSV-level quoting.

This method is the shared export path for `BlockedIPRepository`, `MailingListMemberRepository`, `OrderRepository` (x2), and `ProductSkuRepository`.

## Fix

- Hook a `RowWriterProcessor` into the `CsvWriterSettings` already built in `exportToCsvAllFrom` (`DB.sanitizeRowForCsvFormulaInjection`). This is the extension point univocity's own `CsvRoutines.write(ResultSet, File)` already routes writes through when one is configured, so it applies with no change to the ResultSet-to-CSV streaming logic.
- Any `String` cell whose first character is `=`, `+`, `-`, `@`, or a tab gets prefixed with a single quote (`DB.sanitizeCsvFormulaInjectionValue`) — the standard mitigation, since spreadsheet apps then treat the cell as literal text. Non-string columns (timestamps, booleans, numerics) are left untouched.

## Note on current exploitability

Traced whether this is reachable today, not just a future-proofing concern:
- `MailingListMemberRepository.export()` selects `emails.first_name` (via its join to `emails`), which `EmailSubscribeAjax` populates directly from an unauthenticated request parameter (`context.getParameter("name")`) with no validation beyond a blank check. That's free-form, attacker-controlled text flowing straight into this export path today.
- By contrast, `FormDataRepository` doesn't currently have an `export()` method on `main` — issue #483's CSV export apparently lives on a separate, not-yet-merged branch. Its 5 planned columns (`form_unique_id`, `ip_address`, `created`, `url`, `flagged_as_spam`) are server/admin-controlled scalars, so that particular caller wouldn't be exploitable once merged. The shared-utility gap is real regardless of that caller's status.

## Testing

- New `DBTest`: covers all five trigger characters, confirms ordinary values (including a trigger character in a non-leading position) pass through unchanged, confirms blank/null are unchanged, confirms row-level sanitization only touches `String` cells, and drives the actual `CsvWriterSettings`/`CsvWriter` pipeline (not just the bare function) to confirm univocity really invokes the processor per row and composes correctly with quoting.
- `ant -lib lib/war clean compile`, `ant -lib lib/war compile-jsp`, and `ant -lib lib/tests ci-test` all green (145 test classes, 0 failures).
