### PR TITLE
Document and clarify the navigation menu editor (#496)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -27,7 +27,12 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<small><a href="${ctx}/admin/sitemap">Switch to adding</a></small>
+<p class="help-text">
+  This page renames existing navigation tabs/items and changes the page they link to. Link must start with /
+  (e.g. /solutions). Reorder tabs and items with the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i>
+  drag handles or the arrow buttons. To add a new tab/item or to delete one, use
+  <a href="${ctx}/admin/sitemap">Navigation Menu Editor</a> instead.
+</p>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${empty menuTabList}">
   <p class="subheader">No tabs were found, add one!</p>
@@ -68,9 +73,9 @@
               <strong><c:out value="${menuTab.name}"/></strong>
             </c:when>
             <c:otherwise>
-              <input type="text" name="menuTab${menuTab.id}name" value="<c:out value="${menuTab.name}" />" style="margin-bottom:0"/>
-              <input type="text" name="menuTab${menuTab.id}link" value="<c:out value="${menuTab.link}" />" placeholder="/link" style="margin-bottom:0"/>
-              <input type="text" name="menuTab${menuTab.id}icon" value="<c:out value="${menuTab.icon}" />" placeholder="Optional icon"/>
+              <input type="text" name="menuTab${menuTab.id}name" value="<c:out value="${menuTab.name}" />" title="Tab name shown in the menu" style="margin-bottom:0"/>
+              <input type="text" name="menuTab${menuTab.id}link" value="<c:out value="${menuTab.link}" />" placeholder="/link" title="Page path starting with /, e.g. /solutions" style="margin-bottom:0"/>
+              <input type="text" name="menuTab${menuTab.id}icon" value="<c:out value="${menuTab.icon}" />" placeholder="Optional icon" title="Icon name without the fa- prefix, e.g. briefcase"/>
             </c:otherwise>
           </c:choose>
         </div>
@@ -97,8 +102,8 @@
                 </div>
                 <div class="clear-float"></div>
                 <div>
-                  <input type="text" name="menuItem${menuItem.id}name" value="<c:out value="${menuItem.name}" />" style="margin-bottom:0"/>
-                  <input type="text" name="menuItem${menuItem.id}link" value="<c:out value="${menuItem.link}" />" placeholder="/link" style="margin-bottom:0"/>
+                  <input type="text" name="menuItem${menuItem.id}name" value="<c:out value="${menuItem.name}" />" title="Item name shown in the submenu" style="margin-bottom:0"/>
+                  <input type="text" name="menuItem${menuItem.id}link" value="<c:out value="${menuItem.link}" />" placeholder="/link" title="Page path starting with /, e.g. /government-services" style="margin-bottom:0"/>
                 </div>
               </div>
             </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
@@ -27,11 +27,14 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<div class="grid-x grid-margin-x">
-  <div class="cell small-12">
-    <small><a href="${ctx}/admin/sitemap-editor">Switch to renaming</a></small>
-  </div>
-</div>
+<p class="help-text">
+  This page controls the top navigation menu shown on your website -- not an XML sitemap or a visual page map.
+  A <strong>tab</strong> is a top-level menu entry (e.g. "Solutions"); an <strong>item</strong> is a submenu entry
+  shown when a visitor opens a tab. Add tabs and items below, drag the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i>
+  handles to reorder them, or click <i class="fa fa-circle-xmark"></i> to delete one. Changes take effect as soon as you save.
+  This page can add and delete tabs/items but not change an existing one's link -- to rename an existing tab/item or change
+  where it links, use <a href="${ctx}/admin/sitemap-editor">Navigation Menu Editor - Edit Links</a> instead.
+</p>
 <%@include file="../page_messages.jspf" %>
 <form method="post">
   <%-- Required by controller --%>
@@ -43,13 +46,14 @@
     <div class="small-12 medium-5 cell">
       <div class="input-group">
         <%--<span class="input-group-label">$</span>--%>
-        <input class="input-group-field" type="text" name="name" placeholder="New tab name" value="<c:out value="${menuTab.name}" />" required>
-        <input class="input-group-field" type="text" name="link" placeholder="Optional /link" value="<c:out value="${menuTab.link}" />">
-        <input class="input-group-field" type="text" name="icon" placeholder="Optional icon" value="<c:out value="${menuTab.icon}" />">
+        <input class="input-group-field" type="text" name="name" placeholder="New tab name" title="The name shown in the menu, e.g. Solutions" value="<c:out value="${menuTab.name}" />" required>
+        <input class="input-group-field" type="text" name="link" placeholder="Optional /link" title="Page path starting with /, e.g. /solutions. Leave blank if this tab should only open a submenu." value="<c:out value="${menuTab.link}" />">
+        <input class="input-group-field" type="text" name="icon" placeholder="Optional icon" title="Icon name from the site's icon set, without the fa- prefix, e.g. briefcase" value="<c:out value="${menuTab.icon}" />">
         <div class="input-group-button">
           <input type="submit" class="button success" value="Add Tab">
         </div>
       </div>
+      <p class="help-text">Name is required. Link must start with / (e.g. /solutions) and is optional. Icon is an optional icon name -- do not include the fa- prefix.</p>
     </div>
   </div>
 </form>
@@ -70,7 +74,7 @@
         <div>
           <div style="position: absolute;right: 5px;top: 0;">
             <small>
-              <c:if test="${!status.first}"><a href="javascript:deleteMenuTab(${menuTab.id});"><i class="fa fa-circle-xmark"></i></a></c:if>
+              <c:if test="${!status.first}"><a href="javascript:deleteMenuTab(${menuTab.id}, '<c:out value="${js:escape(menuTab.name)}" />', ${fn:length(menuTab.menuItemList)});" title="Delete this tab"><i class="fa fa-circle-xmark"></i></a></c:if>
                 <%--<a href="javascript:addTabAfter(${menuTab.id});"><i class="fa fa-plus"></i></a>--%>
             </small>
           </div>
@@ -99,7 +103,7 @@
               <div id="site-map-menu-item-${menuItem.id}" class="site-map-submenu-tab">
                 <div style="position: absolute;right: 5px;top: 0;">
                   <small>
-                    <a href="javascript:deleteMenuItem(${menuItem.id});"><i class="fa fa-circle-xmark"></i></a>
+                    <a href="javascript:deleteMenuItem(${menuItem.id}, '<c:out value="${js:escape(menuItem.name)}" />');" title="Delete this item"><i class="fa fa-circle-xmark"></i></a>
                   </small>
                 </div>
                 <div class="float-left">
@@ -115,11 +119,12 @@
               </div>
             </c:forEach>
           </div>
-          <input class="input-group-field" type="text" name="menuTab${menuTab.id}menuItemName" placeholder="New item..." value="">
-          <input class="input-group-field" type="text" name="menuTab${menuTab.id}menuItemLink" placeholder="Optional /link" value="">
+          <input class="input-group-field" type="text" name="menuTab${menuTab.id}menuItemName" placeholder="New item..." title="Adds a new submenu item under ${fn:escapeXml(menuTab.name)}" value="">
+          <input class="input-group-field" type="text" name="menuTab${menuTab.id}menuItemLink" placeholder="Optional /link" title="Page path starting with /, e.g. /government-services" value="">
           <div class="button-container">
             <input type="submit" class="button tiny expanded success" value="Add Item">
           </div>
+          <p class="help-text">Adds a submenu item under <strong><c:out value="${menuTab.name}"/></strong>. Link must start with /.</p>
         </c:if>
       </div>
     </c:forEach>
@@ -143,15 +148,16 @@
     }
   });
 
-  function deleteMenuTab(index) {
-    if (!confirm("Are you sure you want to delete this menu tab and all of its submenu items?")) {
+  function deleteMenuTab(index, name, itemCount) {
+    var itemsPhrase = itemCount > 0 ? (" and its " + itemCount + " submenu item" + (itemCount === 1 ? "" : "s")) : "";
+    if (!confirm("Delete the menu tab \"" + name + "\"" + itemsPhrase + "? This cannot be undone.")) {
       return;
     }
     postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuTabId=' + index);
   }
 
-  function deleteMenuItem(index) {
-    if (!confirm("Are you sure you want to delete this sub menu item?")) {
+  function deleteMenuItem(index, name) {
+    if (!confirm("Delete the menu item \"" + name + "\"? This cannot be undone.")) {
       return;
     }
     postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&menuItemId=' + index);

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -435,7 +435,7 @@
             <ul class="vertical menu">
               <li class="section-title">Content</li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/content/analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/content/analytics"><i class="${font:far()} fa-chart-line fa-fw"></i> <span>Analytics</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/sitemap')}"> class="is-active"</c:if>><a href="${ctx}/admin/sitemap"><i class="${font:far()} fa-sitemap fa-fw"></i> <span>Site Map</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/sitemap')}"> class="is-active"</c:if>><a href="${ctx}/admin/sitemap"><i class="${font:far()} fa-sitemap fa-fw"></i> <span>Navigation Menu</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/web-page')}"> class="is-active"</c:if>><a href="${ctx}/admin/web-pages"><i class="${font:far()} fa-sticky-note fa-fw"></i> <span>Web Pages</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/image')}"> class="is-active"</c:if>><a href="${ctx}/admin/images"><i class="${font:far()} fa-image fa-fw"></i> <span>Images</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/content-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/content-list"><i class="${font:far()} fa-th fa-fw"></i> <span>Content</span></a></li>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -840,7 +840,7 @@
     </section>
   </page>
 
-  <page name="/admin/sitemap" role="admin,content-manager" title="Site Map">
+  <page name="/admin/sitemap" role="admin,content-manager" title="Navigation Menu Editor">
     <!--<section>-->
       <!--<column class="small-12 cell">-->
         <!--<widget name="breadcrumbs">-->
@@ -853,7 +853,7 @@
     <section>
       <column class="small-12 cell">
         <widget name="siteMap">
-          <title>Site Map Editor</title>
+          <title>Navigation Menu Editor</title>
         </widget>
       </column>
     </section>
@@ -890,7 +890,7 @@
     </section>
   </page>
 
-  <page name="/admin/sitemap-editor" role="admin,content-manager" title="Site Map Editor">
+  <page name="/admin/sitemap-editor" role="admin,content-manager" title="Navigation Menu Editor - Edit Links">
     <!--<section>-->
       <!--<column class="small-12 cell">-->
         <!--<widget name="breadcrumbs">-->
@@ -903,7 +903,7 @@
     <section>
       <column class="small-12 cell">
         <widget name="siteMapEditor">
-          <title>Site Map Renaming</title>
+          <title>Navigation Menu Editor - Edit Links</title>
         </widget>
       </column>
     </section>


### PR DESCRIPTION
## Summary

Fixes #496 — the documentation + safety slice (drag-and-drop reordering, visual preview, undo/rollback, export/import, and full form validation are explicitly out of scope, per prior discussion on the ticket).

**Naming.** `/admin/sitemap` edits the top navigation dropdown menu, not an XML sitemap or a visual page map — a genuinely confusing name, made worse by the site having a real, separate, unrelated XML sitemap generator (`SitemapXmlServlet`) and per-page sitemap.xml metadata fields (`web-page-form.jsp`). Renamed both pages, their widget titles, and the matching admin sidebar entry:
- `/admin/sitemap` → **Navigation Menu Editor** (add, delete, and reorder tabs/items; rename tab/item names)
- `/admin/sitemap-editor` → **Navigation Menu Editor - Edit Links** (rename tabs/items and edit their link/URL; reorder)

The old "Switch to renaming" / "Switch to adding" links (no explanation of what "renaming mode" meant) are replaced with plain-language help text on both pages explaining what each page actually does and pointing to the other.

**Documentation.** Added page-level help text explaining what a tab vs. an item is, and field-level help (tooltips + a `help-text` block matching this app's existing pattern, e.g. `group-form.jsp`) for every input, including one genuinely undocumented behavior I confirmed in `main-menu.jsp`: the icon field is rendered as `fa-<value>`, so entering `fa-briefcase` produces a broken `fa-fa-briefcase` class — the help text now says to omit the `fa-` prefix.

**Delete confirmations.** These already existed on the primary page (`confirm()` before every delete) — the ticket's claim otherwise was incorrect. Improved the message itself to name the actual tab/item and submenu-item count, matching what the ticket asked for: `Delete the menu tab "Solutions" and its 8 submenu items? This cannot be undone.` The secondary page has no delete UI at all (a pre-existing, apparently intentional restriction I left alone) so there's nothing to confirm there.

**Also incorrect in the ticket:** "No Reordering Capability" — both pages already have drag-and-drop (dragula), and the secondary page additionally has click-accessible move-left/right/up/down buttons.

## Verification
- `ant clean compile`, `compile-jsp`: clean
- Full `ci-test`: only the known pre-existing JaCoCo-instrumentation flakes (`BlockedIPListCommandTest`, `CaptchaCommandTest`); no new Java behavior in this change (JSP/layout-only), so no new unit tests
- `tools/check-unescaped-el.py`: 0 unallowlisted
- Verified live against the Docker rehearsal environment: added a real tab and item, confirmed both pages render correctly (titles, help text, cross-links, field tooltips), and confirmed all three delete-confirmation messages render with correct dynamic content and singular/plural grammar (0 items / 1 item / named item)