### PR TITLE
Replace hardcoded social media fields with a dynamic link editor

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/SocialMediaLink.java
+++ b/src/main/java/com/simisinc/platform/domain/model/SocialMediaLink.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model;
+
+import java.sql.Timestamp;
+import java.util.Map;
+
+/**
+ * A social media profile link (issue #516) -- any platform name, not a fixed set.
+ *
+ * @author SimIS Inc.
+ */
+public class SocialMediaLink extends Entity {
+
+  // Centralized so both the footer widget and the standard-footer JSPF resolve icons identically,
+  // instead of each hand-maintaining their own copy (the old, hardcoded-per-platform approach).
+  private static final Map<String, String> ICON_BY_PLATFORM = Map.ofEntries(
+      Map.entry("facebook", "fa-facebook-square"),
+      Map.entry("instagram", "fa-instagram"),
+      Map.entry("linkedin", "fa-linkedin"),
+      Map.entry("twitter", "fa-twitter"),
+      Map.entry("flickr", "fa-flickr"),
+      Map.entry("youtube", "fa-youtube"),
+      Map.entry("mastodon", "fa-mastodon"),
+      Map.entry("tiktok", "fa-tiktok"),
+      Map.entry("discord", "fa-discord"),
+      Map.entry("github", "fa-github"));
+  // Bundled FontAwesome Free 6.1.1 predates dedicated Threads/Bluesky/X-rebrand glyphs, and any
+  // future/custom platform name has no known icon at all -- fall back to a generic link icon.
+  private static final String DEFAULT_ICON = "fa-link";
+
+  private Long id = -1L;
+  private String platformName = null;
+  private String url = null;
+  private int linkOrder = 100;
+  private Timestamp created = null;
+
+  public SocialMediaLink() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getPlatformName() {
+    return platformName;
+  }
+
+  public void setPlatformName(String platformName) {
+    this.platformName = platformName;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public int getLinkOrder() {
+    return linkOrder;
+  }
+
+  public void setLinkOrder(int linkOrder) {
+    this.linkOrder = linkOrder;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+
+  public String getIconClass() {
+    if (platformName == null) {
+      return DEFAULT_ICON;
+    }
+    return ICON_BY_PLATFORM.getOrDefault(platformName.trim().toLowerCase(), DEFAULT_ICON);
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/SocialMediaLinkRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/SocialMediaLinkRepository.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves social media link objects (issue #516)
+ *
+ * @author SimIS Inc.
+ */
+public class SocialMediaLinkRepository {
+
+  private static Log LOG = LogFactory.getLog(SocialMediaLinkRepository.class);
+
+  private static String TABLE_NAME = "social_media_links";
+  private static String[] PRIMARY_KEY = new String[]{"social_media_link_id"};
+
+  private static DataResult query(DataConstraints constraints) {
+    return DB.selectAllFrom(TABLE_NAME, null, constraints, SocialMediaLinkRepository::buildRecord);
+  }
+
+  public static List<SocialMediaLink> findAll() {
+    DataConstraints constraints = new DataConstraints();
+    constraints.setDefaultColumnToSortBy("link_order, platform_name");
+    DataResult result = query(constraints);
+    return (List<SocialMediaLink>) result.getRecords();
+  }
+
+  public static SocialMediaLink findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (SocialMediaLink) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("social_media_link_id = ?", id),
+        SocialMediaLinkRepository::buildRecord);
+  }
+
+  public static SocialMediaLink save(SocialMediaLink record) {
+    if (record.getId() > -1) {
+      return update(record);
+    }
+    return add(record);
+  }
+
+  public static SocialMediaLink add(SocialMediaLink record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("platform_name", StringUtils.trimToNull(record.getPlatformName()))
+        .add("url", StringUtils.trimToNull(record.getUrl()))
+        .add("link_order", record.getLinkOrder());
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static SocialMediaLink update(SocialMediaLink record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("platform_name", StringUtils.trimToNull(record.getPlatformName()))
+        .add("url", StringUtils.trimToNull(record.getUrl()))
+        .add("link_order", record.getLinkOrder());
+    SqlUtils where = new SqlUtils()
+        .add("social_media_link_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      return record;
+    }
+    LOG.error("The update failed!");
+    return null;
+  }
+
+  public static boolean remove(SocialMediaLink record) {
+    return DB.deleteFrom(TABLE_NAME, new SqlUtils().add("social_media_link_id = ?", record.getId())) > 0;
+  }
+
+  private static SocialMediaLink buildRecord(ResultSet rs) {
+    try {
+      SocialMediaLink record = new SocialMediaLink();
+      record.setId(rs.getLong("social_media_link_id"));
+      record.setPlatformName(rs.getString("platform_name"));
+      record.setUrl(rs.getString("url"));
+      record.setLinkOrder(rs.getInt("link_order"));
+      record.setCreated(rs.getTimestamp("created"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -24,6 +24,8 @@ import com.simisinc.platform.application.items.LoadCategoryCommand;
 import com.simisinc.platform.application.items.LoadCollectionCommand;
 import com.simisinc.platform.application.items.LoadItemCommand;
 import com.simisinc.platform.application.items.SaveItemCommand;
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
 import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.Stylesheet;
 import com.simisinc.platform.domain.model.cms.TableOfContents;

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -23,6 +23,8 @@ import com.simisinc.platform.application.cms.*;
 import com.simisinc.platform.application.items.LoadCategoryCommand;
 import com.simisinc.platform.application.items.LoadCollectionCommand;
 import com.simisinc.platform.application.items.LoadItemCommand;
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
 import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.Stylesheet;
 import com.simisinc.platform.domain.model.cms.TableOfContents;
@@ -651,6 +653,8 @@ public class PageServlet extends HttpServlet {
       Map<String, String> sitePropertyMap = LoadSitePropertyCommand.loadAsMap("site");
       Map<String, String> themePropertyMap = LoadSitePropertyCommand.loadAsMap("theme");
       Map<String, String> socialPropertyMap = LoadSitePropertyCommand.loadAsMap("social");
+      // issue #516: an admin-editable list of (platform, url) pairs, not a fixed set of properties
+      List<SocialMediaLink> socialMediaLinkList = SocialMediaLinkRepository.findAll();
       Map<String, String> analyticsPropertyMap = LoadSitePropertyCommand.loadAsMap("analytics");
       // Never render a malformed tracking id into the public page's script tags
       AnalyticsTrackingIdCommand.sanitize(analyticsPropertyMap);
@@ -919,6 +923,7 @@ public class PageServlet extends HttpServlet {
       request.setAttribute("sitePropertyMap", sitePropertyMap);
       request.setAttribute("themePropertyMap", themePropertyMap);
       request.setAttribute("socialPropertyMap", socialPropertyMap);
+      request.setAttribute("socialMediaLinkList", socialMediaLinkList);
       request.setAttribute("analyticsPropertyMap", analyticsPropertyMap);
       request.setAttribute("ecommercePropertyMap", ecommercePropertyMap);
 

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkFormWidget.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Adds a social media link (issue #516)
+ *
+ * @author SimIS Inc.
+ */
+public class SocialMediaLinkFormWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/social-media-link-form.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    if (context.getRequestObject() != null) {
+      context.getRequest().setAttribute("socialMediaLink", context.getRequestObject());
+    } else {
+      context.getRequest().setAttribute("socialMediaLink", new SocialMediaLink());
+    }
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    SocialMediaLink socialMediaLinkBean = new SocialMediaLink();
+    BeanUtils.populate(socialMediaLinkBean, context.getParameterMap());
+
+    if (StringUtils.isBlank(socialMediaLinkBean.getPlatformName())) {
+      context.setErrorMessage("Platform name is required");
+      context.setRequestObject(socialMediaLinkBean);
+      return context;
+    }
+    // A simple, lightweight sanity check -- this is an admin-only form, not public input, so a full
+    // URL parser/validator would be more than this needs.
+    String url = StringUtils.trimToEmpty(socialMediaLinkBean.getUrl());
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      context.setErrorMessage("A valid URL starting with http:// or https:// is required");
+      context.setRequestObject(socialMediaLinkBean);
+      return context;
+    }
+
+    SocialMediaLink socialMediaLink = SocialMediaLinkRepository.save(socialMediaLinkBean);
+    if (socialMediaLink == null) {
+      context.setErrorMessage("Your information could not be saved due to a system error. Please try again.");
+      context.setRequestObject(socialMediaLinkBean);
+      return context;
+    }
+
+    AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "social_media_link.save",
+        AuditEventCommand.SUCCESS, "social_media_link", String.valueOf(socialMediaLink.getId()),
+        socialMediaLink.getPlatformName(), null);
+    context.setSuccessMessage("Record was saved");
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkListWidget.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.util.List;
+
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Lists and removes social media links (issue #516)
+ *
+ * @author SimIS Inc.
+ */
+public class SocialMediaLinkListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/social-media-link-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    List<SocialMediaLink> socialMediaLinkList = SocialMediaLinkRepository.findAll();
+    context.getRequest().setAttribute("socialMediaLinkList", socialMediaLinkList);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Show the editor
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext delete(WidgetContext context) {
+    long recordId = context.getParameterAsLong("socialMediaLinkId");
+    if (recordId > -1) {
+      SocialMediaLink socialMediaLink = SocialMediaLinkRepository.findById(recordId);
+      String targetLabel = socialMediaLink != null ? socialMediaLink.getPlatformName() : null;
+      boolean removed = socialMediaLink != null && SocialMediaLinkRepository.remove(socialMediaLink);
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "social_media_link.remove",
+          removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+          "social_media_link", String.valueOf(recordId), targetLabel, null);
+      if (removed) {
+        context.setSuccessMessage("Record deleted");
+      } else {
+        context.setErrorMessage("Error. Record could not be deleted.");
+      }
+    }
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/SocialMediaLinksWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/SocialMediaLinksWidget.java
@@ -16,11 +16,12 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
-import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import java.util.List;
+
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
-
-import java.util.Map;
 
 /**
  * Description
@@ -35,13 +36,13 @@ public class SocialMediaLinksWidget extends GenericWidget {
   static String JSP = "/cms/social-media-links.jsp";
 
   public WidgetContext execute(WidgetContext context) {
-    // Use the property map
-    Map<String, String> socialPropertyMap = LoadSitePropertyCommand.loadNonEmptyAsMap("social");
-    LOG.debug("socialPropertyMap size: " + socialPropertyMap.size());
-    if (socialPropertyMap.isEmpty()) {
+    // issue #516: an admin-editable list of (platform, url) pairs, not a fixed set of properties
+    List<SocialMediaLink> socialMediaLinkList = SocialMediaLinkRepository.findAll();
+    LOG.debug("socialMediaLinkList size: " + socialMediaLinkList.size());
+    if (socialMediaLinkList.isEmpty()) {
       return context;
     }
-    context.getRequest().setAttribute("socialPropertyMap", socialPropertyMap);
+    context.getRequest().setAttribute("socialMediaLinkList", socialMediaLinkList);
 
     // Preferences
     context.getRequest().setAttribute("iconClass", context.getPreferences().getOrDefault("iconClass", "margin-left-10"));

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -174,18 +174,16 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (30, 'Google reCAPTCHA Secret Key', 'captcha.google.secretkey', '');
 
 -- Social Media
+-- issue #516: platform link fields (Facebook/Instagram/LinkedIn/Twitter/Flickr/YouTube) moved to the
+-- dynamic social_media_links table below -- an admin-editable list of (platform, url) pairs instead of
+-- a fixed set of hardcoded properties. Contact info and the Instagram feed-embed integration stay here,
+-- since they aren't platform links.
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (5, 'Email Address', 'social.email', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Telephone', 'social.phone', '');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (15, 'Email Subscribe Link', 'social.subscribe.url', '');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'Facebook', 'social.facebook.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (25, 'Instagram', 'social.instagram.url', '', 'url');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (27, 'Instagram Access Token', 'social.instagram.accessToken', '', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (28, 'Instagram Facebook Page Value', 'social.instagram.facebookPageValue', '', 'text');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (30, 'LinkedIn', 'social.linkedin.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (35, 'Twitter', 'social.twitter.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (40, 'Flickr', 'social.flickr.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (45, 'Youtube', 'social.youtube.url', '', 'url');
 
 -- BI
 
@@ -518,6 +516,16 @@ CREATE TABLE block_list (
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
   reason VARCHAR(255)
 );
+
+-- issue #516: an admin-editable list of (platform, url) pairs -- any platform name, not a fixed set
+CREATE TABLE social_media_links (
+  social_media_link_id BIGSERIAL PRIMARY KEY,
+  platform_name VARCHAR(100) NOT NULL,
+  url VARCHAR(512) NOT NULL,
+  link_order INTEGER DEFAULT 100,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX social_media_links_order_idx ON social_media_links(link_order);
 
 CREATE TABLE world_cities (
   country VARCHAR(2),

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260728.1000__social_media_links.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260728.1000__social_media_links.sql
@@ -1,0 +1,52 @@
+-- issue #516: replace the fixed set of hardcoded social.*.url properties (Facebook, Instagram,
+-- LinkedIn, Twitter, Flickr, YouTube) with an admin-editable list of (platform, url) pairs, so any
+-- platform can be added without a code change. Contact info (social.email/social.phone/social.subscribe.url)
+-- and the Instagram feed-embed integration (social.instagram.accessToken/facebookPageValue) are
+-- unrelated to platform links and are left untouched.
+
+CREATE TABLE IF NOT EXISTS social_media_links (
+  social_media_link_id BIGSERIAL PRIMARY KEY,
+  platform_name VARCHAR(100) NOT NULL,
+  url VARCHAR(512) NOT NULL,
+  link_order INTEGER DEFAULT 100,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS social_media_links_order_idx ON social_media_links(link_order);
+
+-- Carry forward any existing, already-configured links so upgrading doesn't drop them. Only inserts
+-- if the old property has a real (non-empty) value and hasn't already been migrated (safe to re-run).
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'Facebook', property_value, 20 FROM site_properties
+WHERE property_name = 'social.facebook.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'Facebook');
+
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'Instagram', property_value, 25 FROM site_properties
+WHERE property_name = 'social.instagram.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'Instagram');
+
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'LinkedIn', property_value, 30 FROM site_properties
+WHERE property_name = 'social.linkedin.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'LinkedIn');
+
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'Twitter', property_value, 35 FROM site_properties
+WHERE property_name = 'social.twitter.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'Twitter');
+
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'Flickr', property_value, 40 FROM site_properties
+WHERE property_name = 'social.flickr.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'Flickr');
+
+INSERT INTO social_media_links (platform_name, url, link_order)
+SELECT 'YouTube', property_value, 45 FROM site_properties
+WHERE property_name = 'social.youtube.url' AND property_value IS NOT NULL AND property_value <> ''
+  AND NOT EXISTS (SELECT 1 FROM social_media_links WHERE platform_name = 'YouTube');
+
+-- The old fixed fields are now redundant with the dynamic list above
+DELETE FROM site_properties WHERE property_name IN (
+  'social.facebook.url', 'social.instagram.url', 'social.linkedin.url',
+  'social.twitter.url', 'social.flickr.url', 'social.youtube.url'
+);

--- a/src/main/webapp/WEB-INF/jsp/admin/social-media-link-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/social-media-link-form.jsp
@@ -1,0 +1,41 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="socialMediaLink" class="com.simisinc.platform.domain.model.SocialMediaLink" scope="request"/>
+<form method="post">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Title and Message block --%>
+  <c:if test="${!empty title}">
+    <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+  </c:if>
+  <%@include file="../page_messages.jspf" %>
+  <%-- Form Content --%>
+  <label>Platform Name <span class="required">*</span>
+    <input type="text" placeholder="e.g. Instagram, Mastodon, Discord..." name="platformName" value="<c:out value="${socialMediaLink.platformName}"/>" required>
+  </label>
+  <label>URL <span class="required">*</span>
+    <input type="text" placeholder="https://..." name="url" value="<c:out value="${socialMediaLink.url}"/>" required>
+  </label>
+  <p class="help-text">Add any platform -- the name is used to look up an icon for known platforms (Facebook, Instagram, LinkedIn, X/Twitter, Flickr, YouTube, Mastodon, TikTok, Discord, GitHub); anything else shows a generic link icon.</p>
+  <div class="button-container">
+    <input type="submit" class="button radius success expanded" value="Save"/>
+  </div>
+</form>

--- a/src/main/webapp/WEB-INF/jsp/admin/social-media-link-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/social-media-link-list.jsp
@@ -1,0 +1,52 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="socialMediaLinkList" class="java.util.ArrayList" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<table class="unstriped stack">
+  <thead>
+    <tr>
+      <th width="30"></th>
+      <th>Platform</th>
+      <th>URL</th>
+      <th width="30"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${socialMediaLinkList}" var="record">
+    <tr>
+      <td><i class="fa ${fn:escapeXml(record.iconClass)}"></i></td>
+      <td><c:out value="${record.platformName}" /></td>
+      <td><a href="<c:out value="${record.url}"/>" target="_blank" rel="noopener noreferrer"><c:out value="${record.url}" /></a></td>
+      <td nowrap="true">
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to remove <c:out value="${js:escape(record.platformName)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&socialMediaLinkId=${record.id}');"><i class="fa fa-remove"></i></a>
+      </td>
+    </tr>
+    </c:forEach>
+    <c:if test="${empty socialMediaLinkList}">
+      <tr>
+        <td colspan="4">No social media links have been added yet</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>

--- a/src/main/webapp/WEB-INF/jsp/cms/social-media-links.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/social-media-links.jsp
@@ -20,28 +20,7 @@
 <%@ taglib prefix="text" uri="/WEB-INF/tlds/text-functions.tld" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
-<c:set var="firstIcon" scope="request" value=""/>
-<c:if test="${!empty socialPropertyMap['social.instagram.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>"><i class="fa fa-2x fa-instagram"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
-<c:if test="${!empty socialPropertyMap['social.twitter.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>"><i class="fa fa-2x fa-twitter"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
-<c:if test="${!empty socialPropertyMap['social.facebook.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>"><i class="fa fa-2x fa-facebook-square"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
-<c:if test="${!empty socialPropertyMap['social.youtube.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>"><i class="fa fa-2x fa-youtube"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
-<c:if test="${!empty socialPropertyMap['social.flickr.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>"><i class="fa fa-2x fa-flickr"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
-<c:if test="${!empty socialPropertyMap['social.linkedin.url']}">
-  <a <c:if test="${!empty firstIcon}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>"><i class="fa fa-2x fa-linkedin"></i></a>
-  <c:set var="firstIcon" scope="request" value="true"/>
-</c:if>
+<%-- issue #516: any admin-configured platform, not a fixed per-platform <c:if> chain --%>
+<c:forEach items="${socialMediaLinkList}" var="link" varStatus="linkStatus">
+  <a <c:if test="${!linkStatus.first}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" rel="noopener noreferrer" href="<c:out value="${link.url}"/>"><i class="fa fa-2x ${fn:escapeXml(link.iconClass)}"></i></a>
+</c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
@@ -74,26 +74,12 @@
           </c:if>
         </div>
         <div class="small-12 medium-7 cell">
-          <c:if test="${!empty socialPropertyMap}">
+          <c:if test="${!empty socialMediaLinkList}">
             <p class="text-center medium-text-right">
-              <c:if test="${!empty socialPropertyMap['social.facebook.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="Facebook" href="<c:out value="${socialPropertyMap['social.facebook.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
-              <c:if test="${!empty socialPropertyMap['social.twitter.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="Twitter" href="<c:out value="${socialPropertyMap['social.twitter.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-twitter fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
-              <c:if test="${!empty socialPropertyMap['social.linkedin.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" href="<c:out value="${socialPropertyMap['social.linkedin.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-linkedin fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
-              <c:if test="${!empty socialPropertyMap['social.instagram.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="Instagram" href="<c:out value="${socialPropertyMap['social.instagram.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-instagram fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
-              <c:if test="${!empty socialPropertyMap['social.youtube.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="YouTube" href="<c:out value="${socialPropertyMap['social.youtube.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-youtube fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
-              <c:if test="${!empty socialPropertyMap['social.flickr.url']}">
-                <a target="_blank" rel="noopener noreferrer" aria-label="Flickr" href="<c:out value="${socialPropertyMap['social.flickr.url']}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-flickr fa-stack-1x fa-inverse"></i></span></a>
-              </c:if>
+              <%-- issue #516: any admin-configured platform, not a fixed per-platform <c:if> chain --%>
+              <c:forEach items="${socialMediaLinkList}" var="link">
+                <a target="_blank" rel="noopener noreferrer" aria-label="<c:out value="${link.platformName}"/>" href="<c:out value="${link.url}"/>"><span class="fa-stack" aria-hidden="true"><i class="fa fa-circle fa-stack-2x"></i><i class="fa ${fn:escapeXml(link.iconClass)} fa-stack-1x fa-inverse"></i></span></a>
+              </c:forEach>
             </p>
           </c:if>
           <c:if test="${'none' ne themePropertyMap['theme.menu.location']}">

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -192,9 +192,21 @@
       <!--</column>-->
     <!--</section>-->
     <section>
+      <column class="small-12 medium-9 large-8 small-order-2 medium-order-1 small-margin-top-10 cell">
+        <widget name="socialMediaLinkList">
+          <title>Social Profile Links</title>
+        </widget>
+      </column>
+      <column class="small-12 medium-3 large-4 small-order-1 medium-order-2 cell">
+        <widget name="socialMediaLinkForm" class="callout radius primary" sticky="true">
+          <title>Add a Platform</title>
+        </widget>
+      </column>
+    </section>
+    <section>
       <column class="small-12 large-10 cell">
         <widget name="sitePropertiesEditor">
-          <title>Social Media Settings</title>
+          <title>Contact &amp; Integration Settings</title>
           <prefix>social</prefix>
         </widget>
       </column>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -212,6 +212,8 @@
   <widget name="appForm" class="com.simisinc.platform.presentation.widgets.admin.AppFormWidget" />
   <widget name="blockedIP" class="com.simisinc.platform.presentation.widgets.admin.BlockedIPListWidget" />
   <widget name="blockedIPListForm" class="com.simisinc.platform.presentation.widgets.admin.BlockedIPFormWidget" />
+  <widget name="socialMediaLinkList" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkListWidget" />
+  <widget name="socialMediaLinkForm" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkFormWidget" />
   <widget name="formDataList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormDataListWidget" />
   <widget name="datasets" class="com.simisinc.platform.presentation.widgets.admin.datasets.DatasetsWidget" />
   <widget name="datasetName" class="com.simisinc.platform.presentation.widgets.datasets.DatasetNameWidget" />

--- a/src/test/java/com/simisinc/platform/domain/model/SocialMediaLinkTest.java
+++ b/src/test/java/com/simisinc/platform/domain/model/SocialMediaLinkTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author SimIS Inc.
+ */
+class SocialMediaLinkTest {
+
+  @Test
+  void getIconClassResolvesKnownPlatformsCaseInsensitively() {
+    assertEquals("fa-facebook-square", iconFor("Facebook"));
+    assertEquals("fa-instagram", iconFor("instagram"));
+    assertEquals("fa-mastodon", iconFor("MASTODON"));
+    assertEquals("fa-tiktok", iconFor("TikTok"));
+    assertEquals("fa-discord", iconFor("Discord"));
+    assertEquals("fa-github", iconFor("GitHub"));
+  }
+
+  @Test
+  void getIconClassFallsBackForUnknownOrNewPlatforms() {
+    // Bundled FontAwesome predates dedicated Threads/Bluesky glyphs
+    assertEquals("fa-link", iconFor("Threads"));
+    assertEquals("fa-link", iconFor("Bluesky"));
+    assertEquals("fa-link", iconFor("SomeFuturePlatform"));
+  }
+
+  @Test
+  void getIconClassHandlesMissingPlatformNameSafely() {
+    SocialMediaLink link = new SocialMediaLink();
+    assertEquals("fa-link", link.getIconClass());
+  }
+
+  private static String iconFor(String platformName) {
+    SocialMediaLink link = new SocialMediaLink();
+    link.setPlatformName(platformName);
+    return link.getIconClass();
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/SocialMediaLinkRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/SocialMediaLinkRepositoryTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies SocialMediaLinkRepository (issue #516) against a real PostgreSQL instance.
+ *
+ * @author SimIS Inc.
+ */
+class SocialMediaLinkRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping SocialMediaLinkRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE social_media_links RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset social_media_links table", se);
+    }
+  }
+
+  @Test
+  void addSavesAndAssignsAnId() {
+    SocialMediaLink link = new SocialMediaLink();
+    link.setPlatformName("Instagram");
+    link.setUrl("https://instagram.com/SimISInc");
+    link.setLinkOrder(25);
+
+    SocialMediaLink saved = SocialMediaLinkRepository.add(link);
+
+    assertNotNull(saved);
+    assertTrue(saved.getId() > 0);
+    assertEquals(1, DB.selectCountFrom("social_media_links"));
+  }
+
+  @Test
+  void findAllOrdersByLinkOrderThenPlatformName() {
+    addLink("YouTube", "https://youtube.com/@SimISInc", 45);
+    addLink("Facebook", "https://facebook.com/SimISInc", 20);
+    addLink("Discord", "https://discord.gg/simis", 20);
+
+    List<SocialMediaLink> all = SocialMediaLinkRepository.findAll();
+
+    assertEquals(3, all.size());
+    // Same link_order (20) breaks the tie alphabetically by platform name
+    assertEquals("Discord", all.get(0).getPlatformName());
+    assertEquals("Facebook", all.get(1).getPlatformName());
+    assertEquals("YouTube", all.get(2).getPlatformName());
+  }
+
+  @Test
+  void updateChangesTheExistingRowNotACopy() {
+    SocialMediaLink saved = addLink("Mastodon", "https://old-instance.social/@simis", 100);
+
+    saved.setUrl("https://new-instance.social/@simis");
+    SocialMediaLink updated = SocialMediaLinkRepository.update(saved);
+
+    assertNotNull(updated);
+    assertEquals(1, DB.selectCountFrom("social_media_links"));
+    SocialMediaLink reloaded = SocialMediaLinkRepository.findById(saved.getId());
+    assertEquals("https://new-instance.social/@simis", reloaded.getUrl());
+  }
+
+  @Test
+  void removeDeletesTheRow() {
+    SocialMediaLink saved = addLink("TikTok", "https://tiktok.com/@simis", 100);
+
+    boolean removed = SocialMediaLinkRepository.remove(saved);
+
+    assertTrue(removed);
+    assertNull(SocialMediaLinkRepository.findById(saved.getId()));
+    assertEquals(0, DB.selectCountFrom("social_media_links"));
+  }
+
+  @Test
+  void findByIdReturnsNullForAMissingRecord() {
+    assertNull(SocialMediaLinkRepository.findById(999));
+    assertNull(SocialMediaLinkRepository.findById(-1));
+  }
+
+  private static SocialMediaLink addLink(String platformName, String url, int linkOrder) {
+    SocialMediaLink link = new SocialMediaLink();
+    link.setPlatformName(platformName);
+    link.setUrl(url);
+    link.setLinkOrder(linkOrder);
+    return SocialMediaLinkRepository.add(link);
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS social_media_links CASCADE");
+      statement.execute("CREATE TABLE social_media_links ("
+          + "social_media_link_id BIGSERIAL PRIMARY KEY, "
+          + "platform_name VARCHAR(100) NOT NULL, "
+          + "url VARCHAR(512) NOT NULL, "
+          + "link_order INTEGER DEFAULT 100, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the social_media_links schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkFormWidgetTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
+
+/**
+ * @author SimIS Inc.
+ */
+class SocialMediaLinkFormWidgetTest extends WidgetBase {
+
+  @Test
+  void postSavesAValidLink() throws Exception {
+    addQueryParameter(widgetContext, "platformName", "Discord");
+    addQueryParameter(widgetContext, "url", "https://discord.gg/simis");
+
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      repository.when(() -> SocialMediaLinkRepository.save(any())).thenAnswer(invocation -> {
+        SocialMediaLink saved = invocation.getArgument(0);
+        saved.setId(1L);
+        return saved;
+      });
+
+      new SocialMediaLinkFormWidget().post(widgetContext);
+
+      repository.verify(() -> SocialMediaLinkRepository.save(any()));
+    }
+
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void postRejectsABlankPlatformNameWithoutSaving() throws Exception {
+    addQueryParameter(widgetContext, "platformName", "");
+    addQueryParameter(widgetContext, "url", "https://example.com");
+
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      new SocialMediaLinkFormWidget().post(widgetContext);
+
+      repository.verify(() -> SocialMediaLinkRepository.save(any()), never());
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void postRejectsAUrlWithoutAValidScheme() throws Exception {
+    addQueryParameter(widgetContext, "platformName", "Instagram");
+    addQueryParameter(widgetContext, "url", "javascript:alert(1)");
+
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      new SocialMediaLinkFormWidget().post(widgetContext);
+
+      repository.verify(() -> SocialMediaLinkRepository.save(any()), never());
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SocialMediaLinkListWidgetTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
+
+/**
+ * @author SimIS Inc.
+ */
+class SocialMediaLinkListWidgetTest extends WidgetBase {
+
+  @Test
+  void executeListsAllLinks() {
+    SocialMediaLink link = new SocialMediaLink();
+    link.setId(1L);
+    link.setPlatformName("Instagram");
+    List<SocialMediaLink> links = List.of(link);
+
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      repository.when(SocialMediaLinkRepository::findAll).thenReturn(links);
+
+      setRoles(widgetContext, ADMIN);
+      new SocialMediaLinkListWidget().execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SocialMediaLinkListWidget.JSP, widgetContext.getJsp());
+    Assertions.assertEquals(links, request.getAttribute("socialMediaLinkList"));
+  }
+
+  @Test
+  void deleteRemovesTheRecordAndRecordsAnAuditEvent() {
+    SocialMediaLink link = new SocialMediaLink();
+    link.setId(5L);
+    link.setPlatformName("Facebook");
+
+    addQueryParameter(widgetContext, "socialMediaLinkId", "5");
+
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      repository.when(() -> SocialMediaLinkRepository.findById(5L)).thenReturn(link);
+      repository.when(() -> SocialMediaLinkRepository.remove(link)).thenReturn(true);
+
+      new SocialMediaLinkListWidget().delete(widgetContext);
+
+      repository.verify(() -> SocialMediaLinkRepository.remove(link));
+    }
+
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+  }
+
+  @Test
+  void deleteWithoutAValidIdDoesNothing() {
+    try (MockedStatic<SocialMediaLinkRepository> repository = mockStatic(SocialMediaLinkRepository.class)) {
+      new SocialMediaLinkListWidget().delete(widgetContext);
+
+      repository.verify(() -> SocialMediaLinkRepository.remove(any()), never());
+    }
+
+    Assertions.assertNull(widgetContext.getSuccessMessage());
+  }
+}


### PR DESCRIPTION
## Summary

Scoped slice of #516 (the ticket itself bundles OAuth/social login/analytics pixels/cross-posting integrations, which have real open product questions and are explicitly out of scope here -- this is just: replace the fixed platform list with a dynamic one).

**Before**: Facebook/Instagram/LinkedIn/Twitter/Flickr/YouTube were hardcoded `site_properties` rows, and two separate JSPs (the footer `socialMediaLinks` widget, and independently the standard footer template `layout-footer-standard.jspf`) each duplicated the same 6-platform icon lookup with slightly different markup. Adding GitHub, Mastodon, or anything else meant a code change in at least 2 places plus a migration -- I'd actually just done exactly that for GitHub in #552 before realizing it was the pattern this ticket wants removed (closed #552 in favor of this).

**After**: a small dedicated `social_media_links` table (platform_name, url, link_order) with real admin CRUD -- add/remove any platform, no code change needed. Icon resolution for known platforms is centralized once on the `SocialMediaLink` domain model (`getIconClass()`), so both consumers stay in sync automatically instead of hand-maintained separately. Unknown platform names get a generic fallback icon rather than silently not appearing (the old behavior for anything outside the hardcoded 6).

Existing configured links are carried forward by the upgrade migration (copied from the old properties, which are then removed) rather than dropped on upgrade. Contact info (`social.email`/`social.phone`) and the separate Instagram feed-embed integration (`social.instagram.accessToken`/`facebookPageValue` -- a different feature, not a platform link) are untouched and stay on the existing settings page.

**Icon coverage**: Facebook, Instagram, LinkedIn, Twitter, Flickr, YouTube, Mastodon, TikTok, Discord, and GitHub all get real FontAwesome brand icons. Threads and Bluesky fall back to a generic link icon -- the bundled FontAwesome version (6.1.1) predates those platforms' dedicated glyphs.

## Test plan

- `ant -lib lib/war clean compile` / `compile-jsp`: clean
- `ant -lib lib/tests ci-test`: only the known pre-existing flakes failed (`HealthCommandTest` 3, `BlockedIPListCommandTest` 2, `CaptchaCommandTest` 1 -- JaCoCo instrumentation crash unrelated to this change; `ContentWidgetTest` 1 -- tracked flake, issue #534)
- New Testcontainers-backed `SocialMediaLinkRepositoryTest`: add/update/remove round-trip, ordering (link_order then platform name), missing-record lookups
- New `SocialMediaLinkTest`: icon resolution for every named platform, case-insensitivity, fallback for unknown platforms and missing platform names
- New widget tests: list/delete with audit-event recording, form validation (blank platform name rejected, and a `javascript:` URL scheme rejected -- both fields render as raw `href`/link attributes on public pages, so this is a real stored-XSS guard, not just a UX nicety)
- `check-unescaped-el.py --strict`: 0 unallowlisted findings tied to any of the 4 touched/new JSPs