### PR TITLE
Add missing siteStats locations-list tile

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -718,6 +718,14 @@
 <!--          <mapHeight>200</mapHeight>-->
         </widget>
       </column>
+      <column class="small-12 cell">
+        <widget name="siteStats" class="stats card">
+          <icon>fa-map-marker</icon>
+          <title>Locations List</title>
+          <report>locations-list</report>
+          <days>14</days>
+        </widget>
+      </column>
     </section>
     <section>
       <column class="small-12 medium-6 cell">


### PR DESCRIPTION
## Bug

`SiteStatsWidget.runReport()` fully implements a `locations-list` report key (it uses the same `LOCATIONS_JSP` template as the sibling `locations-map` tile), but `admin-layout.xml` never referenced it anywhere -- not even commented out. The `locations-map` tile got wired into the admin dashboard, but its list counterpart was left out, so it's never rendered.

## Fix

Added a sibling `<widget name="siteStats">` block next to the existing `locations-map` tile in `admin-layout.xml`, using the same `days` interval and following the existing title/report pattern.

## Verification

- `ant -lib lib/war clean package` -- BUILD SUCCESSFUL, including a clean Jasper JSP-compile pass (0 errors).
- Confirmed `locations-list` is handled in `SiteStatsWidget.runReport()` and returns the existing `site-stats-locations-table.jsp`, so no Java changes were needed.

## Scope note

This addresses only the `locations-list` part of #680. The other item in that issue -- four previously-wired report keys (`dau`, `daily-mailing-list-subscriptions`, `web-pages`, `conversion-rate`) that were deliberately commented out -- is intentionally not touched here; that needs a product decision on whether they're still wanted before re-enabling. See #680 for details.
