### PR TITLE
Fix Chart.js v3 legend config in site-stats bar/line charts

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-bar-chart.jsp
@@ -68,8 +68,10 @@
       }]
     },
     options: {
-      legend: {
-        display: false
+      plugins: {
+        legend: {
+          display: false
+        }
       },
       scales: {
         yAxes: [{

--- a/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-stats-line-chart.jsp
@@ -71,8 +71,10 @@
       }]
     },
     options: {
-      legend: {
-        display: false
+      plugins: {
+        legend: {
+          display: false
+        }
       },
       scales: {
         yAxes: [{


### PR DESCRIPTION
## Summary

`site-stats-bar-chart.jsp` and `site-stats-line-chart.jsp` set the Chart.js legend option at the Chart.js v2 top-level `options.legend` key. The vendored library is `chartjs-4.4.1` (v3+ API), which moved this under `options.plugins.legend` and silently ignores the old top-level key rather than throwing — so the legend swatch/label rendered above every chart on `/admin/community/analytics` even though the code's intent is clearly to hide it (`display: false`).

Fix moves the option to `options.plugins.legend.display`, as a sibling of `scales:`.

This is scoped to just the legend option. The sibling `scales.yAxes` v2/v3 mismatch in these same two files (which does throw a console error) is tracked separately in #593 and is untouched here.

## Test plan
- [x] `ant -lib lib/war clean compile-jsp` — clean, 0 errors
- [x] Local docker-compose rehearsal, logged into `/admin/community/analytics`:
  - Raw served HTML confirms all 6 chart widgets (3 `line`, 3 `bar`) now emit `plugins: { legend: { display: false } }`, with zero remaining top-level `legend:` instances
  - Live Chart.js runtime instance confirms `options.plugins.legend.display === false`
  - Screenshot confirms all 6 charts render with no legend swatch, correct data, and correct axis ticks