### PR TITLE
Fix #400: make RobotsServlet actually reachable, fix crawler-property lookup

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/RobotsServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/RobotsServlet.java
@@ -22,17 +22,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 
-@WebServlet(name = "RobotsServlet", urlPatterns = {"/robots.txt"})
 public class RobotsServlet extends HttpServlet {
 
   private static final Log LOG = LogFactory.getLog(RobotsServlet.class);
@@ -46,7 +43,7 @@ public class RobotsServlet extends HttpServlet {
     try {
       String robotsContent = loadRobotsTxt();
       if (StringUtils.isBlank(robotsContent)) {
-        robotsContent = generateDefaultRobotsTxt(request);
+        robotsContent = generateDefaultRobotsTxt();
       }
 
       response.setStatus(HttpServletResponse.SC_OK);
@@ -76,11 +73,11 @@ public class RobotsServlet extends HttpServlet {
     return null;
   }
 
-  private String generateDefaultRobotsTxt(HttpServletRequest request) {
+  private String generateDefaultRobotsTxt() {
     StringBuilder sb = new StringBuilder();
 
-    Map<String, String> sitePropertyMap = LoadSitePropertyCommand.loadAsMap("site");
-    String siteUrl = sitePropertyMap.get("site.url");
+    String siteUrl = LoadSitePropertyCommand.loadByName("site.url");
+    Map<String, String> robotsPropertyMap = LoadSitePropertyCommand.loadAsMap("robots");
 
     // Default rules for all crawlers
     sb.append("User-Agent: *\n");
@@ -90,11 +87,11 @@ public class RobotsServlet extends HttpServlet {
     sb.append("Disallow: /admin\n");
 
     // AI training crawler opt-outs (configurable via site properties)
-    addAiCrawlerRules(sb, sitePropertyMap, "gptbot", "GPTBot");
-    addAiCrawlerRules(sb, sitePropertyMap, "claudebot", "ClaudeBot");
-    addAiCrawlerRules(sb, sitePropertyMap, "google-extended", "Google-Extended");
-    addAiCrawlerRules(sb, sitePropertyMap, "perplexitybot", "PerplexityBot");
-    addAiCrawlerRules(sb, sitePropertyMap, "ccbot", "CCBot");
+    addAiCrawlerRules(sb, robotsPropertyMap, "gptbot", "GPTBot");
+    addAiCrawlerRules(sb, robotsPropertyMap, "claudebot", "ClaudeBot");
+    addAiCrawlerRules(sb, robotsPropertyMap, "google-extended", "Google-Extended");
+    addAiCrawlerRules(sb, robotsPropertyMap, "perplexitybot", "PerplexityBot");
+    addAiCrawlerRules(sb, robotsPropertyMap, "ccbot", "CCBot");
 
     sb.append("\n");
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -74,6 +74,10 @@
     <servlet-class>com.simisinc.platform.presentation.controller.StylesheetServlet</servlet-class>
     <load-on-startup>1</load-on-startup>
   </servlet>
+  <servlet>
+    <servlet-name>RobotsServlet</servlet-name>
+    <servlet-class>com.simisinc.platform.presentation.controller.RobotsServlet</servlet-class>
+  </servlet>
   <!--
   <servlet>
     <servlet-name>SitemapXmlServlet</servlet-name>
@@ -85,7 +89,6 @@
   <servlet-mapping>
     <servlet-name>default</servlet-name>
     <!--<url-pattern>/favicon.*</url-pattern>-->
-    <url-pattern>/robots.txt</url-pattern>
     <!-- For Letsencrypt.org -->
     <url-pattern>/.well-known/acme-challenge/*</url-pattern>
     <!-- For BingBot Webmaster -->
@@ -96,6 +99,10 @@
     <url-pattern>/html/*</url-pattern>
     <url-pattern>/images/*</url-pattern>
     <url-pattern>/javascript/*</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>RobotsServlet</servlet-name>
+    <url-pattern>/robots.txt</url-pattern>
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>PageServlet</servlet-name>

--- a/src/main/webapp/robots.txt
+++ b/src/main/webapp/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Crawl-delay: 1
-Disallow:

--- a/src/test/java/com/simisinc/platform/presentation/controller/RobotsServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/RobotsServletTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author SimIS Inc.
+ */
+class RobotsServletTest {
+
+  private final String originalCmsPath = System.getProperty("cms.path");
+
+  @AfterEach
+  void restoreCmsPath() {
+    if (originalCmsPath == null) {
+      System.clearProperty("cms.path");
+    } else {
+      System.setProperty("cms.path", originalCmsPath);
+    }
+  }
+
+  private String runDoGet(Map<String, String> siteProperties) throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadAsMap("robots")).thenReturn(siteProperties);
+      new RobotsServlet().doGet(request, response);
+    }
+
+    return body.toString();
+  }
+
+  @Test
+  void doGetReturns200WithPlainTextContentType() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadAsMap("robots")).thenReturn(new HashMap<>());
+      new RobotsServlet().doGet(request, response);
+    }
+
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);
+    org.mockito.Mockito.verify(response).setContentType("text/plain;charset=UTF-8");
+  }
+
+  @Test
+  void doGetDisallowsAdminByDefaultAndAllowsEveryCrawler() throws Exception {
+    String body = runDoGet(new HashMap<>());
+
+    assertTrue(body.contains("Disallow: /admin/"));
+    assertFalse(body.contains("User-Agent: GPTBot"));
+    assertFalse(body.contains("User-Agent: ClaudeBot"));
+    assertFalse(body.contains("User-Agent: Google-Extended"));
+    assertFalse(body.contains("User-Agent: PerplexityBot"));
+    assertFalse(body.contains("User-Agent: CCBot"));
+  }
+
+  @Test
+  void doGetAddsADisallowBlockForACrawlerDisabledViaSiteProperty() throws Exception {
+    Map<String, String> siteProperties = new HashMap<>();
+    siteProperties.put("robots.ai.claudebot", "false");
+
+    String body = runDoGet(siteProperties);
+
+    assertTrue(body.contains("User-Agent: ClaudeBot\nDisallow: /\n"));
+    // Only the one crawler named false should be blocked
+    assertFalse(body.contains("User-Agent: GPTBot"));
+  }
+
+  @Test
+  void doGetLeavesACrawlerAllowedWhenItsPropertyIsAnythingOtherThanFalse() throws Exception {
+    Map<String, String> siteProperties = new HashMap<>();
+    siteProperties.put("robots.ai.gptbot", "true");
+
+    String body = runDoGet(siteProperties);
+
+    assertFalse(body.contains("User-Agent: GPTBot"));
+  }
+
+  @Test
+  void doGetServesACustomFileVerbatimInsteadOfGeneratedDefaults() throws Exception {
+    File tempCmsPath = Files.createTempDirectory("robots-test").toFile();
+    File configDir = new File(tempCmsPath, "config/cms");
+    configDir.mkdirs();
+    File customRobotsTxt = new File(configDir, "robots.txt");
+    String customContent = "User-agent: *\nDisallow: /private/\n";
+    Files.write(customRobotsTxt.toPath(), customContent.getBytes());
+    System.setProperty("cms.path", tempCmsPath.getAbsolutePath());
+
+    String body = runDoGet(new HashMap<>());
+
+    assertEquals(customContent, body);
+    assertFalse(body.contains("Disallow: /admin/"));
+  }
+
+  @Test
+  void doGetReturns500AndDoesNotThrowWhenSitePropertiesFail() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadAsMap("robots")).thenThrow(new RuntimeException("db unavailable"));
+
+      new RobotsServlet().doGet(request, response);
+    }
+
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+}


### PR DESCRIPTION
## Summary

Issue #400 asked for a configurable `/robots.txt`. PR #481 added `RobotsServlet` and merged, but the servlet has never actually run — the problem #400 was filed for (admin paths open to crawlers, no AI-training-crawler opt-out) is still live today. Two independent, unrelated bugs, both fixed here.

### 1. Routing: the servlet was never reachable

`web.xml` has mapped `/robots.txt` to Tomcat's `default` (static-file) servlet since the original code drop — untouched by #481. A static `src/main/webapp/robots.txt` (`Disallow:` with an empty value, i.e. disallows nothing, `/admin/` included) has been served the entire time. `RobotsServlet`'s `@WebServlet` annotation never won that conflict.

Fixed by giving `RobotsServlet` an explicit `<servlet>`/`<servlet-mapping>` in `web.xml` — the same pattern every other active servlet in this file already uses (`PageServlet`, `RestServlet`, `StylesheetServlet`; none rely on the annotation) — removing `/robots.txt` from the `default` mapping, and deleting the now-superseded static file.

### 2. Even if reachable, the AI-crawler opt-out could never have worked

`generateDefaultRobotsTxt()` loaded properties via `LoadSitePropertyCommand.loadAsMap("site")`, which filters `WHERE property_name LIKE 'site.%'`, then looked up `"robots.ai.*"` keys inside that map — a different prefix. Always empty, regardless of what was configured. Fixed to load the `"robots"` prefix for crawler properties and fetch `site.url` via `loadByName()` directly.

## Verified with a real deploy, not just tests

Packaged the WAR and ran it against Postgres in Docker — the same rehearsal this repo's `deploy-smoke-test` CI job runs:
- Confirmed the default output disallows `/admin/`
- Set `robots.ai.claudebot=false` directly in the database, restarted the app, confirmed `ClaudeBot` (and only `ClaudeBot`) gets a `Disallow: /` block while `GPTBot` stays allowed

```
User-Agent: *
Allow: /
Disallow: /admin/
Disallow: /action/
Disallow: /admin

User-Agent: ClaudeBot
Disallow: /
```

## Scope

Fixes the servlet so it actually runs and its configuration actually works. Does **not** include the admin-UI piece from #400's original scope (a dedicated site-properties section explaining each crawler) — that's real, separate feature work, tracked as a follow-up.

## Test plan

- [x] `ant -lib lib/war clean compile` — passes
- [x] `ant -lib lib/war compile-jsp` — passes
- [x] `ant -lib lib/tests ci-test` — new `RobotsServletTest` (6 tests, none existed before) all passing; remaining failures are the known local-sandbox JaCoCo flakes (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest`), unrelated to this change
- [x] Live deploy via Docker, confirmed above