### PR TITLE
Gate TableWidget's edit mode on canEditContent, not just the layout preference

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.logging.Log;
@@ -88,8 +89,11 @@ public class TableWidget extends GenericWidget {
 
   public WidgetContext execute(WidgetContext context) {
 
-    // Check if in edit mode
-    boolean isEditMode = "true".equals(context.getPreferences().get("editMode"));
+    // Check if in edit mode -- the layout preference alone is not sufficient, since a stored page
+    // could carry editMode=true and would otherwise serve the editable toolbar to any visitor,
+    // including anonymous ones. Match every other content widget's gate (see ContentWidget).
+    boolean isEditMode = "true".equals(context.getPreferences().get("editMode")) &&
+        EditorPermissionCommand.canEditContent(context.getUserSession());
 
     try {
       // Parse table data from content or create default

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
@@ -50,7 +50,8 @@ class TableWidgetTest extends WidgetBase {
   }
 
   @Test
-  void executeInEditModeSelectsTheEditJsp() {
+  void executeInEditModeSelectsTheEditJspForAUserWithEditPermission() {
+    setRoles(widgetContext, CONTENT_MANAGER);
     preferences.put("editMode", "true");
     preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
 
@@ -58,6 +59,32 @@ class TableWidgetTest extends WidgetBase {
 
     assertEquals(TableWidget.EDIT_JSP, result.getJsp());
     assertEquals("true", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeIgnoresTheEditModePreferenceForAUserWithoutEditPermission() {
+    // The default logged-in test user (see WidgetBase.login) has no roles at all -- the layout
+    // preference alone must not be sufficient to serve the editable toolbar, or any visitor to a
+    // page with editMode=true stored in its layout would get it, including anonymous ones.
+    preferences.put("editMode", "true");
+    preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
+
+    WidgetContext result = new TableWidget().execute(widgetContext);
+
+    assertEquals(TableWidget.JSP, result.getJsp(), "without edit permission, editMode=true must still render the read-only JSP");
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeIgnoresTheEditModePreferenceWhenNotLoggedIn() {
+    logout(widgetContext);
+    preferences.put("editMode", "true");
+    preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
+
+    WidgetContext result = new TableWidget().execute(widgetContext);
+
+    assertEquals(TableWidget.JSP, result.getJsp());
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
   }
 
   @Test


### PR DESCRIPTION
## Background

Issue #686 flagged the commit that introduced `TableWidget` (`a0d4f877`) for a governance audit, given it landed in a known-suspect session window and made two independently-false claims about itself (mislabeled roadmap item, a fictional content-pipeline integration).

**Full audit result: no backdoor, no malicious content.** Only 3 new, on-topic files; nothing touching auth/CI/security. The commit message oversold an incomplete feature (a third false claim found: "auto-save"/"persists" is also false -- there's no save path at all), but the code itself is clean. Already-merged PR #699 separately fixed the one real defect from that audit that had a validation gap (dead `isValidTableData` check).

## This PR: the one remaining gap

`TableWidget.execute()` chose between the read-only and fully-editable JSP based solely on the `editMode` widget preference, with no permission check -- every other content widget (`ContentWidget`, etc.) gates this on `EditorPermissionCommand.canEditContent(userSession)`. If a page's stored layout XML ever had `editMode=true` on a `dataTable` instance, any visitor -- including anonymous ones -- would get the full editable admin toolbar.

Not currently exploitable (this widget has zero live placements anywhere in the app today, confirmed via a full repo audit), but a real gap the moment it's placed.

## Fix

`isEditMode` now requires both the layout preference AND `EditorPermissionCommand.canEditContent(context.getUserSession())`, matching the established pattern exactly.

## Tests

Updated `TableWidgetTest`: the existing edit-mode test now grants `content-manager` first (matching real usage); added two new tests confirming `editMode=true` is ignored both for a logged-in user without an editing role and for a logged-out session.

## Verification

- `ant -lib lib/war -lib lib/tests clean ci-test` -- full suite green (988 tests), `TableWidgetTest` 28/28.
- `ant -lib lib/war package` -- clean deployable build.
- No live docker-rehearsal check: this widget has no reachable placement anywhere in the app currently, so there's no page a browser check would actually exercise.

Fixes #686