### PR TITLE
Add CSV export and an IP Address column to form-data (#483)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -334,5 +335,25 @@ public class FormDataRepository {
       LOG.error("buildRecord", se);
       return null;
     }
+  }
+
+  /**
+   * Exports form submissions to a CSV file (issue #483) so an admin can pull the raw IP addresses
+   * offline, e.g. to cross-reference a spam source before adding it to the IP block list.
+   */
+  public static void export(DataConstraints constraints, File file) {
+    SqlUtils selectFields = new SqlUtils()
+        .addNames(
+            "form_unique_id AS \"Form\"",
+            "ip_address AS \"IP Address\"",
+            "created AS \"Submitted\"",
+            "url AS \"URL\"",
+            "flagged_as_spam AS \"Spam Flagged\""
+        );
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("form_data_id desc");
+    DB.exportToCsvAllFrom(TABLE_NAME, selectFields, null, null, null, constraints, file);
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
@@ -16,21 +16,28 @@
 
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.cms.FormData;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataSpecification;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -135,7 +142,17 @@ public class FormDataListWidget extends GenericWidget {
     }
   }
 
-  public WidgetContext post(WidgetContext context) {
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+    // CSV export (issue #483). Permission is required -- this streams a raw file response,
+    // bypassing normal template rendering, so it gets its own explicit role check rather than
+    // relying solely on the page-level access control that gates this widget in the first place.
+    if ("downloadCSVFile".equals(context.getParameter("command"))) {
+      if (!(context.hasRole("admin") || context.hasRole("community-manager"))) {
+        return context;
+      }
+      return downloadCSVFile(context);
+    }
+
     // These are submitted via a real POST (issue #358 moved state-changing admin actions off
     // GET query strings), so they arrive here rather than in action() below. Dispatch through
     // the same table action() uses for a GET caller.
@@ -179,6 +196,34 @@ public class FormDataListWidget extends GenericWidget {
 
   private WidgetContext markAsProcessed(WidgetContext context, FormData formData) {
     FormDataRepository.markAsProcessed(formData, context.getUserId());
+    return context;
+  }
+
+  private WidgetContext downloadCSVFile(WidgetContext context) {
+    String extension = "csv";
+    String displayFilename = "form-data-" + new SimpleDateFormat("yyyyMMdd-HHmm").format(new Date()) + "." + extension;
+    File tempFile = FileSystemCommand.generateTempFile("exports", context.getUserId(), extension);
+    try {
+      FormDataRepository.export(null, tempFile);
+      String mimeType = "text/csv";
+      MultipartFileSender.fromFile(tempFile)
+          .with(context.getRequest())
+          .with(context.getResponse())
+          .withMimeType(mimeType)
+          .withFilename(displayFilename)
+          .serveResource();
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          "form_data", "all", displayFilename, "format=" + extension);
+    } catch (Exception e) {
+      LOG.error("Download CSV Error", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          "form_data", "all", displayFilename, "format=" + extension);
+    } finally {
+      if (tempFile.exists()) {
+        tempFile.delete();
+      }
+    }
+    context.setHandledResponse(true);
     return context;
   }
 }

--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -84,10 +84,19 @@
 <c:if test="${!empty formDataList}">
   <p><small>Forms found: <fmt:formatNumber value="${recordPaging.totalRecordCount}" /></small></p>
 </c:if>
+<form method="post" action="${widgetContext.uri}">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Form --%>
+  <input type="hidden" name="command" value="downloadCSVFile"/>
+  <button type="submit" class="button small secondary radius"><i class="fa fa-download"></i> Download CSV</button>
+</form>
 <table>
   <thead>
   <tr>
     <th colspan="2">Form Values</th>
+    <th>IP Address</th>
     <th>Form</th>
     <th>Action</th>
   </tr>
@@ -115,14 +124,6 @@
               <fmt:formatDate pattern="hh:mm a" value="${formData.created}"/>
             </small>
             <c:if test="${formData.flaggedAsSpam}"><span class="alert label">spam likely</span></c:if>
-          </div>
-        </div>
-        <div class="grid-x grid-padding-x">
-          <div class="small-4 text-right cell">
-            <small>IP Address</small>
-          </div>
-          <div class="small-8 cell">
-            <small><c:out value="${formData.ipAddress}"/></small>
           </div>
         </div>
         <div class="grid-x grid-padding-x">
@@ -184,6 +185,7 @@
           </c:otherwise>
         </c:choose>
       </td>
+      <td nowrap valign="top"><c:out value="${formData.ipAddress}"/></td>
       <td nowrap valign="top"><c:out value="${formData.formUniqueId}"/></td>
       <td nowrap valign="top">
         <a class="button radius small primary" href="javascript:claimForm(${formData.id});">Claim</a>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
@@ -20,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -41,13 +45,21 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.simisinc.platform.domain.model.cms.FormData;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
-import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.database.DataSource;
+import com.simisinc.platform.infrastructure.database.DB;
 
 /**
- * Verifies the FormDataRepository analytics methods (issue #563) against a real PostgreSQL instance --
- * the count/trend/breakdown queries are only meaningful once proven against a real date-range boundary,
- * not just "the SQL doesn't throw."
+ * Verifies the FormDataRepository analytics methods (issue #563) and the CSV
+ * {@link FormDataRepository#export(DataConstraints, File)} method (issue #483) against a real
+ * PostgreSQL instance -- the count/trend/breakdown queries and the exported CSV content are only
+ * meaningful once proven against real rows, not just "the SQL doesn't throw."
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available, so it does not break the build on hosts without a Docker daemon.
+ * </p>
  *
  * @author SimIS Inc.
  * @created 7/28/26
@@ -185,6 +197,64 @@ class FormDataRepositoryTest {
     assertEquals("1", breakdown.get(1).getValue());
   }
 
+  @Test
+  void exportWritesTheHeaderAndFormDataRowsToCsv(@TempDir File tempDir) throws IOException {
+    FormData clean = addFormData("contact-us", "203.0.113.5", "https://example.org/contact", false);
+    FormData spam = addFormData("newsletter-signup", "198.51.100.9", "https://example.org/newsletter", true);
+
+    File file = new File(tempDir, "form-data-export.csv");
+    FormDataRepository.export(null, file);
+
+    List<String> lines = Files.readAllLines(file.toPath());
+    assertEquals(3, lines.size(), "a header row plus one row per seeded record");
+
+    // Header names come from the SQL column aliases in FormDataRepository.export()
+    String header = lines.get(0);
+    assertTrue(header.contains("Form"), "header should contain the Form column: " + header);
+    assertTrue(header.contains("IP Address"), "header should contain the IP Address column: " + header);
+    assertTrue(header.contains("Submitted"), "header should contain the Submitted column: " + header);
+    assertTrue(header.contains("URL"), "header should contain the URL column: " + header);
+    assertTrue(header.contains("Spam Flagged"), "header should contain the Spam Flagged column: " + header);
+
+    // Default sort is form_data_id desc, so the most recently added (spam) record comes first
+    String firstDataRow = lines.get(1);
+    assertTrue(firstDataRow.contains(spam.getFormUniqueId()), "row should contain the form id: " + firstDataRow);
+    assertTrue(firstDataRow.contains(spam.getIpAddress()), "row should contain the IP address: " + firstDataRow);
+    assertTrue(firstDataRow.contains("https://example.org/newsletter"), "row should contain the URL: " + firstDataRow);
+    assertTrue(firstDataRow.contains("true"), "the spam-flagged row should report true: " + firstDataRow);
+
+    String secondDataRow = lines.get(2);
+    assertTrue(secondDataRow.contains(clean.getFormUniqueId()), "row should contain the form id: " + secondDataRow);
+    assertTrue(secondDataRow.contains(clean.getIpAddress()), "row should contain the IP address: " + secondDataRow);
+    assertTrue(secondDataRow.contains("https://example.org/contact"), "row should contain the URL: " + secondDataRow);
+    assertTrue(secondDataRow.contains("false"), "the non-spam row should report false: " + secondDataRow);
+  }
+
+  @Test
+  void exportProducesOnlyAHeaderRowWhenThereAreNoRecords(@TempDir File tempDir) throws IOException {
+    File file = new File(tempDir, "empty-export.csv");
+    FormDataRepository.export(null, file);
+
+    List<String> lines = Files.readAllLines(file.toPath());
+    assertEquals(1, lines.size(), "only the header row should be written when form_data is empty");
+    assertTrue(lines.get(0).contains("IP Address"));
+  }
+
+  @Test
+  void exportHonorsAnExplicitPageSizeFromTheConstraints(@TempDir File tempDir) throws IOException {
+    addFormData("form-a", "192.0.2.1", "https://example.org/a", false);
+    addFormData("form-b", "192.0.2.2", "https://example.org/b", false);
+    FormData mostRecent = addFormData("form-c", "192.0.2.3", "https://example.org/c", false);
+
+    File file = new File(tempDir, "paged-export.csv");
+    // Page 1 of size 1: only the most recently inserted row (form_data_id desc) should come back
+    FormDataRepository.export(new DataConstraints(1, 1), file);
+
+    List<String> lines = Files.readAllLines(file.toPath());
+    assertEquals(2, lines.size(), "header plus exactly one row when the page size limits the export");
+    assertTrue(lines.get(1).contains(mostRecent.getIpAddress()));
+  }
+
   private static FormData addSubmission(String formUniqueId, boolean flaggedAsSpam) {
     FormData formData = new FormData();
     formData.setFormUniqueId(formUniqueId);
@@ -194,6 +264,15 @@ class FormDataRepositoryTest {
     FormData saved = FormDataRepository.add(formData);
     assertTrue(saved.getId() > 0);
     return saved;
+  }
+
+  private static FormData addFormData(String formUniqueId, String ipAddress, String url, boolean flaggedAsSpam) {
+    FormData record = new FormData();
+    record.setFormUniqueId(formUniqueId);
+    record.setIpAddress(ipAddress);
+    record.setUrl(url);
+    record.setFlaggedAsSpam(flaggedAsSpam);
+    return FormDataRepository.add(record);
   }
 
   /** Directly rewrites {@code created} -- add() always inserts with the DB default of NOW(). */

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
@@ -18,21 +18,27 @@ package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.domain.model.cms.FormData;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataSpecification;
 import com.simisinc.platform.presentation.controller.DataConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 /**
@@ -250,5 +256,26 @@ class FormDataListWidgetTest extends WidgetBase {
     String pagingParams = (String) request.getAttribute("recordPagingParams");
     Assertions.assertNotNull(pagingParams);
     Assertions.assertTrue(pagingParams.contains("formUniqueId=contact-us"));
+  }
+
+  @Test
+  void postRejectsCallersWithoutTheRequiredRole() {
+    // Logged in by default (WidgetBase.login()), but no admin/community-manager role granted
+    addQueryParameter(widgetContext, "command", "downloadCSVFile");
+
+    try {
+      try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class)) {
+        FormDataListWidget widget = new FormDataListWidget();
+        WidgetContext result = widget.post(widgetContext);
+
+        // The role gate must return before export() (and therefore any file download) is reached
+        formDataRepositoryMockedStatic.verify(
+            () -> FormDataRepository.export(any(DataConstraints.class), any(File.class)), never());
+        Assertions.assertFalse(widgetContext.handledResponse(), "no file should be streamed back");
+        Assertions.assertSame(widgetContext, result);
+      }
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      fail(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #483. `/admin/form-data` showed each submission's IP address only in a per-row detail block -- no way to see or export IPs in bulk, e.g. to cross-reference a spam source before adding it to the IP block list.

- IP Address is now a real table column instead of a per-row detail line
- A "Download CSV" button exports every field (form, IP, submitted date, URL, spam-flagged) via `FormDataRepository.export()`, which reuses `DB.exportToCsvAllFrom()` -- the same CSV-formula-injection-safe path added in #590 -- rather than building CSV output by hand
- The download is gated behind the admin/community-manager role check that matches this page's own access list; it streams a raw file response, bypassing normal template rendering, so it gets its own explicit check

## History note

This work was originally built stacked on #563/#585 back when both were still open, then blocked waiting for #585 to merge (both merged as of this stretch). The branch it was built on had drifted far enough from current `main` that reapplying directly wasn't safe, so this is a clean reapplication of the same reviewed logic against current `main` -- verified fresh with the full build/test/JSP gates below, not just carried over.

## Test plan

- [x] `ant -lib lib/war clean compile` -- passes
- [x] `ant -lib lib/war compile-jsp` -- passes
- [x] `ant -lib lib/tests ci-test` -- `FormDataListWidgetTest` (10/10) and `FormDataRepositoryTest` (8/8, including a real Testcontainers-backed CSV-content assertion) both passing; remaining failures are the known local-sandbox JaCoCo flakes (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest`), unrelated to this change