### PR TITLE
Fix delete silently no-op'ing on blocked/allowed IP lists

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidget.java
@@ -103,6 +103,11 @@ public class AllowedIPListWidget extends GenericWidget {
       return downloadCSVFile(context);
     } else if ("uploadCSVFile".equals(command)) {
       return uploadCSVFileAction(context);
+    } else if ("delete".equals(command)) {
+      // The row's delete link submits via confirmPostAction(), a real POST -- WebContainerCommand
+      // checks isPost() before isDelete(), so this always reaches post(), never delete() directly.
+      // Forward to it explicitly (same fix shape as PR #577's UserDetailsWidget dispatch gap).
+      return delete(context);
     }
     // Default to nothing
     return null;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidget.java
@@ -134,6 +134,11 @@ public class BlockedIPListWidget extends GenericWidget {
       return downloadCSVFile(context);
     } else if ("uploadCSVFile".equals(command)) {
       return uploadCSVFileAction(context);
+    } else if ("delete".equals(command)) {
+      // The row's delete link submits via confirmPostAction(), a real POST -- WebContainerCommand
+      // checks isPost() before isDelete(), so this always reaches post(), never delete() directly.
+      // Forward to it explicitly (same fix shape as PR #577's UserDetailsWidget dispatch gap).
+      return delete(context);
     }
     // Default to nothing
     return null;

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/AllowedIPListWidgetTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.DeleteAllowedIPListCommand;
+import com.simisinc.platform.domain.model.AllowedIP;
+import com.simisinc.platform.infrastructure.persistence.AllowedIPRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Same dispatch gap as BlockedIPListWidgetTest, on the allow-list side - this widget's delete link
+ * copied the same confirmPostAction()-submits-a-real-POST pattern when it was written, and post() had
+ * the same missing "delete" branch. These tests call post(), not delete() directly, for the same reason.
+ *
+ * @author elizabeth houser
+ */
+class AllowedIPListWidgetTest extends WidgetBase {
+
+  private static AllowedIP allowedIp() {
+    AllowedIP record = new AllowedIP();
+    record.setId(9L);
+    record.setIpAddress("203.0.113.9");
+    return record;
+  }
+
+  @Test
+  void deleteCommandViaPostActuallyDeletesTheRecord() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "allowedIPListId", "9");
+
+    AllowedIP target = allowedIp();
+
+    try (MockedStatic<AllowedIPRepository> repository = mockStatic(AllowedIPRepository.class);
+        MockedStatic<DeleteAllowedIPListCommand> deleteCommand = mockStatic(DeleteAllowedIPListCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      repository.when(() -> AllowedIPRepository.findById(9L)).thenReturn(target);
+      deleteCommand.when(() -> DeleteAllowedIPListCommand.delete(target)).thenReturn(true);
+
+      WidgetContext result = new AllowedIPListWidget().post(widgetContext);
+
+      deleteCommand.verify(() -> DeleteAllowedIPListCommand.delete(target));
+      audit.verify(() -> AuditEventCommand.record(any(), any(), org.mockito.ArgumentMatchers.eq("allowed_ip.remove"),
+          any(), any(), any(), any(), any()));
+      assertEquals("Record deleted", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void deleteCommandIsRefusedWithoutAdminRole() throws Exception {
+    setRoles(widgetContext); // logged in, but no admin role
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "allowedIPListId", "9");
+
+    try (MockedStatic<DeleteAllowedIPListCommand> deleteCommand = mockStatic(DeleteAllowedIPListCommand.class)) {
+      WidgetContext result = new AllowedIPListWidget().post(widgetContext);
+
+      deleteCommand.verify(() -> DeleteAllowedIPListCommand.delete(any()), never());
+      assertNull(result.getSuccessMessage());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/BlockedIPListWidgetTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.DeleteBlockedIPListCommand;
+import com.simisinc.platform.domain.model.BlockedIP;
+import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * The row delete link on /admin/blocked-ip-list submits via confirmPostAction() - a real HTTP POST -
+ * so WebContainerCommand's dispatch (isPost() checked before isDelete()) always routes it to post(),
+ * never to delete() directly. post() previously had no "delete" command branch at all, so every click
+ * silently no-opped: a 302 redirect back to the same page, no error, no repository call, the row still
+ * there on reload (confirmed live via a docker rehearsal + direct curl repro before this fix). These
+ * tests call post(), the method a real request actually reaches, so they fail if that gap reopens - a
+ * test calling delete() directly would pass either way and prove nothing about the real path.
+ *
+ * @author elizabeth houser
+ */
+class BlockedIPListWidgetTest extends WidgetBase {
+
+  private static BlockedIP blockedIp() {
+    BlockedIP record = new BlockedIP();
+    record.setId(5L);
+    record.setIpAddress("203.0.113.5");
+    return record;
+  }
+
+  @Test
+  void deleteCommandViaPostActuallyDeletesTheRecord() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "blockedIPListId", "5");
+
+    BlockedIP target = blockedIp();
+
+    try (MockedStatic<BlockedIPRepository> repository = mockStatic(BlockedIPRepository.class);
+        MockedStatic<DeleteBlockedIPListCommand> deleteCommand = mockStatic(DeleteBlockedIPListCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      repository.when(() -> BlockedIPRepository.findById(5L)).thenReturn(target);
+      deleteCommand.when(() -> DeleteBlockedIPListCommand.delete(target)).thenReturn(true);
+
+      WidgetContext result = new BlockedIPListWidget().post(widgetContext);
+
+      deleteCommand.verify(() -> DeleteBlockedIPListCommand.delete(target));
+      audit.verify(() -> AuditEventCommand.record(any(), any(), org.mockito.ArgumentMatchers.eq("blocked_ip.remove"),
+          any(), any(), any(), any(), any()));
+      assertEquals("Record deleted", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void deleteCommandIsRefusedWithoutAdminRole() throws Exception {
+    setRoles(widgetContext); // logged in, but no admin role
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "blockedIPListId", "5");
+
+    try (MockedStatic<DeleteBlockedIPListCommand> deleteCommand = mockStatic(DeleteBlockedIPListCommand.class)) {
+      WidgetContext result = new BlockedIPListWidget().post(widgetContext);
+
+      deleteCommand.verify(() -> DeleteBlockedIPListCommand.delete(any()), never());
+      assertNull(result.getSuccessMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The per-row delete (unblock) link on both `/admin/blocked-ip-list` and `/admin/allowed-ip-list` submits via `confirmPostAction()` - a real HTTP POST, deliberately, to keep CSRF tokens out of the URL/referrer/access logs (#358/PR #377). `WebContainerCommand`'s method dispatch checks `isPost()` before `isDelete()` (the `command=delete` parameter check), so a real POST always routes to the widget's `post()` method, never `delete()` - and neither `BlockedIPListWidget.post()` nor `AllowedIPListWidget.post()` had a `command=delete` branch. Every delete click silently no-opped: a 302 back to the same page, no error, no repository call, the record still there on reload.

Same bug class as the `UserDetailsWidget` dispatch gap fixed in PR #577. This instance predates my involvement - `BlockedIPListWidget`'s rows were invisible until #640 fixed the unrelated bean-name rendering bug, so the dead delete link was never exercised or noticed; `AllowedIPListWidget` inherited the same broken pattern when written from scratch for #647, copying the working-looking-but-actually-dead JSP pattern verbatim.

## Fix

Forward `command=delete` from `post()` to the existing `delete()` method, mirroring PR #577's fix shape exactly.

## Testing

- `ant -lib lib/war clean compile-jsp` - clean
- `ant -lib lib/tests ci-test` - full suite green, including new `BlockedIPListWidgetTest`/`AllowedIPListWidgetTest` that call `.post()` directly (not `.delete()`) - the method a real request actually reaches, so they fail if this dispatch gap reopens
- Live-verified with a direct repro against a docker-compose rehearsal: added a test IP, POSTed the exact request `confirmPostAction()` sends, confirmed the record was **not** removed on `main` (pre-fix); rebuilt with the fix and confirmed the identical request now correctly deletes the record, on both list pages

Fixes #658