### PR TITLE
Fix duplicated blog name in page title on wildcard blog pages

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -320,13 +320,11 @@ public class WebContainerCommand implements Serializable {
             PageRenderInfo pageRenderInfo = (PageRenderInfo) containerRenderInfo;
             if (StringUtils.isNotBlank(widgetContext.getPageTitle())) {
               if (webContainerContext.getWebPage() != null) {
-                pageRenderInfo.setTitle(
-                    widgetContext.getPageTitle() +
-                        (StringUtils.isNotBlank(webContainerContext.getWebPage().getTitle()) ? " - " + webContainerContext.getWebPage().getTitle() : ""));
+                pageRenderInfo.setTitle(composePageTitle(widgetContext.getPageTitle(), widgetContext.isPageTitleComposed(),
+                    webContainerContext.getWebPage().getTitle()));
               } else if (webContainerContext.getPage() != null) {
-                pageRenderInfo.setTitle(
-                    widgetContext.getPageTitle() +
-                        (StringUtils.isNotBlank(webContainerContext.getPage().getTitle()) ? " - " + webContainerContext.getPage().getTitle() : ""));
+                pageRenderInfo.setTitle(composePageTitle(widgetContext.getPageTitle(), widgetContext.isPageTitleComposed(),
+                    webContainerContext.getPage().getTitle()));
               }
             }
             if (StringUtils.isNotBlank(widgetContext.getPageDescription())) {
@@ -587,5 +585,23 @@ public class WebContainerCommand implements Serializable {
       LOG.error("Malformed widget JSP path, skipping include: " + jspPath);
       return false;
     }
+  }
+
+  /**
+   * Combines a widget's page title with the container's (WebPage or Page) own title. A widget
+   * that has already composed its title in full (e.g. a blog post title with its blog name
+   * appended, via {@link WidgetContext#setComposedPageTitle}) opts out of this so the container's
+   * title is not appended a second time on top of it.
+   *
+   * @param widgetPageTitle    the widget's page title, expected non-blank
+   * @param pageTitleComposed  true if the widget already composed its title in full
+   * @param containerTitle     the WebPage's or Page's own title, may be blank
+   * @return the title to render
+   */
+  protected static String composePageTitle(String widgetPageTitle, boolean pageTitleComposed, String containerTitle) {
+    if (pageTitleComposed || StringUtils.isBlank(containerTitle)) {
+      return widgetPageTitle;
+    }
+    return widgetPageTitle + " - " + containerTitle;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/WidgetContext.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WidgetContext.java
@@ -49,6 +49,7 @@ public class WidgetContext implements Serializable {
   private boolean embedded = false;
 
   private String pageTitle = null;
+  private boolean pageTitleComposed = false;
   private String pageDescription = null;
   private String pageKeywords = null;
 
@@ -145,6 +146,17 @@ public class WidgetContext implements Serializable {
 
   public void setPageTitle(String pageTitle) {
     this.pageTitle = pageTitle;
+  }
+
+  // Use when pageTitle already includes its own section/suffix context (e.g. a blog name) so
+  // the container knows not to append the WebPage's own title on top of it
+  public void setComposedPageTitle(String pageTitle) {
+    this.pageTitle = pageTitle;
+    this.pageTitleComposed = true;
+  }
+
+  public boolean isPageTitleComposed() {
+    return pageTitleComposed;
   }
 
   public String getPageDescription() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
@@ -64,8 +64,9 @@ public class BlogPostWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("blogPost", blogPost);
 
-    // Set the HTML page title
-    context.setPageTitle(blogPost.getTitle() + " - " + blog.getName());
+    // Set the HTML page title -- already includes the blog name, so the container must not
+    // also append the WebPage's own title (e.g. a wildcard page like /news/*) on top of it
+    context.setComposedPageTitle(blogPost.getTitle() + " - " + blog.getName());
     if (StringUtils.isNotBlank(blogPost.getSummary())) {
       context.setPageDescription(blogPost.getSummary());
     }

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
@@ -215,4 +215,34 @@ class WebContainerCommandTest {
     Assertions.assertFalse(WebContainerCommand.widgetJspExists(servletContext, JSP_PATH));
   }
 
+  // A widget's title is combined with its WebPage's/Page's own title (e.g. a wildcard page like
+  // /news/* titled "News") unless the widget already composed its title in full.
+
+  @Test
+  void uncomposedTitleGetsContainerTitleAppended() {
+    String result = WebContainerCommand.composePageTitle("Contact Us", false, "Acme Corp");
+    Assertions.assertEquals("Contact Us - Acme Corp", result);
+  }
+
+  @Test
+  void uncomposedTitleIsUnchangedWhenContainerTitleIsBlank() {
+    String result = WebContainerCommand.composePageTitle("Contact Us", false, "");
+    Assertions.assertEquals("Contact Us", result);
+  }
+
+  @Test
+  void composedTitleIsNotDoubledByContainerTitle() {
+    // BlogPostWidget composes "<post title> - <blog name>" itself; a wildcard WebPage titled
+    // "News" (matching the blog name) must not be appended a second time on top of that.
+    String blogPostTitle = "Launch Announcement" + " - " + "News";
+    String result = WebContainerCommand.composePageTitle(blogPostTitle, true, "News");
+    Assertions.assertEquals("Launch Announcement - News", result);
+  }
+
+  @Test
+  void composedTitleIsUnchangedWhenContainerTitleIsBlank() {
+    String result = WebContainerCommand.composePageTitle("Launch Announcement - News", true, "");
+    Assertions.assertEquals("Launch Announcement - News", result);
+  }
+
 }


### PR DESCRIPTION
## Problem

`BlogPostWidget` composes its page title as `<post title> - <blog name>`. The `WebContainerCommand` bridge that copies a widget's title onto `PageRenderInfo` unconditionally appends the WebPage's own title on top of whatever the widget set.

On a wildcard blog route (e.g. `/news/*`) whose WebPage record also has its own title configured (e.g. "News"), the two get concatenated, so the rendered `<title>` becomes something like:

```
Launch Announcement - News - News
```

instead of the intended `Launch Announcement - News`.

## Fix

- `WidgetContext` gains `setComposedPageTitle(String)` / `isPageTitleComposed()`, letting a widget mark a title as already fully composed so the container knows not to append its own title again. `setPageTitle(String)` is unchanged and keeps defaulting to "not composed," so every other widget's behavior is unaffected.
- The bridge's title-composition logic (previously duplicated inline for the `WebPage` and `Page` branches) is extracted into a small static `WebContainerCommand.composePageTitle(...)` helper, unit-testable directly.
- `BlogPostWidget` is switched to `setComposedPageTitle(...)`.

No other widget currently composes a suffixed title (checked all `WidgetContext.setPageTitle` call sites), so no other call site is affected by this change.

## Testing

- Added unit tests in `WebContainerCommandTest` covering: uncomposed title + blank/non-blank container title (existing behavior, unchanged), and composed title + blank/non-blank container title (the fix, including the exact duplicate-suffix regression case).
- `ant -lib lib/war clean compile` — clean.
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green.