### PR TITLE
Visual Editor P2 slice 1: server-emitted content markers

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/content-card-slider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-card-slider.jsp
@@ -35,7 +35,7 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <c:if test="${isDraft eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-card.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-card.jsp
@@ -36,7 +36,7 @@
 </c:if>
   .card${widgetContext.uniqueId} { border: none; }
 </style>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <c:if test="${isDraft eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-carousel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-carousel.jsp
@@ -27,7 +27,7 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <c:if test="${isDraft eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-gallery.jsp
@@ -25,7 +25,7 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <c:if test="${isDraft eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-reveal.jsp
@@ -25,7 +25,7 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <c:if test="${isDraft eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-tabs-links.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-tabs-links.jsp
@@ -30,7 +30,7 @@
   </ul>
   <div class="tabs-content">
   <c:forEach items="${contentTabList}" var="contentTab" varStatus="tabStatus">
-    <div class="tabs-panel<c:if test="${contentTab.isActive}"> is-active</c:if>">
+    <div class="tabs-panel<c:if test="${contentTab.isActive}"> is-active</c:if>"<c:if test="${showEditor eq 'true' && !empty contentTab.contentUniqueId}"> data-simis-content-id="${contentTab.contentUniqueId}"</c:if>>
       <c:if test="${showEditor eq 'true'}">
         <div class="platform-content-editor"><a class="hollow button small secondary" href="${ctx}/content-editor?uniqueId=${contentTab.contentUniqueId}&returnPage=${returnPage}"><i class="${font:fas()} fa-edit"></i></a></div>
       </c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/content-tabs.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-tabs.jsp
@@ -30,7 +30,7 @@
   </ul>
   <div class="tabs-content" data-tabs-content="deeplinked-tabs">
   <c:forEach items="${contentTabList}" var="contentTab" varStatus="tabStatus">
-    <div class="tabs-panel<c:if test="${tabStatus.first}"> is-active</c:if>" id="${contentTab.linkId}">
+    <div class="tabs-panel<c:if test="${tabStatus.first}"> is-active</c:if>" id="${contentTab.linkId}"<c:if test="${showEditor eq 'true' && !empty contentTab.contentUniqueId}"> data-simis-content-id="${contentTab.contentUniqueId}"</c:if>>
       <c:if test="${showEditor eq 'true'}">
         <div class="platform-content-editor"><a class="hollow button small secondary" href="${ctx}/content-editor?uniqueId=${contentTab.contentUniqueId}&returnPage=${returnPage}#${contentTab.linkId}"><i class="${font:fas()} fa-edit"></i></a></div>
       </c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -24,7 +24,7 @@
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa <c:out value="${icon}"/>"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
-<div class="platform-content-container">
+<div class="platform-content-container"<c:if test="${showEditor eq 'true' && !empty uniqueId}"> data-simis-content-id="${uniqueId}"</c:if>>
   <c:if test="${showEditor eq 'true' && !empty uniqueId}">
     <div class="platform-content-editor">
       <%-- The review affordance is chosen by ContentReviewCommand.offerFor(), so separation of duties


### PR DESCRIPTION
Part of #257 (Visual Editor P2 — Edit-on-page overlay).

## Why

Per the scoping comments already on #257: v2's DOM markers (`data-widget`, `data-row-id`, `data-col-id`) turned out to be built client-side by the designer canvas, never emitted by the server renderer — so they can't be ported, and P2's overlay editor needs a server-emitted marker layer built from scratch. The recommendation there was to build this slice independently of the UX tour, since it's required regardless of how the overlay ends up feeling.

## What this does

Stamps a namespaced `data-simis-content-id` attribute — naming the region's `Content.uniqueId` — onto every editable content region rendered by the 8 `Content`-backed widget JSPs: `content`, `content-card`, `content-card-slider`, `content-carousel`, `content-gallery`, `content-reveal`, `content-tabs`, `content-tabs-links`.

No Java changes. Each of these JSPs already has a `showEditor`/`uniqueId` (or, for the two tabs variants, `contentTab.contentUniqueId`) request attribute pair gating the existing "click to edit" pencil-icon affordance — the marker reuses that exact same condition, so it only ever appears for a viewer who could already reach that affordance. No new permission logic, and no new attacker-reachable data: `uniqueId` is already interpolated unescaped into an `href` in these same files today.

**Deliberately out of scope:** wiki pages and table-of-contents records have their own separate editors and identity fields (`wikiPage.uniqueId`+`wiki.uniqueId`, and a TOC `uniqueId`) — a structurally similar but distinct follow-up, not folded in here.

## Verification

- `ant -lib lib/war clean compile-jsp` — all JSPs still parse, 0 errors.
- `python3 tools/check-unescaped-el.py . --strict` — 0 new findings (`${uniqueId}`/`${contentTab.contentUniqueId}` already match the existing ID-shaped-value heuristic that covers their pre-existing `href` usage in the same files).
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green.
- **Live docker rehearsal**, since JSP rendering isn't exercised by any of the above: created a page with a Content widget, saved real content as an authenticated content-manager, and confirmed `data-simis-content-id="home-hello"` (the actual saved `uniqueId`) appears on the rendered `platform-content-container` div. Then fetched the same page with a cookie-less `curl` request (a genuinely anonymous request) and confirmed both the marker and the pre-existing edit affordance are completely absent.