### PR TITLE
Add Metabase as a second BI platform

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/SecretSitePropertiesCommand.java
@@ -47,6 +47,7 @@ public class SecretSitePropertiesCommand {
       "mailing-list.mailchimp.apiKey",
       "mailing-list.zerobounce.apiKey",
       "bi.superset.secret",
+      "bi.metabase.secret",
       "social.instagram.accessToken",
       "elearning.lrs.key",
       "elearning.lrs.secret",

--- a/src/main/java/com/simisinc/platform/application/dashboards/MetabaseEmbedCommand.java
+++ b/src/main/java/com/simisinc/platform/application/dashboards/MetabaseEmbedCommand.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.dashboards;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.json.JsonCommand;
+
+/**
+ * Builds a signed static-embed iframe URL for a Metabase dashboard.
+ * <p>
+ * Unlike Superset's guest-token flow (a login call, then a separate guest-token call, both
+ * against Superset's own API), Metabase's static embedding needs no round trip to Metabase at
+ * all: the embedding secret key signs a JWT locally, and the token is dropped straight into the
+ * iframe URL. See https://www.metabase.com/docs/latest/embedding/static-embedding.
+ *
+ * @author elizabeth houser
+ */
+public class MetabaseEmbedCommand {
+
+  private static Log LOG = LogFactory.getLog(MetabaseEmbedCommand.class);
+
+  private static final String JWT_HEADER_JSON = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+  private static final long TOKEN_TTL_SECONDS = 600; // matches Metabase's own sample apps
+
+  public static String generateDashboardIframeUrl(String dashboardId, String hashParameters) {
+    if (StringUtils.isBlank(dashboardId)) {
+      LOG.debug("Missing dashboardId");
+      return null;
+    }
+
+    boolean enabled = LoadSitePropertyCommand.loadByNameAsBoolean("bi.metabase.enabled");
+    if (!enabled) {
+      LOG.debug("Metabase BI is not enabled");
+      return null;
+    }
+
+    String serverUrl = LoadSitePropertyCommand.loadByName("bi.metabase.url");
+    String secret = LoadSitePropertyCommand.loadByName("bi.metabase.secret");
+    if (StringUtils.isAnyBlank(serverUrl, secret)) {
+      LOG.error("Metabase url/secret is not configured");
+      return null;
+    }
+
+    String token = sign(dashboardId, secret);
+    if (token == null) {
+      return null;
+    }
+
+    String url = StringUtils.stripEnd(serverUrl, "/") + "/embed/dashboard/" + token;
+    if (StringUtils.isNotBlank(hashParameters)) {
+      url += "#" + hashParameters;
+    }
+    return url;
+  }
+
+  private static String sign(String dashboardId, String secret) {
+    try {
+      Map<String, Object> resource = new HashMap<>();
+      resource.put("dashboard", dashboardId);
+
+      Map<String, Object> payload = new HashMap<>();
+      payload.put("resource", resource);
+      payload.put("params", Collections.emptyMap());
+      payload.put("exp", (System.currentTimeMillis() / 1000) + TOKEN_TTL_SECONDS);
+      String payloadJson = JsonCommand.createJsonNode(payload).toString();
+
+      String signingInput = base64UrlEncode(JWT_HEADER_JSON) + "." + base64UrlEncode(payloadJson);
+
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      byte[] signature = mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+
+      return signingInput + "." + base64UrlEncode(signature);
+    } catch (Exception e) {
+      LOG.error("Could not sign the Metabase embed token", e);
+      return null;
+    }
+  }
+
+  private static String base64UrlEncode(String value) {
+    return base64UrlEncode(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String base64UrlEncode(byte[] bytes) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/MetabaseWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/MetabaseWidget.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.dashboard;
+
+import com.simisinc.platform.application.cms.NumberCommand;
+import com.simisinc.platform.application.dashboards.MetabaseEmbedCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Renders a Metabase dashboard using static (signed) embedding. Unlike SupersetWidget, this needs
+ * no client-side SDK or guest-token AJAX round trip -- the signed iframe URL is computed
+ * synchronously on render.
+ *
+ * @author elizabeth houser
+ */
+public class MetabaseWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  public static String JSP = "/dashboard/metabase-embedded.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    String dashboardId = context.getPreferences().get("dashboardValue");
+
+    boolean hideChartTitle = "true".equals(context.getPreferences().getOrDefault("hideChartTitle", "false"));
+    String hashParameters = "bordered=true&titled=" + (hideChartTitle ? "false" : "true");
+
+    String iframeUrl = MetabaseEmbedCommand.generateDashboardIframeUrl(dashboardId, hashParameters);
+    if (iframeUrl == null) {
+      return context;
+    }
+
+    context.getRequest().setAttribute("iframeUrl", iframeUrl);
+    // height is rendered into a style value, so require a CSS length
+    context.getRequest().setAttribute("height",
+        NumberCommand.filterCssLength(context.getPreferences().getOrDefault("height", "300px"), "300px"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -194,6 +194,9 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (10, 'Superset Url', 'bi.superset.url', '', 'url');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'Superset Id', 'bi.superset.id', '', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (14, 'Superset Secret', 'bi.superset.secret', '', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (16, 'Enable Metabase?', 'bi.metabase.enabled', 'true', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (18, 'Metabase Url', 'bi.metabase.url', '', 'url');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'Metabase Secret', 'bi.metabase.secret', '', 'text');
 
 -- E-Commerce
 

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260729.2001__metabase_bi_properties.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260729.2001__metabase_bi_properties.sql
@@ -1,0 +1,3 @@
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (16, 'Enable Metabase?', 'bi.metabase.enabled', 'true', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (18, 'Metabase Url', 'bi.metabase.url', '', 'url');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'Metabase Secret', 'bi.metabase.secret', '', 'text');

--- a/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/site-properties-editor.jsp
@@ -80,7 +80,7 @@
                   <input type="password" class="no-gap" value="" placeholder="<c:out value="${empty siteProperty.value ? 'not set' : 'value hidden'}"/>" disabled />
                 </c:when>
                 <c:otherwise>
-                  <input type="password" class="no-gap" name="${siteProperty.name}" value="" autocomplete="new-password" placeholder="<c:out value="${empty siteProperty.value ? 'not set' : 'value hidden; leave blank to keep it'}"/>"<c:if test="${siteProperty.name eq 'captcha.google.secretkey'}"> aria-describedby="captchaGoogleSecretkeyHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.superset.secret'}"> aria-describedby="biSupersetSecretHelpText"</c:if> />
+                  <input type="password" class="no-gap" name="${siteProperty.name}" value="" autocomplete="new-password" placeholder="<c:out value="${empty siteProperty.value ? 'not set' : 'value hidden; leave blank to keep it'}"/>"<c:if test="${siteProperty.name eq 'captcha.google.secretkey'}"> aria-describedby="captchaGoogleSecretkeyHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.superset.secret'}"> aria-describedby="biSupersetSecretHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.metabase.secret'}"> aria-describedby="biMetabaseSecretHelpText"</c:if> />
                 </c:otherwise>
               </c:choose>
             </c:when>
@@ -151,7 +151,7 @@
             <c:when test="${siteProperty.type eq 'url'}">
               <div class="input-group">
                 <span class="input-group-label"><i class="fa fa-link"></i></span>
-                <input class="input-group-field" id="${siteProperty.id}" type="text" name="${siteProperty.name}" placeholder="http://..." value="<c:out value="${siteProperty.value}"/>"<c:if test="${siteProperty.name eq 'elearning.lrs.url'}"> aria-describedby="elearningLrsUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'elearning.moodle.url'}"> aria-describedby="elearningMoodleUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'elearning.perls.url'}"> aria-describedby="elearningPerlsUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.superset.url'}"> aria-describedby="biSupersetUrlHelpText"</c:if>>
+                <input class="input-group-field" id="${siteProperty.id}" type="text" name="${siteProperty.name}" placeholder="http://..." value="<c:out value="${siteProperty.value}"/>"<c:if test="${siteProperty.name eq 'elearning.lrs.url'}"> aria-describedby="elearningLrsUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'elearning.moodle.url'}"> aria-describedby="elearningMoodleUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'elearning.perls.url'}"> aria-describedby="elearningPerlsUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.superset.url'}"> aria-describedby="biSupersetUrlHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.metabase.url'}"> aria-describedby="biMetabaseUrlHelpText"</c:if>>
               </div>
             </c:when>
             <c:when test="${siteProperty.type eq 'image'}">
@@ -171,7 +171,7 @@
             </c:when>
             <c:when test="${siteProperty.type eq 'boolean'}">
               <div class="switch large">
-                <input class="switch-input" id="${siteProperty.name}-yes-no" type="checkbox" name="${siteProperty.name}" value="true"<c:if test="${siteProperty.value eq 'true'}"> checked</c:if><c:if test="${siteProperty.name eq 'bi.enabled'}"> aria-describedby="biEnabledHelpText"</c:if>>
+                <input class="switch-input" id="${siteProperty.name}-yes-no" type="checkbox" name="${siteProperty.name}" value="true"<c:if test="${siteProperty.value eq 'true'}"> checked</c:if><c:if test="${siteProperty.name eq 'bi.enabled'}"> aria-describedby="biEnabledHelpText"</c:if><c:if test="${siteProperty.name eq 'bi.metabase.enabled'}"> aria-describedby="biMetabaseEnabledHelpText"</c:if>>
                 <label class="switch-paddle" for="${siteProperty.name}-yes-no">
                 <span class="switch-active" aria-hidden="true">Yes</span>
                 <span class="switch-inactive" aria-hidden="true">No</span>
@@ -251,6 +251,15 @@
           </c:if>
           <c:if test="${siteProperty.name eq 'bi.superset.secret'}">
             <p class="help-text" id="biSupersetSecretHelpText">Despite the label, this is not a static API secret -- it's the <strong>password</strong> for the Superset account named above. This value is stored encrypted and always appears blank here after saving; leave it blank to keep the current password, or enter a new value to replace it.</p>
+          </c:if>
+          <c:if test="${siteProperty.name eq 'bi.metabase.enabled'}">
+            <p class="help-text" id="biMetabaseEnabledHelpText">Turns on embedding dashboards from a separately hosted Metabase instance (this does not install or host Metabase itself), independent of the Superset setting above -- both can be enabled at once if you have dashboards in each. As with Superset, there is currently no admin screen for placing a dashboard on a page -- a developer adds one by hand-editing that page's XML template with a <code>dashboardValue</code> (the Metabase dashboard ID).</p>
+          </c:if>
+          <c:if test="${siteProperty.name eq 'bi.metabase.url'}">
+            <p class="help-text" id="biMetabaseUrlHelpText">The base URL of your organization's Metabase instance, for example <code>https://metabase.example.com</code>. Unlike Superset, no feature flag needs to be enabled on the Metabase side -- static embedding is available out of the box. In Metabase, go to Admin settings &gt; Embedding and turn on embedding, then Share &gt; Embed on each dashboard you want to make embeddable here.</p>
+          </c:if>
+          <c:if test="${siteProperty.name eq 'bi.metabase.secret'}">
+            <p class="help-text" id="biMetabaseSecretHelpText">The embedding secret key from Metabase's Admin settings &gt; Embedding page. Unlike Superset, this is a single shared key (not a username/password pair) used to sign embed requests directly -- anyone with this value can view any dashboard you've published for embedding, so treat it like a password. This value is stored encrypted and always appears blank here after saving; leave it blank to keep the current key, or enter a new value to replace it.</p>
           </c:if>
         </td>
       </tr>

--- a/src/main/webapp/WEB-INF/jsp/dashboard/metabase-embedded.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/metabase-embedded.jsp
@@ -1,0 +1,19 @@
+<%--
+  ~ Copyright 2022 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="iframeUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="height" class="java.lang.String" scope="request"/>
+<iframe src="<c:out value="${iframeUrl}"/>" frameborder="0" width="100%" style="min-height: <c:out value="${height}"/>;"></iframe>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -84,6 +84,7 @@
   <widget name="progressCard" class="com.simisinc.platform.presentation.widgets.dashboard.ProgressCardWidget" />
   <widget name="statisticCard" class="com.simisinc.platform.presentation.widgets.dashboard.StatisticCardWidget" />
   <widget name="superset" class="com.simisinc.platform.presentation.widgets.dashboard.SupersetWidget" />
+  <widget name="metabase" class="com.simisinc.platform.presentation.widgets.dashboard.MetabaseWidget" />
   <!-- User Profile and Management -->
   <widget name="emailSubscribe" class="com.simisinc.platform.presentation.widgets.mailinglists.EmailSubscribeWidget" />
   <widget name="myInfo" class="com.simisinc.platform.presentation.widgets.userProfile.MyInfoWidget" />

--- a/src/test/java/com/simisinc/platform/application/dashboards/MetabaseEmbedCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/dashboards/MetabaseEmbedCommandTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.dashboards;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+
+/**
+ * Verifies the JWT this command builds is one Metabase would actually accept: correct URL shape,
+ * a valid HS256 signature independently re-derived with the same secret (not just "some token was
+ * returned"), and the expected header/claims.
+ *
+ * @author elizabeth houser
+ */
+class MetabaseEmbedCommandTest {
+
+  private static final String SECRET = "test-embedding-secret-key";
+  private static final String SERVER_URL = "https://metabase.example.com";
+
+  private static MockedStatic<LoadSitePropertyCommand> mockEnabledAndConfigured() {
+    MockedStatic<LoadSitePropertyCommand> mock = mockStatic(LoadSitePropertyCommand.class);
+    mock.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("bi.metabase.enabled")).thenReturn(true);
+    mock.when(() -> LoadSitePropertyCommand.loadByName("bi.metabase.url")).thenReturn(SERVER_URL);
+    mock.when(() -> LoadSitePropertyCommand.loadByName("bi.metabase.secret")).thenReturn(SECRET);
+    return mock;
+  }
+
+  @Test
+  void returnsNullWhenDashboardIdIsBlank() {
+    try (MockedStatic<LoadSitePropertyCommand> mock = mockEnabledAndConfigured()) {
+      assertNull(MetabaseEmbedCommand.generateDashboardIframeUrl("", null));
+      assertNull(MetabaseEmbedCommand.generateDashboardIframeUrl(null, null));
+    }
+  }
+
+  @Test
+  void returnsNullWhenMetabaseIsNotEnabled() {
+    try (MockedStatic<LoadSitePropertyCommand> mock = mockStatic(LoadSitePropertyCommand.class)) {
+      mock.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("bi.metabase.enabled")).thenReturn(false);
+      assertNull(MetabaseEmbedCommand.generateDashboardIframeUrl("12", null));
+    }
+  }
+
+  @Test
+  void returnsNullWhenUrlOrSecretIsNotConfigured() {
+    try (MockedStatic<LoadSitePropertyCommand> mock = mockStatic(LoadSitePropertyCommand.class)) {
+      mock.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("bi.metabase.enabled")).thenReturn(true);
+      mock.when(() -> LoadSitePropertyCommand.loadByName("bi.metabase.url")).thenReturn("");
+      mock.when(() -> LoadSitePropertyCommand.loadByName("bi.metabase.secret")).thenReturn(SECRET);
+      assertNull(MetabaseEmbedCommand.generateDashboardIframeUrl("12", null));
+    }
+  }
+
+  @Test
+  void buildsAValidSignedIframeUrl() throws Exception {
+    try (MockedStatic<LoadSitePropertyCommand> mock = mockEnabledAndConfigured()) {
+      String url = MetabaseEmbedCommand.generateDashboardIframeUrl("12", null);
+
+      assertTrue(url.startsWith(SERVER_URL + "/embed/dashboard/"), "unexpected URL shape: " + url);
+      String token = url.substring((SERVER_URL + "/embed/dashboard/").length());
+
+      String[] segments = token.split("\\.");
+      assertEquals(3, segments.length, "a JWT has exactly 3 dot-separated segments");
+
+      String header = decode(segments[0]);
+      assertEquals("{\"alg\":\"HS256\",\"typ\":\"JWT\"}", header);
+
+      String payload = decode(segments[1]);
+      assertTrue(payload.contains("\"dashboard\":\"12\""), "payload missing dashboard id: " + payload);
+      assertTrue(payload.contains("\"exp\":"), "payload missing exp claim: " + payload);
+
+      // Independently re-derive the signature with the same secret and confirm it matches -
+      // proves this is a token Metabase's own HMAC verification would actually accept.
+      String signingInput = segments[0] + "." + segments[1];
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      byte[] expectedSignature = mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+      byte[] actualSignature = Base64.getUrlDecoder().decode(segments[2]);
+      assertArrayEquals(expectedSignature, actualSignature);
+    }
+  }
+
+  @Test
+  void appendsHashParametersWhenProvided() {
+    try (MockedStatic<LoadSitePropertyCommand> mock = mockEnabledAndConfigured()) {
+      String url = MetabaseEmbedCommand.generateDashboardIframeUrl("12", "bordered=true&titled=false");
+      assertTrue(url.endsWith("#bordered=true&titled=false"), "unexpected URL: " + url);
+    }
+  }
+
+  private static String decode(String base64UrlSegment) {
+    return new String(Base64.getUrlDecoder().decode(base64UrlSegment), StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/dashboard/MetabaseWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/dashboard/MetabaseWidgetTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.dashboards.MetabaseEmbedCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class MetabaseWidgetTest extends WidgetBase {
+
+  @Test
+  void rendersTheIframeWhenConfigured() {
+    preferences.put("dashboardValue", "12");
+
+    try (MockedStatic<MetabaseEmbedCommand> mock = mockStatic(MetabaseEmbedCommand.class)) {
+      mock.when(() -> MetabaseEmbedCommand.generateDashboardIframeUrl("12", "bordered=true&titled=true"))
+          .thenReturn("https://metabase.example.com/embed/dashboard/signed-token");
+
+      WidgetContext result = new MetabaseWidget().execute(widgetContext);
+
+      assertEquals(MetabaseWidget.JSP, result.getJsp());
+      assertEquals("https://metabase.example.com/embed/dashboard/signed-token", result.getRequest().getAttribute("iframeUrl"));
+      assertEquals("300px", result.getRequest().getAttribute("height"));
+    }
+  }
+
+  @Test
+  void hidesTheChartTitleWhenRequested() {
+    preferences.put("dashboardValue", "12");
+    preferences.put("hideChartTitle", "true");
+
+    try (MockedStatic<MetabaseEmbedCommand> mock = mockStatic(MetabaseEmbedCommand.class)) {
+      mock.when(() -> MetabaseEmbedCommand.generateDashboardIframeUrl("12", "bordered=true&titled=false"))
+          .thenReturn("https://metabase.example.com/embed/dashboard/signed-token");
+
+      new MetabaseWidget().execute(widgetContext);
+
+      mock.verify(() -> MetabaseEmbedCommand.generateDashboardIframeUrl("12", "bordered=true&titled=false"));
+    }
+  }
+
+  @Test
+  void doesNotRenderWhenTheCommandReturnsNull() {
+    preferences.put("dashboardValue", "12");
+
+    try (MockedStatic<MetabaseEmbedCommand> mock = mockStatic(MetabaseEmbedCommand.class)) {
+      mock.when(() -> MetabaseEmbedCommand.generateDashboardIframeUrl("12", "bordered=true&titled=true")).thenReturn(null);
+
+      WidgetContext result = new MetabaseWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+      assertNull(result.getRequest().getAttribute("iframeUrl"));
+    }
+  }
+
+  @Test
+  void passesThroughAMissingDashboardValueForTheCommandToReject() {
+    try (MockedStatic<MetabaseEmbedCommand> mock = mockStatic(MetabaseEmbedCommand.class)) {
+      mock.when(() -> MetabaseEmbedCommand.generateDashboardIframeUrl(isNull(), eq("bordered=true&titled=true"))).thenReturn(null);
+
+      WidgetContext result = new MetabaseWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of #664 (the Metabase-support half; the docs/labels half is #667, stacked base for this PR since both touch `site-properties-editor.jsp`).

Adds Metabase static (signed) embedding alongside the existing Superset integration.

**Design:**
- Independent enable flag (`bi.metabase.enabled`), not a shared platform selector - the two platforms aren't mutually exclusive; an admin could have dashboards in both. `bi.enabled` (Superset's flag) is untouched.
- New `bi.metabase.url` / `bi.metabase.secret` properties (`bi.metabase.secret` added to `SecretSitePropertiesCommand`'s masked list). Metabase's static embedding uses a single shared secret key, not a username/password pair like Superset - so only 2 new properties, not 3.
- `MetabaseEmbedCommand` signs the embed JWT locally (HMAC-SHA256, hand-rolled with `javax.crypto.Mac` + `java.util.Base64` - no new dependency, same reasoning as `IpRangeCommand`'s hand-rolled CIDR matching earlier in this series). Metabase's flow needs no round trip to Metabase at all, unlike Superset's login-then-guest-token API calls: the signed token goes straight into the iframe URL as a path segment (`<url>/embed/dashboard/<token>#bordered=true&titled=...`).
- New `MetabaseWidget` + `metabase-embedded.jsp`, registered as widget `metabase` in `widget-library.xml`. Reuses the `dashboardValue` preference name from Superset's widget for a consistent authoring concept, but is otherwise independent - no shared code with `SupersetWidget`, so this can't affect any existing Superset dashboard embed.
- Added help text for all 3 new fields to `site-properties-editor.jsp`, matching #667's pattern for the existing Superset fields.

## Test plan

- [x] `ant -lib lib/war clean compile compile-jsp` - clean
- [x] `tools/check-unescaped-el.py` - 0 unallowlisted sites
- [x] `ant -lib lib/tests ci-test` - full suite green, including:
  - `MetabaseEmbedCommandTest` (5 cases) - not-enabled/not-configured/blank-id all return null; the built token's header decodes correctly, the payload contains the dashboard id and exp claim, and the signature is independently re-derived with the same secret and confirmed to match byte-for-byte
  - `MetabaseWidgetTest` (4 cases) - renders/doesn't render based on the command's result, `hideChartTitle` maps to the `titled` hash param, a missing `dashboardValue` is passed through for the command to reject
- [x] Live-verified in a docker-compose rehearsal: configured `bi.metabase.url`/`secret`, placed the widget on a real test page via the raw XML editor, loaded the page, and decoded the rendered iframe's actual JWT - payload matched Metabase's own reference sample exactly (`{"resource":{"dashboard":"12"},"params":{},"exp":...}`), and independently recomputing the HMAC-SHA256 signature with the configured secret matched the token's signature segment byte-for-byte