### PR TITLE
Fix wildcard/template pages getting a literal "*" canonical URL

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -1088,7 +1088,9 @@ public class PageServlet extends HttpServlet {
    * Computes the canonical URL for a page response (issue #401), or null when there's nothing to
    * canonicalize (blank site.url, or no page-identity source matched). pagePath is always safe to
    * append as-is: it comes from request.getRequestURI(), which never carries the query string, so
-   * this can't reflect attacker-controlled query parameters into the tag.
+   * this can't reflect attacker-controlled query parameters into the tag. A wildcard/dynamic-page
+   * match (see LoadWebPageCommand#loadByLink) returns the template's own link (e.g. "/news/*"),
+   * not a real URL, so that case is excluded in favor of the actual pagePath.
    */
   static String computeCanonicalUrl(String siteUrl, String pagePath, WebPage webPage, Item item, Collection collection) {
     if (StringUtils.isBlank(siteUrl)) {
@@ -1100,7 +1102,7 @@ public class PageServlet extends HttpServlet {
     if (collection != null) {
       return siteUrl + "/items/" + collection.getUniqueId();
     }
-    if (webPage != null && StringUtils.isNotBlank(webPage.getLink())) {
+    if (webPage != null && StringUtils.isNotBlank(webPage.getLink()) && !webPage.getLink().endsWith("/*")) {
       return siteUrl + webPage.getLink();
     }
     if (StringUtils.isNotBlank(pagePath)) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -145,6 +145,19 @@ class PageServletTest {
   }
 
   @Test
+  void computeCanonicalUrlUsesTheRequestPathForAWildcardTemplatePage() {
+    // A wildcard/template WebPage (LoadWebPageCommand#loadByLink's dynamic-page fallback, e.g. a
+    // "/news/*" blog listing page) resolves to a WebPage whose own link is the literal template
+    // pattern, not the requested post's URL. Unlike the alias case above, that template link must
+    // NOT be used as the canonical URL -- it would leak the "*" character into the tag.
+    WebPage webPage = new WebPage();
+    webPage.setLink("/news/*");
+
+    assertEquals("https://example.org/news/some-post-slug",
+        PageServlet.computeCanonicalUrl("https://example.org", "/news/some-post-slug", webPage, null, null));
+  }
+
+  @Test
   void computeCanonicalUrlUsesTheCollectionPathForACollectionPage() {
     Collection collection = new Collection();
     collection.setUniqueId("staff");


### PR DESCRIPTION
## Summary

One of two pre-existing bugs called out in #611's description ("found while verifying this live... filing these separately"), not fixed there since it's out of scope for that PR.

A `/*` wildcard/template `WebPage` (e.g. a blog's `/news/*` listing page) is matched via `LoadWebPageCommand#loadByLink`'s dynamic-page fallback -- the returned `WebPage` is the template record itself, whose own `link` is the literal pattern (`/news/*`), not the URL of the specific page that was actually requested (`/news/some-post-slug`). `computeCanonicalUrl()` preferred `webPage.getLink()` unconditionally whenever a `WebPage` was found, so every wildcard-matched page got a canonical tag (and, via `pageRenderInfo.setPageUrl(pageRenderInfo.getCanonicalUrl())`, the Open Graph `og:url` too) containing a literal `*` character instead of its real URL.

Stacked on #606, since that PR is what extracted `computeCanonicalUrl()` into its current standalone, testable form -- this fix doesn't exist as a clean diff against `main` until #606 lands.

## Fix

Excluded the wildcard case (`webPage.getLink().endsWith("/*")`) from the "prefer the WebPage's own link" branch, falling through to the existing `pagePath` fallback instead -- the same fallback every page without a dedicated `WebPage` record already uses.

This is deliberately narrower than "prefer `pagePath` whenever it differs from `webPage.getLink()`": an existing test (`computeCanonicalUrlPrefersTheWebPageLinkOverTheRequestPath`) covers a legitimate case where a page is reached via an alias/trailing-slash-variant path and the *WebPage's own link* is correctly preferred over the request path. A blanket inequality check would have silently broken that case; keying off the actual wildcard signature (`/*`) fixes only the reported bug.

## Test plan

- [x] `ant -lib lib/war clean compile` -- passes
- [x] `ant -lib lib/war compile-jsp` -- passes
- [x] `ant -lib lib/tests ci-test` -- full suite passes; `PageServletTest` 14/14 (13 pre-existing + 1 new, covering a `/news/*` WebPage with request path `/news/some-post-slug` resolving to the real path, not the template)
- [ ] Live Docker re-verification of the `/news/*` scenario -- not re-run in this session; `computeCanonicalUrl()` is a pure function (no I/O), and the unit test uses the exact repro values from the original live-verified report, so live re-verification would be confirming the same deterministic input/output already covered. Happy to run it if wanted before merge.