### PR TITLE
Add missing nav entry for Useful Links admin page

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -456,6 +456,7 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/calendar')}"> class="is-active"</c:if>><a href="${ctx}/admin/calendars"><i class="${font:far()} fa-calendar fa-fw"></i> <span>Calendars</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/folder')}"> class="is-active"</c:if>><a href="${ctx}/admin/folders"><i class="${font:far()} fa-copy fa-fw"></i> <span>Files &amp; Folders</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/wiki')}"> class="is-active"</c:if>><a href="${ctx}/admin/wikis"><i class="${font:far()} fa-file fa-fw"></i> <span>Wikis</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/useful-links')}"> class="is-active"</c:if>><a href="${ctx}/admin/useful-links"><i class="${font:far()} fa-file fa-fw"></i> <span>Useful Links</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/sticky-footer-links')}"> class="is-active"</c:if>><a href="${ctx}/admin/sticky-footer-links"><i class="${font:far()} fa-file fa-fw"></i> <span>Sticky Page Buttons</span></a></li>
             </ul>
           </c:if>


### PR DESCRIPTION
## Bug

Issue #693: `/admin/useful-links` is a real, working page that edits two live public-site footer columns, but it has no inbound nav link anywhere in the admin UI - the only way to reach it is by typing the URL directly. Two developer TODO comments sit directly above its `<page>` definition in `admin-layout.xml`: "Turn this into a menu, then link to additional config pages, also sticky-footer-links". That sibling page, `/admin/sticky-footer-links`, did subsequently get linked into the Content nav menu - `/admin/useful-links` never did, making the omission look like incomplete follow-through on a known TODO rather than a deliberate decision.

## Fix

Added a nav `<li>` for `/admin/useful-links` in the Content menu of `main.jsp`, positioned directly next to the existing "Sticky Page Buttons" entry and copying its markup exactly (`fn:startsWith` active-state check, icon class, `${ctx}`-relative href), labeled "Useful Links".

## Verification

- `ant -lib lib/war clean package` - `BUILD SUCCESSFUL`, including a clean Jasper JSP-compile pass (`Generation completed with [0] errors`).

Fixes #693
