### PR TITLE
JSON-LD: Article/Person schema for blog posts (#403)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageRenderInfo.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageRenderInfo.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.controller;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +47,14 @@ public class PageRenderInfo implements ContainerRenderInfo, Serializable {
   private String pageUrl;
   private String cssClass = null;
   private String jsonLdData;
+
+  // Article schema fields (issue #403), bridged from a content widget like BlogPostWidget --
+  // kept separate from title/description since those carry a browser-tab suffix that doesn't
+  // belong in a JSON-LD headline
+  private String articleHeadline;
+  private Timestamp articlePublishedDate;
+  private Timestamp articleModifiedDate;
+  private String articleAuthorName;
 
   public PageRenderInfo() {
   }
@@ -165,6 +174,38 @@ public class PageRenderInfo implements ContainerRenderInfo, Serializable {
 
   public void setJsonLdData(String jsonLdData) {
     this.jsonLdData = jsonLdData;
+  }
+
+  public String getArticleHeadline() {
+    return articleHeadline;
+  }
+
+  public void setArticleHeadline(String articleHeadline) {
+    this.articleHeadline = articleHeadline;
+  }
+
+  public Timestamp getArticlePublishedDate() {
+    return articlePublishedDate;
+  }
+
+  public void setArticlePublishedDate(Timestamp articlePublishedDate) {
+    this.articlePublishedDate = articlePublishedDate;
+  }
+
+  public Timestamp getArticleModifiedDate() {
+    return articleModifiedDate;
+  }
+
+  public void setArticleModifiedDate(Timestamp articleModifiedDate) {
+    this.articleModifiedDate = articleModifiedDate;
+  }
+
+  public String getArticleAuthorName() {
+    return articleAuthorName;
+  }
+
+  public void setArticleAuthorName(String articleAuthorName) {
+    this.articleAuthorName = articleAuthorName;
   }
 
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -839,14 +839,6 @@ public class PageServlet extends HttpServlet {
         }
       }
 
-      // Generate JSON-LD structured data for search engines and AI (issue #403)
-      if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, webPage);
-        if (StringUtils.isNotBlank(jsonLd)) {
-          pageRenderInfo.setJsonLdData(jsonLd);
-        }
-      }
-
       // Finally... we have a page ready to be processed...
       if (LOG.isDebugEnabled()) {
         LOG.debug(request.getMethod() + " page " + pageRef.getName());
@@ -889,7 +881,7 @@ public class PageServlet extends HttpServlet {
       // into pageRenderInfo during its own execute() -- generating it earlier would only ever see
       // the generic item/collection/webPage title & description, never a widget-specific one.
       if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, webPage);
         if (StringUtils.isNotBlank(jsonLd)) {
           pageRenderInfo.setJsonLdData(jsonLd);
         }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -839,14 +839,6 @@ public class PageServlet extends HttpServlet {
         }
       }
 
-      // Generate JSON-LD structured data for search engines and AI (issue #403)
-      if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, pagePath, sitePropertyMap, thisItem, thisCollection, webPage);
-        if (StringUtils.isNotBlank(jsonLd)) {
-          pageRenderInfo.setJsonLdData(jsonLd);
-        }
-      }
-
       // Finally... we have a page ready to be processed...
       if (LOG.isDebugEnabled()) {
         LOG.debug(request.getMethod() + " page " + pageRef.getName());
@@ -889,7 +881,7 @@ public class PageServlet extends HttpServlet {
       // into pageRenderInfo during its own execute() -- generating it earlier would only ever see
       // the generic item/collection/webPage title & description, never a widget-specific one.
       if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection, webPage);
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, pagePath, sitePropertyMap, thisItem, thisCollection, webPage);
         if (StringUtils.isNotBlank(jsonLd)) {
           pageRenderInfo.setJsonLdData(jsonLd);
         }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -850,14 +850,6 @@ public class PageServlet extends HttpServlet {
         }
       }
 
-      // Generate JSON-LD structured data for search engines and AI (issue #403)
-      if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
-        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
-        if (StringUtils.isNotBlank(jsonLd)) {
-          pageRenderInfo.setJsonLdData(jsonLd);
-        }
-      }
-
       // Finally... we have a page ready to be processed...
       if (LOG.isDebugEnabled()) {
         LOG.debug(request.getMethod() + " page " + pageRef.getName());
@@ -893,6 +885,17 @@ public class PageServlet extends HttpServlet {
       if (WebContainerCommand.processWidgets(webContainerContext, pageRef.getSections(), pageRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap)) {
         // The widget processor handled the response, immediately return
         return;
+      }
+
+      // Generate JSON-LD structured data for search engines and AI (issue #403). This runs after
+      // processWidgets so it can see page metadata a content widget (e.g. BlogPostWidget) bridged
+      // into pageRenderInfo during its own execute() -- generating it earlier would only ever see
+      // the generic item/collection/webPage title & description, never a widget-specific one.
+      if (StringUtils.isNotBlank(siteUrl) && StringUtils.isNotBlank(sitePropertyMap.get("site.name"))) {
+        String jsonLd = generateJsonLdData(pageRenderInfo, siteUrl, sitePropertyMap, thisItem, thisCollection);
+        if (StringUtils.isNotBlank(jsonLd)) {
+          pageRenderInfo.setJsonLdData(jsonLd);
+        }
       }
 
       // Render the header
@@ -1052,6 +1055,12 @@ public class PageServlet extends HttpServlet {
       }
       graph.add(webPage);
 
+      // Add Article schema for blog post pages (issue #403)
+      Map<String, Object> article = computeArticleSchema(pageRenderInfo);
+      if (article != null) {
+        graph.add(article);
+      }
+
       // Add Product schema if this is an item (catalog product)
       if (item != null && StringUtils.isNotBlank(item.getName())) {
         Map<String, Object> product = new LinkedHashMap<>();
@@ -1076,6 +1085,33 @@ public class PageServlet extends HttpServlet {
       LOG.warn("Error generating JSON-LD data: " + e.getMessage());
       return null;
     }
+  }
+
+  /**
+   * Builds the Article schema for a blog post page (issue #403). Gated on articleHeadline since
+   * that's only set by a content widget (BlogPostWidget) for a post that's actually published --
+   * every other page type leaves it blank, so this doubles as the "is this a blog post" check.
+   */
+  static Map<String, Object> computeArticleSchema(PageRenderInfo pageRenderInfo) {
+    if (StringUtils.isBlank(pageRenderInfo.getArticleHeadline())) {
+      return null;
+    }
+    Map<String, Object> article = new LinkedHashMap<>();
+    article.put("@type", "Article");
+    article.put("headline", pageRenderInfo.getArticleHeadline());
+    if (pageRenderInfo.getArticlePublishedDate() != null) {
+      article.put("datePublished", pageRenderInfo.getArticlePublishedDate().toInstant().toString());
+    }
+    if (pageRenderInfo.getArticleModifiedDate() != null) {
+      article.put("dateModified", pageRenderInfo.getArticleModifiedDate().toInstant().toString());
+    }
+    if (StringUtils.isNotBlank(pageRenderInfo.getArticleAuthorName())) {
+      Map<String, Object> author = new LinkedHashMap<>();
+      author.put("@type", "Person");
+      author.put("name", pageRenderInfo.getArticleAuthorName());
+      article.put("author", author);
+    }
+    return article;
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -335,6 +335,19 @@ public class WebContainerCommand implements Serializable {
             if (StringUtils.isNotBlank(widgetContext.getPageKeywords())) {
               pageRenderInfo.setKeywords(widgetContext.getPageKeywords());
             }
+            // Article schema fields (issue #403), e.g. from BlogPostWidget
+            if (StringUtils.isNotBlank(widgetContext.getArticleHeadline())) {
+              pageRenderInfo.setArticleHeadline(widgetContext.getArticleHeadline());
+            }
+            if (widgetContext.getArticlePublishedDate() != null) {
+              pageRenderInfo.setArticlePublishedDate(widgetContext.getArticlePublishedDate());
+            }
+            if (widgetContext.getArticleModifiedDate() != null) {
+              pageRenderInfo.setArticleModifiedDate(widgetContext.getArticleModifiedDate());
+            }
+            if (StringUtils.isNotBlank(widgetContext.getArticleAuthorName())) {
+              pageRenderInfo.setArticleAuthorName(widgetContext.getArticleAuthorName());
+            }
           }
 
           // Expect JSON first and return early

--- a/src/main/java/com/simisinc/platform/presentation/controller/WidgetContext.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WidgetContext.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.controller;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,6 +52,14 @@ public class WidgetContext implements Serializable {
   private String pageTitle = null;
   private String pageDescription = null;
   private String pageKeywords = null;
+
+  // Article schema fields (issue #403) -- separate from pageTitle/pageDescription above since
+  // those get a " - Site/Section Name" suffix applied for the browser tab, which would be wrong
+  // inside a JSON-LD headline
+  private String articleHeadline = null;
+  private Timestamp articlePublishedDate = null;
+  private Timestamp articleModifiedDate = null;
+  private String articleAuthorName = null;
 
   private String jsp = null;
   private String html = null;
@@ -161,6 +170,38 @@ public class WidgetContext implements Serializable {
 
   public void setPageKeywords(String pageKeywords) {
     this.pageKeywords = pageKeywords;
+  }
+
+  public String getArticleHeadline() {
+    return articleHeadline;
+  }
+
+  public void setArticleHeadline(String articleHeadline) {
+    this.articleHeadline = articleHeadline;
+  }
+
+  public Timestamp getArticlePublishedDate() {
+    return articlePublishedDate;
+  }
+
+  public void setArticlePublishedDate(Timestamp articlePublishedDate) {
+    this.articlePublishedDate = articlePublishedDate;
+  }
+
+  public Timestamp getArticleModifiedDate() {
+    return articleModifiedDate;
+  }
+
+  public void setArticleModifiedDate(Timestamp articleModifiedDate) {
+    this.articleModifiedDate = articleModifiedDate;
+  }
+
+  public String getArticleAuthorName() {
+    return articleAuthorName;
+  }
+
+  public void setArticleAuthorName(String articleAuthorName) {
+    this.articleAuthorName = articleAuthorName;
   }
 
   public String getJsp() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
@@ -16,8 +16,11 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.UserCommand;
 import com.simisinc.platform.application.cms.LoadBlogCommand;
 import com.simisinc.platform.application.cms.LoadBlogPostCommand;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
@@ -71,6 +74,19 @@ public class BlogPostWidget extends GenericWidget {
     }
     if (StringUtils.isNotBlank(blogPost.getKeywords())) {
       context.setPageKeywords(blogPost.getKeywords());
+    }
+
+    // Set Article schema fields for JSON-LD (issue #403); a post that isn't actually published
+    // yet (visible here only to admin/content-manager, see retrieveValidatedBlogPostFromUrl)
+    // has nothing citable, so it gets no Article markup at all rather than a fabricated date
+    if (blogPost.getPublished() != null) {
+      context.setArticleHeadline(blogPost.getTitle());
+      context.setArticlePublishedDate(blogPost.getPublished());
+      context.setArticleModifiedDate(blogPost.getModified());
+      User author = LoadUserCommand.loadUser(blogPost.getCreatedBy());
+      if (author != null) {
+        context.setArticleAuthorName(UserCommand.name(author));
+      }
     }
 
     // Show the editor

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -87,6 +88,65 @@ class PageServletTest {
     JsonNode product = parsed.get("@graph").get(2);
     assertEquals("Product", product.get("@type").asText());
     assertTrue(product.get("name").asText().contains("</script><script>"));
+  }
+
+  @Test
+  void computeArticleSchemaReturnsNullWhenNotABlogPostPage() {
+    // articleHeadline is only ever set by a content widget like BlogPostWidget; a plain page
+    // (or one whose bridged data hasn't run yet) must not get a fabricated Article entry
+    assertNull(PageServlet.computeArticleSchema(new PageRenderInfo()));
+  }
+
+  @Test
+  void computeArticleSchemaIncludesHeadlineDatesAndAuthor() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setArticleHeadline("Launch Announcement");
+    pageRenderInfo.setArticlePublishedDate(Timestamp.from(java.time.Instant.parse("2026-07-01T09:00:00Z")));
+    pageRenderInfo.setArticleModifiedDate(Timestamp.from(java.time.Instant.parse("2026-07-15T14:30:00Z")));
+    pageRenderInfo.setArticleAuthorName("Jane Author");
+
+    Map<String, Object> article = PageServlet.computeArticleSchema(pageRenderInfo);
+
+    assertEquals("Article", article.get("@type"));
+    assertEquals("Launch Announcement", article.get("headline"));
+    assertEquals("2026-07-01T09:00:00Z", article.get("datePublished"));
+    assertEquals("2026-07-15T14:30:00Z", article.get("dateModified"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> author = (Map<String, Object>) article.get("author");
+    assertEquals("Person", author.get("@type"));
+    assertEquals("Jane Author", author.get("name"));
+  }
+
+  @Test
+  void computeArticleSchemaOmitsAuthorWhenNotResolved() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setArticleHeadline("Launch Announcement");
+    pageRenderInfo.setArticlePublishedDate(Timestamp.from(java.time.Instant.parse("2026-07-01T09:00:00Z")));
+
+    Map<String, Object> article = PageServlet.computeArticleSchema(pageRenderInfo);
+
+    assertNull(article.get("author"));
+    assertNull(article.get("dateModified"));
+  }
+
+  @Test
+  void generateJsonLdDataIncludesArticleForABlogPostPage() {
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+    pageRenderInfo.setPageUrl("https://example.org/news/launch-announcement");
+    pageRenderInfo.setArticleHeadline("Launch Announcement");
+    pageRenderInfo.setArticlePublishedDate(Timestamp.from(java.time.Instant.parse("2026-07-01T09:00:00Z")));
+    pageRenderInfo.setArticleAuthorName("Jane Author");
+
+    Map<String, String> sitePropertyMap = new HashMap<>();
+    sitePropertyMap.put("site.name", "Example Co");
+
+    String jsonLd = PageServlet.generateJsonLdData(pageRenderInfo, "https://example.org", sitePropertyMap, null, null);
+
+    JsonNode parsed = assertDoesNotThrow(() -> MAPPER.readTree(jsonLd));
+    JsonNode article = parsed.get("@graph").get(2);
+    assertEquals("Article", article.get("@type").asText());
+    assertEquals("Launch Announcement", article.get("headline").asText());
+    assertEquals("Jane Author", article.get("author").get("name").asText());
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidgetTest.java
@@ -17,16 +17,20 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.cms.LoadBlogCommand;
 import com.simisinc.platform.application.cms.LoadBlogPostCommand;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+import java.sql.Timestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -76,5 +80,77 @@ class BlogPostWidgetTest extends WidgetBase {
           eq(AuditEventCommand.SUCCESS), eq("blog_post"), eq("9"), eq("Launch Announcement"), any()), times(1));
       Assertions.assertEquals("Post was deleted", result.getSuccessMessage());
     }
+  }
+
+  @Test
+  void executeSetsArticleSchemaFieldsForAPublishedPost() throws Exception {
+    Mockito.when(request.getRequestURI()).thenReturn("/news/launch-announcement");
+    preferences.put("blogUniqueId", "news");
+
+    Blog blog = new Blog();
+    blog.setId(2L);
+    blog.setUniqueId("news");
+    blog.setName("News");
+    blog.setEnabled(true);
+
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(9L);
+    blogPost.setBlogId(2L);
+    blogPost.setTitle("Launch Announcement");
+    blogPost.setCreatedBy(7L);
+    blogPost.setPublished(Timestamp.valueOf("2026-07-01 09:00:00"));
+    blogPost.setModified(Timestamp.valueOf("2026-07-15 14:30:00"));
+
+    User author = new User();
+    author.setId(7L);
+    author.setNickname("Jane Author");
+
+    try (MockedStatic<LoadBlogCommand> loadBlog = mockStatic(LoadBlogCommand.class);
+        MockedStatic<LoadBlogPostCommand> loadBlogPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+      loadBlog.when(() -> LoadBlogCommand.loadBlogByUniqueId("news")).thenReturn(blog);
+      loadBlogPost.when(() -> LoadBlogPostCommand.loadBlogPostByUniqueId(2L, "launch-announcement")).thenReturn(blogPost);
+      loadUser.when(() -> LoadUserCommand.loadUser(7L)).thenReturn(author);
+
+      new BlogPostWidget().execute(widgetContext);
+    }
+
+    Assertions.assertEquals("Launch Announcement", widgetContext.getArticleHeadline());
+    Assertions.assertEquals(blogPost.getPublished(), widgetContext.getArticlePublishedDate());
+    Assertions.assertEquals(blogPost.getModified(), widgetContext.getArticleModifiedDate());
+    Assertions.assertEquals("Jane Author", widgetContext.getArticleAuthorName());
+  }
+
+  @Test
+  void executeDoesNotSetArticleSchemaFieldsForAnUnpublishedPost() throws Exception {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    Mockito.when(request.getRequestURI()).thenReturn("/news/draft-post");
+    preferences.put("blogUniqueId", "news");
+
+    Blog blog = new Blog();
+    blog.setId(2L);
+    blog.setUniqueId("news");
+    blog.setName("News");
+    blog.setEnabled(true);
+
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(10L);
+    blogPost.setBlogId(2L);
+    blogPost.setTitle("Draft Post");
+    blogPost.setCreatedBy(7L);
+    // published is intentionally left null -- this post is still a draft
+
+    try (MockedStatic<LoadBlogCommand> loadBlog = mockStatic(LoadBlogCommand.class);
+        MockedStatic<LoadBlogPostCommand> loadBlogPost = mockStatic(LoadBlogPostCommand.class)) {
+      loadBlog.when(() -> LoadBlogCommand.loadBlogByUniqueId("news")).thenReturn(blog);
+      loadBlogPost.when(() -> LoadBlogPostCommand.loadBlogPostByUniqueId(2L, "draft-post")).thenReturn(blogPost);
+
+      new BlogPostWidget().execute(widgetContext);
+    }
+
+    Assertions.assertNull(widgetContext.getArticleHeadline());
+    Assertions.assertNull(widgetContext.getArticlePublishedDate());
+    Assertions.assertNull(widgetContext.getArticleModifiedDate());
+    Assertions.assertNull(widgetContext.getArticleAuthorName());
   }
 }


### PR DESCRIPTION
## Summary
Part of #403 (JSON-LD structured data), split out as its own reviewable piece per Elizabeth's scoping call to ship #403's five sub-schemas as separate PRs. This one is more invasive than #403a/b/c (touches 5 files, not just PageServlet) -- see "Also fixes" below for why.

- `BlogPostWidget` now bridges headline/published-date/modified-date/author-name into `pageRenderInfo` via new `WidgetContext` setters (`setArticleHeadline`/`setArticlePublishedDate`/`setArticleModifiedDate`/`setArticleAuthorName`), following the exact same bridge pattern the widget already uses for the browser-tab title/description/keywords. `WebContainerCommand`'s existing widget-to-pageRenderInfo bridge is extended to carry these through.
- A post with no `published` date at all (a draft, only visible to admin/content-manager) gets no Article markup whatsoever -- there's nothing to cite yet, so no fabricated date.
- Author resolution reuses `UserCommand.name()`, the same helper `blog-post-details.jsp` already uses for the "by {author}" byline, so the JSON-LD author matches what's shown on the page.

**Also fixes:** JSON-LD generation ran *before* widget processing in `PageServlet.service()`, so it could only ever see the generic item/collection/webPage title & description -- never a widget-bridged one. That means the WebPage schema's `name`/`description` have been silently wrong for blog post pages since #403a/b merged (or will be, once they do): they'd show the wildcard template page's own title, not the post's. Article schema is impossible to add without fixing this ordering, since BlogPostWidget's data doesn't exist yet at the old generation point. Moved the JSON-LD block to right after `processWidgets` returns; verified live that non-blog pages are unaffected.

**Heads up on merge order:** since #403a/#403b/#403c and this PR are all independent branches off the same `main` commit, and this one relocates the JSON-LD generation call itself, merging more than one of these together will need manual conflict resolution regardless of order.

**Two more pre-existing bugs found while verifying this live** (not fixed here -- out of scope, and neither is caused by this change): a wildcard/template page (e.g. this blog's `/news/*`) produces a canonical/OG/JSON-LD URL containing the literal `*` character, and the widget-bridged page title gets a doubled `" - PageName"` suffix when the wildcard page also has its own title set. Filing these separately.

## Test plan
- [x] `ant -lib lib/war clean compile` -- clean
- [x] `ant -lib lib/war compile-jsp` -- JSP syntax gate passes
- [x] `ant -lib lib/tests ci-test` -- full suite passes; only the pre-existing, unrelated local-sandbox flakes appear (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest` -- same names/counts as every prior run this cycle, unaffected by this change)
- [x] New `BlogPostWidgetTest` cases: a published post sets all four Article fields correctly; an unpublished draft (viewed as content-manager) sets none of them
- [x] New `PageServletTest` cases for `computeArticleSchema` (headline/dates/author present; author omitted when not resolved; null for a non-blog page) and a `generateJsonLdData` integration case
- [x] Live Docker verification: seeded a real blog + published post behind a `/news/*` wildcard page, confirmed the rendered JSON-LD's Article block shows the correct headline, `datePublished`, `dateModified`, and `author.name`; confirmed a plain non-blog page (`/legal/privacy`) still renders its Organization/WebPage JSON-LD correctly after the generation-point move