### PR TITLE
Move MediaApiController off /api/* so RestRequestFilter stops blocking it

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -41,10 +41,10 @@ import java.util.UUID;
 /**
  * P5.2: Media Library API endpoints for the visual editor panel
  *
- * GET /api/media?search=query&limit=20&offset=0 - List media assets with pagination and search
- * POST /api/media - Create stub asset record
- * POST /api/media/upload - Handle file upload from drag-and-drop or file picker (not yet implemented)
- * POST /api/media/widget-update - Apply a selected asset to a widget's preference on a page's draft
+ * GET /visual-editor/media?search=query&limit=20&offset=0 - List media assets with pagination and search
+ * POST /visual-editor/media - Create stub asset record
+ * POST /visual-editor/media/upload - Handle file upload from drag-and-drop or file picker (not yet implemented)
+ * POST /visual-editor/media/widget-update - Apply a selected asset to a widget's preference on a page's draft
  * layout. Requires builder-tier permission and the session CSRF token, and identifies the target
  * widget the same way {@link PageServlet}'s {@code mutateDraftLayout} action does -- by structural
  * position, not by a render-time {@code widgetContext.uniqueId} -- so it can safely delegate to
@@ -54,7 +54,7 @@ import java.util.UUID;
  * @author claude
  * @created 7/26/26
  */
-@WebServlet(name = "MediaApi", urlPatterns = {"/api/media", "/api/media/*"})
+@WebServlet(name = "MediaApi", urlPatterns = {"/visual-editor/media", "/visual-editor/media/*"})
 public class MediaApiController extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(MediaApiController.class);

--- a/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
@@ -376,7 +376,7 @@
       params.append('search', search);
     }
 
-    fetch('/api/media?' + params)
+    fetch('/visual-editor/media?' + params)
       .then(r => r.json())
       .then(data => {
         filteredAssets = data.assets || [];

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -112,8 +112,8 @@
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>MediaApi</servlet-name>
-    <url-pattern>/api/media</url-pattern>
-    <url-pattern>/api/media/*</url-pattern>
+    <url-pattern>/visual-editor/media</url-pattern>
+    <url-pattern>/visual-editor/media/*</url-pattern>
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>StylesheetServlet</servlet-name>


### PR DESCRIPTION
**Stacked on #697 → merge that one first.** This builds on #697's already-fixed session auth; reviewing/testing this diff in isolation won't show the right base state.

## Why

#697 fixed `MediaApiController`'s auth (it was permanently unauthenticated — checking a session key nothing ever sets) but flagged a second, separate problem it deliberately left alone: `RestRequestFilter` is filter-mapped to `/api` and `/api/*` in `web.xml` and demands an `X-API-Key`/`key` param validated against the `App` table before any servlet under that path runs. `MediaApiController`'s auth is session-cookie based — a completely different, incompatible model. So even with #697 merged, every real browser call to `/api/media` still gets rejected by the filter before the servlet's own (now-correct) logic ever executes.

This servlet is an internal AJAX endpoint for the browser-based visual editor, not a public REST API for external API-key consumers — it doesn't structurally belong under `/api/*` at all, matching this repo's existing convention (per project memory) that differently-authenticated endpoints live outside that prefix.

## What changed

Moved from `/api/media` + `/api/media/*` to `/visual-editor/media` + `/visual-editor/media/*`:
- `MediaApiController.java`'s `@WebServlet` `urlPatterns` + its javadoc endpoint list
- `web.xml`'s matching `<servlet-mapping>`
- The one real caller: `media-library-panel.jsp`'s `fetch('/api/media?' + params)` → `fetch('/visual-editor/media?' + params)`

Confirmed via repo-wide grep that no other real source file referenced the old path (only unrelated `docs/scaffolding/` stubs did — a different, uncompiled Spring-annotated file in a different package, not this servlet).

## Verification

- No collision with any existing `<servlet-mapping>`: `PageServlet`'s bare `/` is correctly superseded by this more specific path-prefix mapping under standard servlet-mapping resolution (exact match → longest prefix match → default).
- Checked every `<filter-mapping>` in `web.xml`, not just `RestRequestFilter`'s: the two `/*`-scoped filters (`TrustedProxyIpFilter`, `WebRequestFilter`) already applied and continue to; nothing else newly intercepts `/visual-editor/*`.
- The 11 existing `MediaApiControllerTest` cases are unaffected — they mock the request directly and never route through a real URL.
- `ant -lib lib/war -lib lib/tests clean ci-test` → full suite green, 191 test classes, 0 failures. Independently re-verified by a second reviewer pass (adversarial-verify), which also re-ran the full suite itself and confirmed the same result.

One adjacent, non-blocking observation surfaced during review: this move shifts the servlet from the `/api/*`-specific `<security-constraint>` (which omits only unusual HTTP methods there) to the broader `/*` one — functionally equivalent here since the servlet only implements `doGet`/`doPost`, but noting it for whoever next edits either constraint.