### PR TITLE
Wire up bot-traffic summary tiles into Site Analytics page (#561)

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -556,6 +556,27 @@
         </widget>
       </column>
       <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-user</icon>
+          <title>Real Sessions Today</title>
+          <report>real-sessions-today</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-robot</icon>
+          <title>Bot Sessions Today</title>
+          <report>bot-sessions-today-total</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-percentage</icon>
+          <title>Bot Traffic %</title>
+          <report>bot-traffic-percentage</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
         <widget name="communityStats">
           <icon>fa-mail-bulk</icon>
           <title>Total Sign-ups</title>


### PR DESCRIPTION
## Summary

Issue #561's status comment claims "Real Sessions Today / Bot Sessions Today / Bot Traffic % tiles" shipped in #572, but that's only half true: `SiteStatsWidget` already has working `real-sessions-today` / `bot-sessions-today-total` / `bot-traffic-percentage` report branches, and `SessionRepository` has the backing queries (`countDistinctSessions`, `countBotSessions`), all covered by tests -- but `admin-layout.xml` never got `<column>` entries for them. Only the two `daily-real-sessions`/`daily-bot-sessions` trend charts made it into the layout. The tiles are live, tested code with no way for an admin to see them.

This adds the three missing `<column>` stats-card entries to the Site Analytics page (`/admin/community/analytics`), right next to the existing "Online Now" / "Sessions Today" cards, matching their exact XML shape (plain `siteStats` widget, no `class="stats card"`, same `small-12 medium-6 large-3 cell callout` column).

## Stacked on #572

This branches from `feature/bot-vs-real-traffic` (not `main`) because the report keys it wires up don't exist anywhere else yet -- they're part of #572's still-unmerged Java changes. Please merge #572 first; this PR's diff is just the 21-line layout addition on top of it.

## Verification

- `python3 tools/check-unescaped-el.py . --strict`: identical output before/after (8 pre-existing unallowlisted ATTR findings, unrelated to this change and already covered by #576 -- this PR adds zero `${...}` expressions).
- `ant -lib lib/war clean compile` and `ant -lib lib/war package`: clean.
- Live-verified via local `docker compose` rehearsal: logged in as admin, loaded Site Analytics, confirmed all three tiles render with real values and correct icons, no server-side errors in the container logs.

## Test plan

- [ ] Merge #572 first
- [ ] Confirm this PR's diff is just the `admin-layout.xml` addition once rebased onto `main`
- [ ] Load `/admin/community/analytics` as an admin/community-manager and confirm Real Sessions Today, Bot Sessions Today, and Bot Traffic % tiles render
