### PR TITLE
Build the actual newsletter send mechanism (#600)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/mailinglists/NewsletterEmailCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/NewsletterEmailCommand.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.HtmlCommand;
+import com.simisinc.platform.application.email.EmailCommand;
+import com.simisinc.platform.application.email.EmailTemplateCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.ImageHtmlEmail;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
+
+import jakarta.servlet.ServletContext;
+
+/**
+ * Sends a single newsletter email to a single recipient. Every call prepares its own, independent
+ * ImageHtmlEmail with exactly one addTo -- unlike SendAdminEmailCommand/SendCommunityManagerEmailCommand
+ * /SendEcommerceManagerEmailCommand, which all add every intended recipient to the SAME email's To:
+ * field before a single send(). That shared-object pattern is fine for a small trusted internal
+ * role-based list, but would leak every subscriber's address to every other subscriber if reused
+ * here for a public newsletter -- so this intentionally does not follow it.
+ *
+ * @author SimIS Inc.
+ */
+public class NewsletterEmailCommand {
+
+  private static final String BLOG_POST_TEMPLATE = "mailinglists/newsletter-blog-post";
+
+  public static void sendBlogPostNotification(String toEmail, BlogPost blogPost, String unsubscribeUrl)
+      throws EmailException, DataException {
+
+    ServletContext servletContext = SchedulerManager.getServletContext();
+    if (servletContext == null) {
+      throw new DataException("Servlet context is not available");
+    }
+
+    JakartaServletWebApplication application = JakartaServletWebApplication.buildApplication(servletContext);
+    WebApplicationTemplateResolver templateResolver = new WebApplicationTemplateResolver(application);
+    templateResolver.setTemplateMode(TemplateMode.HTML);
+    templateResolver.setPrefix("/WEB-INF/email-templates/");
+    templateResolver.setSuffix(".html");
+    templateResolver.setCacheable(true);
+    templateResolver.setCacheTTLMs(3600000L);
+
+    TemplateEngine templateEngine = new TemplateEngine();
+    templateEngine.setTemplateResolver(templateResolver);
+
+    String siteUrl = LoadSitePropertyCommand.loadByName("site.url");
+
+    Context ctx = EmailTemplateCommand.createSiteContext();
+    ctx.setVariable("blogPost", blogPost);
+    ctx.setVariable("blogPostUrl", siteUrl + blogPost.getLink());
+    ctx.setVariable("unsubscribeUrl", unsubscribeUrl);
+
+    String html = templateEngine.process(BLOG_POST_TEMPLATE, ctx);
+    if (StringUtils.isBlank(html)) {
+      throw new DataException("Newsletter email template did not render: " + BLOG_POST_TEMPLATE);
+    }
+
+    ImageHtmlEmail email = EmailCommand.prepareNewEmail(siteUrl);
+    email.addTo(toEmail);
+    email.setSubject(blogPost.getTitle());
+    email.setHtmlMsg(html);
+    email.setTextMsg(HtmlCommand.text(html));
+    email.send();
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/mailinglists/NewsletterSendCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/NewsletterSendCommand.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListHistory;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.database.AutoRollback;
+import com.simisinc.platform.infrastructure.database.AutoStartTransaction;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListHistoryRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListSentRepository;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Queues a newsletter send: one batch header (mailing_list_history) plus one queued row
+ * (mailing_list_sent) per currently-subscribed member of the list. The actual sending happens
+ * later, asynchronously, via NewsletterQueueJob -- this only enqueues.
+ *
+ * <p>
+ * Shared by both the manual admin page (issue #600) and the blog editor's "Notify subscribers"
+ * checkbox (issue #500), so both paths enqueue identically.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class NewsletterSendCommand {
+
+  public static int enqueueBlogPostNotification(MailingList mailingList, BlogPost blogPost, long actorUserId)
+      throws DataException {
+    if (mailingList == null) {
+      throw new DataException("Mailing list was not found");
+    }
+    if (blogPost == null) {
+      throw new DataException("Blog post was not found");
+    }
+
+    List<MailingListMember> members = MailingListMemberRepository.findActiveMembersForList(mailingList.getId());
+    if (members.isEmpty()) {
+      return 0;
+    }
+
+    try (Connection connection = DB.getConnection();
+        AutoStartTransaction a = new AutoStartTransaction(connection);
+        AutoRollback transaction = new AutoRollback(connection)) {
+
+      MailingListHistory history = new MailingListHistory();
+      history.setListId(mailingList.getId());
+      history.setCreatedBy(actorUserId);
+      history.setService("smtp");
+      history.setEmailCount(members.size());
+      history.setSubject(blogPost.getTitle());
+      history.setBlogPostId(blogPost.getId());
+      history = MailingListHistoryRepository.add(connection, history);
+      if (history == null) {
+        throw new DataException("Could not create the send batch record");
+      }
+
+      List<Long> emailIds = members.stream()
+          .map(MailingListMember::getEmailId)
+          .collect(Collectors.toList());
+      MailingListSentRepository.enqueue(connection, history.getId(), mailingList.getId(), emailIds);
+
+      transaction.commit();
+      return members.size();
+    } catch (SQLException se) {
+      throw new DataException("Could not enqueue the newsletter send: " + se.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListHistory.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListHistory.java
@@ -35,6 +35,8 @@ public class MailingListHistory extends Entity {
   private Timestamp created = null;
   private String service = null;
   private int emailCount = 0;
+  private String subject = null;
+  private long blogPostId = -1;
 
   public MailingListHistory() {
   }
@@ -85,5 +87,21 @@ public class MailingListHistory extends Entity {
 
   public void setEmailCount(int emailCount) {
     this.emailCount = emailCount;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public long getBlogPostId() {
+    return blogPostId;
+  }
+
+  public void setBlogPostId(long blogPostId) {
+    this.blogPostId = blogPostId;
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
@@ -43,6 +43,10 @@ public class MailingListMember extends Entity {
   private boolean isValid = false;
   private Timestamp quarantined = null;
   private String quarantineReason = null;
+  private String unsubscribeToken = null;
+
+  /** Only populated by queries that join to emails -- not a mailing_list_members column. */
+  private String emailAddress = null;
 
   public MailingListMember() {
   }
@@ -157,5 +161,21 @@ public class MailingListMember extends Entity {
 
   public void setQuarantineReason(String quarantineReason) {
     this.quarantineReason = quarantineReason;
+  }
+
+  public String getUnsubscribeToken() {
+    return unsubscribeToken;
+  }
+
+  public void setUnsubscribeToken(String unsubscribeToken) {
+    this.unsubscribeToken = unsubscribeToken;
+  }
+
+  public String getEmailAddress() {
+    return emailAddress;
+  }
+
+  public void setEmailAddress(String emailAddress) {
+    this.emailAddress = emailAddress;
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListSent.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListSent.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.mailinglists;
+
+import com.simisinc.platform.domain.model.Entity;
+
+import java.sql.Timestamp;
+
+/**
+ * A single recipient's row within a mailing list send batch (mailing_list_history), tracked from
+ * queued through sent or failed.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListSent extends Entity {
+
+  public static final String QUEUED = "queued";
+  public static final String PROCESSING = "processing";
+  public static final String SENT = "sent";
+  public static final String FAILED = "failed";
+  /** The recipient unsubscribed (or their membership row was removed) between enqueue and send. */
+  public static final String SKIPPED = "skipped";
+
+  private Long id = -1L;
+
+  private long emailId = -1;
+  private long listId = -1;
+  private long historyId = -1;
+  private Timestamp created = null;
+  private String status = QUEUED;
+  private int attemptCount = 0;
+  private String errorMessage = null;
+  private Timestamp claimedAt = null;
+  private Timestamp modified = null;
+
+  public MailingListSent() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public long getEmailId() {
+    return emailId;
+  }
+
+  public void setEmailId(long emailId) {
+    this.emailId = emailId;
+  }
+
+  public long getListId() {
+    return listId;
+  }
+
+  public void setListId(long listId) {
+    this.listId = listId;
+  }
+
+  public long getHistoryId() {
+    return historyId;
+  }
+
+  public void setHistoryId(long historyId) {
+    this.historyId = historyId;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public int getAttemptCount() {
+    return attemptCount;
+  }
+
+  public void setAttemptCount(int attemptCount) {
+    this.attemptCount = attemptCount;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public Timestamp getClaimedAt() {
+    return claimedAt;
+  }
+
+  public void setClaimedAt(Timestamp claimedAt) {
+    this.claimedAt = claimedAt;
+  }
+
+  public Timestamp getModified() {
+    return modified;
+  }
+
+  public void setModified(Timestamp modified) {
+    this.modified = modified;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListHistoryRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListHistoryRepository.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.mailinglists;
+
+import com.simisinc.platform.domain.model.mailinglists.MailingListHistory;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Persists and retrieves mailing list send batch header records.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListHistoryRepository {
+
+  private static Log LOG = LogFactory.getLog(MailingListHistoryRepository.class);
+
+  private static String TABLE_NAME = "mailing_list_history";
+  private static String[] PRIMARY_KEY = new String[] { "history_id" };
+
+  public static MailingListHistory add(Connection connection, MailingListHistory record) throws SQLException {
+    SqlUtils insertValues = new SqlUtils()
+        .add("list_id", record.getListId())
+        .add("created_by", record.getCreatedBy(), -1)
+        .add("service", record.getService())
+        .add("email_count", record.getEmailCount())
+        .addIfExists("subject", record.getSubject())
+        .add("blog_post_id", record.getBlogPostId(), -1);
+    record.setId(DB.insertInto(connection, TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static MailingListHistory findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (MailingListHistory) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("history_id = ?", id),
+        MailingListHistoryRepository::buildRecord);
+  }
+
+  private static MailingListHistory buildRecord(ResultSet rs) {
+    try {
+      MailingListHistory record = new MailingListHistory();
+      record.setId(rs.getLong("history_id"));
+      record.setListId(rs.getLong("list_id"));
+      record.setCreatedBy(rs.getLong("created_by"));
+      record.setCreated(rs.getTimestamp("created"));
+      record.setService(rs.getString("service"));
+      record.setEmailCount(rs.getInt("email_count"));
+      record.setSubject(rs.getString("subject"));
+      record.setBlogPostId(DB.getLong(rs, "blog_post_id", -1));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.database.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -33,6 +34,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Persists and retrieves mailing list member objects
@@ -115,6 +117,114 @@ public class MailingListMemberRepository {
         .add("list_id = ?", mailingList.getId())
         .add("email_id = ?", email.getId());
     DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  /**
+   * Every currently-subscribed, valid member of a list, for enqueueing a send. Generates and
+   * persists an unsubscribe_token for any member who doesn't already have one -- a token is only
+   * ever needed once a member is actually about to be emailed.
+   */
+  public static List<MailingListMember> findActiveMembersForList(long listId) {
+    SqlUtils select = new SqlUtils().addNames("emails.email AS email_address");
+    SqlJoins joins = new SqlJoins().add(JOIN);
+    SqlUtils where = new SqlUtils()
+        .add("mailing_list_members.list_id = ?", listId)
+        .add("mailing_list_members.is_valid = ?", true)
+        .add("mailing_list_members.unsubscribed IS NULL");
+    DataResult result = DB.selectAllFrom(TABLE_NAME, select, joins, where, null,
+        new DataConstraints().setUseCount(false), MailingListMemberRepository::buildRecordWithEmail);
+    List<MailingListMember> members = (List<MailingListMember>) result.getRecords();
+    if (members == null) {
+      return new ArrayList<>();
+    }
+    for (MailingListMember member : members) {
+      ensureUnsubscribeToken(member);
+    }
+    return members;
+  }
+
+  /** Looks up a member by their single-use unsubscribe link token. */
+  public static MailingListMember findByUnsubscribeToken(String token) {
+    if (StringUtils.isBlank(token)) {
+      return null;
+    }
+    SqlUtils select = new SqlUtils().addNames("emails.email AS email_address");
+    SqlJoins joins = new SqlJoins().add(JOIN);
+    SqlUtils where = new SqlUtils().add("mailing_list_members.unsubscribe_token = ?", token);
+    return (MailingListMember) DB.selectRecordFrom(TABLE_NAME, select, joins, where,
+        MailingListMemberRepository::buildRecordWithEmail);
+  }
+
+  /**
+   * Looks up a member by (list, email), for the send job to re-check current subscription status
+   * and unsubscribe token immediately before sending -- the member may have unsubscribed, or never
+   * had a token generated, since the row was enqueued.
+   */
+  public static MailingListMember findByListAndEmail(long listId, long emailId) {
+    SqlUtils select = new SqlUtils().addNames("emails.email AS email_address");
+    SqlJoins joins = new SqlJoins().add(JOIN);
+    SqlUtils where = new SqlUtils()
+        .add("mailing_list_members.list_id = ?", listId)
+        .add("mailing_list_members.email_id = ?", emailId);
+    MailingListMember member = (MailingListMember) DB.selectRecordFrom(TABLE_NAME, select, joins, where,
+        MailingListMemberRepository::buildRecordWithEmail);
+    if (member != null) {
+      ensureUnsubscribeToken(member);
+    }
+    return member;
+  }
+
+  private static void ensureUnsubscribeToken(MailingListMember member) {
+    if (StringUtils.isNotBlank(member.getUnsubscribeToken())) {
+      return;
+    }
+    String token = UUID.randomUUID().toString();
+    SqlUtils updateValues = new SqlUtils().add("unsubscribe_token", token);
+    SqlUtils memberWhere = new SqlUtils().add("member_id = ?", member.getId());
+    DB.update(TABLE_NAME, updateValues, memberWhere);
+    member.setUnsubscribeToken(token);
+  }
+
+  /**
+   * Unsubscribes an anonymous recipient by their token (no logged-in User -- the token itself is
+   * the authorization). Single-use: clears the token so a re-clicked link lands on a graceful
+   * already-unsubscribed state instead of erroring, matching UserRepository's account-token flow.
+   */
+  public static void unsubscribeByToken(MailingListMember member) {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    SqlUtils updateValues = new SqlUtils()
+        .add("unsubscribed", now)
+        .add("unsubscribed_by", -1, -1)
+        .add("modified", now)
+        .add("modified_by", -1, -1)
+        .add("is_valid", false)
+        .add("unsubscribe_token", (String) null);
+    SqlUtils where = new SqlUtils().add("member_id = ?", member.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  private static MailingListMember buildRecordWithEmail(ResultSet rs) {
+    try {
+      MailingListMember record = new MailingListMember();
+      record.setId(rs.getLong("member_id"));
+      record.setListId(rs.getLong("list_id"));
+      record.setEmailId(rs.getLong("email_id"));
+      record.setCreatedBy(rs.getLong("created_by"));
+      record.setModifiedBy(rs.getLong("modified_by"));
+      record.setCreated(rs.getTimestamp("created"));
+      record.setModified(rs.getTimestamp("modified"));
+      record.setLastEmailed(rs.getTimestamp("last_emailed"));
+      record.setUnsubscribed(rs.getTimestamp("unsubscribed"));
+      record.setUnsubscribedBy(rs.getLong("unsubscribed_by"));
+      record.setUnsubscribeReason(rs.getString("unsubscribe_reason"));
+      record.setIsValid(rs.getBoolean("is_valid"));
+      record.setUnsubscribeToken(rs.getString("unsubscribe_token"));
+      record.setEmailAddress(rs.getString("email_address"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecordWithEmail", se);
+      return null;
+    }
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListSentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListSentRepository.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.mailinglists;
+
+import com.simisinc.platform.domain.model.mailinglists.MailingListSent;
+import com.simisinc.platform.infrastructure.database.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+/**
+ * Persists and retrieves per-recipient rows within a mailing list send batch
+ * (mailing_list_history) -- queued, processing, sent, or failed.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListSentRepository {
+
+  private static Log LOG = LogFactory.getLog(MailingListSentRepository.class);
+
+  private static String TABLE_NAME = "mailing_list_sent";
+  private static String[] PRIMARY_KEY = new String[] { "item_id" };
+
+  /** Queues one row per member, all belonging to the same batch (history). */
+  public static void enqueue(Connection connection, long historyId, long listId, List<Long> emailIds)
+      throws SQLException {
+    for (Long emailId : emailIds) {
+      SqlUtils insertValues = new SqlUtils()
+          .add("email_id", emailId)
+          .add("list_id", listId)
+          .add("history_id", historyId)
+          .add("status", MailingListSent.QUEUED);
+      DB.insertInto(connection, TABLE_NAME, insertValues, PRIMARY_KEY);
+    }
+  }
+
+  /**
+   * Claims up to batchSize queued rows for processing by this node. Safe under this codebase's
+   * existing job-locking convention (LockManager ensures only one node's job execution is inside
+   * the caller at a time), matching every other scheduled job here -- there is no row-level
+   * SELECT-FOR-UPDATE/claim pattern precedent to follow, so this uses a plain select-then-update.
+   */
+  public static List<MailingListSent> claimBatch(int batchSize) {
+    SqlUtils where = new SqlUtils().add("status = ?", MailingListSent.QUEUED);
+    DataConstraints constraints = new DataConstraints(1, batchSize)
+        .setDefaultColumnToSortBy("item_id")
+        .setUseCount(false);
+    DataResult result = DB.selectAllFrom(TABLE_NAME, where, constraints, MailingListSentRepository::buildRecord);
+    List<MailingListSent> claimed = (List<MailingListSent>) result.getRecords();
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    for (MailingListSent record : claimed) {
+      SqlUtils updateValues = new SqlUtils()
+          .add("status", MailingListSent.PROCESSING)
+          .add("claimed_at", now)
+          .add("modified", now);
+      SqlUtils itemWhere = new SqlUtils().add("item_id = ?", record.getId());
+      DB.update(TABLE_NAME, updateValues, itemWhere);
+      record.setStatus(MailingListSent.PROCESSING);
+      record.setClaimedAt(now);
+    }
+    return claimed;
+  }
+
+  /** The recipient unsubscribed (or their membership was removed) between enqueue and send. */
+  public static void markSkipped(MailingListSent record) {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    SqlUtils updateValues = new SqlUtils()
+        .add("status", MailingListSent.SKIPPED)
+        .add("modified", now);
+    SqlUtils where = new SqlUtils().add("item_id = ?", record.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  public static void markSent(MailingListSent record) {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    SqlUtils updateValues = new SqlUtils()
+        .add("status", MailingListSent.SENT)
+        .add("modified", now);
+    SqlUtils where = new SqlUtils().add("item_id = ?", record.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  /**
+   * Records a failed send attempt. Requeues for another try if under the retry cap, otherwise
+   * marks permanently failed -- neither OrderManagementProcessNewOrders nor any other job in this
+   * codebase demonstrates a retry-count/cutoff pattern, so this is new, not copied.
+   */
+  public static void markFailedOrRequeue(MailingListSent record, String errorMessage, int maxAttempts) {
+    int attemptCount = record.getAttemptCount() + 1;
+    boolean permanentlyFailed = attemptCount >= maxAttempts;
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    SqlUtils updateValues = new SqlUtils()
+        .add("status", permanentlyFailed ? MailingListSent.FAILED : MailingListSent.QUEUED)
+        .add("attempt_count", attemptCount)
+        .add("error_message", errorMessage, 500)
+        .add("modified", now);
+    SqlUtils where = new SqlUtils().add("item_id = ?", record.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  private static MailingListSent buildRecord(ResultSet rs) {
+    try {
+      MailingListSent record = new MailingListSent();
+      record.setId(rs.getLong("item_id"));
+      record.setEmailId(rs.getLong("email_id"));
+      record.setListId(rs.getLong("list_id"));
+      record.setHistoryId(rs.getLong("history_id"));
+      record.setCreated(rs.getTimestamp("created"));
+      record.setStatus(rs.getString("status"));
+      record.setAttemptCount(DB.getInt(rs, "attempt_count", 0));
+      record.setErrorMessage(rs.getString("error_message"));
+      record.setClaimedAt(rs.getTimestamp("claimed_at"));
+      record.setModified(rs.getTimestamp("modified"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -36,6 +36,7 @@ import com.simisinc.platform.infrastructure.scheduler.ecommerce.OrderManagementP
 import com.simisinc.platform.infrastructure.scheduler.login.UserTokensCleanupJob;
 import com.simisinc.platform.infrastructure.scheduler.mailinglists.EmailClassificationJob;
 import com.simisinc.platform.infrastructure.scheduler.mailinglists.MailingListQuarantineJob;
+import com.simisinc.platform.infrastructure.scheduler.mailinglists.NewsletterQueueJob;
 import com.simisinc.platform.infrastructure.scheduler.medicine.ProcessMedicineSchedulesJob;
 import com.simisinc.platform.infrastructure.scheduler.socialmedia.InstagramMediaSnapshotJob;
 import org.apache.commons.logging.Log;
@@ -90,6 +91,7 @@ public class SchedulerManager {
   public static final String EMAIL_CLASSIFICATION_JOB = "EmailClassification";
   public static final String MAILING_LIST_QUARANTINE_JOB = "MailingListQuarantine";
   public static final String FORM_SUBMISSION_FAILURE_RETENTION_JOB = "FormSubmissionFailureRetention";
+  public static final String NEWSLETTER_QUEUE_JOB = "NewsletterQueue";
 
   // Jobs which can be run by multiple clients
   public static final String DATASETS_DOWNLOAD_AND_SYNC_JOB = "DatasetsDownloadAndSync";
@@ -181,6 +183,7 @@ public class SchedulerManager {
         // night, not a full day later.
         BackgroundJob.scheduleRecurrently(MAILING_LIST_QUARANTINE_JOB, Cron.daily(3, 30), MailingListQuarantineJob::execute);
         BackgroundJob.scheduleRecurrently(FORM_SUBMISSION_FAILURE_RETENTION_JOB, Cron.daily(5), FormSubmissionFailureRetentionJob::execute);
+        BackgroundJob.scheduleRecurrently(NEWSLETTER_QUEUE_JOB, Cron.minutely(), NewsletterQueueJob::execute);
       }
     } catch (Exception se) {
       LOG.error("Error starting jobrunr: ", se);

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/NewsletterQueueJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/mailinglists/NewsletterQueueJob.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.mailinglists;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.application.mailinglists.NewsletterEmailCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingListHistory;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.domain.model.mailinglists.MailingListSent;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListHistoryRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListSentRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jobrunr.jobs.annotations.Job;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Sends queued newsletter emails a batch at a time. Modeled on
+ * OrderManagementProcessNewOrders, with two additions that template doesn't demonstrate: a real
+ * claim-before-work step (MailingListSentRepository.claimBatch flips queued rows to processing
+ * before this job touches them) and a bounded retry count, since neither exists anywhere else in
+ * this codebase's scheduled jobs to copy.
+ *
+ * <p>
+ * The batch size (rather than draining the whole queue in one run) keeps a single execution well
+ * under the lock duration below, so a slow run can't overlap the next minutely tick.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class NewsletterQueueJob {
+
+  private static Log LOG = LogFactory.getLog(NewsletterQueueJob.class);
+
+  private static final int BATCH_SIZE = 25;
+  private static final int MAX_ATTEMPTS = 3;
+
+  @Job(name = "Send queued newsletter emails")
+  public static void execute() {
+
+    // Distributed lock -- comfortably longer than a 25-email batch should ever take, so an
+    // overrunning execution blocks the next tick rather than racing it
+    String lock = LockManager.lock(SchedulerManager.NEWSLETTER_QUEUE_JOB, Duration.ofMinutes(5));
+    if (lock == null) {
+      return;
+    }
+
+    List<MailingListSent> batch = MailingListSentRepository.claimBatch(BATCH_SIZE);
+    if (batch.isEmpty()) {
+      return;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Newsletter items claimed for sending: " + batch.size());
+    }
+
+    String siteUrl = LoadSitePropertyCommand.loadByName("site.url");
+
+    // A batch is very likely dominated by rows from the same send -- avoid re-loading the same
+    // history/blog post record once per recipient
+    Map<Long, MailingListHistory> historyCache = new HashMap<>();
+    Map<Long, BlogPost> blogPostCache = new HashMap<>();
+
+    for (MailingListSent item : batch) {
+      try {
+        MailingListHistory history = historyCache.computeIfAbsent(item.getHistoryId(),
+            MailingListHistoryRepository::findById);
+        if (history == null || history.getBlogPostId() == -1) {
+          MailingListSentRepository.markFailedOrRequeue(item, "Send batch record was not found", MAX_ATTEMPTS);
+          continue;
+        }
+
+        BlogPost blogPost = blogPostCache.computeIfAbsent(history.getBlogPostId(), BlogPostRepository::findById);
+        if (blogPost == null) {
+          MailingListSentRepository.markFailedOrRequeue(item, "The blog post no longer exists", MAX_ATTEMPTS);
+          continue;
+        }
+
+        // Re-check current status immediately before sending -- the recipient may have
+        // unsubscribed, or their row may have been removed, since this was enqueued
+        MailingListMember member = MailingListMemberRepository.findByListAndEmail(item.getListId(), item.getEmailId());
+        if (member == null || member.getUnsubscribed() != null || !member.getIsValid()
+            || StringUtils.isBlank(member.getEmailAddress())) {
+          MailingListSentRepository.markSkipped(item);
+          continue;
+        }
+
+        String unsubscribeUrl = siteUrl + "/unsubscribe?token=" + UrlCommand.encodeUri(member.getUnsubscribeToken());
+        NewsletterEmailCommand.sendBlogPostNotification(member.getEmailAddress(), blogPost, unsubscribeUrl);
+        MailingListSentRepository.markSent(item);
+      } catch (Exception e) {
+        LOG.error("Newsletter send error for item " + item.getId() + ": " + e.getMessage(), e);
+        MailingListSentRepository.markFailedOrRequeue(item, StringUtils.left(e.getMessage(), 500), MAX_ATTEMPTS);
+      }
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidget.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Admin UI for issue #600: an admin picks a mailing list and a published blog post, and queues a
+ * newsletter email to every current subscriber of that list. Sending itself happens
+ * asynchronously afterward, via NewsletterQueueJob.
+ *
+ * @author SimIS Inc.
+ */
+public class NewsletterSendWidget extends GenericWidget {
+
+  static final long serialVersionUID = 6217552971314772871L;
+
+  static String JSP = "/admin/newsletter-send.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    List<MailingList> allLists = MailingListRepository.findAll();
+    List<MailingList> enabledLists = new ArrayList<>();
+    if (allLists != null) {
+      for (MailingList mailingList : allLists) {
+        if (mailingList.getEnabled()) {
+          enabledLists.add(mailingList);
+        }
+      }
+    }
+    context.getRequest().setAttribute("mailingLists", enabledLists);
+
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setPublishedOnly(true);
+    DataConstraints constraints = new DataConstraints(1, 50).setDefaultColumnToSortBy("published DESC");
+    List<BlogPost> blogPosts = BlogPostRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("blogPosts", blogPosts);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+    // Defense in depth: this page is already role-gated at the page-config level
+    // (admin-layout.xml), matching SeoSitemapWidget's convention for a state-changing POST. The
+    // role set spans both halves of this action -- content-manager (picks the blog post, per
+    // /blog-editor's own role) and community-manager (owns mailing lists, per /admin/mailing-lists).
+    if (!context.hasRole("admin") && !context.hasRole("content-manager") && !context.hasRole("community-manager")) {
+      return execute(context);
+    }
+
+    long mailingListId = context.getParameterAsLong("mailingListId");
+    long blogPostId = context.getParameterAsLong("blogPostId");
+
+    MailingList mailingList = mailingListId > -1 ? MailingListRepository.findById(mailingListId) : null;
+    BlogPost blogPost = blogPostId > -1 ? BlogPostRepository.findById(blogPostId) : null;
+    if (mailingList == null || blogPost == null) {
+      context.setWarningMessage("Choose a mailing list and a blog post");
+      return execute(context);
+    }
+
+    int queuedCount;
+    try {
+      queuedCount = NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, context.getUserId());
+    } catch (DataException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "newsletter.enqueue", AuditEventCommand.FAILURE,
+          "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(), e.getMessage());
+      context.setErrorMessage(e.getMessage());
+      return execute(context);
+    }
+
+    AuditEventCommand.record(context, AuditEventCommand.CONTENT, "newsletter.enqueue", AuditEventCommand.SUCCESS,
+        "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(),
+        queuedCount + " recipient(s) queued for \"" + blogPost.getTitle() + "\"");
+
+    context.setSuccessMessage(queuedCount == 0
+        ? "No active subscribers were found on that list."
+        : queuedCount + " subscriber" + (queuedCount == 1 ? "" : "s") + " queued. Emails will go out shortly.");
+    context.setRedirect("/admin/newsletter-send");
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Anonymous, no-login-required unsubscribe link (issue #600). Modeled on
+ * AccountValidationWidget's no-password-needed branch: the mutation happens directly on GET, no
+ * form/POST required, since unsubscribing needs no additional input from the visitor. The token
+ * itself is the authorization; a missing, invalid, or already-used token gets the same graceful
+ * "not found" page rather than an error, so a re-clicked email link never looks broken.
+ *
+ * @author SimIS Inc.
+ */
+public class NewsletterUnsubscribeWidget extends GenericWidget {
+
+  static final long serialVersionUID = -3963577018820473218L;
+
+  static String JSP = "/mailinglists/newsletter-unsubscribed.jsp";
+  static String NOT_FOUND_JSP = "/mailinglists/newsletter-unsubscribe-not-found.jsp";
+  static String RATE_LIMITED_JSP = "/cms/error-rate-limited.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // The token is a guessable-length concern only in aggregate (brute force); rate limit the
+    // same way ForgotPasswordWidget rate limits its own anonymous, token-adjacent surface.
+    if (!RateLimitCommand.isIpAllowedRightNow(context.getRequest().getRemoteAddr(), false)) {
+      context.setJsp(RATE_LIMITED_JSP);
+      return context;
+    }
+
+    String token = context.getParameter("token");
+    if (StringUtils.isBlank(token)) {
+      context.setJsp(NOT_FOUND_JSP);
+      return context;
+    }
+
+    MailingListMember member = MailingListMemberRepository.findByUnsubscribeToken(token);
+    if (member == null) {
+      RateLimitCommand.isIpAllowedRightNow(context.getRequest().getRemoteAddr(), true);
+      context.setJsp(NOT_FOUND_JSP);
+      return context;
+    }
+
+    if (member.getUnsubscribed() == null) {
+      MailingListMemberRepository.unsubscribeByToken(member);
+    }
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
+++ b/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
@@ -92,13 +92,15 @@ CREATE TABLE mailing_list_members (
   unsubscribe_reason VARCHAR(100),
   is_valid BOOLEAN DEFAULT true,
   quarantined TIMESTAMP(3),
-  quarantine_reason VARCHAR(50)
+  quarantine_reason VARCHAR(50),
+  unsubscribe_token VARCHAR(255)
 );
 CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id);
 CREATE INDEX mail_lis_mem_lid_idx ON mailing_list_members(list_id);
 CREATE INDEX mail_lis_mem_eid_idx ON mailing_list_members(email_id);
 CREATE INDEX mail_lis_mem_quarantined_idx ON mailing_list_members(quarantined);
 CREATE INDEX mail_lis_mem_val_idx ON mailing_list_members(is_valid);
+CREATE UNIQUE INDEX mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token);
 
 CREATE TABLE mailing_list_history (
   history_id BIGSERIAL PRIMARY KEY,
@@ -106,20 +108,30 @@ CREATE TABLE mailing_list_history (
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
   created_by BIGINT REFERENCES users(user_id),
   service VARCHAR(20),
-  email_count INTEGER DEFAULT 0
+  email_count INTEGER DEFAULT 0,
+  subject VARCHAR(255),
+  blog_post_id BIGINT REFERENCES blog_posts(post_id)
 );
 CREATE INDEX mail_lis_his_lid_idx ON mailing_list_history(list_id);
 CREATE INDEX mail_lis_his_cre_idx ON mailing_list_history(created);
 
+-- item_id/status: one row per recipient of a batch (mailing_list_history), tracked from queued
+-- through sent or failed -- see UPGRADE_20260729.1004__newsletter_send_queue.sql for why.
 CREATE TABLE mailing_list_sent (
   item_id BIGSERIAL PRIMARY KEY,
   email_id BIGINT REFERENCES emails(email_id),
   list_id BIGINT REFERENCES mailing_lists(list_id),
   history_id BIGINT REFERENCES mailing_list_history(history_id),
-  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  status VARCHAR(20) DEFAULT 'queued',
+  attempt_count INTEGER DEFAULT 0,
+  error_message VARCHAR(500),
+  claimed_at TIMESTAMP(3),
+  modified TIMESTAMP(3)
 );
 CREATE INDEX mail_list_sent_em_idx ON mailing_list_sent(email_id);
 CREATE INDEX mail_list_sent_li_idx ON mailing_list_sent(list_id);
 CREATE INDEX mail_list_sent_hi_idx ON mailing_list_sent(history_id);
 CREATE INDEX mail_list_sent_cr_idx ON mailing_list_sent(created);
+CREATE INDEX mail_list_sent_status_idx ON mailing_list_sent(status);
 

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260729.1006__newsletter_send_queue.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260729.1006__newsletter_send_queue.sql
@@ -1,0 +1,23 @@
+-- Issues #600/#500: an actual "send" mechanism for the newsletter -- mailing_list_history and
+-- mailing_list_sent have existed since the original 2019 design (NEW_10070__new_mailing_lists.sql)
+-- but nothing has ever written to either table. This extends them to serve as the send queue:
+-- mailing_list_history becomes the batch header (one row per send), mailing_list_sent becomes the
+-- per-recipient queue/log row (one row per member of that batch, tracked from queued through sent
+-- or failed) rather than only ever representing an already-completed send.
+
+ALTER TABLE mailing_list_history ADD COLUMN IF NOT EXISTS subject VARCHAR(255);
+ALTER TABLE mailing_list_history ADD COLUMN IF NOT EXISTS blog_post_id BIGINT REFERENCES blog_posts(post_id);
+
+ALTER TABLE mailing_list_sent ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'queued';
+ALTER TABLE mailing_list_sent ADD COLUMN IF NOT EXISTS attempt_count INTEGER DEFAULT 0;
+ALTER TABLE mailing_list_sent ADD COLUMN IF NOT EXISTS error_message VARCHAR(500);
+ALTER TABLE mailing_list_sent ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP(3);
+ALTER TABLE mailing_list_sent ADD COLUMN IF NOT EXISTS modified TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS mail_list_sent_status_idx ON mailing_list_sent(status);
+
+-- Single-use, per-member unsubscribe link (mutate-on-GET, no login required -- see
+-- UserRepository.account_token for the analogous pattern). Scoped to the membership row, not the
+-- email address, since unsubscribe is naturally per-list.
+ALTER TABLE mailing_list_members ADD COLUMN IF NOT EXISTS unsubscribe_token VARCHAR(255);
+CREATE UNIQUE INDEX IF NOT EXISTS mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token);

--- a/src/main/webapp/WEB-INF/email-templates/mailinglists/newsletter-blog-post.html
+++ b/src/main/webapp/WEB-INF/email-templates/mailinglists/newsletter-blog-post.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title></title>
+  <style type="text/css">
+    /* Client Specific Styles */
+    body,
+    table,
+    td,
+    a {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table,
+    td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+    }
+    /* Reset Styles */
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      max-width: 100%;
+    }
+    table {
+      border-collapse: collapse !important;
+    }
+    body {
+      height: 100% !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+    /* iOS Links */
+    a[x-apple-data-detectors] {
+      color: inherit !important;
+      text-decoration: none !important;
+      font-size: inherit !important;
+      font-family: inherit !important;
+      font-weight: inherit !important;
+      line-height: inherit !important;
+    }
+    /* Mobile Styles */
+    @media screen and (max-width: 600px) {
+      .mobile-wrapper {
+        width: 95% !important;
+        max-width: 95% !important;
+      }
+      .mobile-padding {
+        padding-left: 3% !important;
+        padding-right: 3% !important;
+      }
+    }
+    /* Android Center Fix */
+    div[style*="margin: 16px 0;"] {
+      margin: 0 !important;
+    }
+    /* Styles */
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-weight: 600;
+      color: #333333;
+      line-height: 1.5;
+      margin: 0 0 20px 0;
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+    }
+    h1 {
+      font-size: 22px;
+    }
+    h2 {
+      font-size: 18px;
+    }
+    p {
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+      font-size: 16px;
+      line-height: 1.5;
+      margin: 0 0 20px 0;
+      color: #868e96;
+    }
+    a {
+      color: #329af0;
+      text-decoration: underline;
+    }
+    a.web-button {
+      font-size: 20px;
+      font-weight: 600;
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      color: #f8f9fa;
+      display: inline-block;
+      border: 1px solid #1c7cd6;
+      padding: 16px 48px;
+      border-radius: 4px;
+      text-decoration: none;
+      background-color: #1c7cd6;
+    }
+  </style>
+</head>
+<body th:inline="text" style="margin: 0 !important; padding: 0; !important background-color: #f8f9fa !important; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; color: #495057;" bgcolor="#f8f9fa">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td align="center" height="100%" valign="top" width="100%" bgcolor="#f8f9fa" style="padding: 25px 15px 25px 15px;" class="mobile-padding">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="mobile-wrapper" style="max-width:700px">
+        <tr>
+          <td align="center" valign="top" style="padding: 0; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+            <table cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="border-radius: 8px; padding: 40px;" class="mobile-padding">
+                  <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                    <tr>
+                      <td align="center" valign="top" style="padding: 10px 50px 40px 50px;">
+                        <div th:if="${site.logo != null}">
+                          <img src="logo.png" th:src="${site.logo}" width="300" style="max-width: 430px !important; max-height: 150px !important;" alt="Site Name" th:alt="${site.name}" />
+                        </div>
+                        <div th:if="${site.logo == null}">
+                          <h1 style="margin: 0; text-align:center; color: #333333; font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; font-size: 22px; line-height: 1.5;"><span th:text="${site.name}">Site Name</span></h1>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="template-content" style="font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; padding: 0;">
+                        <h2 style="text-align:center" th:text="${blogPost.title}">Blog Post Title</h2>
+                        <p th:if="${blogPost.summary != null}" th:text="${blogPost.summary}">A short summary of the post.</p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <div style="text-align: center !important" align="center"><a class="web-button" target="_blank" href="https://example.com/post" th:href="${blogPostUrl}" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #1c7cd6; border: 1px solid #1c7cd6; border-radius: 4px; color: #f8f9fa; display: inline-block; font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 20px; font-weight: 600; padding: 16px 48px; text-decoration: none; margin: 20px 0 20px">Read the full post</a></div>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" height="100%" valign="top" width="100%" bgcolor="#f8f9fa" style="padding: 25px 15px 50px 15px;" class="mobile-padding">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="80%" class="mobile-wrapper">
+        <tr>
+          <td align="center" valign="top" style="padding: 0 0 5px 0; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #868e96;">
+            <p style="font-size: 14px; line-height: 20px; color: #868e96;">
+              [[${site.name}]]<th:block th:if="${site.state != null}"><br></th:block>
+              <th:block th:if="${site.addressLine1 != null}">[[${site.addressLine1}]],</th:block>
+              <th:block th:if="${site.city != null}">[[${site.city}]],</th:block>
+              <th:block th:if="${site.state != null}">[[${site.state}]]</th:block>
+              <th:block th:if="${site.postalCode != null}">[[${site.postalCode}]]</th:block>
+            </p>
+            <p style="font-size: 12px; line-height: 18px; color: #adb5bd;">
+              You're receiving this because you subscribed to updates from [[${site.name}]].
+              <a th:href="${unsubscribeUrl}" href="https://example.com/unsubscribe" style="color: #adb5bd;" target="_blank">Unsubscribe</a>
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/admin/newsletter-send.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/newsletter-send.jsp
@@ -1,0 +1,113 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="mailingLists" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="blogPosts" class="java.util.ArrayList" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+
+<p>
+  Pick a mailing list and a published blog post to queue a notification email to everyone
+  currently subscribed to that list. Sending happens in the background over the next few
+  minutes, not instantly -- the page won't wait for it, and re-checking this page won't show a
+  progress bar.
+</p>
+<ul>
+  <li>Only people currently subscribed to (and not unsubscribed from) the chosen list receive it.</li>
+  <li>Every email includes an unsubscribe link specific to that person and that list.</li>
+  <li>Emails go out via the site's own configured SMTP settings -- if those aren't set up, sends
+    will fail quietly in the background rather than error here; check the Audit Log if subscribers
+    report not receiving anything.</li>
+</ul>
+
+<c:if test="${empty mailingLists}">
+  <div class="callout radius warning" style="margin-bottom:20px">
+    <p style="margin-bottom:0">
+      <i class="fa fa-exclamation-triangle"></i> No enabled mailing lists were found. Create or
+      enable one from <a href="${ctx}/admin/mailing-lists">Mailing Lists</a> first.
+    </p>
+  </div>
+</c:if>
+<c:if test="${empty blogPosts}">
+  <div class="callout radius warning" style="margin-bottom:20px">
+    <p style="margin-bottom:0">
+      <i class="fa fa-exclamation-triangle"></i> No published blog posts were found to notify
+      subscribers about.
+    </p>
+  </div>
+</c:if>
+
+<c:if test="${!empty mailingLists && !empty blogPosts}">
+  <form method="post">
+    <%-- Required by controller --%>
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}" />
+    <input type="hidden" name="token" value="${userSession.formToken}" />
+
+    <div class="grid-x grid-margin-x">
+      <div class="medium-6 cell">
+        <label>Mailing list
+          <select name="mailingListId" id="mailingListId">
+            <option value="">Choose a list...</option>
+            <c:forEach items="${mailingLists}" var="mailingList">
+              <option value="${mailingList.id}"><c:out value="${mailingList.title}" /> (<c:out value="${mailingList.memberCount}" /> members)</option>
+            </c:forEach>
+          </select>
+        </label>
+      </div>
+      <div class="medium-6 cell">
+        <label>Blog post
+          <select name="blogPostId" id="blogPostId" onchange="NewsletterSendPreview.update(this)">
+            <option value="">Choose a post...</option>
+            <c:forEach items="${blogPosts}" var="blogPost">
+              <option value="${blogPost.id}"
+                  data-title="${fn:escapeXml(blogPost.title)}"
+                  data-summary="${fn:escapeXml(blogPost.summary)}"><c:out value="${blogPost.title}" /></option>
+            </c:forEach>
+          </select>
+        </label>
+      </div>
+    </div>
+
+    <div id="newsletterPreview" class="callout radius" style="display:none; margin-bottom:20px">
+      <p style="margin-bottom:4px"><strong>Preview</strong></p>
+      <h5 id="newsletterPreviewTitle" style="margin-bottom:8px"></h5>
+      <p id="newsletterPreviewSummary" style="margin-bottom:0"></p>
+    </div>
+
+    <button type="submit" class="button radius primary">Send Newsletter</button>
+  </form>
+
+  <script nonce="${cspNonce}">
+    var NewsletterSendPreview = {
+      update: function (select) {
+        var preview = document.getElementById('newsletterPreview');
+        var option = select.options[select.selectedIndex];
+        if (!option.value) {
+          preview.style.display = 'none';
+          return;
+        }
+        document.getElementById('newsletterPreviewTitle').textContent = option.getAttribute('data-title') || '';
+        document.getElementById('newsletterPreviewSummary').textContent = option.getAttribute('data-summary') || '';
+        preview.style.display = '';
+      }
+    };
+  </script>
+</c:if>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/newsletter-unsubscribe-not-found.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/newsletter-unsubscribe-not-found.jsp
@@ -1,0 +1,27 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<h4>This unsubscribe link is no longer valid</h4>
+<p>
+  It may have already been used, or the link may be incomplete. If you're still receiving emails
+  you didn't ask for, use the unsubscribe link from a more recent email, or contact us.
+</p>
+<p>
+  <a href="${ctx}/" class="button primary radius">Visit Home Page <i class="fa fa-angle-right"></i></a>
+  <a href="${ctx}/contact-us" class="button secondary radius">Contact Us <i class="fa fa-angle-right"></i></a>
+</p>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/newsletter-unsubscribed.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/newsletter-unsubscribed.jsp
@@ -1,0 +1,25 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<div class="callout success">
+  <h4>You've been unsubscribed</h4>
+  <p>You won't receive any more emails from this mailing list.</p>
+</div>
+<p>
+  <a href="${ctx}/" class="button primary radius">Visit Home Page <i class="fa fa-angle-right"></i></a>
+</p>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -437,6 +437,7 @@
               </c:if>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/form-')}"> class="is-active"</c:if>><a href="${ctx}/admin/form-data"><i class="${font:far()} fa-list-alt fa-fw"></i> <span>Form Data</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/mailing-list') && !fn:startsWith(pageRenderInfo.name, '/admin/mailing-list-properties')}"> class="is-active"</c:if>><a href="${ctx}/admin/mailing-lists"><i class="${font:far()} fa-envelope fa-fw"></i> <span>Mailing Lists</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/newsletter-send')}"> class="is-active"</c:if>><a href="${ctx}/admin/newsletter-send"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>Send Newsletter</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/user') || fn:startsWith(pageRenderInfo.name, '/admin/modify-user')}"> class="is-active"</c:if>><a href="${ctx}/admin/users"><i class="${font:far()} fa-user-circle fa-fw"></i> <span>Users</span></a></li>
               <c:if test="${userSession.hasRole('admin')}">
                 <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/group')}"> class="is-active"</c:if>><a href="${ctx}/admin/groups"><i class="${font:far()} fa-users fa-fw"></i> <span>User Groups</span></a></li>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -415,6 +415,17 @@
     </section>
   </page>
 
+  <page name="/admin/newsletter-send" role="admin,content-manager,community-manager" title="Send Newsletter">
+    <section>
+      <column class="small-12 large-10 cell">
+        <widget name="newsletterSend">
+          <icon>fa-paper-plane</icon>
+          <title>Send Newsletter</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/mail-properties" role="admin" title="Mail Server Settings">
     <!--<section>-->
       <!--<column class="small-12 cell">-->

--- a/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
@@ -171,6 +171,14 @@
     </section>
   </page>
 
+  <page name="/unsubscribe" title="Unsubscribe">
+    <section class="align-center">
+      <column class="small-12 medium-6 cell">
+        <widget name="newsletterUnsubscribe" class="callout box radius" />
+      </column>
+    </section>
+  </page>
+
   <page name="/forgot-password" role="guest,admin,content-manager" title="Forgot Password" class="platform-dialog">
     <section id="platform-forgot-password" class="align-center">
       <column class="small-12 medium-7 large-5 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -194,6 +194,8 @@
   <widget name="mailingListForm" class="com.simisinc.platform.presentation.widgets.mailinglists.MailingListFormWidget" />
   <widget name="mailingListSearchForm" class="com.simisinc.platform.presentation.widgets.mailinglists.MailingListSearchFormWidget" />
   <widget name="mailingListMembers" class="com.simisinc.platform.presentation.widgets.mailinglists.MailingListMembersWidget" />
+  <widget name="newsletterSend" class="com.simisinc.platform.presentation.widgets.admin.NewsletterSendWidget" />
+  <widget name="newsletterUnsubscribe" class="com.simisinc.platform.presentation.widgets.mailinglists.NewsletterUnsubscribeWidget" />
   <widget name="folderList" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderListWidget" />
   <widget name="folderDetails" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderDetailsWidget" />
   <widget name="folderForm" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderFormWidget" />

--- a/src/test/java/com/simisinc/platform/application/email/EmailTemplateTests.java
+++ b/src/test/java/com/simisinc/platform/application/email/EmailTemplateTests.java
@@ -162,6 +162,14 @@ class EmailTemplateTests {
       Map<String, Object> shippingMethod = new HashMap<>();
       shippingMethod.put("title", "Standard Delivery");
       ctx.setVariable("shippingMethod", shippingMethod);
+    } else if ("mailinglists".equals(parent)) {
+      // Newsletter blog post notification
+      Map<String, Object> blogPost = new HashMap<>();
+      blogPost.put("title", "A Blog Post Title");
+      blogPost.put("summary", "A short summary of the post.");
+      ctx.setVariable("blogPost", blogPost);
+      ctx.setVariable("blogPostUrl", "http://site.example.com/blog/a-post");
+      ctx.setVariable("unsubscribeUrl", "http://site.example.com/unsubscribe?token=TEST");
     }
 
     String html = templateEngine.process(template, ctx);

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListHistory;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.domain.model.mailinglists.MailingListSent;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies the newsletter send-queue repository pieces (issue #600) against a real PostgreSQL
+ * instance -- claiming a batch, retry-cap behavior, token generation/lookup, and the anonymous
+ * unsubscribe write. Minimal schema replicated from NEW_10070__new_mailing_lists.sql plus
+ * UPGRADE_20260729.1004__newsletter_send_queue.sql, without the blog_posts FK (not needed here).
+ *
+ * @author SimIS Inc.
+ */
+class NewsletterSendQueueRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(), "Docker is not available - skipping newsletter send-queue integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void clearTables() throws SQLException {
+    Assumptions.assumeTrue(isDockerAvailable(), "Docker is not available - skipping newsletter send-queue integration test");
+    try (Connection connection = DB.getConnection(); Statement statement = connection.createStatement()) {
+      statement.execute(
+          "TRUNCATE TABLE mailing_list_sent, mailing_list_history, mailing_list_members, mailing_lists, emails RESTART IDENTITY CASCADE");
+    }
+  }
+
+  @Test
+  void historyRoundTripsSubjectAndBlogPostId() {
+    long listId = seedList("News");
+    MailingListHistory history = new MailingListHistory();
+    history.setListId(listId);
+    history.setService("smtp");
+    history.setEmailCount(3);
+    history.setSubject("A Post Title");
+    history.setBlogPostId(42L);
+
+    MailingListHistory saved = withConnection(connection -> {
+      try {
+        return MailingListHistoryRepository.add(connection, history);
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+
+    assertNotNull(saved);
+    MailingListHistory found = MailingListHistoryRepository.findById(saved.getId());
+    assertEquals("A Post Title", found.getSubject());
+    assertEquals(42L, found.getBlogPostId());
+    assertEquals(3, found.getEmailCount());
+  }
+
+  @Test
+  void enqueueBlogPostNotificationCreatesABatchAndOneQueuedRowPerActiveMember() throws DataException {
+    long listId = seedList("News");
+    seedMembership(listId, seedEmail("active1@example.com"), true, null, null);
+    seedMembership(listId, seedEmail("active2@example.com"), true, null, null);
+    seedMembership(listId, seedEmail("unsub@example.com"), true, "2026-07-01 00:00:00", null);
+
+    MailingList mailingList = MailingListRepository.findById(listId);
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(99L);
+    blogPost.setTitle("A New Post");
+
+    int queuedCount = NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, 1L);
+
+    assertEquals(2, queuedCount, "only active, non-unsubscribed members should be queued");
+    List<MailingListSent> claimed = MailingListSentRepository.claimBatch(10);
+    assertEquals(2, claimed.size());
+  }
+
+  @Test
+  void enqueueBlogPostNotificationReturnsZeroForAListWithNoActiveMembers() throws DataException {
+    long listId = seedList("Empty List");
+    MailingList mailingList = MailingListRepository.findById(listId);
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(99L);
+    blogPost.setTitle("A New Post");
+
+    int queuedCount = NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, 1L);
+
+    assertEquals(0, queuedCount);
+    assertTrue(MailingListSentRepository.claimBatch(10).isEmpty());
+  }
+
+  @Test
+  void enqueueCreatesOneQueuedRowPerEmail() {
+    long listId = seedList("News");
+    long historyId = seedHistory(listId);
+    long email1 = seedEmail("a@example.com");
+    long email2 = seedEmail("b@example.com");
+
+    withConnectionVoid(connection -> {
+      try {
+        MailingListSentRepository.enqueue(connection, historyId, listId, List.of(email1, email2));
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+
+    List<MailingListSent> claimed = MailingListSentRepository.claimBatch(10);
+    assertEquals(2, claimed.size());
+    assertTrue(claimed.stream().allMatch(item -> MailingListSent.PROCESSING.equals(item.getStatus())),
+        "claiming should flip queued rows to processing");
+  }
+
+  @Test
+  void claimBatchOnlyClaimsUpToTheRequestedSize() {
+    long listId = seedList("News");
+    long historyId = seedHistory(listId);
+    List<Long> emailIds = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      emailIds.add(seedEmail("member" + i + "@example.com"));
+    }
+    withConnectionVoid(connection -> {
+      try {
+        MailingListSentRepository.enqueue(connection, historyId, listId, emailIds);
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+
+    List<MailingListSent> firstBatch = MailingListSentRepository.claimBatch(2);
+    assertEquals(2, firstBatch.size());
+
+    // The other 3 remain queued, not claimed
+    List<MailingListSent> secondBatch = MailingListSentRepository.claimBatch(10);
+    assertEquals(3, secondBatch.size());
+  }
+
+  @Test
+  void markFailedOrRequeueGoesBackToQueuedUnderTheAttemptCap() {
+    long listId = seedList("News");
+    long historyId = seedHistory(listId);
+    long emailId = seedEmail("a@example.com");
+    withConnectionVoid(connection -> {
+      try {
+        MailingListSentRepository.enqueue(connection, historyId, listId, List.of(emailId));
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+
+    MailingListSent item = MailingListSentRepository.claimBatch(1).get(0);
+    MailingListSentRepository.markFailedOrRequeue(item, "SMTP timeout", 3);
+
+    List<MailingListSent> requeued = MailingListSentRepository.claimBatch(1);
+    assertEquals(1, requeued.size(), "should be claimable again, not permanently failed");
+    assertEquals(1, requeued.get(0).getAttemptCount());
+  }
+
+  @Test
+  void markFailedOrRequeuePermanentlyFailsAtTheAttemptCap() {
+    long listId = seedList("News");
+    long historyId = seedHistory(listId);
+    long emailId = seedEmail("a@example.com");
+    withConnectionVoid(connection -> {
+      try {
+        MailingListSentRepository.enqueue(connection, historyId, listId, List.of(emailId));
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+
+    MailingListSent item = MailingListSentRepository.claimBatch(1).get(0);
+    item.setAttemptCount(2); // simulate this being the 3rd attempt
+    MailingListSentRepository.markFailedOrRequeue(item, "SMTP timeout", 3);
+
+    assertTrue(MailingListSentRepository.claimBatch(1).isEmpty(), "must not be claimable once permanently failed");
+  }
+
+  @Test
+  void findActiveMembersForListGeneratesATokenOncePerMember() {
+    long listId = seedList("News");
+    long emailId = seedEmail("a@example.com");
+    seedMembership(listId, emailId, true, null, null);
+
+    List<MailingListMember> firstLookup = MailingListMemberRepository.findActiveMembersForList(listId);
+    assertEquals(1, firstLookup.size());
+    String token = firstLookup.get(0).getUnsubscribeToken();
+    assertNotNull(token);
+    assertEquals("a@example.com", firstLookup.get(0).getEmailAddress());
+
+    List<MailingListMember> secondLookup = MailingListMemberRepository.findActiveMembersForList(listId);
+    assertEquals(token, secondLookup.get(0).getUnsubscribeToken(), "the same token should be reused, not regenerated");
+  }
+
+  @Test
+  void findActiveMembersForListExcludesUnsubscribedAndInvalidMembers() {
+    long listId = seedList("News");
+    seedMembership(listId, seedEmail("active@example.com"), true, null, null);
+    seedMembership(listId, seedEmail("unsub@example.com"), true, "2026-07-01 00:00:00", null);
+    seedMembership(listId, seedEmail("invalid@example.com"), false, null, null);
+
+    List<MailingListMember> members = MailingListMemberRepository.findActiveMembersForList(listId);
+    assertEquals(1, members.size());
+    assertEquals("active@example.com", members.get(0).getEmailAddress());
+  }
+
+  @Test
+  void findByUnsubscribeTokenFindsTheRightMember() {
+    long listId = seedList("News");
+    long emailId = seedEmail("a@example.com");
+    seedMembership(listId, emailId, true, null, "tok-123");
+
+    MailingListMember member = MailingListMemberRepository.findByUnsubscribeToken("tok-123");
+    assertNotNull(member);
+    assertEquals("a@example.com", member.getEmailAddress());
+  }
+
+  @Test
+  void findByUnsubscribeTokenReturnsNullForAnUnknownToken() {
+    assertNull(MailingListMemberRepository.findByUnsubscribeToken("does-not-exist"));
+  }
+
+  @Test
+  void unsubscribeByTokenClearsTheTokenSoItIsSingleUse() {
+    long listId = seedList("News");
+    long emailId = seedEmail("a@example.com");
+    seedMembership(listId, emailId, true, null, "tok-123");
+    MailingListMember member = MailingListMemberRepository.findByUnsubscribeToken("tok-123");
+
+    MailingListMemberRepository.unsubscribeByToken(member);
+
+    assertNull(MailingListMemberRepository.findByUnsubscribeToken("tok-123"), "token must be cleared after use");
+    MailingListMember reloaded = MailingListMemberRepository.findByListAndEmail(listId, emailId);
+    assertNotNull(reloaded.getUnsubscribed());
+    assertFalse(reloaded.getIsValid());
+  }
+
+  @Test
+  void findByListAndEmailGeneratesATokenIfNoneExistsYet() {
+    long listId = seedList("News");
+    long emailId = seedEmail("a@example.com");
+    seedMembership(listId, emailId, true, null, null);
+
+    MailingListMember member = MailingListMemberRepository.findByListAndEmail(listId, emailId);
+
+    assertNotNull(member.getUnsubscribeToken());
+  }
+
+  private long seedList(String name) {
+    return withConnection(connection -> {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("INSERT INTO mailing_lists (name, title) VALUES ('" + name + "', '" + name + "')");
+        try (var rs = statement.executeQuery("SELECT list_id FROM mailing_lists WHERE name = '" + name + "'")) {
+          rs.next();
+          return rs.getLong(1);
+        }
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+  }
+
+  private long seedHistory(long listId) {
+    return withConnection(connection -> {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("INSERT INTO mailing_list_history (list_id, service, blog_post_id) VALUES ("
+            + listId + ", 'smtp', 1)");
+        try (var rs = statement.executeQuery("SELECT history_id FROM mailing_list_history WHERE list_id = " + listId)) {
+          rs.next();
+          return rs.getLong(1);
+        }
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+  }
+
+  private long seedEmail(String email) {
+    return withConnection(connection -> {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("INSERT INTO emails (email) VALUES ('" + email + "')");
+        try (var rs = statement.executeQuery("SELECT email_id FROM emails WHERE email = '" + email + "'")) {
+          rs.next();
+          return rs.getLong(1);
+        }
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+  }
+
+  private void seedMembership(long listId, long emailId, boolean isValid, String unsubscribed, String unsubscribeToken) {
+    withConnectionVoid(connection -> {
+      try (Statement statement = connection.createStatement()) {
+        String unsubscribedSql = unsubscribed == null ? "NULL" : "'" + unsubscribed + "'";
+        String tokenSql = unsubscribeToken == null ? "NULL" : "'" + unsubscribeToken + "'";
+        statement.execute("INSERT INTO mailing_list_members (list_id, email_id, is_valid, unsubscribed, unsubscribe_token) VALUES ("
+            + listId + ", " + emailId + ", " + isValid + ", " + unsubscribedSql + ", " + tokenSql + ")");
+      } catch (SQLException se) {
+        throw new RuntimeException(se);
+      }
+    });
+  }
+
+  private interface ConnectionFunction<T> {
+    T apply(Connection connection);
+  }
+
+  private static <T> T withConnection(ConnectionFunction<T> function) {
+    try (Connection connection = DB.getConnection()) {
+      return function.apply(connection);
+    } catch (SQLException se) {
+      throw new RuntimeException(se);
+    }
+  }
+
+  private interface ConnectionConsumer {
+    void accept(Connection connection);
+  }
+
+  private static void withConnectionVoid(ConnectionConsumer consumer) {
+    try (Connection connection = DB.getConnection()) {
+      consumer.accept(connection);
+    } catch (SQLException se) {
+      throw new RuntimeException(se);
+    }
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE TABLE emails ("
+          + "email_id BIGSERIAL PRIMARY KEY, "
+          + "email VARCHAR(255) UNIQUE NOT NULL, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+      statement.execute("CREATE TABLE mailing_lists ("
+          + "list_id BIGSERIAL PRIMARY KEY, "
+          + "list_order INTEGER DEFAULT 100, "
+          + "name VARCHAR(200) NOT NULL, "
+          + "title VARCHAR(200) NOT NULL, "
+          + "description TEXT, "
+          + "member_count INTEGER DEFAULT 0, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "created_by BIGINT, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT, "
+          + "last_emailed TIMESTAMP(3), "
+          + "show_online BOOLEAN DEFAULT false, "
+          + "enabled BOOLEAN DEFAULT true)");
+      statement.execute("CREATE TABLE mailing_list_members ("
+          + "member_id BIGSERIAL PRIMARY KEY, "
+          + "list_id BIGINT REFERENCES mailing_lists(list_id), "
+          + "email_id BIGINT REFERENCES emails(email_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "created_by BIGINT, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT, "
+          + "last_emailed TIMESTAMP(3), "
+          + "unsubscribed TIMESTAMP(3), "
+          + "unsubscribed_by BIGINT, "
+          + "unsubscribe_reason VARCHAR(100), "
+          + "is_valid BOOLEAN DEFAULT true, "
+          + "unsubscribe_token VARCHAR(255))");
+      statement.execute("CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id)");
+      statement.execute("CREATE UNIQUE INDEX mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token)");
+      statement.execute("CREATE TABLE mailing_list_history ("
+          + "history_id BIGSERIAL PRIMARY KEY, "
+          + "list_id BIGINT REFERENCES mailing_lists(list_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "created_by BIGINT, "
+          + "service VARCHAR(20), "
+          + "email_count INTEGER DEFAULT 0, "
+          + "subject VARCHAR(255), "
+          + "blog_post_id BIGINT)");
+      statement.execute("CREATE TABLE mailing_list_sent ("
+          + "item_id BIGSERIAL PRIMARY KEY, "
+          + "email_id BIGINT REFERENCES emails(email_id), "
+          + "list_id BIGINT REFERENCES mailing_lists(list_id), "
+          + "history_id BIGINT REFERENCES mailing_list_history(history_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "status VARCHAR(20) DEFAULT 'queued', "
+          + "attempt_count INTEGER DEFAULT 0, "
+          + "error_message VARCHAR(500), "
+          + "claimed_at TIMESTAMP(3), "
+          + "modified TIMESTAMP(3))");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the newsletter send-queue test schema", se);
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (RuntimeException | LinkageError e) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidgetTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class NewsletterSendWidgetTest extends WidgetBase {
+
+  private static MailingList mailingList(long id, String title, boolean enabled) {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(id);
+    mailingList.setTitle(title);
+    mailingList.setEnabled(enabled);
+    return mailingList;
+  }
+
+  private static BlogPost blogPost(long id, String title) {
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(id);
+    blogPost.setTitle(title);
+    return blogPost;
+  }
+
+  @Test
+  void executeOnlyListsEnabledMailingLists() {
+    List<MailingList> lists = new ArrayList<>();
+    lists.add(mailingList(1L, "Active List", true));
+    lists.add(mailingList(2L, "Disabled List", false));
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(lists);
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      WidgetContext result = new NewsletterSendWidget().execute(widgetContext);
+
+      List<MailingList> shown = (List<MailingList>) result.getRequest().getAttribute("mailingLists");
+      assertEquals(1, shown.size());
+      assertEquals("Active List", shown.get(0).getTitle());
+    }
+  }
+
+  @Test
+  void postEnqueuesAndReportsTheQueuedCount() throws DataException {
+    setRoles(widgetContext, ADMIN);
+    MailingList mailingList = mailingList(1L, "News", true);
+    BlogPost blogPost = blogPost(2L, "A Post");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "blogPostId", "2");
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      listRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList);
+      blogRepo.when(() -> BlogPostRepository.findById(2L)).thenReturn(blogPost);
+      sendCommand.when(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, 1L))
+          .thenReturn(42);
+
+      WidgetContext result = new NewsletterSendWidget().post(widgetContext);
+
+      assertEquals("42 subscribers queued. Emails will go out shortly.", result.getSuccessMessage());
+      assertEquals("/admin/newsletter-send", result.getRedirect());
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.CONTENT), eq("newsletter.enqueue"),
+          eq(AuditEventCommand.SUCCESS), eq("mailing_list"), any(), any(), any()));
+    }
+  }
+
+  @Test
+  void postReportsZeroQueuedDistinctlyFromASuccessfulNonZeroQueue() throws DataException {
+    setRoles(widgetContext, ADMIN);
+    MailingList mailingList = mailingList(1L, "News", true);
+    BlogPost blogPost = blogPost(2L, "A Post");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "blogPostId", "2");
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      listRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList);
+      blogRepo.when(() -> BlogPostRepository.findById(2L)).thenReturn(blogPost);
+      sendCommand.when(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, 1L))
+          .thenReturn(0);
+
+      WidgetContext result = new NewsletterSendWidget().post(widgetContext);
+
+      assertEquals("No active subscribers were found on that list.", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postRequiresBothAMailingListAndABlogPostToBeSelected() {
+    setRoles(widgetContext, ADMIN);
+    // Neither mailingListId nor blogPostId params are set
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      WidgetContext result = new NewsletterSendWidget().post(widgetContext);
+
+      assertEquals("Choose a mailing list and a blog post", result.getWarningMessage());
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(any(), any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void postDoesNothingForAUserWithoutTheRequiredRole() {
+    // WidgetBase's default logged-in test user has no roles at all
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "blogPostId", "2");
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      new NewsletterSendWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(any(), any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void postAllowsACommunityManagerRole() throws DataException {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    MailingList mailingList = mailingList(1L, "News", true);
+    BlogPost blogPost = blogPost(2L, "A Post");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "blogPostId", "2");
+
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      listRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList);
+      blogRepo.when(() -> BlogPostRepository.findById(2L)).thenReturn(blogPost);
+      sendCommand.when(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, 1L))
+          .thenReturn(5);
+
+      WidgetContext result = new NewsletterSendWidget().post(widgetContext);
+
+      assertEquals("5 subscribers queued. Emails will go out shortly.", result.getSuccessMessage());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class NewsletterUnsubscribeWidgetTest extends WidgetBase {
+
+  private static MailingListMember member(long id, boolean alreadyUnsubscribed) {
+    MailingListMember member = new MailingListMember();
+    member.setId(id);
+    member.setUnsubscribeToken("tok-123");
+    if (alreadyUnsubscribed) {
+      member.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
+    }
+    return member;
+  }
+
+  @Test
+  void executeUnsubscribesAValidToken() {
+    MailingListMember member = member(1L, false);
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
+
+      WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/newsletter-unsubscribed.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.unsubscribeByToken(member));
+    }
+  }
+
+  @Test
+  void executeDoesNotReUnsubscribeAnAlreadyUnsubscribedMember() {
+    MailingListMember member = member(1L, true);
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
+
+      WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/newsletter-unsubscribed.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.unsubscribeByToken(any()), never());
+    }
+  }
+
+  @Test
+  void executeShowsNotFoundForAnUnknownToken() {
+    addQueryParameter(widgetContext, "token", "does-not-exist");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("does-not-exist")).thenReturn(null);
+
+      WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/newsletter-unsubscribe-not-found.jsp", result.getJsp());
+    }
+  }
+
+  @Test
+  void executeShowsNotFoundForAMissingToken() {
+    // No "token" param at all
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+
+      WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/newsletter-unsubscribe-not-found.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.findByUnsubscribeToken(any()), never());
+    }
+  }
+
+  @Test
+  void executeShowsRateLimitedPageWhenThrottled() {
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(false);
+
+      WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      assertEquals("/cms/error-rate-limited.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.findByUnsubscribeToken(any()), never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Issue #491 found the newsletter system 50% built: 331 subscribers collected, nothing ever sent. This resurrects the long-dormant `mailing_list_history`/`mailing_list_sent` tables (present since the original 2019 design, never once written to) as a real send queue.

- **`/admin/newsletter-send`** — a new admin page: pick a mailing list and a published blog post, queue a notification to every current subscriber of that list, with a live preview.
- **`NewsletterQueueJob`** — a background job (minutely) that drains the queue a batch at a time. Modeled on `OrderManagementProcessNewOrders`, but adds a real claim-before-work step and a bounded retry count (3 attempts) — neither of which the closest existing job template demonstrates.
- **`NewsletterEmailCommand`** — gives every recipient their own email (one `addTo` per send), rather than reusing the `SendAdminEmailCommand`-style pattern of adding every recipient to one shared email's `To:` field. Fine for a small internal role-based list, but a real address-leak risk for ~300 public subscribers.
- **Anonymous unsubscribe** — a single-use, no-login-required link (`/unsubscribe?token=...`), modeled on the existing account-validation token pattern, mutate-on-GET, graceful "already unsubscribed"/"invalid link" state on reuse.
- MailChimp's own sync is unaffected — it only ever talks to the Members API (tagging/list membership), never Campaigns, so there's no overlap with this SMTP-based send.
- Composes correctly with the recently-merged mailing-list quarantine feature (#564) — quarantine already sets `is_valid = false`, so quarantined members are automatically excluded from sends without any extra logic.

Closes #600.

## Test plan
- [x] Repository tests against real Postgres (Testcontainers): queue claiming, retry-cap requeue vs. permanent failure, token generation/reuse, unsubscribe-by-token, concurrent-unsubscribe-before-send skip.
- [x] Command-level tests: enqueue only queues active/non-unsubscribed members, batch header created with correct subject/count.
- [x] Widget tests for the admin page and the unsubscribe widget (role gating, rate limiting, missing/invalid/already-used token).
- [x] Full `ant -lib lib/tests ci-test`, `ant -lib lib/war compile-jsp`, and `tools/check-unescaped-el.py --strict .` all green.
- [x] Live end-to-end verified against a Docker rehearsal with a real SMTP catcher (MailHog): published a post with a subscriber on the list → queue populated → background job picked it up within a minute → real email arrived with correct subject/content and a working unsubscribe link → clicking it unsubscribed the member and cleared the token (single-use) → re-clicking showed the graceful "no longer valid" page instead of erroring.