### PR TITLE
Fix /admin/blocked-ip-list pagination bug and document IP blocking strategy

### DIFF
--- a/docs/ip-blocking.md
+++ b/docs/ip-blocking.md
@@ -1,0 +1,57 @@
+---
+id: ip-blocking
+title: IP Blocking Strategy
+# prettier-ignore
+description: How SimIS CMS's IP firewall decides which requests to block, where each list lives, and its current limitations.
+---
+
+SimIS CMS blocks requests by IP address before they reach any page, form, or API. This describes what the firewall actually does today (as implemented in `WebRequestFilter` and `BlockedIPListCommand`), where each list lives, and its known gaps.
+
+## What happens on a match
+
+Every request's IP is checked in `WebRequestFilter`, before authentication, routing, or any page rendering. A blocked IP receives an HTTP **404 (Not Found)** response — not a 403 — so a blocked client sees the same response as a nonexistent page, with no indication it was blocked deliberately.
+
+## Check order
+
+Four lists are consulted, in this order, and the first match decides the outcome:
+
+1. **Allow list** — `config/cms/ip-allow-list.csv`. A match here always passes, short-circuiting the remaining checks.
+2. **Deny list** — `config/cms/ip-deny-list.csv`. A match here always blocks.
+3. **Blocked IP list** — the database-backed list managed at `/admin/blocked-ip-list` (this is the only one of the four with an admin UI). A match blocks.
+4. **URL probe list** — `config/cms/url-block-list.csv`, a list of request paths associated with known scanning/attack tools (e.g. common admin-panel or vulnerability-scanner probe paths). If the *requested path* — not the IP — matches an entry here, the requesting IP is added to the database-backed blocked IP list immediately and blocks going forward.
+
+The two file-based lists (1 and 2) and the probe-path list (4) are **not editable from any admin screen** — they're deployment-time files on the server, polled for changes every 5 minutes by a background job (and loaded once at startup), so edits take effect without a restart, just not instantly.
+
+There is no automatic blocking tied to failed logins, rate limiting, or form submissions today — the only automatic path onto the blocked IP list is #4 above (hitting a known probe path).
+
+## Matching and validation
+
+All four lists match by **exact IP address string** — there is no CIDR/subnet range support anywhere in this path. An entry added through `/admin/blocked-ip-list` (manually or via CSV) must be a valid IPv4 or IPv6 address; invalid or blank input is rejected.
+
+## Managing the blocked IP list (`/admin/blocked-ip-list`)
+
+- **Add** — the sidebar form adds a single IP with a free-text reason.
+- **Delete** — the delete icon next to a row removes that IP, unblocking it immediately.
+- **CSV upload** — bulk add/update/remove. Columns:
+  - `IP Address` (required)
+  - `Reason` (optional)
+  - `Date` (optional, `yyyy-MM-dd hh:mm:ss`)
+  - `Remove` (optional; set to `true` on a row to unblock that IP instead of adding/updating it)
+  - Rows matching an existing IP with the same reason are skipped as duplicates.
+- **CSV download** — exports `IP Address`, `Date`, `Reason` for every currently blocked IP.
+- **Self-lockout guard** — both the manual add form and the CSV upload path reject any attempt to block the IP address the request is currently coming from. This is enforced in code, not just a warning.
+
+## Audit trail
+
+Every add, delete, CSV import, and CSV export on `/admin/blocked-ip-list` is recorded through the platform's audit logging (`blocked_ip.remove`, `blocked_ip.import`, `data.export` events). These do not appear inline on the page — view them from the **Audit Log** admin screen.
+
+## Known limitations
+
+- No admin UI for the allow list or deny list — they're server-file-only today, so exempting an IP (e.g. your own office network) requires file access to `config/cms/ip-allow-list.csv` on the deployment, not just admin-panel access.
+- No CIDR/subnet blocking — blocking a range means adding every address individually.
+- No expiration — a manually or automatically blocked IP stays blocked until someone deletes it; there's no time-limited or graduated blocking.
+- No search/filter on the blocked IP list UI beyond pagination.
+
+## Related
+
+- If SimIS CMS runs behind a reverse proxy, load balancer, or CDN, set `CMS_TRUSTED_PROXIES` (see [Production Installation](installation.md)) so this firewall — along with rate limiting and geo filtering — evaluates the real client IP instead of the proxy's address.

--- a/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
@@ -22,11 +22,12 @@
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
-<jsp:useBean id="blockedIP" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="blockedIPList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
+<p class="help-text">A blocked IP is checked on every request, before the page loads; a match returns a 404 (not found) response rather than the actual page. IPs land on this list three ways: added manually below, uploaded via CSV, or automatically when a request path matches a known attack-probe pattern (see the server's <code>config/cms/url-block-list.csv</code>). Matching is an exact address match only - IPv4 or IPv6, no CIDR/subnet ranges. Two other server-side lists also apply on every request but aren't editable here: an allow list checked before this one (<code>config/cms/ip-allow-list.csv</code>) and a deny list checked after it (<code>config/cms/ip-deny-list.csv</code>). You can't block your own current IP, manually or via CSV - the save is rejected instead. Deleting a row below unblocks that IP immediately, and every add, delete, import, and export here is recorded in the platform's audit log. See <code>docs/ip-blocking.md</code> in the repository for the fuller strategy write-up.</p>
 <%@include file="../page_messages.jspf" %>
 <form id="fileForm" method="post" enctype="multipart/form-data">
   <%-- Required by controller --%>
@@ -50,6 +51,7 @@
   <input type="hidden" name="command" value="downloadCSVFile" />
   <button class="button small secondary radius float-left margin-left-10"><i class="fa fa-download"></i> Download CSV File</button>
 </form>
+<p class="help-text">Upload requires an "IP Address" column, plus optional "Reason", "Date", and "Remove" columns; set Remove to "true" on a row to unblock that IP instead of adding it. Matching existing IPs with the same reason are skipped. Download includes IP Address, Date, and Reason.</p>
 <table class="unstriped stack">
   <thead>
     <tr>
@@ -60,7 +62,7 @@
     </tr>
   </thead>
   <tbody>
-    <c:forEach items="${blockedIP}" var="record">
+    <c:forEach items="${blockedIPList}" var="record">
     <tr>
       <td nowrap="true">
         <c:out value="${text:trim(record.ipAddress, 24, true)}" />
@@ -71,7 +73,7 @@
       <td nowrap="true"><fmt:formatDate pattern="yyyy-MM-dd" value="${record.created}" /></td>
     </tr>
     </c:forEach>
-    <c:if test="${empty blockedIP}">
+    <c:if test="${empty blockedIPList}">
       <tr>
         <td colspan="4">No records were found</td>
       </tr>


### PR DESCRIPTION
## Problem

`/admin/blocked-ip-list` showed "Page 1 of 773" with an empty table. The pagination count was accurate - it's a real `SELECT COUNT(*)` against `block_list` - the bug was that `blocked-ip-list.jsp` declared and read a request bean named `blockedIP`, but `BlockedIPListWidget` only ever sets `blockedIPList`. JSP `jsp:useBean` silently instantiates a fresh empty `ArrayList` when no matching request attribute exists, so the table always rendered "No records were found" no matter how many rows the widget loaded.

## Fix

Renamed the JSP's bean id / `forEach` / `empty` checks from `blockedIP` to `blockedIPList`, matching the widget's attribute name and the bean-id-equals-attribute-key convention every other list widget in this codebase already follows (`formDataList`, `userList`, `auditLogList`).

## Documentation

Added in-page help text (matching the pattern from #586's Captcha Settings help text) plus `docs/ip-blocking.md`, grounded in what `WebRequestFilter`/`BlockedIPListCommand` actually do today rather than speculation. Notable corrections to assumptions in the issue:

- Blocked requests get a **404**, not 403.
- Automatic blocking is triggered only by a request path matching `config/cms/url-block-list.csv` (known probe paths) - not failed logins or rate limiting.
- **Delete already exists** (per-row delete icon) - it just never rendered, because of this same bug, so it looked missing.
- **Bulk unblock already exists** via CSV re-upload with a `Remove=true` column.
- **Audit logging already exists** for every add/delete/import/export here - it's on the Audit Log screen, not inline on this page.
- Self-lockout is already actively prevented in code, both for the manual add form and CSV upload.
- Confirmed: no CIDR/subnet matching (exact IP only), and the allow-list/deny-list are server-file-only with no admin UI.

## Scope

This PR covers the P0 (pagination) and P1 (documentation) items from #514. The P2/P3 asks in that issue (whitelist admin UI, search/filter, bulk-select UI beyond CSV, inline audit trail, CIDR support) are filed as separate follow-up issues rather than bundled in here.

## Testing

- `ant -lib lib/war clean compile` - clean
- `ant -lib lib/war compile-jsp` - all 301 JSPs translate/compile, including the fixed one
- `ant -lib lib/tests ci-test` - full suite green, including the existing `BlockedIPListCommandTest`

Fixes #514