### PR TITLE
Add a database-backed, admin-manageable IP allow list

### DIFF
--- a/docs/ip-blocking.md
+++ b/docs/ip-blocking.md
@@ -13,20 +13,27 @@ Every request's IP is checked in `WebRequestFilter`, before authentication, rout
 
 ## Check order
 
-Four lists are consulted, in this order, and the first match decides the outcome:
+Five lists are consulted, in this order, and the first match decides the outcome:
 
-1. **Allow list** — `config/cms/ip-allow-list.csv`. A match here always passes, short-circuiting the remaining checks.
-2. **Deny list** — `config/cms/ip-deny-list.csv`. A match here always blocks.
-3. **Blocked IP list** — the database-backed list managed at `/admin/blocked-ip-list` (this is the only one of the four with an admin UI). A match blocks.
-4. **URL probe list** — `config/cms/url-block-list.csv`, a list of request paths associated with known scanning/attack tools (e.g. common admin-panel or vulnerability-scanner probe paths). If the *requested path* — not the IP — matches an entry here, the requesting IP is added to the database-backed blocked IP list immediately and blocks going forward.
+1. **Allow list (file)** — `config/cms/ip-allow-list.csv`. A match here always passes, short-circuiting the remaining checks.
+2. **Allow list (admin UI)** — the database-backed list managed at `/admin/allowed-ip-list`. A match also always passes.
+3. **Deny list** — `config/cms/ip-deny-list.csv`. A match here always blocks.
+4. **Blocked IP list** — the database-backed list managed at `/admin/blocked-ip-list`. A match blocks.
+5. **URL probe list** — `config/cms/url-block-list.csv`, a list of request paths associated with known scanning/attack tools (e.g. common admin-panel or vulnerability-scanner probe paths). If the *requested path* — not the IP — matches an entry here, the requesting IP is added to the database-backed blocked IP list immediately and blocks going forward.
 
-The two file-based lists (1 and 2) and the probe-path list (4) are **not editable from any admin screen** — they're deployment-time files on the server, polled for changes every 5 minutes by a background job (and loaded once at startup), so edits take effect without a restart, just not instantly.
+The two file-based lists (1 and 3) and the probe-path list (5) are **not editable from any admin screen** — they're deployment-time files on the server, polled for changes every 5 minutes by a background job (and loaded once at startup), so edits take effect without a restart, just not instantly. The two database-backed lists (2 and 4) take effect immediately.
 
-There is no automatic blocking tied to failed logins, rate limiting, or form submissions today — the only automatic path onto the blocked IP list is #4 above (hitting a known probe path).
+There is no automatic blocking tied to failed logins, rate limiting, or form submissions today — the only automatic path onto the blocked IP list is #5 above (hitting a known probe path).
 
 ## Matching and validation
 
-All four lists match by **exact IP address string** — there is no CIDR/subnet range support anywhere in this path. An entry added through `/admin/blocked-ip-list` (manually or via CSV) must be a valid IPv4 or IPv6 address; invalid or blank input is rejected.
+All five lists match by **exact IP address string** — there is no CIDR/subnet range support anywhere in this path. An entry added through `/admin/blocked-ip-list` or `/admin/allowed-ip-list` (manually or via CSV) must be a valid IPv4 or IPv6 address; invalid or blank input is rejected.
+
+## Managing the allow list (`/admin/allowed-ip-list`)
+
+Same shape as the blocked IP list below (add form, per-row delete, CSV upload/download with the same column conventions), but a match here passes the request instead of blocking it. There's no self-add guard here — unlike the blocked list, allowing your own current IP isn't a lockout risk, so it's not restricted.
+
+Note this UI manages the database-backed allow list only (check #2 above). The file-based allow list (`config/cms/ip-allow-list.csv`, check #1) still exists, is still checked first, and still requires server file access to edit — this UI doesn't replace it, it adds a second, admin-manageable allow path alongside it.
 
 ## Managing the blocked IP list (`/admin/blocked-ip-list`)
 
@@ -43,14 +50,14 @@ All four lists match by **exact IP address string** — there is no CIDR/subnet 
 
 ## Audit trail
 
-Every add, delete, CSV import, and CSV export on `/admin/blocked-ip-list` is recorded through the platform's audit logging (`blocked_ip.remove`, `blocked_ip.import`, `data.export` events). These do not appear inline on the page — view them from the **Audit Log** admin screen.
+Every add, delete, CSV import, and CSV export on `/admin/blocked-ip-list` and `/admin/allowed-ip-list` is recorded through the platform's audit logging (`blocked_ip.*`/`allowed_ip.*`, `data.export` events). These do not appear inline on either page — view them from the **Audit Log** admin screen.
 
 ## Known limitations
 
-- No admin UI for the allow list or deny list — they're server-file-only today, so exempting an IP (e.g. your own office network) requires file access to `config/cms/ip-allow-list.csv` on the deployment, not just admin-panel access.
-- No CIDR/subnet blocking — blocking a range means adding every address individually.
+- No admin UI for the deny list — it's server-file-only today (`config/cms/ip-deny-list.csv`), requiring file access to the deployment, not just admin-panel access. (The allow list has an admin UI as of `/admin/allowed-ip-list`, though its underlying file counterpart is still file-only too — see above.)
+- No CIDR/subnet blocking — blocking or allowing a range means adding every address individually.
 - No expiration — a manually or automatically blocked IP stays blocked until someone deletes it; there's no time-limited or graduated blocking.
-- No search/filter on the blocked IP list UI beyond pagination.
+- No search/filter on either list's UI beyond pagination.
 
 ## Related
 

--- a/src/main/java/com/simisinc/platform/application/admin/ProcessAllowListCSVFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/ProcessAllowListCSVFileCommand.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.DeleteAllowedIPListCommand;
+import com.simisinc.platform.application.cms.SaveAllowedIPCommand;
+import com.simisinc.platform.application.cms.SaveFilePartCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.univocity.parsers.common.record.Record;
+import com.univocity.parsers.conversions.Conversions;
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Handles an uploaded allow-list CSV file
+ *
+ * @author elizabeth houser
+ */
+public class ProcessAllowListCSVFileCommand {
+
+  private static Log LOG = LogFactory.getLog(ProcessAllowListCSVFileCommand.class);
+
+  public static int processCSV(WidgetContext context) throws DataException {
+
+    int recordCount = 0;
+    int removeCount = 0;
+
+    FileItem fileItemBean = null;
+    try {
+      // Check for a file
+      fileItemBean = SaveFilePartCommand.saveFile(context);
+      if (fileItemBean == null) {
+        throw new DataException("Valid file not found");
+      }
+      String serverRootPath = FileSystemCommand.getFileServerRootPath();
+      File csvFile = FileSystemCommand.resolveWithinRoot(serverRootPath, fileItemBean.getFileServerPath());
+      if (csvFile == null || !csvFile.exists()) {
+        throw new DataException("Valid file not found");
+      }
+
+      // Determine the CSV configuration
+      CsvParserSettings parserSettings = new CsvParserSettings();
+      parserSettings.setLineSeparatorDetectionEnabled(true);
+      parserSettings.setHeaderExtractionEnabled(true);
+
+      // Parses all records in one go
+      CsvParser parser = new CsvParser(parserSettings);
+      List<Record> recordList = parser.parseAllRecords(csvFile);
+      parser.getRecordMetadata().convertFields(Conversions.toDate("yyyy-MM-dd hh:mm:ss")).set("Date");
+
+      // Validate the results
+      if (!parser.getRecordMetadata().containsColumn("IP Address")) {
+        throw new DataException("CSV requires: IP Address column; optionally Date, Reason, Remove");
+      }
+
+      // Process the records
+      for (Record record : recordList) {
+
+        // IP Address is required
+        String ipAddress = record.getString("IP Address");
+
+        String reason = null;
+        String remove = null;
+        if (parser.getRecordMetadata().containsColumn("Reason")) {
+          reason = record.getString("Reason");
+        }
+        if (parser.getRecordMetadata().containsColumn("Remove")) {
+          remove = record.getString("Remove");
+        }
+
+        // Handle deleted records
+        AllowedIP allowedIP = AllowedIPRepository.findByIpAddress(ipAddress);
+        if ("true".equalsIgnoreCase(remove)) {
+          if (allowedIP != null) {
+            if (DeleteAllowedIPListCommand.delete(allowedIP)) {
+              ++removeCount;
+            }
+          }
+          continue;
+        }
+
+        // Skip duplicates
+        if (allowedIP != null) {
+          if ((StringUtils.isBlank(allowedIP.getReason()) &&
+              StringUtils.isBlank(reason)) ||
+              (allowedIP.getReason() != null && reason != null &&
+                  allowedIP.getReason().equals(reason))) {
+            continue;
+          }
+        } else {
+          allowedIP = new AllowedIP();
+          allowedIP.setIpAddress(ipAddress);
+        }
+
+        // Optional fields
+        Date date = null;
+        if (parser.getRecordMetadata().containsColumn("Date")) {
+          date = record.getDate("Date");
+        }
+
+        // Prepare the new record
+        allowedIP.setReason(reason);
+        if (date != null) {
+          allowedIP.setCreated(new Timestamp(date.getTime()));
+        }
+        SaveAllowedIPCommand.save(allowedIP);
+        ++recordCount;
+      }
+
+    } catch (DataException data) {
+      LOG.debug("An exception occurred: " + data.getMessage());
+      // Let the user know
+      context.setErrorMessage(data.getMessage());
+      throw data;
+    } finally {
+      // Clean up the file if it exists
+      SaveFilePartCommand.cleanupFile(fileItemBean);
+    }
+    LOG.debug("Records removed: " + removeCount);
+    return recordCount;
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/cms/BlockedIPListCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/BlockedIPListCommand.java
@@ -74,9 +74,15 @@ public class BlockedIPListCommand {
 
     LOG.debug("Checking IP: " + ipAddress);
 
-    // If allowed, return quickly
+    // If allowed via the server-side file list, return quickly
     List<String> ipAllowList = listMap.get(IP_ALLOW_LIST);
     if (ipAllowList != null && ipAllowList.contains(ipAddress)) {
+      LOG.debug("Allowed IP: " + ipAddress);
+      return true;
+    }
+
+    // If allowed via the admin-managed, database-backed allow list, return quickly
+    if (LoadAllowedIPListCommand.retrieveCachedIpAddressList().contains(ipAddress)) {
       LOG.debug("Allowed IP: " + ipAddress);
       return true;
     }

--- a/src/main/java/com/simisinc/platform/application/cms/DeleteAllowedIPListCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/DeleteAllowedIPListCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Deletes allowed IP records
+ *
+ * @author elizabeth houser
+ */
+public class DeleteAllowedIPListCommand {
+
+  private static Log LOG = LogFactory.getLog(DeleteAllowedIPListCommand.class);
+
+  public static boolean delete(AllowedIP record) {
+    boolean removed = AllowedIPRepository.remove(record);
+    LoadAllowedIPListCommand.removeIpFromCache(record);
+    return removed;
+  }
+
+}

--- a/src/main/java/com/simisinc/platform/application/cms/LoadAllowedIPListCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/LoadAllowedIPListCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads allowed IP addresses list from cache or storage and handles updating the cache
+ *
+ * @author elizabeth houser
+ */
+public class LoadAllowedIPListCommand {
+
+  private static Log LOG = LogFactory.getLog(LoadAllowedIPListCommand.class);
+
+  private static List<String> ipAddressList = null;
+
+  public static List<String> retrieveCachedIpAddressList() {
+    if (ipAddressList == null) {
+      ipAddressList = loadIpAddressList();
+    }
+    return ipAddressList;
+  }
+
+  public static void refreshCachedIpAddressList() {
+    ipAddressList = loadIpAddressList();
+  }
+
+  public static void addIpToCache(AllowedIP allowedIP) {
+    if (!ipAddressList.contains(allowedIP.getIpAddress())) {
+      ipAddressList.add(allowedIP.getIpAddress());
+    }
+  }
+
+  public static void removeIpFromCache(AllowedIP allowedIP) {
+    while (ipAddressList.contains(allowedIP.getIpAddress())) {
+      ipAddressList.remove(allowedIP.getIpAddress());
+    }
+  }
+
+  public static List<String> loadIpAddressList() {
+    List<String> ipAddressList = new ArrayList<>();
+    List<AllowedIP> allowedIPList = AllowedIPRepository.findAll();
+    for (AllowedIP record : allowedIPList) {
+      ipAddressList.add(record.getIpAddress());
+    }
+    LOG.info("Allowed IPs found: " + ipAddressList.size());
+    return ipAddressList;
+  }
+
+}

--- a/src/main/java/com/simisinc/platform/application/cms/SaveAllowedIPCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveAllowedIPCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hc.core5.net.InetAddressUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+
+/**
+ * Validates and saves allowed IP objects
+ *
+ * @author elizabeth houser
+ */
+public class SaveAllowedIPCommand {
+
+  private static Log LOG = LogFactory.getLog(SaveAllowedIPCommand.class);
+
+  public static AllowedIP save(AllowedIP allowedIPBean) throws DataException {
+
+    // Validate the required fields
+    StringBuilder errorMessages = new StringBuilder();
+    if (StringUtils.isBlank(allowedIPBean.getIpAddress())) {
+      errorMessages.append("An IP address is required");
+    } else if (!InetAddressUtils.isIPv4(allowedIPBean.getIpAddress()) &&
+        !InetAddressUtils.isIPv6(allowedIPBean.getIpAddress())) {
+      errorMessages.append("A valid IPv4 or IPv6 address is required");
+    }
+    if (errorMessages.length() > 0) {
+      throw new DataException("Please check the form and try again:\n" + errorMessages.toString());
+    }
+
+    // Transform the fields and store...
+    AllowedIP allowedIP;
+    if (allowedIPBean.getId() > -1) {
+      LOG.debug("Saving an existing record... ");
+      allowedIP = AllowedIPRepository.findById(allowedIPBean.getId());
+      if (allowedIP == null) {
+        throw new DataException("The existing record could not be found");
+      }
+    } else {
+      LOG.debug("Saving a new record... ");
+      allowedIP = new AllowedIP();
+    }
+    allowedIP.setIpAddress(allowedIPBean.getIpAddress());
+    allowedIP.setReason(allowedIPBean.getReason());
+    if (allowedIPBean.getCreated() != null) {
+      allowedIP.setCreated(allowedIPBean.getCreated());
+    }
+    allowedIP = AllowedIPRepository.save(allowedIP);
+    if (allowedIP != null) {
+      LoadAllowedIPListCommand.addIpToCache(allowedIP);
+    }
+    return allowedIP;
+  }
+
+}

--- a/src/main/java/com/simisinc/platform/domain/model/AllowedIP.java
+++ b/src/main/java/com/simisinc/platform/domain/model/AllowedIP.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model;
+
+import java.sql.Timestamp;
+
+/**
+ * An allowed IP, exempt from the blocked-IP firewall checks
+ *
+ * @author elizabeth houser
+ */
+public class AllowedIP extends Entity {
+
+  private Long id = -1L;
+  private String ipAddress = null;
+  private String reason = null;
+  private Timestamp created = null;
+
+  public AllowedIP() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public void setIpAddress(String ipAddress) {
+    this.ipAddress = ipAddress;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/AllowedIPRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/AllowedIPRepository.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.database.*;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Persists and retrieves allowed IP objects
+ *
+ * @author elizabeth houser
+ */
+public class AllowedIPRepository {
+
+  private static Log LOG = LogFactory.getLog(AllowedIPRepository.class);
+
+  private static String TABLE_NAME = "allow_list";
+  private static String[] PRIMARY_KEY = new String[]{"allow_list_id"};
+
+  private static DataResult query(DataConstraints constraints) {
+    return DB.selectAllFrom(TABLE_NAME, null, constraints, AllowedIPRepository::buildRecord);
+  }
+
+  public static List<AllowedIP> findAll() {
+    return findAll(null);
+  }
+
+  public static List<AllowedIP> findAll(DataConstraints constraints) {
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("created DESC");
+    DataResult result = query(constraints);
+    return (List<AllowedIP>) result.getRecords();
+  }
+
+  public static AllowedIP findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (AllowedIP) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("allow_list_id = ?", id),
+        AllowedIPRepository::buildRecord);
+  }
+
+  public static AllowedIP findByIpAddress(String ipAddress) {
+    if (StringUtils.isBlank(ipAddress)) {
+      return null;
+    }
+    return (AllowedIP) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("ip_address = ?", ipAddress),
+        AllowedIPRepository::buildRecord);
+  }
+
+  public static AllowedIP save(AllowedIP record) {
+    if (record.getId() > -1) {
+      return update(record);
+    }
+    return add(record);
+  }
+
+  public static AllowedIP add(AllowedIP record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("ip_address", StringUtils.trimToNull(record.getIpAddress()))
+        .addIfExists("reason", StringUtils.trimToNull(record.getReason()))
+        .addIfExists("created", record.getCreated());
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static AllowedIP update(AllowedIP record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("ip_address", StringUtils.trimToNull(record.getIpAddress()))
+        .addIfExists("reason", StringUtils.trimToNull(record.getReason()));
+    SqlUtils where = new SqlUtils()
+        .add("allow_list_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      return record;
+    }
+    LOG.error("The update failed!");
+    return null;
+  }
+
+  public static boolean remove(AllowedIP record) {
+    try {
+      try (Connection connection = DB.getConnection();
+           AutoStartTransaction a = new AutoStartTransaction(connection);
+           AutoRollback transaction = new AutoRollback(connection)) {
+        DB.deleteFrom(connection, TABLE_NAME, new SqlUtils().add("allow_list_id = ?", record.getId()));
+        transaction.commit();
+        return true;
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return false;
+  }
+
+  private static AllowedIP buildRecord(ResultSet rs) {
+    try {
+      AllowedIP record = new AllowedIP();
+      record.setId(rs.getLong("allow_list_id"));
+      record.setIpAddress(rs.getString("ip_address"));
+      record.setCreated(rs.getTimestamp("created"));
+      record.setReason(rs.getString("reason"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+
+  public static void export(DataConstraints constraints, File file) {
+    SqlUtils selectFields = new SqlUtils()
+        .addNames(
+            "ip_address AS \"IP Address\"",
+            "created AS \"Date\"",
+            "reason AS \"Reason\""
+        );
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("allow_list_id");
+    DB.exportToCsvAllFrom(TABLE_NAME, selectFields, null, null, null, constraints, file);
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPFormWidget.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import com.simisinc.platform.application.AppException;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.SaveAllowedIPCommand;
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import org.apache.commons.beanutils.BeanUtils;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * The "Add to List" sidebar form for the IP allow list
+ *
+ * @author elizabeth houser
+ */
+public class AllowedIPFormWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/admin/allowed-ip-list-form.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Form bean
+    if (context.getRequestObject() != null) {
+      context.getRequest().setAttribute("allowedIPList", context.getRequestObject());
+    } else {
+      int allowedIPListId = context.getParameterAsInt("allowedIPListId");
+      AllowedIP allowedIP = AllowedIPRepository.findById(allowedIPListId);
+      context.getRequest().setAttribute("allowedIPList", allowedIP);
+    }
+
+    // Show the editor
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    // Populate the fields
+    AllowedIP allowedIPBean = new AllowedIP();
+    BeanUtils.populate(allowedIPBean, context.getParameterMap());
+
+    // Skip duplicates
+    if (AllowedIPRepository.findByIpAddress(allowedIPBean.getIpAddress()) != null) {
+      context.setWarningMessage("IP already exists");
+      return context;
+    }
+
+    // Save the record
+    AllowedIP allowedIP = null;
+    try {
+      allowedIP = SaveAllowedIPCommand.save(allowedIPBean);
+      if (allowedIP == null) {
+        throw new AppException("Your information could not be saved due to a system error. Please try again.");
+      }
+    } catch (DataException | AppException e) {
+      context.setErrorMessage(e.getMessage());
+      context.setRequestObject(allowedIPBean);
+      return context;
+    }
+
+    // Determine the page to return to
+    context.setSuccessMessage("Record was saved");
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidget.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import com.simisinc.platform.application.admin.ProcessAllowListCSVFileCommand;
+import com.simisinc.platform.application.cms.DeleteAllowedIPListCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import com.simisinc.platform.presentation.controller.MultipartFileSender;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Manages the admin-facing, database-backed IP allow list
+ *
+ * @author elizabeth houser
+ */
+public class AllowedIPListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/admin/allowed-ip-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "20"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    // Load the list
+    constraints.setColumnToSortBy("created", "desc");
+    List<AllowedIP> allowedIPList = AllowedIPRepository.findAll(constraints);
+    context.getRequest().setAttribute("allowedIPList", allowedIPList);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Show the editor
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext delete(WidgetContext context) {
+    // Determine what's being deleted
+    long recordId = context.getParameterAsLong("allowedIPListId");
+    if (recordId > -1) {
+      AllowedIP allowedIP = AllowedIPRepository.findById(recordId);
+      // Capture the address before removal
+      String targetLabel = allowedIP != null ? allowedIP.getIpAddress() : null;
+      try {
+        boolean removed = DeleteAllowedIPListCommand.delete(allowedIP);
+        AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "allowed_ip.remove",
+            removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+            "allowed_ip", String.valueOf(recordId), targetLabel, null);
+        context.setSuccessMessage("Record deleted");
+        return context;
+      } catch (Exception e) {
+        AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "allowed_ip.remove",
+            AuditEventCommand.FAILURE, "allowed_ip", String.valueOf(recordId), targetLabel, e.getMessage());
+        context.setErrorMessage("Error. Record could not be deleted.");
+        return context;
+      }
+    }
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+    // Permission is required
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+    // Determine the action
+    String command = context.getParameter("command");
+    if ("downloadCSVFile".equals(command)) {
+      return downloadCSVFile(context);
+    } else if ("uploadCSVFile".equals(command)) {
+      return uploadCSVFileAction(context);
+    }
+    // Default to nothing
+    return null;
+  }
+
+  private WidgetContext downloadCSVFile(WidgetContext context) {
+    // Prepare to save the temporary file
+    String extension = "csv";
+    String displayFilename = "allowed-ip-list-" + new SimpleDateFormat("yyyyMMdd-HHmm").format(new Date()) + "." + extension;
+    File tempFile = FileSystemCommand.generateTempFile("exports", context.getUserId(), extension);
+    try {
+      // Export the data to the file
+      AllowedIPRepository.export(null, tempFile);
+      // Send it
+      String mimeType = "text/csv";
+      MultipartFileSender.fromFile(tempFile)
+          .with(context.getRequest())
+          .with(context.getResponse())
+          .withMimeType(mimeType)
+          .withFilename(displayFilename)
+          .serveResource();
+      // Record the export of the security allow list
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.SUCCESS,
+          "allowed_ip_list", "all", displayFilename, "format=" + extension);
+    } catch (Exception e) {
+      LOG.error("Download CSV Error", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.export", AuditEventCommand.FAILURE,
+          "allowed_ip_list", "all", displayFilename, "format=" + extension);
+    } finally {
+      if (tempFile.exists()) {
+        LOG.warn("Deleting a temporary file: " + tempFile.getAbsolutePath());
+        tempFile.delete();
+      }
+    }
+    context.setHandledResponse(true);
+    return context;
+  }
+
+  private WidgetContext uploadCSVFileAction(WidgetContext context) {
+    LOG.info("User is uploading an allow-list CSV file...");
+    try {
+      int recordCount = ProcessAllowListCSVFileCommand.processCSV(context);
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "allowed_ip.import", AuditEventCommand.SUCCESS,
+          "allowed_ip", null, null, "records=" + recordCount);
+      context.setSuccessMessage(recordCount + " record" + (recordCount != 1 ? "s" : "") + " added");
+    } catch (Exception e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "allowed_ip.import", AuditEventCommand.FAILURE,
+          "allowed_ip", null, null, e.getMessage());
+      context.setErrorMessage(e.getMessage());
+    }
+    return context;
+  }
+}

--- a/src/main/resources/database/install/NEW_10120__new_allow_list.sql
+++ b/src/main/resources/database/install/NEW_10120__new_allow_list.sql
@@ -1,0 +1,10 @@
+-- Issue #641: admin-manageable, database-backed IP allow list (previously the allow list
+-- was a server-side file only, config/cms/ip-allow-list.csv, with no admin UI). Mirrors the
+-- existing block_list table so the allow list gets the same CRUD/CSV/paging admin UI.
+
+CREATE TABLE allow_list (
+  allow_list_id BIGSERIAL PRIMARY KEY,
+  ip_address VARCHAR(200) UNIQUE NOT NULL,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  reason VARCHAR(255)
+);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260729.1003__create_allow_list_table.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260729.1003__create_allow_list_table.sql
@@ -1,0 +1,10 @@
+-- Issue #641: admin-manageable, database-backed IP allow list (previously the allow list
+-- was a server-side file only, config/cms/ip-allow-list.csv, with no admin UI). Mirrors the
+-- existing block_list table so the allow list gets the same CRUD/CSV/paging admin UI.
+
+CREATE TABLE IF NOT EXISTS allow_list (
+  allow_list_id BIGSERIAL PRIMARY KEY,
+  ip_address VARCHAR(200) UNIQUE NOT NULL,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  reason VARCHAR(255)
+);

--- a/src/main/webapp/WEB-INF/jsp/admin/allowed-ip-list-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/allowed-ip-list-form.jsp
@@ -1,0 +1,42 @@
+<%--
+  ~ Copyright 2022 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="allowedIPList" class="com.simisinc.platform.domain.model.AllowedIP" scope="request"/>
+<form method="post">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Form values --%>
+  <input type="hidden" name="id" value="${allowedIPList.id}"/>
+  <%-- Title and Message block --%>
+  <c:if test="${!empty title}">
+    <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+  </c:if>
+  <%@include file="../page_messages.jspf" %>
+  <%-- Form Content --%>
+  <label>IP Address to Allow <span class="required">*</span>
+    <input type="text" placeholder="ip address" name="ipAddress" value="<c:out value="${allowedIPList.ipAddress}"/>" required>
+  </label>
+  <label>Reason
+    <input type="text" placeholder="" name="reason" value="<c:out value="${allowedIPList.reason}"/>">
+  </label>
+  <div class="button-container">
+    <input type="submit" class="button radius success expanded" value="Save"/>
+  </div>
+</form>

--- a/src/main/webapp/WEB-INF/jsp/admin/allowed-ip-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/allowed-ip-list.jsp
@@ -22,12 +22,12 @@
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
-<jsp:useBean id="blockedIPList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="allowedIPList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
-<p class="help-text">A blocked IP is checked on every request, before the page loads; a match returns a 404 (not found) response rather than the actual page. IPs land on this list three ways: added manually below, uploaded via CSV, or automatically when a request path matches a known attack-probe pattern (see the server's <code>config/cms/url-block-list.csv</code>). Matching is an exact address match only - IPv4 or IPv6, no CIDR/subnet ranges. Two other lists also apply on every request: the <a href="${ctx}/admin/allowed-ip-list">Allowed IP list</a>, checked before this one, and a server-side deny list checked after it (<code>config/cms/ip-deny-list.csv</code>, not editable here). A separate, server-file-based allow list (<code>config/cms/ip-allow-list.csv</code>) is also still checked, ahead of the admin-managed one. You can't block your own current IP, manually or via CSV - the save is rejected instead. Deleting a row below unblocks that IP immediately, and every add, delete, import, and export here is recorded in the platform's audit log. See <code>docs/ip-blocking.md</code> in the repository for the fuller strategy write-up.</p>
+<p class="help-text">IPs on this list bypass every other check in <code>WebRequestFilter</code> - the deny list, the <a href="${ctx}/admin/blocked-ip-list">Blocked IP list</a>, and the URL-probe auto-block - so a match here always lets the request through. Matching is exact - IPv4 or IPv6, no CIDR/subnet ranges. A separate, server-file-based allow list (<code>config/cms/ip-allow-list.csv</code>) is also still checked and isn't managed here; see <code>docs/ip-blocking.md</code>.</p>
 <%@include file="../page_messages.jspf" %>
 <form id="fileForm" method="post" enctype="multipart/form-data">
   <%-- Required by controller --%>
@@ -43,7 +43,7 @@
     document.getElementById("fileForm").submit();
   }
 </script>
-<form method="post" action="${ctx}/admin/blockedIP">
+<form method="post" action="${ctx}/admin/allowedIP">
   <%-- Required by controller --%>
   <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
   <input type="hidden" name="token" value="${userSession.formToken}"/>
@@ -51,7 +51,7 @@
   <input type="hidden" name="command" value="downloadCSVFile" />
   <button class="button small secondary radius float-left margin-left-10"><i class="fa fa-download"></i> Download CSV File</button>
 </form>
-<p class="help-text">Upload requires an "IP Address" column, plus optional "Reason", "Date", and "Remove" columns; set Remove to "true" on a row to unblock that IP instead of adding it. Matching existing IPs with the same reason are skipped. Download includes IP Address, Date, and Reason.</p>
+<p class="help-text">Upload requires an "IP Address" column, plus optional "Reason", "Date", and "Remove" columns; set Remove to "true" on a row to remove that IP from the allow list instead of adding it. Download includes IP Address, Date, and Reason.</p>
 <table class="unstriped stack">
   <thead>
     <tr>
@@ -62,18 +62,18 @@
     </tr>
   </thead>
   <tbody>
-    <c:forEach items="${blockedIPList}" var="record">
+    <c:forEach items="${allowedIPList}" var="record">
     <tr>
       <td nowrap="true">
         <c:out value="${text:trim(record.ipAddress, 24, true)}" />
-        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(record.ipAddress)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&blockedIPListId=${record.id}');"><i class="fa fa-remove"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to remove <c:out value="${js:escape(record.ipAddress)}" /> from the allow list?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&allowedIPListId=${record.id}');"><i class="fa fa-remove"></i></a>
       </td>
       <td><c:out value='${geoip:location(record.ipAddress, " ")}'/></td>
       <td nowrap="true"><small<c:if test="${fn:length(record.reason) > 40}"> title="<c:out value="${record.reason}" />"</c:if>><c:out value="${text:trim(record.reason, 40, true)}" /></small></td>
       <td nowrap="true"><fmt:formatDate pattern="yyyy-MM-dd" value="${record.created}" /></td>
     </tr>
     </c:forEach>
-    <c:if test="${empty blockedIPList}">
+    <c:if test="${empty allowedIPList}">
       <tr>
         <td colspan="4">No records were found</td>
       </tr>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -490,6 +490,7 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/api')}"> class="is-active"</c:if>><a href="${ctx}/admin/apis"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>APIs</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/app')}"> class="is-active"</c:if>><a href="${ctx}/admin/apps"><i class="${font:far()} fa-mobile fa-fw"></i> <span>Apps</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/blocked-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/blocked-ip-list"><i class="${font:far()} fa-shield-halved fa-fw"></i> <span>Blocked IPs</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/allowed-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/allowed-ip-list"><i class="${font:far()} fa-shield fa-fw"></i> <span>Allowed IPs</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/audit-log')}"> class="is-active"</c:if>><a href="${ctx}/admin/audit-log"><i class="${font:far()} fa-clipboard-list fa-fw"></i> <span>Audit Log</span></a></li>
             </ul>
           </c:if>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1482,6 +1482,21 @@
     </section>
   </page>
 
+  <page name="/admin/allowed-ip-list" role="admin" title="Allowed IP list">
+    <section>
+      <column class="small-12 medium-9 large-8 small-order-2 medium-order-1 small-margin-top-10 cell">
+        <widget name="allowedIP">
+          <title>Allowed IP List</title>
+        </widget>
+      </column>
+      <column class="small-12 medium-3 large-4 small-order-1 medium-order-2 cell">
+        <widget name="allowedIPListForm" class="callout radius primary" sticky="true">
+          <title>Add to List</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/activity" role="admin,content-manager,community-manager,ecommerce-manager" title="Activity">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -214,6 +214,8 @@
   <widget name="appForm" class="com.simisinc.platform.presentation.widgets.admin.AppFormWidget" />
   <widget name="blockedIP" class="com.simisinc.platform.presentation.widgets.admin.BlockedIPListWidget" />
   <widget name="blockedIPListForm" class="com.simisinc.platform.presentation.widgets.admin.BlockedIPFormWidget" />
+  <widget name="allowedIP" class="com.simisinc.platform.presentation.widgets.admin.AllowedIPListWidget" />
+  <widget name="allowedIPListForm" class="com.simisinc.platform.presentation.widgets.admin.AllowedIPFormWidget" />
   <widget name="socialMediaLinkList" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkListWidget" />
   <widget name="socialMediaLinkForm" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkFormWidget" />
   <widget name="formDataList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormDataListWidget" />

--- a/src/test/java/com/simisinc/platform/application/cms/BlockedIPListCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/BlockedIPListCommandTest.java
@@ -46,10 +46,12 @@ class BlockedIPListCommandTest {
       try (MockedStatic<FileSystemCommand> staticFileSystemCommand = mockStatic(FileSystemCommand.class)) {
         staticFileSystemCommand.when(FileSystemCommand::getFileServerConfigPath).thenReturn(".");
 
-        // Mock cached list
+        // Mock cached lists
         List<String> emptyList = new ArrayList<>();
-        try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class)) {
+        try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class);
+            MockedStatic<LoadAllowedIPListCommand> staticLoadAllowedIpListCommand = mockStatic(LoadAllowedIPListCommand.class)) {
           staticLoadBlockedIpListCommand.when(LoadBlockedIPListCommand::retrieveCachedIpAddressList).thenReturn(emptyList);
+          staticLoadAllowedIpListCommand.when(LoadAllowedIPListCommand::retrieveCachedIpAddressList).thenReturn(emptyList);
           BlockedIPListCommand.load();
 
           String resource = "/resource";
@@ -66,10 +68,12 @@ class BlockedIPListCommandTest {
     try (MockedStatic<FileSystemCommand> staticFileSystemCommand = mockStatic(FileSystemCommand.class)) {
       staticFileSystemCommand.when(FileSystemCommand::getFileServerConfigPath).thenReturn(".");
 
-      try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class)) {
+      try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class);
+          MockedStatic<LoadAllowedIPListCommand> staticLoadAllowedIpListCommand = mockStatic(LoadAllowedIPListCommand.class)) {
         List<String> blockedIpList = new ArrayList<>();
         blockedIpList.add("1.2.3.4");
         staticLoadBlockedIpListCommand.when(LoadBlockedIPListCommand::retrieveCachedIpAddressList).thenReturn(blockedIpList);
+        staticLoadAllowedIpListCommand.when(LoadAllowedIPListCommand::retrieveCachedIpAddressList).thenReturn(new ArrayList<>());
 
         BlockedIPListCommand.load();
 
@@ -92,10 +96,12 @@ class BlockedIPListCommandTest {
       try (MockedStatic<FileSystemCommand> staticFileSystemCommand = mockStatic(FileSystemCommand.class)) {
         staticFileSystemCommand.when(FileSystemCommand::getFileServerConfigPath).thenReturn(".");
 
-        // Mock cached list
+        // Mock cached lists
         List<String> emptyList = new ArrayList<>();
-        try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class)) {
+        try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class);
+            MockedStatic<LoadAllowedIPListCommand> staticLoadAllowedIpListCommand = mockStatic(LoadAllowedIPListCommand.class)) {
           staticLoadBlockedIpListCommand.when(LoadBlockedIPListCommand::retrieveCachedIpAddressList).thenReturn(emptyList);
+          staticLoadAllowedIpListCommand.when(LoadAllowedIPListCommand::retrieveCachedIpAddressList).thenReturn(emptyList);
           BlockedIPListCommand.load();
 
           String invalidResource = "/resource";
@@ -107,6 +113,33 @@ class BlockedIPListCommandTest {
           boolean passesCheck = BlockedIPListCommand.passesCheck(invalidResource, ipAddress);
           Assertions.assertFalse(passesCheck);
         }
+      }
+    }
+  }
+
+  @Test
+  void allowedViaDatabaseListBypassesEverythingElse() {
+    // Mock directory path
+    try (MockedStatic<FileSystemCommand> staticFileSystemCommand = mockStatic(FileSystemCommand.class)) {
+      staticFileSystemCommand.when(FileSystemCommand::getFileServerConfigPath).thenReturn(".");
+
+      try (MockedStatic<LoadBlockedIPListCommand> staticLoadBlockedIpListCommand = mockStatic(LoadBlockedIPListCommand.class);
+          MockedStatic<LoadAllowedIPListCommand> staticLoadAllowedIpListCommand = mockStatic(LoadAllowedIPListCommand.class)) {
+        // The IP is on BOTH the blocked list and the allowed list -- allow must win, since the
+        // allow checks run first and short-circuit (see BlockedIPListCommand.passesCheck).
+        List<String> blockedIpList = new ArrayList<>();
+        blockedIpList.add("1.2.3.4");
+        staticLoadBlockedIpListCommand.when(LoadBlockedIPListCommand::retrieveCachedIpAddressList).thenReturn(blockedIpList);
+
+        List<String> allowedIpList = new ArrayList<>();
+        allowedIpList.add("1.2.3.4");
+        staticLoadAllowedIpListCommand.when(LoadAllowedIPListCommand::retrieveCachedIpAddressList).thenReturn(allowedIpList);
+
+        BlockedIPListCommand.load();
+
+        String resource = "/resource";
+        String ipAddress = "1.2.3.4";
+        Assertions.assertTrue(BlockedIPListCommand.passesCheck(resource, ipAddress));
       }
     }
   }


### PR DESCRIPTION
## Problem

The IP allow list was server-file-only (`config/cms/ip-allow-list.csv`), checked first in `BlockedIPListCommand.passesCheck()` but with no admin UI - exempting an IP (e.g. an office network) required file access to the deployment, not just admin-panel access.

## Design decision

Went with the DB-backed table option discussed on #641, mirroring `block_list`/`/admin/blocked-ip-list` rather than building a UI over the CSV file - more consistent with every other admin list in this codebase, drops the 5-minute file-poll lag for entries added here, and gets CSV import/export for free by copying the established pattern.

The file-based allow list keeps working exactly as before - this adds a second, admin-manageable path alongside it (checked right after the file list, before the deny list and block list) rather than replacing it. Ops workflows that already edit the CSV directly aren't affected.

## What's new

- `allow_list` table (mirrors `block_list`'s shape exactly) - `NEW_10120` (install) + `UPGRADE_20260729.1003` (upgrade)
- `AllowedIP` domain model, `AllowedIPRepository`, `Save`/`Delete`/`LoadAllowedIPListCommand`
- CSV import/export (`ProcessAllowListCSVFileCommand`) - same `IP Address`/`Reason`/`Date`/`Remove` columns as the block list
- `AllowedIPListWidget` + `AllowedIPFormWidget` ("Add to List" sidebar), new page `/admin/allowed-ip-list`, nav link next to Blocked IPs
- `BlockedIPListCommand.passesCheck()` now also checks the new DB-backed list

One intentional difference from the block list: no self-add guard. Blocking your own current IP is a lockout risk (guarded against); allowing it isn't, so it's not restricted here.

`docs/ip-blocking.md` and the blocked-ip-list help text are updated for the new check order (5 lists now, not 4) and where the allow list is manageable.

## Testing

- `ant -lib lib/war clean compile` - clean
- `ant -lib lib/war compile-jsp` - all 311 JSPs translate/compile, including the 2 new ones
- `ant -lib lib/tests ci-test` - full suite green, including a real Postgres run via Testcontainers that applied the new install migration cleanly ("Migrating schema to version 10120 - new allow list")
- Extended `BlockedIPListCommandTest` with a case proving an IP on both the allow and block lists is allowed (the allow checks short-circuit first)

Fixes #641