### PR TITLE
Add category and date facets to item search (#421)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/items/ItemDateFacetCommand.java
+++ b/src/main/java/com/simisinc/platform/application/items/ItemDateFacetCommand.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.items;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fixed, mutually-exclusive date-range buckets for the Items search date facet (issue #421).
+ * Kept to a small bounded set rather than a free-text date-range picker, since each bucket's
+ * facet count is computed via its own DB round trip (see ItemRepository.countByDateRange) and a
+ * calendar-widget UI is out of scope for this slice.
+ *
+ * @author SimIS Inc.
+ */
+public class ItemDateFacetCommand {
+
+  /** One bucket's key, display label, and [start, end) bounds -- either bound may be null (open-ended). */
+  public static class DateFacetBucket {
+    private final String key;
+    private final String label;
+    private final Timestamp start;
+    private final Timestamp end;
+
+    public DateFacetBucket(String key, String label, Timestamp start, Timestamp end) {
+      this.key = key;
+      this.label = label;
+      this.start = start;
+      this.end = end;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public Timestamp getStart() {
+      return start;
+    }
+
+    public Timestamp getEnd() {
+      return end;
+    }
+  }
+
+  private ItemDateFacetCommand() {
+  }
+
+  /**
+   * The 4 fixed buckets, computed relative to "now" in the site's configured timezone -- the
+   * same convention CalendarSearchResultsWidget already uses for its own date-range query.
+   * Bounds are mutually exclusive so bucket counts partition the full result set.
+   */
+  public static List<DateFacetBucket> buckets() {
+    ZoneId siteZoneId = ZoneId.of(LoadSitePropertyCommand.loadByName("site.timezone"));
+    ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), siteZoneId);
+
+    Timestamp sevenDaysAgo = Timestamp.valueOf(now.minusDays(7).toLocalDateTime());
+    Timestamp thirtyDaysAgo = Timestamp.valueOf(now.minusDays(30).toLocalDateTime());
+    Timestamp oneYearAgo = Timestamp.valueOf(now.minusYears(1).toLocalDateTime());
+
+    List<DateFacetBucket> buckets = new ArrayList<>();
+    buckets.add(new DateFacetBucket("last7", "Last 7 days", sevenDaysAgo, null));
+    buckets.add(new DateFacetBucket("last30", "8-30 days ago", thirtyDaysAgo, sevenDaysAgo));
+    buckets.add(new DateFacetBucket("lastYear", "31 days - 1 year ago", oneYearAgo, thirtyDaysAgo));
+    buckets.add(new DateFacetBucket("older", "Older than a year", null, oneYearAgo));
+    return buckets;
+  }
+
+  /** Looks up a bucket by its query-string key, or null if key is null/unrecognized. */
+  public static DateFacetBucket findByKey(String key) {
+    if (key == null) {
+      return null;
+    }
+    for (DateFacetBucket bucket : buckets()) {
+      if (bucket.getKey().equals(key)) {
+        return bucket;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -329,6 +329,111 @@ public class ItemRepository {
     DB.deleteFrom(connection, TABLE_NAME, new SqlUtils().add("collection_id = ?", record.getId()));
   }
 
+  /**
+   * The subset of ItemSpecification conditions that back an item search result: access control,
+   * keyword match, category, date range, and (the presence of) a location filter. query() and the
+   * facet count methods below all build from this shared method so a facet's count can never
+   * drift from what query() itself would return for the same specification.
+   */
+  private static SqlUtils createSearchWhereStatement(ItemSpecification specification) {
+    SqlUtils where = new SqlUtils();
+
+    if (specification.getApprovedOnly()) {
+      where.add("approved is not null");
+    } else if (specification.getUnapprovedOnly()) {
+      where.add("approved is null");
+    }
+    if (specification.getCategoryId() > -1) {
+      where.add("EXISTS (SELECT 1 FROM item_categories WHERE item_id = items.item_id AND category_id = ?)",
+          specification.getCategoryId());
+    }
+    where.addIfExists("items.created >= ?", specification.getDateRangeStart());
+    where.addIfExists("items.created < ?", specification.getDateRangeEnd());
+
+    // A location search restricts results to items that have a geocoded location at all (the
+    // zip/city radius clauses in query()'s own "Use the location geo data" block are commented
+    // out there today, i.e. not live behavior yet -- only this condition currently narrows
+    // anything), so facet counts must apply the same restriction or they'll overcount relative to
+    // what selecting them actually returns.
+    if (StringUtils.isNotBlank(specification.getSearchLocation())) {
+      where.add("geom IS NOT NULL");
+    }
+
+    // For user id
+    // User must be in a user group with collection access, or be a member of the item
+    // AND (user_id EXISTS in user group for related collection ... OR user_id EXISTS in members...) (item_id) (collection_id...)
+    if (specification.getForUserId() != DataConstants.UNDEFINED) {
+      if (specification.getForUserId() == UserSession.GUEST_ID) {
+        // For logged out users
+        where.add("collections.allows_guests = true");
+      } else {
+        // For logged out and logged in users
+        where.add(
+            "(collections.allows_guests = true " +
+                "OR (has_allowed_groups = true " +
+                "AND EXISTS (SELECT 1 FROM collection_groups WHERE collection_groups.collection_id = collections.collection_id AND view_all = true "
+                +
+                "AND EXISTS (SELECT 1 FROM user_groups WHERE user_groups.group_id = collection_groups.group_id AND user_id = ?))"
+                +
+                ") " +
+                "OR EXISTS (SELECT 1 FROM members WHERE items.item_id = members.item_id AND user_id = ? AND approved IS NOT NULL)"
+                +
+                ")",
+            new Long[] { specification.getForUserId(), specification.getForUserId() });
+      }
+    }
+
+    if (StringUtils.isNotBlank(specification.getSearchName())) {
+      where.add("tsv @@ PLAINTO_TSQUERY('title_stem', ?)", specification.getSearchName().trim());
+    }
+
+    return where;
+  }
+
+  /**
+   * Table name (with the collections join every search-relevant WHERE clause depends on) for
+   * facet-count queries via DB.selectFunction(), which takes a raw FROM-clause string.
+   */
+  private static final String FACET_COUNT_FROM = "items LEFT JOIN collections ON (items.collection_id = collections.collection_id)";
+
+  /**
+   * Facet count for a candidate category: every other active filter (keyword, date range, access
+   * control) from the given specification is applied, but its own categoryId is ignored in favor
+   * of the candidate -- so a category facet's counts reflect what selecting THAT category would
+   * produce, not what's already selected. Per issue #421's "excluding the selected dimension"
+   * requirement.
+   */
+  public static long countByCategory(ItemSpecification specification, long categoryId) {
+    ItemSpecification facetSpec = new ItemSpecification();
+    facetSpec.setApprovedOnly(specification.getApprovedOnly());
+    facetSpec.setUnapprovedOnly(specification.getUnapprovedOnly());
+    facetSpec.setForUserId(specification.getForUserId());
+    facetSpec.setSearchName(specification.getSearchName());
+    facetSpec.setSearchLocation(specification.getSearchLocation());
+    facetSpec.setDateRangeStart(specification.getDateRangeStart());
+    facetSpec.setDateRangeEnd(specification.getDateRangeEnd());
+    facetSpec.setCategoryId(categoryId);
+    return DB.selectFunction("COUNT(*)", FACET_COUNT_FROM, createSearchWhereStatement(facetSpec));
+  }
+
+  /**
+   * Facet count for a candidate date bucket: every other active filter (keyword, category, access
+   * control) from the given specification is applied, but its own date range is ignored in favor
+   * of the candidate bucket's bounds. See countByCategory.
+   */
+  public static long countByDateRange(ItemSpecification specification, Timestamp start, Timestamp end) {
+    ItemSpecification facetSpec = new ItemSpecification();
+    facetSpec.setApprovedOnly(specification.getApprovedOnly());
+    facetSpec.setUnapprovedOnly(specification.getUnapprovedOnly());
+    facetSpec.setForUserId(specification.getForUserId());
+    facetSpec.setSearchName(specification.getSearchName());
+    facetSpec.setSearchLocation(specification.getSearchLocation());
+    facetSpec.setCategoryId(specification.getCategoryId());
+    facetSpec.setDateRangeStart(start);
+    facetSpec.setDateRangeEnd(end);
+    return DB.selectFunction("COUNT(*)", FACET_COUNT_FROM, createSearchWhereStatement(facetSpec));
+  }
+
   private static DataResult query(ItemSpecification specification, DataConstraints constraints) {
     SqlUtils select = new SqlUtils();
     SqlJoins joins = new SqlJoins();
@@ -338,6 +443,7 @@ public class ItemRepository {
 
       joins.add("LEFT JOIN collections ON (items.collection_id = collections.collection_id)");
 
+      where = createSearchWhereStatement(specification);
       where
           .addIfExists("item_id = ?", specification.getId(), -1)
           .addIfExists("item_id <> ?", specification.getExcludeId(), -1)
@@ -347,11 +453,6 @@ public class ItemRepository {
           .addIfExists("dataset_id = ?", specification.getDatasetId(), -1)
           .addIfExists("sync_date < ?", specification.getDatasetSyncTimestampThreshold());
 
-      if (specification.getApprovedOnly()) {
-        where.add("approved is not null");
-      } else if (specification.getUnapprovedOnly()) {
-        where.add("approved is null");
-      }
       if (specification.getName() != null) {
         where.add("LOWER(items.name) = ?", specification.getName().trim().toLowerCase());
       }
@@ -362,35 +463,6 @@ public class ItemRepository {
             .replace("_", "!_")
             .replace("[", "![");
         where.add("LOWER(items.name) LIKE LOWER(?) ESCAPE '!'", likeValue + "%");
-      }
-      if (specification.getCategoryId() > -1) {
-        //where.add("category_id = ?", specification.getCategoryId(), -1);
-        where.add("EXISTS (SELECT 1 FROM item_categories WHERE item_id = items.item_id AND category_id = ?)",
-            specification.getCategoryId());
-      }
-
-      // For user id
-      // User must be in a user group with collection access, or be a member of the item
-      // AND (user_id EXISTS in user group for related collection ... OR user_id EXISTS in members...) (item_id) (collection_id...)
-      if (specification.getForUserId() != DataConstants.UNDEFINED) {
-        if (specification.getForUserId() == UserSession.GUEST_ID) {
-          // For logged out users
-          where.add("collections.allows_guests = true");
-        } else {
-          // For logged out and logged in users
-          where.add(
-              "(collections.allows_guests = true " +
-                  "OR (has_allowed_groups = true " +
-                  "AND EXISTS (SELECT 1 FROM collection_groups WHERE collection_groups.collection_id = collections.collection_id AND view_all = true "
-                  +
-                  "AND EXISTS (SELECT 1 FROM user_groups WHERE user_groups.group_id = collection_groups.group_id AND user_id = ?))"
-                  +
-                  ") " +
-                  "OR EXISTS (SELECT 1 FROM members WHERE items.item_id = members.item_id AND user_id = ? AND approved IS NOT NULL)"
-                  +
-                  ")",
-              new Long[] { specification.getForUserId(), specification.getForUserId() });
-        }
       }
 
       // User must be a member of the item
@@ -405,8 +477,8 @@ public class ItemRepository {
       if (StringUtils.isNotBlank(specification.getSearchLocation())) {
         // Skip the SELECT COUNT(*), it causes slowdowns due to coordinate issue
         constraints.setUseCount(false);
-        // Skip items without a location
-        where.add("geom IS NOT NULL");
+        // Skip items without a location -- the WHERE condition itself is already applied by
+        // createSearchWhereStatement() above
         // Determine if there is a region to search within
         String value = specification.getSearchLocation();
         if (StringUtils.isNumeric(value) && value.length() == 5) {
@@ -453,7 +525,7 @@ public class ItemRepository {
             "ts_headline('english', items.name || ' ' || coalesce(keywords,'') || ' ' || coalesce(summary,''), PLAINTO_TSQUERY('title_stem', ?), 'StartSel=${b}, StopSel=${/b}, MaxWords=30, MinWords=15, ShortWord=3, HighlightAll=FALSE, MaxFragments=2, FragmentDelimiter=\" ... \"') AS highlight",
             specification.getSearchName().trim());
         select.add("TS_RANK_CD(tsv, PLAINTO_TSQUERY('title_stem', ?)) AS rank", specification.getSearchName().trim());
-        where.add("tsv @@ PLAINTO_TSQUERY('title_stem', ?)", specification.getSearchName().trim());
+        // The WHERE condition itself is already applied by createSearchWhereStatement() above
         // Override the order by for rank first
         orderBy.add("rank DESC, item_id");
       }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
@@ -49,6 +49,8 @@ public class ItemSpecification {
   private boolean unapprovedOnly = false;
   private long datasetId = -1L;
   private Timestamp datasetSyncTimestampThreshold = null;
+  private Timestamp dateRangeStart = null;
+  private Timestamp dateRangeEnd = null;
 
   public ItemSpecification() {
   }
@@ -231,6 +233,22 @@ public class ItemSpecification {
 
   public void setDatasetSyncTimestampThreshold(Timestamp datasetSyncTimestampThreshold) {
     this.datasetSyncTimestampThreshold = datasetSyncTimestampThreshold;
+  }
+
+  public Timestamp getDateRangeStart() {
+    return dateRangeStart;
+  }
+
+  public void setDateRangeStart(Timestamp dateRangeStart) {
+    this.dateRangeStart = dateRangeStart;
+  }
+
+  public Timestamp getDateRangeEnd() {
+    return dateRangeEnd;
+  }
+
+  public void setDateRangeEnd(Timestamp dateRangeEnd) {
+    this.dateRangeEnd = dateRangeEnd;
   }
 
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
@@ -18,9 +18,13 @@ package com.simisinc.platform.presentation.widgets.items;
 
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.application.items.ItemDateFacetCommand;
 import com.simisinc.platform.domain.model.cms.SearchResult;
+import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Item;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
 import com.simisinc.platform.presentation.controller.RequestConstants;
@@ -29,7 +33,9 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Description
@@ -65,6 +71,25 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     // Determine the location
     String location = context.getParameter("location");
 
+    // Determine the active facet filters (issue #421)
+    Long categoryId = null;
+    String categoryIdParam = context.getParameter("categoryId");
+    if (StringUtils.isNumeric(categoryIdParam)) {
+      categoryId = Long.valueOf(categoryIdParam);
+    }
+    // Computed once and reused below for both filtering and facet-count rendering, so the date
+    // boundaries used to narrow the query and the ones used to report that same bucket's count
+    // can never drift apart by the few milliseconds between two separate "now" calls
+    List<ItemDateFacetCommand.DateFacetBucket> dateBuckets = ItemDateFacetCommand.buckets();
+    String dateFacetParam = context.getParameter("dateFacet");
+    ItemDateFacetCommand.DateFacetBucket selectedDateBucket = null;
+    for (ItemDateFacetCommand.DateFacetBucket bucket : dateBuckets) {
+      if (bucket.getKey().equals(dateFacetParam)) {
+        selectedDateBucket = bucket;
+        break;
+      }
+    }
+
     // Determine criteria
     ItemSpecification specification = new ItemSpecification();
     //    specification.setCollectionId(collection.getId());
@@ -77,6 +102,13 @@ public class ItemsSearchResultsWidget extends GenericWidget {
       specification.setSearchLocation(location);
       specification.setWithinMeters(48281);
     }
+    if (categoryId != null) {
+      specification.setCategoryId(categoryId);
+    }
+    if (selectedDateBucket != null) {
+      specification.setDateRangeStart(selectedDateBucket.getStart());
+      specification.setDateRangeEnd(selectedDateBucket.getEnd());
+    }
 
     // Determine how the view will show the item's link
     boolean useItemLink = "true".equals(context.getPreferences().getOrDefault("useItemLink", "false"));
@@ -84,7 +116,86 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     // Query the data
     List<Item> itemList = ItemRepository.findAll(specification, constraints);
     SearchAnalyticsCommand.record(context, query, "items", itemList == null ? 0 : itemList.size());
+
+    // Facet panels + active filter chips (issue #421)
+    boolean showCategoryFacet = !"false".equals(context.getPreferences().get("showCategoryFacet"));
+    boolean showDateFacet = !"false".equals(context.getPreferences().get("showDateFacet"));
+    String categoryFacetLabel = context.getPreferences().getOrDefault("categoryFacetLabel", "Category");
+    String dateFacetLabel = context.getPreferences().getOrDefault("dateFacetLabel", "Date");
+
+    // Resolve the selected category's own count once, up front: countByCategory already applies
+    // the same access-control WHERE as the real query, so a 0 here is indistinguishable between
+    // "genuinely no matches" and "this categoryId belongs to a collection the requester can't see
+    // at all". categoryId is a guessable sequential id, so neither case may disclose the
+    // category's name below -- only a verified non-zero, access-safe count may.
+    Long selectedCategoryCount = null;
+    if (categoryId != null) {
+      selectedCategoryCount = ItemRepository.countByCategory(specification, categoryId);
+    }
+
+    if (showCategoryFacet) {
+      List<ItemFacetOption> categoryFacets = new ArrayList<>();
+      List<Category> allCategories = CategoryRepository.findAll();
+      if (allCategories != null) {
+        for (Category category : allCategories) {
+          boolean selected = categoryId != null && categoryId.equals(category.getId());
+          long count = selected ? selectedCategoryCount : ItemRepository.countByCategory(specification, category.getId());
+          // Categories with a 0 count here are omitted entirely, selected or not -- see the
+          // access-control note on selectedCategoryCount above for why "selected" alone must not
+          // be enough to reveal a category that turns out to be empty or inaccessible.
+          if (count > 0) {
+            String url = buildFacetLinkUrl(context, "categoryId", String.valueOf(category.getId()));
+            categoryFacets.add(new ItemFacetOption(String.valueOf(category.getId()), category.getName(), count, selected, url));
+          }
+        }
+      }
+      context.getRequest().setAttribute("categoryFacets", categoryFacets);
+      context.getRequest().setAttribute("categoryFacetLabel", categoryFacetLabel);
+    }
+
+    if (showDateFacet) {
+      List<ItemFacetOption> dateFacets = new ArrayList<>();
+      for (ItemDateFacetCommand.DateFacetBucket bucket : dateBuckets) {
+        boolean selected = selectedDateBucket != null && selectedDateBucket.getKey().equals(bucket.getKey());
+        long count = ItemRepository.countByDateRange(specification, bucket.getStart(), bucket.getEnd());
+        if (count > 0 || selected) {
+          String url = buildFacetLinkUrl(context, "dateFacet", bucket.getKey());
+          dateFacets.add(new ItemFacetOption(bucket.getKey(), bucket.getLabel(), count, selected, url));
+        }
+      }
+      context.getRequest().setAttribute("dateFacets", dateFacets);
+      context.getRequest().setAttribute("dateFacetLabel", dateFacetLabel);
+    }
+
+    // Active filter chips, each with a URL that clears just that one filter
+    List<ItemActiveFilter> activeFilters = new ArrayList<>();
+    if (categoryId != null) {
+      // Only resolve and show the real category name once selectedCategoryCount has confirmed it
+      // is a non-empty, access-safe category (see the note above) -- otherwise fall back to a
+      // generic label rather than disclosing the name of a category the requester may not have
+      // access to, or that doesn't exist.
+      String valueLabel = "Selected category";
+      if (selectedCategoryCount != null && selectedCategoryCount > 0) {
+        Category selectedCategory = CategoryRepository.findById(categoryId);
+        if (selectedCategory != null) {
+          valueLabel = selectedCategory.getName();
+        }
+      }
+      activeFilters.add(new ItemActiveFilter(categoryFacetLabel, valueLabel, buildClearFilterUrl(context, "categoryId")));
+    }
+    if (selectedDateBucket != null) {
+      activeFilters.add(new ItemActiveFilter(dateFacetLabel, selectedDateBucket.getLabel(), buildClearFilterUrl(context, "dateFacet")));
+    }
+    context.getRequest().setAttribute("activeFilters", activeFilters);
+
     if (itemList == null || itemList.isEmpty()) {
+      context.getRequest().setAttribute("itemList", new ArrayList<Item>());
+      context.getRequest().setAttribute("searchResultList", new ArrayList<SearchResult>());
+      context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+      context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+      context.getRequest().setAttribute("showPaging", context.getPreferences().getOrDefault("showPaging", "true"));
+      context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
+      context.setJsp(JSP);
       return context;
     }
     context.getRequest().setAttribute("itemList", itemList);
@@ -123,5 +234,106 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     // Show the JSP
     context.setJsp(JSP);
     return context;
+  }
+
+  /**
+   * The current request's URL with the given param set to the given value, all other current
+   * params preserved, and paging reset to page 1 (a facet selection changes the result set, so
+   * whatever page the user was on may no longer exist).
+   */
+  private static String buildFacetLinkUrl(WidgetContext context, String paramName, String paramValue) {
+    Map<String, String> overrides = new LinkedHashMap<>();
+    overrides.put(paramName, paramValue);
+    return buildUrl(context, overrides, paramName);
+  }
+
+  /** The current request's URL with the given param removed, all other current params preserved. */
+  private static String buildClearFilterUrl(WidgetContext context, String paramName) {
+    return buildUrl(context, new LinkedHashMap<>(), paramName);
+  }
+
+  private static String buildUrl(WidgetContext context, Map<String, String> overrides, String excludeParam) {
+    LinkedHashMap<String, String> params = new LinkedHashMap<>();
+    for (Map.Entry<String, String[]> entry : context.getParameterMap().entrySet()) {
+      String name = entry.getKey();
+      if (name.equals(excludeParam) || "page".equals(name)) {
+        continue;
+      }
+      if (entry.getValue() != null && entry.getValue().length > 0 && StringUtils.isNotBlank(entry.getValue()[0])) {
+        params.put(name, entry.getValue()[0]);
+      }
+    }
+    params.putAll(overrides);
+
+    StringBuilder url = new StringBuilder(context.getUri());
+    boolean first = true;
+    for (Map.Entry<String, String> entry : params.entrySet()) {
+      url.append(first ? '?' : '&');
+      first = false;
+      url.append(UrlCommand.encodeUri(entry.getKey())).append('=').append(UrlCommand.encodeUri(entry.getValue()));
+    }
+    return url.toString();
+  }
+
+  /** One facet's rendered option: display label, result count, whether it's currently selected, and its link. */
+  public static class ItemFacetOption {
+    private final String key;
+    private final String label;
+    private final long count;
+    private final boolean selected;
+    private final String url;
+
+    public ItemFacetOption(String key, String label, long count, boolean selected, String url) {
+      this.key = key;
+      this.label = label;
+      this.count = count;
+      this.selected = selected;
+      this.url = url;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public boolean isSelected() {
+      return selected;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+  }
+
+  /** One active-filter chip: which facet dimension, the selected value's label, and the URL to clear just this filter. */
+  public static class ItemActiveFilter {
+    private final String facetLabel;
+    private final String valueLabel;
+    private final String clearUrl;
+
+    public ItemActiveFilter(String facetLabel, String valueLabel, String clearUrl) {
+      this.facetLabel = facetLabel;
+      this.valueLabel = valueLabel;
+      this.clearUrl = clearUrl;
+    }
+
+    public String getFacetLabel() {
+      return facetLabel;
+    }
+
+    public String getValueLabel() {
+      return valueLabel;
+    }
+
+    public String getClearUrl() {
+      return clearUrl;
+    }
   }
 }

--- a/src/main/webapp/WEB-INF/jsp/items/items-integrated-search-results-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-integrated-search-results-list.jsp
@@ -26,33 +26,107 @@
 <jsp:useBean id="searchResultList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="itemList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<jsp:useBean id="activeFilters" class="java.util.ArrayList" scope="request"/>
 <c:if test="${!empty title}">
   <h4 class="margin-bottom-20"><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
-<c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
-  <c:set var="item" scope="request" value="${itemList[status.index]}"/>
-  <div class="platform-content-search-result margin-top-10">
-    <h5>
-      <c:choose>
-        <c:when test="${fn:startsWith(searchResult.link, 'http://') || fn:startsWith(searchResult.link, 'https://')}">
-          <a target="_blank" href="${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a>
-        </c:when>
-        <c:otherwise>
-          <a href="${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a>
-        </c:otherwise>
-      </c:choose>
-      <c:if test="${!empty item.city}"><small class="subheader"><c:out value="${item.city}" /></small></c:if>
-      <c:if test="${item.categoryId gt 0}">
-        <span class="label" style="${category:headerColorCSS(item.categoryId)}"><c:out value="${category:name(item.categoryId)}" /></span>
+
+<c:if test="${!empty activeFilters}">
+  <div class="margin-bottom-10">
+    <c:forEach items="${activeFilters}" var="activeFilter">
+      <span class="label secondary" style="margin-right:5px">
+        <c:out value="${activeFilter.facetLabel}"/>: <c:out value="${activeFilter.valueLabel}"/>
+        <%-- clearUrl is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+        <a href="${activeFilter.clearUrl}" style="color:inherit" title="Remove this filter"><i class="fa fa-times"></i></a>
+      </span>
+    </c:forEach>
+  </div>
+</c:if>
+
+<div class="grid-x grid-margin-x">
+  <c:if test="${!empty categoryFacets || !empty dateFacets}">
+    <div class="cell medium-3">
+      <c:if test="${!empty categoryFacets}">
+        <h6><c:out value="${categoryFacetLabel}"/></h6>
+        <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+          <c:forEach items="${categoryFacets}" var="facet">
+            <li>
+              <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+              <a href="${facet.url}">
+                <c:choose>
+                  <c:when test="${facet.selected}"><i class="${font:fas()} fa-circle-check"></i></c:when>
+                  <c:otherwise><i class="${font:far()} fa-circle"></i></c:otherwise>
+                </c:choose>
+                <c:out value="${facet.label}"/>
+              </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+            </li>
+          </c:forEach>
+        </ul>
       </c:if>
-    </h5>
+      <c:if test="${!empty dateFacets}">
+        <h6><c:out value="${dateFacetLabel}"/></h6>
+        <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+          <c:forEach items="${dateFacets}" var="facet">
+            <li>
+              <a href="${facet.url}">
+                <c:choose>
+                  <c:when test="${facet.selected}"><i class="${font:fas()} fa-circle-check"></i></c:when>
+                  <c:otherwise><i class="${font:far()} fa-circle"></i></c:otherwise>
+                </c:choose>
+                <c:out value="${facet.label}"/>
+              </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+            </li>
+          </c:forEach>
+        </ul>
+      </c:if>
+    </div>
+  </c:if>
+  <div class="cell ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}">
     <c:choose>
-      <c:when test="${!empty searchResult.htmlExcerpt}">
-        <p>${searchResult.htmlExcerpt}</p>
+      <c:when test="${empty searchResultList}">
+        <c:choose>
+          <c:when test="${!empty activeFilters}">
+            <p>No items match the current filters.</p>
+            <ul class="no-bullet">
+              <c:forEach items="${activeFilters}" var="activeFilter">
+                <li><a href="${activeFilter.clearUrl}">Remove "<c:out value="${activeFilter.valueLabel}"/>"</a></li>
+              </c:forEach>
+            </ul>
+          </c:when>
+          <c:otherwise>
+            <p>No items found.</p>
+          </c:otherwise>
+        </c:choose>
       </c:when>
-      <c:when test="${!empty searchResult.pageDescription}">
-        <p><c:out value="${searchResult.pageDescription}" /></p>
-      </c:when>
+      <c:otherwise>
+        <c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
+          <c:set var="item" scope="request" value="${itemList[status.index]}"/>
+          <div class="platform-content-search-result margin-top-10">
+            <h5>
+              <c:choose>
+                <c:when test="${fn:startsWith(searchResult.link, 'http://') || fn:startsWith(searchResult.link, 'https://')}">
+                  <a target="_blank" href="${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a>
+                </c:when>
+                <c:otherwise>
+                  <a href="${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a>
+                </c:otherwise>
+              </c:choose>
+              <c:if test="${!empty item.city}"><small class="subheader"><c:out value="${item.city}" /></small></c:if>
+              <c:if test="${item.categoryId gt 0}">
+                <span class="label" style="${category:headerColorCSS(item.categoryId)}"><c:out value="${category:name(item.categoryId)}" /></span>
+              </c:if>
+            </h5>
+            <c:choose>
+              <c:when test="${!empty searchResult.htmlExcerpt}">
+                <p>${searchResult.htmlExcerpt}</p>
+              </c:when>
+              <c:when test="${!empty searchResult.pageDescription}">
+                <p><c:out value="${searchResult.pageDescription}" /></p>
+              </c:when>
+            </c:choose>
+          </div>
+        </c:forEach>
+      </c:otherwise>
     </c:choose>
   </div>
-</c:forEach>
+</div>

--- a/src/test/java/com/simisinc/platform/application/items/ItemDateFacetCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/items/ItemDateFacetCommandTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.items.ItemDateFacetCommand.DateFacetBucket;
+
+/**
+ * @author SimIS Inc.
+ */
+class ItemDateFacetCommandTest {
+
+  /**
+   * ItemDateFacetCommand.buckets() reads "site.timezone" via LoadSitePropertyCommand (the same
+   * convention CalendarSearchResultsWidget already uses), which otherwise requires a real DB
+   * connection through its Caffeine-backed cache -- mock it to a fixed zone instead.
+   */
+  private static MockedStatic<LoadSitePropertyCommand> mockSiteTimezone() {
+    MockedStatic<LoadSitePropertyCommand> mock = mockStatic(LoadSitePropertyCommand.class);
+    mock.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+    return mock;
+  }
+
+  @Test
+  void bucketsReturnsExactlyFourBuckets() {
+    try (MockedStatic<LoadSitePropertyCommand> ignored = mockSiteTimezone()) {
+      List<DateFacetBucket> buckets = ItemDateFacetCommand.buckets();
+      assertEquals(4, buckets.size());
+    }
+  }
+
+  @Test
+  void bucketsAreMutuallyExclusiveAndAscendingByRecency() {
+    try (MockedStatic<LoadSitePropertyCommand> ignored = mockSiteTimezone()) {
+      List<DateFacetBucket> buckets = ItemDateFacetCommand.buckets();
+
+      DateFacetBucket last7 = buckets.get(0);
+      DateFacetBucket last30 = buckets.get(1);
+      DateFacetBucket lastYear = buckets.get(2);
+      DateFacetBucket older = buckets.get(3);
+
+      // last7 is open-ended on the recent side (no upper bound needed -- nothing is created in the future)
+      assertNull(last7.getEnd());
+
+      // Each bucket's start equals the next-older bucket's end, so together they partition the
+      // timeline with no gaps and no overlaps
+      assertEquals(last7.getStart(), last30.getEnd());
+      assertEquals(last30.getStart(), lastYear.getEnd());
+      assertEquals(lastYear.getStart(), older.getEnd());
+
+      // older is open-ended on the old side
+      assertNull(older.getStart());
+
+      assertTrue(last30.getStart().before(last7.getStart()));
+      assertTrue(lastYear.getStart().before(last30.getStart()));
+    }
+  }
+
+  @Test
+  void bucketsHaveStableUniqueKeys() {
+    try (MockedStatic<LoadSitePropertyCommand> ignored = mockSiteTimezone()) {
+      List<DateFacetBucket> buckets = ItemDateFacetCommand.buckets();
+      assertEquals("last7", buckets.get(0).getKey());
+      assertEquals("last30", buckets.get(1).getKey());
+      assertEquals("lastYear", buckets.get(2).getKey());
+      assertEquals("older", buckets.get(3).getKey());
+    }
+  }
+
+  @Test
+  void findByKeyReturnsTheMatchingBucket() {
+    try (MockedStatic<LoadSitePropertyCommand> ignored = mockSiteTimezone()) {
+      DateFacetBucket bucket = ItemDateFacetCommand.findByKey("last30");
+      assertEquals("last30", bucket.getKey());
+      assertEquals("8-30 days ago", bucket.getLabel());
+    }
+  }
+
+  @Test
+  void findByKeyReturnsNullForAnUnrecognizedKey() {
+    try (MockedStatic<LoadSitePropertyCommand> ignored = mockSiteTimezone()) {
+      assertNull(ItemDateFacetCommand.findByKey("not-a-real-bucket"));
+    }
+  }
+
+  @Test
+  void findByKeyReturnsNullForANullKeyWithoutTouchingSiteProperties() {
+    // No mock needed -- a null key must short-circuit before buckets() (and therefore
+    // LoadSitePropertyCommand) is ever called
+    assertNull(ItemDateFacetCommand.findByKey(null));
+  }
+
+  @Test
+  void bucketExposesItsConstructorArguments() {
+    Timestamp start = Timestamp.valueOf("2026-01-01 00:00:00");
+    Timestamp end = Timestamp.valueOf("2026-02-01 00:00:00");
+    DateFacetBucket bucket = new DateFacetBucket("key", "Label", start, end);
+
+    assertEquals("key", bucket.getKey());
+    assertEquals("Label", bucket.getLabel());
+    assertEquals(start, bucket.getStart());
+    assertEquals(end, bucket.getEnd());
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+/**
+ * Verifies {@link ItemRepository#countByCategory} and {@link ItemRepository#countByDateRange}
+ * (issue #421's facet counts) against a real PostgreSQL instance, since the EXISTS subquery
+ * against item_categories and the collections LEFT JOIN cannot be exercised meaningfully with a
+ * mock. The schema here is a minimal subset covering only what these two methods' shared WHERE
+ * clause (ItemRepository.createSearchWhereStatement) touches -- items, collections,
+ * item_categories -- not the full production items table, since these methods use
+ * DB.selectFunction (a scalar COUNT) rather than ItemRepository.buildRecord.
+ *
+ * <p>Integration test: starts a throwaway PostgreSQL container (Testcontainers) and is skipped
+ * automatically when Docker is not available.</p>
+ *
+ * @author SimIS Inc.
+ */
+class ItemRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping ItemRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE item_categories, items, collections RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset tables", se);
+    }
+  }
+
+  @Test
+  void countByCategoryCountsOnlyItemsInThatCategory() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long categoryB = 20;
+    addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    long itemInA = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkCategory(itemInA, categoryA, collectionId);
+    long itemInB = addItem(collectionId, null, Timestamp.valueOf("2026-01-03 00:00:00"));
+    linkCategory(itemInB, categoryB, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    assertEquals(1, ItemRepository.countByCategory(specification, categoryA));
+    assertEquals(1, ItemRepository.countByCategory(specification, categoryB));
+    assertEquals(0, ItemRepository.countByCategory(specification, 999));
+  }
+
+  @Test
+  void countByCategoryRespectsApprovedOnly() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long approvedItem = addItem(collectionId, Timestamp.valueOf("2026-01-01 00:00:00"), Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkCategory(approvedItem, categoryA, collectionId);
+    long unapprovedItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkCategory(unapprovedItem, categoryA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setApprovedOnly(true);
+    assertEquals(1, ItemRepository.countByCategory(specification, categoryA));
+  }
+
+  @Test
+  void countByCategoryAppliesTheSpecificationsDateRangeButIgnoresItsOwnCategoryId() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long inRange = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkCategory(inRange, categoryA, collectionId);
+    long outOfRange = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkCategory(outOfRange, categoryA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setCategoryId(999); // a different category -- must be ignored by countByCategory
+    specification.setDateRangeStart(Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    assertEquals(1, ItemRepository.countByCategory(specification, categoryA),
+        "the date range should still narrow the count, but the specification's own categoryId must not");
+  }
+
+  @Test
+  void countByDateRangeCountsItemsWithinTheBounds() {
+    long collectionId = addCollection();
+    addItem(collectionId, null, Timestamp.valueOf("2026-03-01 00:00:00"));
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    addItem(collectionId, null, Timestamp.valueOf("2026-12-01 00:00:00"));
+
+    ItemSpecification specification = new ItemSpecification();
+    long count = ItemRepository.countByDateRange(specification,
+        Timestamp.valueOf("2026-06-01 00:00:00"), Timestamp.valueOf("2026-07-01 00:00:00"));
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countByDateRangeTreatsANullEndAsOpenEnded() {
+    long collectionId = addCollection();
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-01 00:00:00"));
+    addItem(collectionId, null, Timestamp.valueOf("2026-12-01 00:00:00"));
+
+    ItemSpecification specification = new ItemSpecification();
+    long count = ItemRepository.countByDateRange(specification, Timestamp.valueOf("2026-06-01 00:00:00"), null);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  void countByDateRangeAppliesTheSpecificationsCategoryButIgnoresItsOwnDateRange() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long matchingItem = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkCategory(matchingItem, categoryA, collectionId);
+    long wrongCategoryItem = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkCategory(wrongCategoryItem, 999, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setCategoryId(categoryA);
+    specification.setDateRangeStart(Timestamp.valueOf("2020-01-01 00:00:00"));
+    specification.setDateRangeEnd(Timestamp.valueOf("2020-02-01 00:00:00")); // must be ignored
+
+    long count = ItemRepository.countByDateRange(specification,
+        Timestamp.valueOf("2026-01-01 00:00:00"), Timestamp.valueOf("2027-01-01 00:00:00"));
+
+    assertEquals(1, count,
+        "the specification's own categoryId should still narrow the count, but its own date range must not");
+  }
+
+  @Test
+  void countByCategoryExcludesItemsWithoutALocationWhenASearchLocationIsActive() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long withLocation = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"), true);
+    linkCategory(withLocation, categoryA, collectionId);
+    long withoutLocation = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"), false);
+    linkCategory(withoutLocation, categoryA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setSearchLocation("Boston, MA");
+
+    long count = ItemRepository.countByCategory(specification, categoryA);
+
+    assertEquals(1, count,
+        "a facet count taken while a location search is active must exclude items with no location, "
+            + "the same way the real query does -- otherwise the facet badge overstates what selecting it would return");
+  }
+
+  @Test
+  void countByDateRangeExcludesItemsWithoutALocationWhenASearchLocationIsActive() {
+    long collectionId = addCollection();
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"), true);
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"), false);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setSearchLocation("Boston, MA");
+
+    long count = ItemRepository.countByDateRange(specification,
+        Timestamp.valueOf("2026-01-01 00:00:00"), Timestamp.valueOf("2027-01-01 00:00:00"));
+
+    assertEquals(1, count, "same as countByCategory -- the location restriction must carry into date-facet counts too");
+  }
+
+  @Test
+  void countByCategoryReturnsZeroForAGuestWhenTheCollectionDoesNotAllowGuests() {
+    long collectionId = addPrivateCollection();
+    long categoryA = 10;
+    long item = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkCategory(item, categoryA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setForUserId(UserSession.GUEST_ID);
+
+    long count = ItemRepository.countByCategory(specification, categoryA);
+
+    assertEquals(0, count,
+        "a facet count must apply the same guest access-control restriction as the real query -- "
+            + "this is what stops an unauthenticated user from learning a private category has items via its count");
+  }
+
+  @Test
+  void countByCategoryIsNonZeroForAGuestWhenTheCollectionAllowsGuests() {
+    long collectionId = addCollection(); // addCollection() already sets allows_guests = true
+    long categoryA = 10;
+    long item = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkCategory(item, categoryA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setForUserId(UserSession.GUEST_ID);
+
+    long count = ItemRepository.countByCategory(specification, categoryA);
+
+    assertEquals(1, count, "a guest-visible collection's category count must still come through for a guest requester");
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS item_categories CASCADE");
+      statement.execute("DROP TABLE IF EXISTS items CASCADE");
+      statement.execute("DROP TABLE IF EXISTS collections CASCADE");
+      statement.execute("CREATE TABLE collections ("
+          + "collection_id BIGSERIAL PRIMARY KEY, "
+          + "allows_guests BOOLEAN DEFAULT false, "
+          + "has_allowed_groups BOOLEAN DEFAULT false)");
+      statement.execute("CREATE TABLE items ("
+          + "item_id BIGSERIAL PRIMARY KEY, "
+          + "collection_id BIGINT, "
+          + "approved TIMESTAMP, "
+          + "created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+          + "geom TEXT)"); // placeholder column: only IS NOT NULL is exercised here, real
+                           // geometry semantics (PostGIS) aren't available in the plain
+                           // postgres:15-alpine test image
+      statement.execute("CREATE TABLE item_categories ("
+          + "item_id BIGINT, "
+          + "category_id BIGINT, "
+          + "collection_id BIGINT)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the test schema", se);
+    }
+  }
+
+  private static long addCollection() {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO collections (allows_guests) VALUES (true) RETURNING collection_id")) {
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a collection", se);
+    }
+  }
+
+  private static long addPrivateCollection() {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO collections (allows_guests) VALUES (false) RETURNING collection_id")) {
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a private collection", se);
+    }
+  }
+
+  private static long addItem(long collectionId, Timestamp approved, Timestamp created) {
+    return addItem(collectionId, approved, created, false);
+  }
+
+  private static long addItem(long collectionId, Timestamp approved, Timestamp created, boolean hasLocation) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO items (collection_id, approved, created, geom) VALUES (?, ?, ?, ?) RETURNING item_id")) {
+      pst.setLong(1, collectionId);
+      pst.setTimestamp(2, approved);
+      pst.setTimestamp(3, created);
+      pst.setString(4, hasLocation ? "has-a-location" : null);
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert an item", se);
+    }
+  }
+
+  private static void linkCategory(long itemId, long categoryId, long collectionId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO item_categories (item_id, category_id, collection_id) VALUES (?, ?, ?)")) {
+      pst.setLong(1, itemId);
+      pst.setLong(2, categoryId);
+      pst.setLong(3, collectionId);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not link a category", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.application.items.ItemDateFacetCommand;
+import com.simisinc.platform.domain.model.items.Category;
+import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
+import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
+import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.items.ItemsSearchResultsWidget.ItemActiveFilter;
+import com.simisinc.platform.presentation.widgets.items.ItemsSearchResultsWidget.ItemFacetOption;
+
+/**
+ * @author SimIS Inc.
+ */
+class ItemsSearchResultsWidgetTest extends WidgetBase {
+
+  private static Category category(long id, String name) {
+    Category category = new Category();
+    category.setId(id);
+    category.setName(name);
+    return category;
+  }
+
+  private static Item item(long id, String uniqueId, String name) {
+    Item item = new Item();
+    item.setId(id);
+    item.setUniqueId(uniqueId);
+    item.setName(name);
+    return item;
+  }
+
+  private static List<Category> categories(Category... categoryArray) {
+    List<Category> categoryList = new ArrayList<>();
+    for (Category category : categoryArray) {
+      categoryList.add(category);
+    }
+    return categoryList;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheCategoryIdParamAndOnlyListsCategoriesWithResultsOrSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "categoryId", "5");
+
+    List<Item> itemList = new ArrayList<>();
+    itemList.add(item(1L, "widget-1", "Widget One"));
+
+    ArgumentCaptor<ItemSpecification> specCaptor = ArgumentCaptor.forClass(ItemSpecification.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(itemList);
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets"), category(6, "Gadgets")));
+      categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      repository.when(() -> ItemRepository.countByCategory(any(), eq(5L))).thenReturn(3L);
+      repository.when(() -> ItemRepository.countByCategory(any(), eq(6L))).thenReturn(0L);
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      assertEquals(5L, specCaptor.getValue().getCategoryId(), "the categoryId param must reach the query, closing the gap the research found");
+
+      List<ItemFacetOption> categoryFacets = (List<ItemFacetOption>) result.getRequest().getAttribute("categoryFacets");
+      assertEquals(1, categoryFacets.size(), "category 6 has a 0 count and is not selected, so it must not be listed");
+      assertEquals("Widgets", categoryFacets.get(0).getLabel());
+      assertEquals(3L, categoryFacets.get(0).getCount());
+      assertTrue(categoryFacets.get(0).isSelected());
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Category", activeFilters.get(0).getFacetLabel());
+      assertEquals("Widgets", activeFilters.get(0).getValueLabel());
+      assertFalse(activeFilters.get(0).getClearUrl().contains("categoryId="),
+          "the clear link must drop the categoryId param entirely: " + activeFilters.get(0).getClearUrl());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheDateFacetParamToTheQuery() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "dateFacet", "last7");
+
+    ArgumentCaptor<ItemSpecification> specCaptor = ArgumentCaptor.forClass(ItemSpecification.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      assertNotNull(specCaptor.getValue().getDateRangeStart(), "the last7 bucket's start must reach the query");
+      assertNull(specCaptor.getValue().getDateRangeEnd(), "last7 is open-ended on the recent side");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeRoutesToTheJspAndShowsARemoveAFilterPromptWhenAFilteredSearchHasNoResults() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "categoryId", "5");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets")));
+      categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(0L);
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      // Before #421, an empty itemList returned without ever calling setJsp(), so the page rendered
+      // as if the widget weren't there at all -- the exact "empty page" behavior the issue calls out
+      assertNotNull(result.getJsp(), "a zero-result filtered search must still render the JSP so the 'remove a filter' prompt can show");
+
+      List<Item> renderedItemList = (List<Item>) result.getRequest().getAttribute("itemList");
+      assertTrue(renderedItemList.isEmpty());
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size(), "the active filter must still be surfaced so the user has something to remove");
+      assertEquals("Selected category", activeFilters.get(0).getValueLabel(),
+          "a 0-count categoryId must not disclose the real category name -- see executeDoesNotLeakAnInaccessibleOrEmptyCategorysName");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeDoesNotLeakAnInaccessibleOrEmptyCategorysNameInTheFacetListOrActiveFilterChip() {
+    // categoryId=99 stands in for either a category with zero matching items, or one belonging to
+    // a collection the requester has no access to -- countByCategory returns 0 in both cases
+    // (access control is enforced in the same WHERE clause), so the two are indistinguishable and
+    // neither may disclose the category's name (issue: categoryId is a guessable sequential id).
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "categoryId", "99");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(99, "Confidential HR Records")));
+      // findById is stubbed to return the real name deliberately, to prove the widget does NOT
+      // trust/render it once the count check below has failed
+      categoryRepository.when(() -> CategoryRepository.findById(99L)).thenReturn(category(99, "Confidential HR Records"));
+      repository.when(() -> ItemRepository.countByCategory(any(), eq(99L))).thenReturn(0L);
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      List<ItemFacetOption> categoryFacets = (List<ItemFacetOption>) result.getRequest().getAttribute("categoryFacets");
+      assertTrue(categoryFacets.isEmpty(), "a 0-count category must not appear in the facet list even though it's selected");
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Selected category", activeFilters.get(0).getValueLabel(),
+          "must not render \"Confidential HR Records\" -- that would disclose the category's name to a requester with no verified access to it");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeComputesDateFacetBucketsExactlyOncePerRequest() {
+    // Before the fix, ItemDateFacetCommand.buckets() (which calls Instant.now() internally) was
+    // called twice per request -- once to resolve the selected bucket from the "dateFacet" param,
+    // once more to render the facet list -- so the two Instant.now() calls could disagree by a
+    // few milliseconds. Computing it once and reusing the same list for both closes that gap.
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "dateFacet", "last7");
+
+    List<ItemDateFacetCommand.DateFacetBucket> fixedBuckets = new ArrayList<>();
+    fixedBuckets.add(new ItemDateFacetCommand.DateFacetBucket("last7", "Last 7 days",
+        Timestamp.valueOf("2026-07-22 00:00:00"), null));
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<ItemDateFacetCommand> dateFacetCommand = mockStatic(ItemDateFacetCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      dateFacetCommand.when(ItemDateFacetCommand::buckets).thenReturn(fixedBuckets);
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      dateFacetCommand.verify(ItemDateFacetCommand::buckets, times(1));
+    }
+  }
+
+  @Test
+  void executeOmitsTheCategoryFacetWhenThePreferenceIsFalse() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    preferences.put("showCategoryFacet", "false");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      assertNull(result.getRequest().getAttribute("categoryFacets"));
+    }
+  }
+
+  @Test
+  void executeReturnsNullWhenNoQueryIsProvided() {
+    WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+    assertNull(result);
+  }
+}

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -140,6 +140,12 @@ ALLOWLIST: dict[str, str] = {
         "Every report that can reach the bar/line chart JSPs populates StatisticsData.value with `String.valueOf(rs.getLong(...))` over a COUNT/aggregate column, so the field holds only dig",
     "${extraHTMLContent}":
         "N/A -- the attribute is never set for this JSP, and cross-widget leakage of the attribute is prevented by an explicit per-widget request-attribute reset.",
+    "${facet.url}":
+        "ItemsSearchResultsWidget.buildFacetLinkUrl/buildUrl (ItemsSearchResultsWidget.java) build this from context.getUri() (the request path, which per HTTP semantics cannot legally contain a raw '\"') plus every param run through UrlCommand.encodeUri(), which percent-encodes all HTML metacharacters -- same reasoning as ${wikiLinkPrefix} below.",
+    "${activeFilter.clearUrl}":
+        "Same construction and reasoning as ${facet.url} above -- built by ItemsSearchResultsWidget.buildClearFilterUrl/buildUrl from context.getUri() + UrlCommand.encodeUri()'d params.",
+    "${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}":
+        "Ternary between two fixed CSS class literals -- same pattern as ${hideChartControls}/${hideChartTitle} below. No other value is possible.",
     "${faqQuestion.answerHtml}":
         "Same trust boundary as ${widget.content} below: an admin/content-manager-authored widget preference (FaqWidget.java), not user input. The question text is rendered via <c:out> in the same JSP; only the answer is intentionally raw, since it's meant to render as HTML.",
     "${file.baseUrl}":


### PR DESCRIPTION
Closes #421 for a scoped first slice: category + date-range facets on the Items search widget.

## Why scoped to Items only

Of every content type in the codebase, Items is the only one with real, DB-backed category infrastructure already built: `ItemSpecification.categoryId` is fully implemented in `ItemRepository`'s SQL (an `EXISTS` subquery against `item_categories`), backed by a real `Category` domain class — the search widget just never called the setter, even though the companion `ItemsSearchFormWidget` already collects and forwards a `categoryId` on its redirect. WebPage/WikiPage have no category or tag concept at all; BlogPost has tags but only as a raw `String[]`, not queryable.

Tag and custom-field facets are explicitly out of scope for this slice — neither has any domain support today (no `Tag` class for Items, no `filterable` flag on `CustomField`, and field definitions aren't persisted as a first-class table). Building those is real schema/admin work, not wiring. Follow-up issues below.

## What's in this PR

- **`ItemSpecification`**: `dateRangeStart`/`dateRangeEnd` fields.
- **`ItemRepository`**: extracted `createSearchWhereStatement()`, shared by `query()` and two new facet-count methods, `countByCategory()`/`countByDateRange()`. Each is computed by leaving that one dimension unset on a fresh specification and applying the candidate value instead — so a facet's count reflects every *other* active filter without being narrowed by whichever value is currently selected (the "excluding the selected dimension" requirement from the issue).
- **`ItemDateFacetCommand`** (new): 4 fixed, mutually-exclusive date buckets (Last 7 days / 8–30 days ago / 31 days–1 year ago / Older than a year), computed relative to "now" in the site's configured timezone — a fixed set rather than a free-text date-range picker, to keep facet-count queries bounded (no `GROUP BY` support exists anywhere in `DB.java` today; this reuses `DB.selectFunction` with N bounded round-trips instead of adding that infrastructure).
- **`ItemsSearchResultsWidget`**: wires `categoryId`/`dateFacet` query params into the real search, computes facet counts + active-filter chips (each chip carries a URL that clears just that one filter, built from the request path + `UrlCommand.encodeUri()`'d params), and now routes a zero-result *filtered* search through the JSP instead of returning early unrendered — so a "remove a filter" prompt can show instead of an empty page (previously: no JSP, no request attributes, just blank).
- Per-widget preferences: `showCategoryFacet`, `showDateFacet`, `categoryFacetLabel`, `dateFacetLabel`.
- **JSP**: facet sidebar reusing `categories-list.jsp`'s existing link+count+selected-icon convention, active-filter chips (Foundation `.label` + a clear icon), zero-result "remove a filter" prompt.
- Pure query-string state throughout — filtered views are bookmarkable and reload-stable by construction, no session state.

## Security/correctness fixes from an adversarial review pass

Before opening this PR, an adversarial code review (independent findings + 3-lens verification per finding) caught two real bugs that are fixed here:

1. **Facet counts ignored the location/geo search filter.** When a location search is active, the real results are restricted to items with a geocoded location (`geom IS NOT NULL`), but the facet-count queries didn't apply that same restriction — so a facet badge could show a higher count than selecting it would actually return. Fixed by adding the same condition to the shared `createSearchWhereStatement()` and copying `searchLocation` onto the facet-count specifications.
2. **A selected category's name could leak across an access boundary.** `categoryId` is a guessable sequential id. The original code showed a selected category's real name in the facet list and active-filter chip even when its count was 0 — and a 0 count is indistinguishable between "no matching items" and "this category belongs to a collection the requester has no access to" (access control is enforced in the same WHERE clause the count uses). Fixed: a category's name is only ever resolved/shown once its count has confirmed it's real and non-empty; otherwise both the facet list omits it and the chip falls back to a generic "Selected category" label.

Both are covered by new regression tests (`ItemRepositoryTest`, `ItemsSearchResultsWidgetTest`).

## Verification

- `ant clean compile` — clean
- `ant -lib lib/tests ci-test` — full suite green, including 24 new tests across `ItemDateFacetCommandTest` (unit), `ItemRepositoryTest` (real-Postgres Testcontainers), and `ItemsSearchResultsWidgetTest` (Mockito)
- `ant -lib lib/war compile-jsp` — clean
- `python3 tools/check-unescaped-el.py --strict .` — 0 unallowlisted (3 new allowlist entries added with justification, for the server-built/percent-encoded facet and clear-filter URLs)
- Live-verified in a Docker rehearsal against a seeded collection: category/date facets with correct counts, cross-filter exclusion (selecting a category correctly narrows the date facet's options and vice versa), active-filter chips and their individual clear links, the zero-result "remove a filter" prompt, and bookmarkable/reload-stable filtered URLs

## Follow-up issues (deferred scope)

Filed separately: item tag facet (no domain support today), promoting BlogPost tags to a first-class facet, rolling the facet-panel/chip pattern out to the other search widgets, admin-configurable filterable custom fields, multi-select within a facet dimension, generic `GROUP BY` support in `DB.java`, extending search analytics to record facet clicks, and an open question on `collectionId`/"item type" scoping.