### PR TITLE
Add missing edit link to Apps admin list rows

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/apps-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/apps-list.jsp
@@ -16,6 +16,7 @@
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
@@ -31,6 +32,7 @@
       <th width="100" class="text-center">Devices</th>
       <th width="100" class="text-center">Enabled?</th>
       <th width="200">Created</th>
+      <th width="60">Action</th>
     </tr>
   </thead>
   <tbody>
@@ -53,11 +55,14 @@
         </c:choose>
       </td>
       <td class="text-center"><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${app.created}" /></td>
+      <td>
+        <a href="${ctx}/admin/app?appId=${app.id}"><i class="${font:fas()} fa-edit"></i></a>
+      </td>
     </tr>
     </c:forEach>
     <c:if test="${empty appList}">
       <tr>
-        <td colspan="4">No apps were found</td>
+        <td colspan="5">No apps were found</td>
       </tr>
     </c:if>
   </tbody>


### PR DESCRIPTION
## Bug

Issue #688: `/admin/apps` shows every registered app as a plain read-only row. There is no edit link anywhere on the page, unlike every comparable admin list (`/admin/calendars`, `/admin/wikis`, `/admin/groups`), which all have a working edit-pencil link on each row. The app detail page (`/admin/app?appId=X`) is fully built and already routable, it was just never linked to from the list.

## Fix

Added an "Action" column to `apps-list.jsp` with an edit-pencil link per row, following the exact markup convention `groups-list.jsp` already uses (`groups-list.jsp` was the closest match since, like apps, its edit widget has no `returnPage` support, unlike the calendar/wiki forms):

```jsp
<a href="${ctx}/admin/app?appId=${app.id}"><i class="${font:fas()} fa-edit"></i></a>
```

`App.getId()` was already exposed on the domain model and `AppsListWidget` already put the full `App` objects on the request, so no Java changes were needed — this was JSP-only.

## Verification

- `ant -lib lib/war clean package` — BUILD SUCCESSFUL, including a clean Jasper JSP-compile pass (0 errors) covering the edited JSP.
- Confirmed `/admin/app{?appId}` is registered in `admin-layout.xml` and reads `appId` via `AppFormWidget`, matching the link's query parameter.

Fixes #688
