### PR TITLE
Add missing EcommerceStatsWidget tiles: total-orders-today and locations-list

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-ecommerce-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-ecommerce-layout.xml
@@ -45,6 +45,13 @@
           <report>total-orders</report>
         </widget>
       </column>
+      <column class="small-12 medium-4 cell callout">
+        <widget name="ecommerceStats">
+          <icon>fa-cash-register</icon>
+          <title>Orders Today</title>
+          <report>total-orders-today</report>
+        </widget>
+      </column>
     </section>
     <section>
       <column class="small-12 medium-12 large-4 cell">
@@ -87,6 +94,13 @@
           <report>top-locations</report>
           <days>90</days>
           <limit>6</limit>
+        </widget>
+      </column>
+      <column class="small-12 medium-12 large-4 cell">
+        <widget name="ecommerceStats" class="stats card">
+          <title>Locations</title>
+          <report>locations-list</report>
+          <days>90</days>
         </widget>
       </column>
     </section>


### PR DESCRIPTION
## Bug

`EcommerceStatsWidget.execute()` dispatches on 10 `report` values. 8 of them are wired into `/admin/e-commerce/analytics` via `admin-ecommerce-layout.xml`, but two are not:

- `total-orders-today` — calls `OrderRepository.countTotalOrders(1)` and renders via `CARD_JSP`, the same template used by the wired `total-orders`, `total-not-shipped`, and `total-shipped` tiles.
- `locations-list` — calls `OrderRepository.findDailyUniqueLocations(days)` and renders via `LOCATIONS_JSP`, the same table template `SiteStatsWidget` already exercises for its own `locations-list` report.

A repo-wide search for both literal keys (excluding build output) only turns up the Java source — zero XML hits. The report branches are live, working code with no way for an admin to reach them.

## Fix

Added two more `ecommerceStats` `<column><widget>` tiles to the Analytics page, following the icon/title conventions of the tiles they sit next to:

- **Orders Today** — added to the row of `CARD_JSP` tiles (Orders Not Shipped / Orders Shipped / Total Orders), reusing the `fa-cash-register` icon from Total Orders since it's the same metric scoped to today.
- **Locations** — added to the row with the Last 90 Days map and Top Locations list, using the same `days=90` preference as its neighbors.

No Java changes — this is a layout-only fix, matching the pattern used for the earlier bot-traffic tile fix (#592).

## Verification

- `ant -lib lib/war clean package`: `BUILD SUCCESSFUL`, including a clean Jasper JSP-compile pass (0 errors).
- Confirmed the two new report keys (`total-orders-today`, `locations-list`) now appear in `admin-ecommerce-layout.xml` alongside their siblings.

Fixes #685
