### PR TITLE
Fix wildcard/template pages getting a literal "*" canonical URL

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -1220,7 +1220,9 @@ public class PageServlet extends HttpServlet {
    * Computes the canonical URL for a page response (issue #401), or null when there's nothing to
    * canonicalize (blank site.url, or no page-identity source matched). pagePath is always safe to
    * append as-is: it comes from request.getRequestURI(), which never carries the query string, so
-   * this can't reflect attacker-controlled query parameters into the tag.
+   * this can't reflect attacker-controlled query parameters into the tag. A wildcard/dynamic-page
+   * match (see LoadWebPageCommand#loadByLink) returns the template's own link (e.g. "/news/*"),
+   * not a real URL, so that case is excluded in favor of the actual pagePath.
    */
   static String computeCanonicalUrl(String siteUrl, String pagePath, WebPage webPage, Item item, Collection collection) {
     if (StringUtils.isBlank(siteUrl)) {
@@ -1232,7 +1234,7 @@ public class PageServlet extends HttpServlet {
     if (collection != null) {
       return siteUrl + "/items/" + collection.getUniqueId();
     }
-    if (webPage != null && StringUtils.isNotBlank(webPage.getLink())) {
+    if (webPage != null && StringUtils.isNotBlank(webPage.getLink()) && !webPage.getLink().endsWith("/*")) {
       return siteUrl + webPage.getLink();
     }
     if (StringUtils.isNotBlank(pagePath)) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -289,6 +289,19 @@ class PageServletTest {
   }
 
   @Test
+  void computeCanonicalUrlUsesTheRequestPathForAWildcardTemplatePage() {
+    // A wildcard/template WebPage (LoadWebPageCommand#loadByLink's dynamic-page fallback, e.g. a
+    // "/news/*" blog listing page) resolves to a WebPage whose own link is the literal template
+    // pattern, not the requested post's URL. Unlike the alias case above, that template link must
+    // NOT be used as the canonical URL -- it would leak the "*" character into the tag.
+    WebPage webPage = new WebPage();
+    webPage.setLink("/news/*");
+
+    assertEquals("https://example.org/news/some-post-slug",
+        PageServlet.computeCanonicalUrl("https://example.org", "/news/some-post-slug", webPage, null, null));
+  }
+
+  @Test
   void computeCanonicalUrlUsesTheCollectionPathForACollectionPage() {
     Collection collection = new Collection();
     collection.setUniqueId("staff");


### PR DESCRIPTION
## Summary
- A `/*` wildcard WebPage (e.g. a `/news/*` blog listing page) resolves via `LoadWebPageCommand#loadByLink`'s dynamic-page fallback to a WebPage whose own link is the template pattern itself, not the requested page's real path. `computeCanonicalUrl()` preferred that link unconditionally, so every wildcard-matched page got a canonical/OG/JSON-LD URL containing the literal `*` character instead of its actual URL.
- Excludes the wildcard case and falls through to the real request path instead, without disturbing the alias/trailing-slash case the preceding branch exists for.
- Found while live-verifying #611 against a real Docker deployment.

This is a revival of #613, which was originally stacked on #606's branch and got auto-closed (not merged) when that branch was deleted post-merge. Cherry-picked cleanly onto current `main` -- no changes to the original fix or test.

## Test plan
- [x] `ant clean compile`, full `ant -lib lib/tests ci-test`, `ant -lib lib/war compile-jsp`, `python3 tools/check-unescaped-el.py --strict .` all green