### PR TITLE
Add a 'Notify subscribers' option to the blog editor (#500)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidget.java
@@ -18,13 +18,16 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.*;
+import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
 import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.cms.WebPageTemplate;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageTemplateRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -33,6 +36,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Description
@@ -118,6 +123,18 @@ public class BlogEditorWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("blog", blog);
 
+    // For the "Notify subscribers" mailing list picker (issue #500)
+    List<MailingList> allLists = MailingListRepository.findAll();
+    List<MailingList> enabledLists = new ArrayList<>();
+    if (allLists != null) {
+      for (MailingList mailingList : allLists) {
+        if (mailingList.getEnabled()) {
+          enabledLists.add(mailingList);
+        }
+      }
+    }
+    context.getRequest().setAttribute("mailingLists", enabledLists);
+
     // Show the editor
     context.setJsp(JSP);
     return context;
@@ -142,6 +159,16 @@ public class BlogEditorWidget extends GenericWidget {
 
     String returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));
 
+    // Determine (independently of SaveBlogPostCommand's own identical check) whether this save is
+    // the transition into being published, for the "Notify subscribers" option below -- an edit to
+    // an already-published post, or unpublishing, must never (re-)send a notification.
+    boolean wasAlreadyPublished = false;
+    if (blogPostBean.getId() > -1) {
+      BlogPost existingPost = LoadBlogPostCommand.loadBlogPostById(blogPostBean.getId());
+      wasAlreadyPublished = existingPost != null && existingPost.getPublished() != null;
+    }
+    boolean justPublished = isPublished && !wasAlreadyPublished;
+
     // Save the blog post
     BlogPost blogPost = null;
     try {
@@ -162,8 +189,30 @@ public class BlogEditorWidget extends GenericWidget {
     AuditEventCommand.record(context, AuditEventCommand.CONTENT, eventType, AuditEventCommand.SUCCESS,
         "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), null);
 
+    // Notify subscribers (issue #500), only on the actual publish transition
+    String notifiedSuffix = "";
+    if (justPublished && StringUtils.isNotBlank(context.getParameter("notifySubscribers"))) {
+      long mailingListId = context.getParameterAsLong("notifyMailingListId");
+      MailingList mailingList = mailingListId > -1 ? MailingListRepository.findById(mailingListId) : null;
+      if (mailingList != null) {
+        try {
+          int queuedCount = NewsletterSendCommand.enqueueBlogPostNotification(mailingList, blogPost, context.getUserId());
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "newsletter.enqueue", AuditEventCommand.SUCCESS,
+              "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(),
+              queuedCount + " recipient(s) queued for \"" + blogPost.getTitle() + "\"");
+          notifiedSuffix = queuedCount == 0
+              ? " No active subscribers were found on that list."
+              : " " + queuedCount + " subscriber" + (queuedCount == 1 ? "" : "s") + " will be notified.";
+        } catch (DataException e) {
+          AuditEventCommand.record(context, AuditEventCommand.CONTENT, "newsletter.enqueue", AuditEventCommand.FAILURE,
+              "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(), e.getMessage());
+          notifiedSuffix = " Subscribers could not be notified: " + e.getMessage();
+        }
+      }
+    }
+
     // Determine the page to return to
-    context.setSuccessMessage("Blog post was saved");
+    context.setSuccessMessage("Blog post was saved" + notifiedSuffix);
     if (StringUtils.isNotBlank(returnPage)) {
       context.setRedirect(returnPage);
     } else {

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-editor.jsp
@@ -158,6 +158,20 @@
     </div>
   </div>
   <input id="enabled" type="checkbox" name="enabled" value="true" <c:if test="${blogPost.id == -1 || !empty blogPost.published}">checked</c:if>/><label for="enabled">Publish it?</label>
+  <c:if test="${!empty mailingLists}">
+    <div class="full-container" style="margin-top:10px">
+      <input id="notifySubscribers" type="checkbox" name="notifySubscribers" value="true"
+          onchange="document.getElementById('notifyMailingListId').disabled = !this.checked;" />
+      <label for="notifySubscribers">Notify subscribers of a mailing list about this post?</label>
+      <small>Only sent the moment this post is first published -- editing an already-published post won't re-notify anyone.</small>
+      <select id="notifyMailingListId" name="notifyMailingListId" disabled>
+        <option value="">Choose a mailing list...</option>
+        <c:forEach items="${mailingLists}" var="mailingList">
+          <option value="${mailingList.id}"><c:out value="${mailingList.title}" /></option>
+        </c:forEach>
+      </select>
+    </div>
+  </c:if>
   <div class="full-container">
     <div class="grid-x grid-margin-x">
       <div class="medium-6 cell">

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogEditorWidgetTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.LoadBlogPostCommand;
+import com.simisinc.platform.application.cms.SaveBlogPostCommand;
+import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class BlogEditorWidgetTest extends WidgetBase {
+
+  private static BlogPost blogPost(long id, Timestamp published) {
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(id);
+    blogPost.setTitle("A Post");
+    blogPost.setPublished(published);
+    return blogPost;
+  }
+
+  private static MailingList mailingList(long id) {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(id);
+    mailingList.setTitle("News");
+    mailingList.setName("news");
+    return mailingList;
+  }
+
+  @Test
+  void postNotifiesSubscribersWhenAnUnpublishedPostIsPublishedWithNotifyChecked()
+      throws InvocationTargetException, IllegalAccessException {
+    BlogPost existing = blogPost(5L, null); // was unpublished
+    BlogPost saved = blogPost(5L, new Timestamp(System.currentTimeMillis()));
+    MailingList mailingList = mailingList(9L);
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "enabled", "true");
+    addQueryParameter(widgetContext, "notifySubscribers", "true");
+    addQueryParameter(widgetContext, "notifyMailingListId", "9");
+
+    try (MockedStatic<LoadBlogPostCommand> loadPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<SaveBlogPostCommand> savePost = mockStatic(SaveBlogPostCommand.class);
+        MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      loadPost.when(() -> LoadBlogPostCommand.loadBlogPostById(5L)).thenReturn(existing);
+      savePost.when(() -> SaveBlogPostCommand.saveBlogPost(any())).thenReturn(saved);
+      listRepo.when(() -> MailingListRepository.findById(9L)).thenReturn(mailingList);
+      sendCommand.when(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, saved, 1L)).thenReturn(7);
+
+      WidgetContext result = new BlogEditorWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, saved, 1L));
+      assertTrue(result.getSuccessMessage().contains("7 subscribers will be notified"), result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postDoesNotNotifyWhenEditingAnAlreadyPublishedPost()
+      throws InvocationTargetException, IllegalAccessException {
+    BlogPost existing = blogPost(5L, new Timestamp(System.currentTimeMillis())); // already published
+    BlogPost saved = blogPost(5L, existing.getPublished());
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "enabled", "true");
+    addQueryParameter(widgetContext, "notifySubscribers", "true");
+    addQueryParameter(widgetContext, "notifyMailingListId", "9");
+
+    try (MockedStatic<LoadBlogPostCommand> loadPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<SaveBlogPostCommand> savePost = mockStatic(SaveBlogPostCommand.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      loadPost.when(() -> LoadBlogPostCommand.loadBlogPostById(5L)).thenReturn(existing);
+      savePost.when(() -> SaveBlogPostCommand.saveBlogPost(any())).thenReturn(saved);
+
+      WidgetContext result = new BlogEditorWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(any(), any(), anyLong()), never());
+      assertEquals("Blog post was saved", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postNotifiesSubscribersForABrandNewPostPublishedImmediately()
+      throws InvocationTargetException, IllegalAccessException {
+    BlogPost saved = blogPost(6L, new Timestamp(System.currentTimeMillis()));
+    MailingList mailingList = mailingList(9L);
+    // No "id" param at all -- a brand new post
+    addQueryParameter(widgetContext, "enabled", "true");
+    addQueryParameter(widgetContext, "notifySubscribers", "true");
+    addQueryParameter(widgetContext, "notifyMailingListId", "9");
+
+    try (MockedStatic<LoadBlogPostCommand> loadPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<SaveBlogPostCommand> savePost = mockStatic(SaveBlogPostCommand.class);
+        MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      savePost.when(() -> SaveBlogPostCommand.saveBlogPost(any())).thenReturn(saved);
+      listRepo.when(() -> MailingListRepository.findById(9L)).thenReturn(mailingList);
+      sendCommand.when(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, saved, 1L)).thenReturn(3);
+
+      new BlogEditorWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(mailingList, saved, 1L));
+      loadPost.verify(() -> LoadBlogPostCommand.loadBlogPostById(anyLong()), never());
+    }
+  }
+
+  @Test
+  void postDoesNotNotifyWhenTheCheckboxIsUnchecked() throws InvocationTargetException, IllegalAccessException {
+    BlogPost existing = blogPost(5L, null);
+    BlogPost saved = blogPost(5L, new Timestamp(System.currentTimeMillis()));
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "enabled", "true");
+    // notifySubscribers not set at all
+
+    try (MockedStatic<LoadBlogPostCommand> loadPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<SaveBlogPostCommand> savePost = mockStatic(SaveBlogPostCommand.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      loadPost.when(() -> LoadBlogPostCommand.loadBlogPostById(5L)).thenReturn(existing);
+      savePost.when(() -> SaveBlogPostCommand.saveBlogPost(any())).thenReturn(saved);
+
+      WidgetContext result = new BlogEditorWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(any(), any(), anyLong()), never());
+      assertEquals("Blog post was saved", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postDoesNotNotifyWhenUnpublishing() throws InvocationTargetException, IllegalAccessException {
+    BlogPost existing = blogPost(5L, new Timestamp(System.currentTimeMillis()));
+    BlogPost saved = blogPost(5L, null);
+    addQueryParameter(widgetContext, "id", "5");
+    // "enabled" checkbox absent -- unpublishing
+    addQueryParameter(widgetContext, "notifySubscribers", "true");
+    addQueryParameter(widgetContext, "notifyMailingListId", "9");
+
+    try (MockedStatic<LoadBlogPostCommand> loadPost = mockStatic(LoadBlogPostCommand.class);
+        MockedStatic<SaveBlogPostCommand> savePost = mockStatic(SaveBlogPostCommand.class);
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+      loadPost.when(() -> LoadBlogPostCommand.loadBlogPostById(5L)).thenReturn(existing);
+      savePost.when(() -> SaveBlogPostCommand.saveBlogPost(any())).thenReturn(saved);
+
+      new BlogEditorWidget().post(widgetContext);
+
+      sendCommand.verify(() -> NewsletterSendCommand.enqueueBlogPostNotification(any(), any(), anyLong()), never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Stacked on #660 (#600) — reuses its `NewsletterSendCommand.enqueueBlogPostNotification` directly.

Blog post publishing has never triggered any subscriber notification (the workflow engine's `blog-post-published` handler only writes an activity-stream record). Rather than a persistent blog-to-mailing-list association (issue #599, still an open design question), this adds a per-publish checkbox and list picker: the admin explicitly chooses whether and which list to notify each time they publish, using the same enqueue mechanism as the manual `/admin/newsletter-send` page (#600).

Only fires on the actual unpublished-to-published transition — editing an already-published post, or unpublishing, never (re-)notifies anyone.

Closes #500.

## Test plan
- [x] Widget tests: publish-with-notify-checked enqueues; editing an already-published post does not; a brand-new post published immediately does; unchecked checkbox never notifies; unpublishing never notifies.
- [x] Full `ant -lib lib/tests ci-test`, `ant -lib lib/war compile-jsp`, and `tools/check-unescaped-el.py --strict .` all green (run together with #660's changes).
- [x] Live-verified against the same Docker rehearsal as #660: published a new blog post with "Notify subscribers" checked and a list selected → `mailing_list_history`/`mailing_list_sent` rows created correctly → the queued email was sent and received exactly as expected.

**Note:** this PR targets `feature/newsletter-send-mechanism-600` (base of #660), not `main` — merge #660 first.