### PR TITLE
Stop leaking raw SMTP exception text to the admin UI on a failed mail test

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidget.java
@@ -25,7 +25,16 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.mail.ImageHtmlEmail;
 
+import javax.mail.AuthenticationFailedException;
+import javax.mail.SendFailedException;
+import javax.net.ssl.SSLException;
+
 import java.lang.reflect.InvocationTargetException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.UUID;
 
 /**
  * Description
@@ -63,8 +72,10 @@ public class SendMailWidget extends GenericWidget {
       email.setMsg("This is a test message sent from the Mail Server Settings page to confirm the configured SMTP settings are working.");
       email.send();
     } catch (Exception e) {
-      LOG.warn("Mail test failed to send", e);
-      context.setErrorMessage("Mail test failed: " + e.getMessage());
+      String correlationId = UUID.randomUUID().toString();
+      LOG.warn("Mail test failed to send [" + correlationId + "]", e);
+      context.setErrorMessage(
+          "Mail test failed (" + categorize(e) + "). Reference: " + correlationId + ". Check the server logs for details.");
       context.setRedirect("/admin/mail-properties");
       return context;
     }
@@ -73,5 +84,32 @@ public class SendMailWidget extends GenericWidget {
     context.setSuccessMessage("A test email was sent to " + user.getEmail());
     context.setRedirect("/admin/mail-properties");
     return context;
+  }
+
+  /**
+   * Maps a mail-send failure to a stable, non-sensitive category for display to admins.
+   * Never returns raw exception text, which can contain hostnames, ports, or credentials.
+   */
+  private static String categorize(Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (current instanceof AuthenticationFailedException) {
+        return "auth";
+      }
+      if (current instanceof SendFailedException) {
+        return "rejected";
+      }
+      if (current instanceof SSLException) {
+        return "tls";
+      }
+      if (current instanceof SocketTimeoutException) {
+        return "timeout";
+      }
+      if (current instanceof ConnectException || current instanceof UnknownHostException
+          || current instanceof NoRouteToHostException) {
+        return "connect";
+      }
+    }
+    return "unknown";
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SendMailWidgetTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+
+import java.net.ConnectException;
+
+import javax.mail.AuthenticationFailedException;
+
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.ImageHtmlEmail;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.email.EmailCommand;
+import com.simisinc.platform.domain.model.User;
+
+/**
+ * @author SimIS Inc.
+ */
+class SendMailWidgetTest extends WidgetBase {
+
+  private static User adminUser() {
+    User user = new User();
+    user.setId(1L);
+    user.setEmail("admin@example.com");
+    user.setFirstName("Admin");
+    user.setLastName("User");
+    return user;
+  }
+
+  /**
+   * A real ImageHtmlEmail (not a Mockito mock) so the production addTo/setSubject/setMsg calls run their
+   * normal validation; only send() is overridden to succeed or throw on command.
+   */
+  private static class StubEmail extends ImageHtmlEmail {
+    private final EmailException toThrow;
+
+    StubEmail(EmailException toThrow) {
+      this.toThrow = toThrow;
+    }
+
+    @Override
+    public String send() throws EmailException {
+      if (toThrow != null) {
+        throw toThrow;
+      }
+      return "stub-message-id";
+    }
+  }
+
+  @Test
+  void postSendsATestEmailAndReportsSuccess() throws Exception {
+    try (MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<EmailCommand> emailCommand = mockStatic(EmailCommand.class)) {
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+      emailCommand.when(EmailCommand::prepareNewEmail).thenReturn(new StubEmail(null));
+
+      new SendMailWidget().post(widgetContext);
+    }
+
+    Assertions.assertNotNull(widgetContext.getSuccessMessage());
+    Assertions.assertNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void postCategorizesAnAuthenticationFailureWithoutLeakingTheRawMessage() throws Exception {
+    EmailException toThrow = new EmailException(new AuthenticationFailedException(
+        "535 5.7.8 Username and Password not accepted, secret-app-password-xyz"));
+
+    try (MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<EmailCommand> emailCommand = mockStatic(EmailCommand.class)) {
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+      emailCommand.when(EmailCommand::prepareNewEmail).thenReturn(new StubEmail(toThrow));
+
+      new SendMailWidget().post(widgetContext);
+    }
+
+    Assertions.assertNull(widgetContext.getSuccessMessage());
+    String errorMessage = widgetContext.getErrorMessage();
+    Assertions.assertNotNull(errorMessage);
+    Assertions.assertTrue(errorMessage.contains("auth"));
+    Assertions.assertFalse(errorMessage.contains("secret-app-password-xyz"));
+  }
+
+  @Test
+  void postCategorizesAConnectionFailureWithoutLeakingTheRawMessage() throws Exception {
+    EmailException toThrow = new EmailException(new ConnectException("Connection refused to internal-relay.simis.local:25"));
+
+    try (MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<EmailCommand> emailCommand = mockStatic(EmailCommand.class)) {
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+      emailCommand.when(EmailCommand::prepareNewEmail).thenReturn(new StubEmail(toThrow));
+
+      new SendMailWidget().post(widgetContext);
+    }
+
+    String errorMessage = widgetContext.getErrorMessage();
+    Assertions.assertNotNull(errorMessage);
+    Assertions.assertTrue(errorMessage.contains("connect"));
+    Assertions.assertFalse(errorMessage.contains("internal-relay.simis.local"));
+  }
+
+  @Test
+  void postFallsBackToAnUnknownCategoryWithoutLeakingTheRawMessage() throws Exception {
+    EmailException toThrow = new EmailException(
+        "Something unexpected involving admin@simisinc.com and other internal details");
+
+    try (MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<EmailCommand> emailCommand = mockStatic(EmailCommand.class)) {
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+      emailCommand.when(EmailCommand::prepareNewEmail).thenReturn(new StubEmail(toThrow));
+
+      new SendMailWidget().post(widgetContext);
+    }
+
+    String errorMessage = widgetContext.getErrorMessage();
+    Assertions.assertNotNull(errorMessage);
+    Assertions.assertTrue(errorMessage.contains("unknown"));
+    Assertions.assertFalse(errorMessage.contains("admin@simisinc.com"));
+  }
+}


### PR DESCRIPTION
## Summary

When the Mail Test panel on `/admin/mail-properties` fails, it reported the failure as `"Mail test failed: " + e.getMessage()` — the raw exception message passed straight to the admin UI. SMTP exception text routinely carries the relay hostname and port, and an authentication failure echoes back the server's own rejection string, which can include the configured account. The full exception was already being logged server-side, so nothing was gained by also rendering it.

Failures now map to a stable category and a correlation ID:

> Mail test failed (auth). Reference: 3f2c1e9a-.... Check the server logs for details.

Categories: `auth`, `rejected`, `tls`, `timeout`, `connect`, `unknown`. The correlation ID is logged alongside the full stack trace, so an admin can hand the reference to whoever reads the logs without the UI itself disclosing transport details.

Categorization walks the cause chain (bounded to 5 levels) because Commons Email wraps the underlying `javax.mail` / `java.net` exception — verified empirically that `EmailException.getCause()` and `MessagingException.getCause()` do chain through.

## Scope

One defect, from #522. That issue bundles three problems; this is only the error-disclosure piece of the mail test. Not addressed here:
- The `mail.ssl` boolean is ambiguous — Commons Email maps it to `setSSLOnConnect(true)` (implicit TLS), so it cannot express STARTTLS. Replacing it with an explicit transport mode needs a settings migration for existing deployments and is its own change.
- The remaining SMTP-configuration question from #522.

Both raised by @zac343 on #522.

## Test plan

- [x] `ant -lib lib/war clean compile` — passes
- [x] `ant -lib lib/war compile-jsp` — passes
- [x] `ant -lib lib/tests ci-test` — `SendMailWidgetTest` 4/4 passing; remaining failures are the known local-sandbox JaCoCo flakes (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest`), unrelated to this change
- [x] New `SendMailWidgetTest` asserts each category is reported **and** that the sensitive substring (app password, internal relay hostname, admin address) is absent from the admin-facing message

Note for future test authors: `ImageHtmlEmail` cannot be Mockito-mocked under the JDK the test runner uses (inline mock maker fails on the Commons Email class hierarchy), so the test uses a small real subclass overriding `send()` instead.