### PR TITLE
Fix publish-images CVE-2026-26197 VEX gap blocking every recent push to main

### DIFF
--- a/docker/db/vex/simis-cms-db.openvex.json
+++ b/docker/db/vex/simis-cms-db.openvex.json
@@ -2,8 +2,8 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/SimisRnD/simis-cms/docker/db/vex/simis-cms-db",
   "author": "SimIS Inc. (SimIS CMS maintainers)",
-  "timestamp": "2026-07-21T12:51:42+00:00",
-  "version": 4,
+  "timestamp": "2026-07-29T23:20:00+00:00",
+  "version": 5,
   "tooling": "tools/generate-db-vex.py",
   "statements": [
     {
@@ -1064,7 +1064,28 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-26197"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/simis-cms-db",
+          "subcomponents": [
+            {
+              "@id": "pkg:deb/debian/libhdf5-103-1"
+            },
+            {
+              "@id": "pkg:deb/debian/libhdf5-hl-100"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Present only as a transitive dependency of the PostGIS package's GDAL stack. The database enables vector PostGIS only (`CREATE EXTENSION postgis`); postgis_raster is never created, so GDAL's raster/image decoders, its remote-dataset (curl/ssh2) drivers and its embedded SQLite/HDF5/XML readers are never loaded or reachable from SQL. The CVE's out-of-bounds read requires opening a corrupted HDF5 file through libhdf5's own reader, which is only reachable via GDAL's HDF5 driver -- never loaded here, consistent with the existing CVE-2018-11205 statement for these same two packages."
     }
   ],
-  "last_updated": "2026-07-28T06:06:34Z"
+  "last_updated": "2026-07-29T23:20:00Z"
 }


### PR DESCRIPTION
## Summary

Found while investigating #597 (whether #484/PR #589's reCAPTCHA fix is actually live on simisinc.com): it isn't, but that turned out to be one layer of a bigger problem. The **"Publish container images"** workflow -- the one that builds, scans, and (when configured) rolling-deploys the app to Azure App Service -- has failed on **every push to main since ~2026-07-29T22:22** (PRs #659, #660, #661, #662 all failed this job, confirmed via `gh run list`).

**Root cause:** a new HIGH-severity CVE, `CVE-2026-26197` (`libhdf5-103-1` / `libhdf5-hl-100`, no fixed version yet), started showing up in the `simis-cms-db` image scan. The "Enforce the database image scan gate" step correctly fails closed on any CRITICAL/HIGH finding not already triaged into `docker/db/vex/simis-cms-db.openvex.json` -- and this CVE, being new, wasn't in there yet. So every publish since has died on that gate before the image is ever pushed, let alone deployed.

**Why this is safe to mark not_affected:** these are the exact same two packages (`libhdf5-103-1`/`libhdf5-hl-100`) already covered by an identical `not_affected` statement for `CVE-2018-11205`, with the same reasoning: they're a transitive PostGIS/GDAL dependency, but this schema only ever runs `CREATE EXTENSION postgis` (`NEW_10000__new_database.sql`) -- `postgis_raster` is never created, so GDAL's HDF5 reader (the only code path to this CVE's corrupted-file out-of-bounds read) is never loaded or reachable from SQL.

**Deliberately a minimal, hand-added statement, not a full `tools/generate-db-vex.py` regen:** I ran the generator to see what it'd produce, and it would silently regress two existing hand-curated `not_affected` entries (libldap `CVE-2023-2953`, sysstat `CVE-2023-33204`) back to `under_investigation` -- the script's package/CVE policy tables don't have entries for those two, so a full regen would drop real, already-accepted risk determinations. Appended just the one new statement instead, matching the existing file's style and the CVE-2018-11205 precedent exactly.

## Test plan

- [x] Confirmed via `gh api repos/SimisRnD/simis-cms/code-scanning/alerts` that `CVE-2026-26197` is open, Trivy-sourced, on exactly `libhdf5-103-1`/`libhdf5-hl-100`, with no fixed version
- [x] Confirmed `postgis_raster` is never created anywhere in `src/main/resources/database/install/` (only `CREATE EXTENSION postgis`)
- [x] Built `docker/db/Dockerfile` locally (digest-pinned base images, reproducible) and ran the exact CI gate command (`trivy image --scanners vuln --severity CRITICAL,HIGH --exit-code 1 --vex ... --ignorefile ...`) against it:
  - **Before this change:** CVE-2026-26197 flagged, gate would fail
  - **After this change:** 0 vulnerabilities reported, exit 0
- [x] `python3 -m json.tool` validates the edited file

## Note

This unblocks the publish/scan gate, but I want to flag two things I found alongside it that are outside this PR's scope:
1. No `ACR_LOGIN_SERVER`/`ACR_APP_SERVICE_NAME`/`ACR_APP_RESOURCE_GROUP`/Azure OIDC repo variables appear to be set (`gh variable list` returns empty) -- so even with this gate green, the "Deploy to Azure App Service" step in this same workflow will just skip, not actually deploy anywhere.
2. `simisinc.com` currently resolves to `159.203.123.72`, a DigitalOcean IP, not an Azure endpoint -- so even a fully working Azure deploy pipeline wouldn't be reflected on the public production domain until DNS is repointed.

Neither of those is a code fix I can make from here; flagging for whoever owns the Azure/DNS side of Milestone #4.