### PR TITLE
Show IP address on /admin/mailing-list-members

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -59,6 +59,7 @@
       <th>Name</th>
       <th>Email</th>
       <th>Location</th>
+      <th width="120">IP Address</th>
       <th width="200">Added</th>
       <th width="100">Action</th>
     </tr>
@@ -77,6 +78,7 @@
         </c:if>
       </td>
       <td><small><c:out value="${geoip:location(email.ipAddress, '--')}"/></small></td>
+      <td><small><c:out value="${empty email.ipAddress ? '--' : email.ipAddress}" /></small></td>
       <td><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${email.created}" /></td>
       <td>
         <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape(email.email)}" />?');"><i class="fa fa-remove"></i></a>
@@ -85,7 +87,7 @@
     </c:forEach>
     <c:if test="${empty emailList}">
       <tr>
-        <td colspan="5">No members were found</td>
+        <td colspan="6">No members were found</td>
       </tr>
     </c:if>
   </tbody>


### PR DESCRIPTION
## Problem

`/admin/mailing-list-members` shows subscriber location (city/country) but not the underlying IP address, even though it's fully captured and stored. `emails.ip_address` is populated at signup time - both `EmailSubscribeAjax.java` and `EmailSubscribeWidget.java` call `emailBean.setIpAddress(context.getUserSession().getIpAddress())` before saving. The data exists and the JSP already reads `email.ipAddress` - it feeds the `geoip:location(...)` lookup for the Location column - it just was never rendered as its own column, so there was no way to see or act on repeat/spam IPs from this screen.

## Fix

Added an "IP Address" column between Location and Added, matching this page's existing display convention (small text, "--" for a missing value). One JSP, 3 lines.

## Scope

This covers the core ask in #596. The issue also floated "consider a 'block this IP' row action feeding the existing blocked-IP list" as an optional stretch goal - filed as a separate follow-up issue rather than bundled in here, since it's a distinct feature (needs its own design: does it require a reason, does it also remove the member, does the self-IP guard apply, etc.).

The `CMS_TRUSTED_PROXIES` question raised in #596 (whether the IP this page displays is the real client IP or a proxy's, on the actual production deployment) is infra-side and out of scope for this PR.

## Testing

- `ant -lib lib/war clean compile-jsp` - all JSPs translate/compile clean
- `ant -lib lib/tests ci-test` - full suite green

Fixes #596