### PR TITLE
Add search to /admin/blocked-ip-list

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/BlockedIPRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/BlockedIPRepository.java
@@ -58,6 +58,25 @@ public class BlockedIPRepository {
     return (List<BlockedIP>) result.getRecords();
   }
 
+  private static SqlUtils createWhereStatement(BlockedIPSpecification specification) {
+    SqlUtils where = new SqlUtils();
+    if (specification != null && StringUtils.isNotBlank(specification.getQuery())) {
+      String likeValue = "%" + specification.getQuery().toLowerCase() + "%";
+      where.add("(LOWER(ip_address) LIKE ? OR LOWER(reason) LIKE ?)", new String[]{likeValue, likeValue});
+    }
+    return where;
+  }
+
+  public static List<BlockedIP> findAll(BlockedIPSpecification specification, DataConstraints constraints) {
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("created DESC");
+    SqlUtils where = createWhereStatement(specification);
+    DataResult result = DB.selectAllFrom(TABLE_NAME, where, constraints, BlockedIPRepository::buildRecord);
+    return (List<BlockedIP>) result.getRecords();
+  }
+
   public static BlockedIP findById(long id) {
     if (id == -1) {
       return null;

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/BlockedIPSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/BlockedIPSpecification.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+/**
+ * Properties for querying blocked IP records - an unset field (null) does not constrain the query.
+ *
+ * @author elizabeth houser
+ */
+public class BlockedIPSpecification {
+
+  // Matched case-insensitively, as a substring, against ip_address OR reason
+  private String query = null;
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
@@ -22,14 +22,18 @@ import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.BlockedIP;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
+import com.simisinc.platform.infrastructure.persistence.BlockedIPSpecification;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -55,10 +59,26 @@ public class BlockedIPListWidget extends GenericWidget {
     DataConstraints constraints = new DataConstraints(page, itemsPerPage);
     context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
 
+    // Determine the search
+    String query = context.getParameter("query");
+    context.getRequest().setAttribute("query", query);
+
+    // Determine criteria
+    BlockedIPSpecification specification = new BlockedIPSpecification();
+    if (StringUtils.isNotBlank(query)) {
+      specification.setQuery(query);
+    }
+
     // Load the list
     constraints.setColumnToSortBy("created", "desc");
-    List<BlockedIP> blockedIPList = BlockedIPRepository.findAll(constraints);
+    List<BlockedIP> blockedIPList = BlockedIPRepository.findAll(specification, constraints);
     context.getRequest().setAttribute("blockedIPList", blockedIPList);
+
+    // Carry the search through pagination (paging_control.jspf appends this to each page link).
+    // URL-encoded so a free-text query cannot break the query string or the href.
+    StringBuilder pagingParams = new StringBuilder();
+    appendParam(pagingParams, "query", query);
+    context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
 
     // Standard request items
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
@@ -67,6 +87,16 @@ public class BlockedIPListWidget extends GenericWidget {
     // Show the editor
     context.setJsp(JSP);
     return context;
+  }
+
+  private void appendParam(StringBuilder sb, String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if (sb.length() > 0) {
+      sb.append("&");
+    }
+    sb.append(name).append("=").append(URLEncoder.encode(value, StandardCharsets.UTF_8));
   }
 
   public WidgetContext delete(WidgetContext context) {

--- a/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blocked-ip-list.jsp
@@ -24,6 +24,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="blockedIPList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<jsp:useBean id="query" class="java.lang.String" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
@@ -52,6 +53,16 @@
   <button class="button small secondary radius float-left margin-left-10"><i class="fa fa-download"></i> Download CSV File</button>
 </form>
 <p class="help-text">Upload requires an "IP Address" column, plus optional "Reason", "Date", and "Remove" columns; set Remove to "true" on a row to unblock that IP instead of adding it. Matching existing IPs with the same reason are skipped. Download includes IP Address, Date, and Reason.</p>
+<%-- Search (GET so the query lives in the URL and paging preserves it) --%>
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <div class="input-group">
+    <label for="blockedIpQuery" class="show-for-sr">Search by IP address or reason</label>
+    <input id="blockedIpQuery" class="input-group-field" type="search" name="query" placeholder="Search by IP address or reason..."<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if>>
+    <div class="input-group-button">
+      <button type="submit" class="button">Search</button>
+    </div>
+  </div>
+</form>
 <table class="unstriped stack">
   <thead>
     <tr>
@@ -75,7 +86,7 @@
     </c:forEach>
     <c:if test="${empty blockedIPList}">
       <tr>
-        <td colspan="4">No records were found</td>
+        <td colspan="4"><c:choose><c:when test="${!empty query}">No records matched your search</c:when><c:otherwise>No records were found</c:otherwise></c:choose></td>
       </tr>
     </c:if>
   </tbody>


### PR DESCRIPTION
## Problem

The blocked IP list is paginated but had no search or filter - with a large list (this one had ~773 pages of real data before #640's fix), finding a specific IP or reason meant paging through one screen at a time.

## What's new

- A search box, case-insensitive substring match against `ip_address` OR `reason`
- `BlockedIPSpecification` + a `BlockedIPRepository.findAll(specification, constraints)` overload
- `BlockedIPListWidget` echoes the query back and builds `recordPagingParams` server-side via an `appendParam()` helper (mirrors `AuditLogListWidget` exactly) so the search survives clicking to another page

## Why `AuditLogListWidget`'s pattern and not `UsersListWidget`'s

Both were named as precedent in #642. Looking closer, `UsersListWidget` builds `recordPagingParams` in the JSP via `<c:set>` and only includes `statusFilter` - its own search `query` param is silently dropped once you click to page 2 (a pre-existing, separate bug, not touched here). `AuditLogListWidget` builds the full params string in Java and includes every active filter, which is what actually satisfies "survives pagination." Followed that one.

## Testing

- `ant -lib lib/war clean compile-jsp` - clean
- `ant -lib lib/tests ci-test` - full suite green
- Live-verified in a docker-compose rehearsal against a real Postgres backend: added two IPs with different reasons, confirmed reason-substring search, IP-substring search, the "No records matched your search" message for a non-matching query, and clearing the search back to the full list - all behaved correctly through the real UI, not just the build gates.

## Scope

This is for `/admin/blocked-ip-list` per the issue title. The now-parallel `/admin/allowed-ip-list` (added in #647) doesn't have search either - happy to add it as a fast follow if wanted, not bundled in here.

Fixes #642