### PR TITLE
Fix Chart.js v3 scale config in site-stats bar/line charts

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
@@ -72,7 +72,7 @@
         display: false
       },
       scales: {
-        yAxes: [{
+        y: {
           display: true,
           ticks: {
             suggestedMin: 0,
@@ -80,7 +80,7 @@
             // beginAtZero: true,
             precision:0
           }
-        }]
+        }
       }
     }
   });

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
@@ -75,14 +75,14 @@
         display: false
       },
       scales: {
-        yAxes: [{
+        y: {
           display: true,
           ticks: {
             suggestedMin: 0,
             suggestedMax: 10,
             precision:0
           }
-        }]
+        }
       }
     }
   });


### PR DESCRIPTION
## What
`site-stats-bar-chart.jsp` and `site-stats-line-chart.jsp` build their Chart.js config using the Chart.js v2 `scales.yAxes` array key. The vendored library is `chartjs-4.4.1`, which renamed that config in v3 to a single `scales.y` object. The mismatch throws in the browser console on every chart instance:

```
Invalid scale configuration for scale: yAxes
```

## Fix
Migrate `scales: { yAxes: [{...}] }` to `scales: { y: {...} }` in both files, keeping the existing `display`/`ticks` options unchanged.

## Verification
- `ant -lib lib/war clean compile-jsp` — JSP syntax check passes.
- `ant -lib lib/war package` — WAR builds.
- Local docker-compose rehearsal: logged in as admin, loaded `/admin/community/analytics` (7 chart widgets on the page use these two JSPs). Before the fix this page throws one `Invalid scale configuration for scale: yAxes` console error per chart; after the fix, zero console errors and all charts render with correct axis ticks and labels.