### PR TITLE
Fix web page tsvector search: reuse title_stem, add tests (#404)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -242,8 +242,8 @@ public class WebPageRepository {
     SqlUtils where = new SqlUtils()
         .add("enabled = true")
         .add("searchable = true")
-        .add("tsv @@ PLAINTO_TSQUERY('page_stem', ?)", searchTerm.trim());
-    select.add("TS_RANK_CD(tsv, PLAINTO_TSQUERY('page_stem', ?)) AS rank", searchTerm.trim());
+        .add("tsv @@ PLAINTO_TSQUERY('title_stem', ?)", searchTerm.trim());
+    select.add("TS_RANK_CD(tsv, PLAINTO_TSQUERY('title_stem', ?)) AS rank", searchTerm.trim());
     SqlUtils orderBy = new SqlUtils().add("rank DESC, link");
     DataResult result = DB.selectAllFrom(TABLE_NAME, select, where, orderBy, constraints, WebPageRepository::buildRecord);
     return result.hasRecords() ? (List<WebPage>) result.getRecords() : new java.util.ArrayList<>();

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260726.1003__web_pages_tsvector.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260726.1003__web_pages_tsvector.sql
@@ -5,30 +5,18 @@
 -- Add tsvector column to store the searchable text vector
 ALTER TABLE web_pages ADD COLUMN IF NOT EXISTS tsv tsvector;
 
--- Create text search configuration for page-level content (if not exists)
--- Uses English stemmer via Snowball algorithm for intelligent matching
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_text_search_config WHERE cfgname = 'page_stem') THEN
-    CREATE TEXT SEARCH DICTIONARY page_stem (
-      TEMPLATE = snowball,
-      Language = english
-    );
-    CREATE TEXT SEARCH CONFIGURATION page_stem (copy = english);
-    ALTER TEXT SEARCH CONFIGURATION page_stem
-      ALTER MAPPING FOR asciihword, asciiword, hword, hword_asciipart, hword_part, word
-      WITH page_stem;
-  END IF;
-END $$;
+-- Reuses title_stem (NEW_10024__new_items.sql), the same English-stemming text search
+-- configuration items/blog_posts/wikis/ecommerce already share, rather than creating a redundant,
+-- functionally identical one -- there is no page-specific stemming need here.
 
 -- Create or replace trigger function to maintain tsvector on insert/update
 -- Weights: A=title (most important), B=keywords, C=description
 CREATE OR REPLACE FUNCTION web_pages_tsv_trigger() RETURNS trigger AS $$
 begin
   new.tsv :=
-    setweight(to_tsvector('page_stem', COALESCE(new.page_title, '')), 'A') ||
-    setweight(to_tsvector('page_stem', COALESCE(new.page_keywords, '')), 'B') ||
-    setweight(to_tsvector('page_stem', COALESCE(new.page_description, '')), 'C');
+    setweight(to_tsvector('title_stem', COALESCE(new.page_title, '')), 'A') ||
+    setweight(to_tsvector('title_stem', COALESCE(new.page_keywords, '')), 'B') ||
+    setweight(to_tsvector('title_stem', COALESCE(new.page_description, '')), 'C');
   return new;
 end $$ LANGUAGE plpgsql;
 
@@ -41,9 +29,9 @@ ON web_pages FOR EACH ROW EXECUTE PROCEDURE web_pages_tsv_trigger();
 
 -- Backfill tsvector for all existing web pages
 UPDATE web_pages
-SET tsv = setweight(to_tsvector('page_stem', COALESCE(page_title, '')), 'A') ||
-          setweight(to_tsvector('page_stem', COALESCE(page_keywords, '')), 'B') ||
-          setweight(to_tsvector('page_stem', COALESCE(page_description, '')), 'C')
+SET tsv = setweight(to_tsvector('title_stem', COALESCE(page_title, '')), 'A') ||
+          setweight(to_tsvector('title_stem', COALESCE(page_keywords, '')), 'B') ||
+          setweight(to_tsvector('title_stem', COALESCE(page_description, '')), 'C')
 WHERE tsv IS NULL;
 
 -- Create GIN index for fast full-text search queries

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link WebPageRepository#search(String, com.simisinc.platform.infrastructure.database.DataConstraints)}
+ * against a real PostgreSQL instance, since ranking and tsvector matching cannot be exercised
+ * meaningfully with a mock.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack, including the web_pages_tsv_trigger
+ * this test schema installs. It is skipped automatically when Docker is not available.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class WebPageRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping WebPageRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_pages table", se);
+    }
+  }
+
+  @Test
+  void searchRanksATitleMatchAboveADescriptionOnlyMatch() {
+    addWebPage("/about", "Widgets", null, "A page about our company", true, true, false);
+    addWebPage("/faq", "Frequently Asked Questions", null, "Where do widgets come from?", true, true, false);
+
+    List<WebPage> results = WebPageRepository.search("widgets", null);
+
+    assertEquals(2, results.size());
+    assertEquals("/about", results.get(0).getLink(), "the title match should outrank the description-only match");
+  }
+
+  @Test
+  void searchExcludesPagesThatAreNotSearchable() {
+    addWebPage("/hidden", "Widgets", null, "A page about widgets", true, false, false);
+
+    List<WebPage> results = WebPageRepository.search("widgets", null);
+
+    assertTrue(results.isEmpty(), "a page with searchable=false must not appear in results");
+  }
+
+  @Test
+  void searchExcludesDisabledPages() {
+    addWebPage("/disabled", "Widgets", null, "A page about widgets", false, true, false);
+
+    List<WebPage> results = WebPageRepository.search("widgets", null);
+
+    assertTrue(results.isEmpty(), "a page with enabled=false must not appear in results");
+  }
+
+  @Test
+  void searchMatchesOnKeywordsToo() {
+    addWebPage("/products", "Our Catalog", "widgets, gadgets", "See what we sell", true, true, false);
+
+    List<WebPage> results = WebPageRepository.search("gadgets", null);
+
+    assertEquals(1, results.size());
+    assertEquals("/products", results.get(0).getLink());
+  }
+
+  @Test
+  void searchReturnsAllSearchablePagesWhenTheTermIsBlank() {
+    addWebPage("/one", "One", null, null, true, true, false);
+    addWebPage("/two", "Two", null, null, true, true, false);
+
+    List<WebPage> results = WebPageRepository.search("", null);
+
+    assertEquals(2, results.size());
+  }
+
+  @Test
+  void searchReturnsNoMatchesForAnUnrelatedTerm() {
+    addWebPage("/about", "Widgets", null, "A page about our company", true, true, false);
+
+    List<WebPage> results = WebPageRepository.search("xylophone", null);
+
+    assertTrue(results.isEmpty());
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real web_pages schema, plus the title_stem text search config and
+    // web_pages_tsv_trigger this migration installs (title_stem itself lives in the real app's
+    // NEW_10024__new_items.sql, which this throwaway DB never runs, so it's recreated here too).
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
+      statement.execute("CREATE TABLE web_pages ("
+          + "web_page_id BIGSERIAL PRIMARY KEY, "
+          + "link VARCHAR(255) UNIQUE NOT NULL, "
+          + "redirect_url VARCHAR(255), "
+          + "page_title VARCHAR(255), "
+          + "page_keywords VARCHAR(255), "
+          + "page_description VARCHAR(255), "
+          + "draft BOOLEAN DEFAULT false, "
+          + "enabled BOOLEAN DEFAULT true, "
+          + "created_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT, "
+          + "role_id_list VARCHAR(100), "
+          + "page_xml TEXT, "
+          + "draft_page_xml TEXT, "
+          + "comments TEXT, "
+          + "page_image_url VARCHAR(255), "
+          + "searchable BOOLEAN DEFAULT true, "
+          + "show_in_sitemap BOOLEAN DEFAULT true, "
+          + "has_redirect BOOLEAN DEFAULT false, "
+          + "sitemap_priority NUMERIC(2,1) DEFAULT 0.5, "
+          + "sitemap_changefreq VARCHAR(20), "
+          + "publish_at TIMESTAMP, "
+          + "expires_at TIMESTAMP, "
+          + "tsv tsvector)");
+
+      statement.execute("CREATE TEXT SEARCH DICTIONARY title_stem (TEMPLATE = snowball, Language = english)");
+      statement.execute("CREATE TEXT SEARCH CONFIGURATION title_stem (copy = english)");
+      statement.execute("ALTER TEXT SEARCH CONFIGURATION title_stem "
+          + "ALTER MAPPING FOR asciihword, asciiword, hword, hword_asciipart, hword_part, word WITH title_stem");
+
+      statement.execute("CREATE OR REPLACE FUNCTION web_pages_tsv_trigger() RETURNS trigger AS $$ "
+          + "begin "
+          + "  new.tsv := "
+          + "    setweight(to_tsvector('title_stem', COALESCE(new.page_title, '')), 'A') || "
+          + "    setweight(to_tsvector('title_stem', COALESCE(new.page_keywords, '')), 'B') || "
+          + "    setweight(to_tsvector('title_stem', COALESCE(new.page_description, '')), 'C'); "
+          + "  return new; "
+          + "end $$ LANGUAGE plpgsql");
+      statement.execute("CREATE TRIGGER web_pages_tsv_trigger BEFORE INSERT OR UPDATE "
+          + "ON web_pages FOR EACH ROW EXECUTE PROCEDURE web_pages_tsv_trigger()");
+      statement.execute("CREATE INDEX web_pages_tsv_idx ON web_pages USING gin(tsv)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_pages schema", se);
+    }
+  }
+
+  private static WebPage addWebPage(String link, String title, String keywords, String description,
+      boolean enabled, boolean searchable, boolean draft) {
+    WebPage webPage = new WebPage();
+    webPage.setLink(link);
+    webPage.setTitle(title);
+    webPage.setKeywords(keywords);
+    webPage.setDescription(description);
+    webPage.setEnabled(enabled);
+    webPage.setSearchable(searchable);
+    webPage.setDraft(draft);
+    webPage.setCreatedBy(1L);
+    return WebPageRepository.save(webPage);
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageTitleSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageTitleSearchResultsWidgetTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.ValidateUserAccessToWebPageCommand;
+import com.simisinc.platform.domain.model.cms.SearchResult;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author elizabeth houser
+ */
+class WebPageTitleSearchResultsWidgetTest extends WidgetBase {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeReturnsSearchResultsForAccessiblePages() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    WebPage found = new WebPage();
+    found.setLink("/about");
+    found.setTitle("Widgets");
+    found.setDescription("A page about our company");
+    List<WebPage> webPageList = new ArrayList<>();
+    webPageList.add(found);
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateUserAccessToWebPageCommand> access = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      repository.when(() -> WebPageRepository.search(eq("widgets"), any())).thenReturn(webPageList);
+      access.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/about"), any())).thenReturn(true);
+
+      WidgetContext result = new WebPageTitleSearchResultsWidget().execute(widgetContext);
+
+      Assertions.assertNotNull(result);
+      List<SearchResult> searchResultList = (List<SearchResult>) result.getRequest().getAttribute("searchResultList");
+      assertEquals(1, searchResultList.size());
+      assertEquals("/about", searchResultList.get(0).getLink());
+      assertEquals("Widgets", searchResultList.get(0).getPageTitle());
+      assertEquals("A page about our company", searchResultList.get(0).getPageDescription());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeExcludesPagesTheUserCannotAccess() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    WebPage restricted = new WebPage();
+    restricted.setLink("/staff-only");
+    restricted.setTitle("Widgets (Internal)");
+    List<WebPage> webPageList = new ArrayList<>();
+    webPageList.add(restricted);
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateUserAccessToWebPageCommand> access = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      repository.when(() -> WebPageRepository.search(eq("widgets"), any())).thenReturn(webPageList);
+      access.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/staff-only"), any())).thenReturn(false);
+
+      new WebPageTitleSearchResultsWidget().execute(widgetContext);
+
+      List<SearchResult> searchResultList = (List<SearchResult>) widgetContext.getRequest().getAttribute("searchResultList");
+      Assertions.assertTrue(searchResultList.isEmpty());
+    }
+  }
+
+  @Test
+  void executeReturnsNullWhenNoQueryIsProvided() {
+    WidgetContext result = new WebPageTitleSearchResultsWidget().execute(widgetContext);
+
+    assertNull(result);
+  }
+
+  @Test
+  void executeReturnsNullWhenResultsAreEmptyAndShowWhenEmptyIsFalse() {
+    addQueryParameter(widgetContext, "query", "xylophone");
+    preferences.put("showWhenEmpty", "false");
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class)) {
+      repository.when(() -> WebPageRepository.search(anyString(), any())).thenReturn(new ArrayList<>());
+
+      WidgetContext result = new WebPageTitleSearchResultsWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #404, but not by building new functionality from scratch -- a prior attempt (migration `UPGRADE_20260726.1003__web_pages_tsvector.sql`) had already added the `tsv` column, trigger, GIN index, and wired `WebPageTitleSearchResultsWidget` to a new `WebPageRepository.search()` method using `tsv @@ PLAINTO_TSQUERY(...)` with `ts_rank` ordering. Structurally this already matched the issue's ask. Two things were actually wrong:

1. **The migration invented a redundant `page_stem` text search config** instead of reusing `title_stem` -- the identical English-stemming config (`CREATE TEXT SEARCH DICTIONARY ... TEMPLATE = snowball, Language = english`) that `items`/`blog_posts`/`wikis`/ecommerce already share, created in `NEW_10024__new_items.sql`. Fixed by reusing `title_stem` in the trigger, backfill, and the repository's `PLAINTO_TSQUERY`/`TS_RANK_CD` calls, and dropping the `CREATE TEXT SEARCH DICTIONARY page_stem` block entirely.
2. **Neither the migration nor the search path had any test coverage.**

**A naming mismatch worth flagging explicitly:** the issue's prose names `WebPageSearchResultsWidget`, but that widget does something unrelated -- it takes already-matched `Content` blocks (from `ContentRepository`'s own, separate full-text search) and associates them back to whichever pages embed them, via a `page_xml` substring scan. It is not searching page title/keywords/description at all, and its real bottleneck (an O(matches × pages) association scan) wouldn't be fixed by anything in this issue's stated scope anyway. `WebPageTitleSearchResultsWidget` is the widget that actually does what the issue's acceptance criteria describe (relevance-ranked title/keyword/description search) -- it's already registered, already placed on the same "Search Results" page template as `webPageSearchResults` (under a different heading, "Pages found:" vs "Web Pages Found:"), and already uses the exact machinery #404 asks for. I've treated the acceptance criteria as authoritative and left `WebPageSearchResultsWidget` untouched, since it's doing a legitimately different, unrelated job. Flagging this here in case the issue should instead be re-scoped or split -- happy to adjust if the intent was actually about the other widget.

## Test plan
- [x] `ant -lib lib/war clean compile` -- clean
- [x] `ant -lib lib/war compile-jsp` -- JSP syntax gate passes
- [x] `ant -lib lib/tests ci-test` -- full suite passes; only the pre-existing, unrelated local-sandbox flakes appear (`HealthCommandTest`, `BlockedIPListCommandTest`, `CaptchaCommandTest` -- same names/counts as every prior run this cycle, unaffected by this change)
- [x] New `WebPageRepositoryTest` (Testcontainers, real PostgreSQL, same pattern as `ContentRepositoryTest`): title match outranks a description-only match, `enabled=false` and `searchable=false` pages are excluded, keyword matches work, blank query returns all searchable pages, an unrelated term returns nothing
- [x] New `WebPageTitleSearchResultsWidgetTest`: results are built correctly from `WebPageRepository.search()`, a page the user can't access (per `ValidateUserAccessToWebPageCommand`) is excluded, no-query returns null, empty results with `showWhenEmpty=false` sets no JSP
- [x] Live Docker verification: since upgrade/ migrations don't run against a fresh install (only `install/` does; confirmed via the app's Flyway boot log), applied this migration's SQL directly against a running fresh-install container to simulate a real upgrade -- it applied without error, reusing the `title_stem` config the install scripts already created, and backfilled `tsv` on the two seeded pages. Then created a real `/search` page using the actual `webPageTitleSearchResults` widget and confirmed a real HTTP request for "widget" correctly returned only the matching page, correctly excluding both a disabled page and a non-searchable page with the same term in their title/description.