### PR TITLE
Add a "Block IP" row action to /admin/mailing-list-members

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
@@ -16,13 +16,18 @@
 
 package com.simisinc.platform.presentation.widgets.mailinglists;
 
+import com.simisinc.platform.application.AppException;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.IpRangeCommand;
+import com.simisinc.platform.application.cms.SaveBlockedIPCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.application.mailinglists.ProcessEmailCSVFileCommand;
 import com.simisinc.platform.application.mailinglists.SaveEmailCommand;
+import com.simisinc.platform.domain.model.BlockedIP;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.*;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
@@ -30,6 +35,7 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -105,6 +111,10 @@ public class MailingListMembersWidget extends GenericWidget {
     String command = context.getParameter("command");
     if ("uploadCSVFile".equals(command)) {
       return uploadCSVFileAction(context, mailingList);
+    }
+
+    if ("blockIP".equals(command)) {
+      return blockIPAction(context, mailingList);
     }
 
     if ("downloadCSVFile".equals(command)) {
@@ -186,6 +196,58 @@ public class MailingListMembersWidget extends GenericWidget {
     // Determine the page to return to
     context.setSuccessMessage("Email was added");
     context.setRedirect("/admin/mailing-list-members?mailingListId=" + mailingList.getId());
+    return context;
+  }
+
+  /**
+   * Feeds a member's captured IP into the database-backed blocked-IP list (see docs/ip-blocking.md).
+   * Blocks the IP only - the mailing-list member row is left untouched; use the separate Delete action
+   * if the member itself should also be removed.
+   */
+  private WidgetContext blockIPAction(WidgetContext context, MailingList mailingList) {
+    context.setRedirect("/admin/mailing-list-members?mailingListId=" + mailingList.getId());
+
+    long emailId = context.getParameterAsLong("emailId");
+    Email email = EmailRepository.findById(emailId);
+    if (email == null) {
+      context.setErrorMessage("Email record was not found");
+      return context;
+    }
+
+    String ipAddress = email.getIpAddress();
+    if (StringUtils.isBlank(ipAddress)) {
+      context.setErrorMessage("No IP address is on file for this member");
+      return context;
+    }
+
+    // Don't allow blocking your own current IP, whether an exact match or as part of a CIDR range
+    if (IpRangeCommand.matches(ipAddress, context.getRequest().getRemoteAddr())) {
+      context.setErrorMessage("Cannot block your own IP");
+      return context;
+    }
+
+    // Skip if already blocked
+    if (BlockedIPRepository.findByIpAddress(ipAddress) != null) {
+      context.setWarningMessage("That IP is already blocked");
+      return context;
+    }
+
+    BlockedIP blockedIPBean = new BlockedIP();
+    blockedIPBean.setIpAddress(ipAddress);
+    blockedIPBean.setReason("Blocked from mailing list member: " + email.getEmail());
+    try {
+      BlockedIP blockedIP = SaveBlockedIPCommand.save(blockedIPBean);
+      if (blockedIP == null) {
+        throw new AppException("The IP could not be blocked due to a system error. Please try again.");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.add", AuditEventCommand.SUCCESS,
+          "blocked_ip", String.valueOf(blockedIP.getId()), blockedIP.getIpAddress(), blockedIP.getReason());
+      context.setSuccessMessage("IP " + ipAddress + " has been blocked");
+    } catch (DataException | AppException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "blocked_ip.add", AuditEventCommand.FAILURE,
+          "blocked_ip", null, ipAddress, e.getMessage());
+      context.setErrorMessage(e.getMessage());
+    }
     return context;
   }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -81,7 +81,10 @@
       <td><small><c:out value="${empty email.ipAddress ? '--' : email.ipAddress}" /></small></td>
       <td><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${email.created}" /></td>
       <td>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape(email.email)}" />?');"><i class="fa fa-remove"></i></a>
+        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape(email.email)}" />?');" title="Remove member"><i class="fa fa-remove"></i></a>
+        <c:if test="${!empty email.ipAddress}">
+          <a href="#" onclick="return confirmPostAction('Block IP <c:out value="${js:escape(email.ipAddress)}" />? This will prevent that IP from accessing the site. The member itself is not removed.', '${widgetContext.uri}?command=blockIP&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}');" title="Block this IP"><i class="fa fa-ban"></i></a>
+        </c:if>
       </td>
     </tr>
     </c:forEach>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.SaveBlockedIPCommand;
+import com.simisinc.platform.domain.model.BlockedIP;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * The "Block IP" row action (#646) feeds a mailing-list member's captured IP into the database-backed
+ * blocked-IP list. Blocks the IP only - the member row is untouched. These tests call post() directly,
+ * the method a real confirmPostAction()-submitted request actually reaches (see #658/PR #659, found
+ * while building this feature: the sibling delete links on the blocked/allowed IP list pages had used
+ * the same confirmPostAction() convention but their post() never checked for the matching command, so
+ * every click silently no-opped).
+ *
+ * @author elizabeth houser
+ */
+class MailingListMembersWidgetTest extends WidgetBase {
+
+  private static MailingList mailingList() {
+    MailingList list = new MailingList();
+    list.setId(1L);
+    list.setName("Newsletter");
+    return list;
+  }
+
+  private static Email emailWithIp(String ip) {
+    Email email = new Email();
+    email.setId(2L);
+    email.setEmail("spammer@example.com");
+    email.setIpAddress(ip);
+    return email;
+  }
+
+  @Test
+  void blockIPSuccessfullyBlocksTheMembersIp() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    Email target = emailWithIp("203.0.113.20");
+    BlockedIP saved = new BlockedIP();
+    saved.setId(42L);
+    saved.setIpAddress("203.0.113.20");
+    saved.setReason("Blocked from mailing list member: spammer@example.com");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<BlockedIPRepository> blockedIpRepo = mockStatic(BlockedIPRepository.class);
+        MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(target);
+      blockedIpRepo.when(() -> BlockedIPRepository.findByIpAddress("203.0.113.20")).thenReturn(null);
+      saveCommand.when(() -> SaveBlockedIPCommand.save(any(BlockedIP.class))).thenReturn(saved);
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveBlockedIPCommand.save(any(BlockedIP.class)));
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("blocked_ip.add"),
+          eq(AuditEventCommand.SUCCESS), eq("blocked_ip"), eq("42"), eq("203.0.113.20"), any()));
+      assertEquals("IP 203.0.113.20 has been blocked", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void blockIPRefusesToBlockTheAdminsOwnCurrentIp() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+    when(request.getRemoteAddr()).thenReturn("203.0.113.20");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveBlockedIPCommand.save(any()), never());
+      assertEquals("Cannot block your own IP", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void blockIPWarnsInsteadOfDuplicatingAnAlreadyBlockedIp() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    BlockedIP existing = new BlockedIP();
+    existing.setId(7L);
+    existing.setIpAddress("203.0.113.20");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<BlockedIPRepository> blockedIpRepo = mockStatic(BlockedIPRepository.class);
+        MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
+      blockedIpRepo.when(() -> BlockedIPRepository.findByIpAddress("203.0.113.20")).thenReturn(existing);
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveBlockedIPCommand.save(any()), never());
+      assertEquals("That IP is already blocked", result.getWarningMessage());
+    }
+  }
+
+  @Test
+  void blockIPFailsClearlyWhenNoIpIsOnFile() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp(null));
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveBlockedIPCommand.save(any()), never());
+      assertEquals("No IP address is on file for this member", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void blockIPDoesNotRemoveTheMailingListMember() throws Exception {
+    // The whole point of this action's scope decision: block the IP, leave the subscriber record alone.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    BlockedIP saved = new BlockedIP();
+    saved.setId(42L);
+    saved.setIpAddress("203.0.113.20");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<BlockedIPRepository> blockedIpRepo = mockStatic(BlockedIPRepository.class);
+        MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
+      blockedIpRepo.when(() -> BlockedIPRepository.findByIpAddress("203.0.113.20")).thenReturn(null);
+      saveCommand.when(() -> SaveBlockedIPCommand.save(any(BlockedIP.class))).thenReturn(saved);
+
+      new MailingListMembersWidget().post(widgetContext);
+
+      memberRepo.verify(() -> MailingListMemberRepository.remove(any(), any()), never());
+    }
+  }
+
+  @Test
+  void blockIPIsRefusedWithoutAdminOrCommunityManagerRole() throws Exception {
+    setRoles(widgetContext); // logged in, no relevant role
+    addQueryParameter(widgetContext, "command", "blockIP");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    try (MockedStatic<SaveBlockedIPCommand> saveCommand = mockStatic(SaveBlockedIPCommand.class)) {
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      saveCommand.verifyNoInteractions();
+      assertNull(result.getSuccessMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a per-row "Block IP" action on `/admin/mailing-list-members` that feeds a member's captured IP into the existing database-backed blocked-IP list (`docs/ip-blocking.md`), with an auto-generated, traceable reason
- Blocks the IP only - the mailing-list member row is untouched (use the existing Delete action separately to remove the subscriber)
- Guards against self-lockout (own current IP, exact or CIDR-contained) and against duplicating an already-blocked IP; a member with no IP on file gets a clear error
- Records a `blocked_ip.add` audit event on success/failure, same pattern as #644/#656

**Also fixes #658** (found while building this): the per-row delete links on `/admin/blocked-ip-list` and `/admin/allowed-ip-list` use `confirmPostAction()`, which submits a real POST. `WebContainerCommand` checks `isPost()` before `isDelete()`, so `command=delete` in the POST body never reached `delete()` - it silently no-opped with a 302 back to the same page and the record still present. Fixed both widgets' `post()` to forward to `delete()`, same shape as PR #577's `UserDetailsWidget` fix.

Fixes #646
Fixes #658

## Test plan
- [x] `ant -lib lib/war clean compile compile-jsp` - clean
- [x] `tools/check-unescaped-el.py` - 0 unallowlisted sites
- [x] `ant -lib lib/tests ci-test` - full suite green, including 6 new `MailingListMembersWidgetTest` cases (success, self-lockout, duplicate warning, no-IP-on-file, member-not-removed, permission check)
- [x] Live-verified in a docker-compose rehearsal against a real Postgres backend:
  - Blocked a member's IP, confirmed the auto-generated reason and `blocked_ip.add` audit event via the row's History link
  - Confirmed the self-lockout guard rejects blocking the requester's own current IP, and that the IP is not added to the blocked list
  - Confirmed the delete-dispatch fix with a direct curl repro (add IP -> POST the exact `confirmPostAction()` payload -> record actually gone on reload)