### PR TITLE
Wire up calendar event tags

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveCalendarEventCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveCalendarEventCommand.java
@@ -105,6 +105,7 @@ public class SaveCalendarEventCommand {
     calendarEvent.setLocation(calendarEventBean.getLocation());
     calendarEvent.setImageUrl(calendarEventBean.getImageUrl());
     calendarEvent.setVideoUrl(calendarEventBean.getVideoUrl());
+    calendarEvent.setTagsList(calendarEventBean.getTagsList());
     calendarEvent.setCreatedBy(calendarEventBean.getCreatedBy());
     calendarEvent.setModifiedBy(calendarEventBean.getModifiedBy());
     calendarEvent.setPublished(calendarEventBean.getPublished());

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
@@ -28,6 +28,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -42,6 +43,15 @@ public class CalendarEventRepository {
 
   private static String TABLE_NAME = "calendar_events";
   private static String[] PRIMARY_KEY = new String[]{"event_id"};
+
+  // tags_list is stored as a single comma-joined VARCHAR(255) column with no escaping of
+  // embedded commas. The only writer today (CalendarWidget.post()) pre-splits user input on
+  // comma, so a comma inside a "tag" simply becomes two tags before it ever gets here. Any
+  // future writer of CalendarEvent.setTagsList(String[]) (bulk import, API, data fix) must not
+  // put a literal comma inside a single tag, or it will be silently split into two tags on the
+  // next read. The joined value is also truncated to TAGS_LIST_MAX_LENGTH to avoid the whole
+  // event save failing on a VARCHAR(255) overflow.
+  private static int TAGS_LIST_MAX_LENGTH = 255;
 
   private static SqlUtils createWhereStatement(CalendarEventSpecification specification) {
     SqlUtils where = new SqlUtils();
@@ -169,6 +179,7 @@ public class CalendarEventRepository {
         .add("location_name", StringUtils.trimToNull(record.getLocation()))
         .add("image_url", StringUtils.trimToNull(record.getImageUrl()))
         .add("video_url", StringUtils.trimToNull(record.getVideoUrl()))
+        .add("tags_list", record.getTagsList() == null || record.getTagsList().length == 0 ? null : String.join(",", record.getTagsList()), TAGS_LIST_MAX_LENGTH)
         .add("created_by", record.getCreatedBy())
         .add("modified_by", record.getModifiedBy())
         .add("published", record.getPublished())
@@ -196,6 +207,7 @@ public class CalendarEventRepository {
         .add("location_name", StringUtils.trimToNull(record.getLocation()))
         .add("image_url", StringUtils.trimToNull(record.getImageUrl()))
         .add("video_url", StringUtils.trimToNull(record.getVideoUrl()))
+        .add("tags_list", record.getTagsList() == null || record.getTagsList().length == 0 ? null : String.join(",", record.getTagsList()), TAGS_LIST_MAX_LENGTH)
         .add("modified_by", record.getModifiedBy())
         .add("modified", new Timestamp(System.currentTimeMillis()))
         .add("published", record.getPublished())
@@ -272,6 +284,15 @@ public class CalendarEventRepository {
       record.setVideoUrl(rs.getString("video_url"));
       record.setVideoEmbed(rs.getString("video_embed"));
       record.setScriptEmbed(rs.getString("script_embed"));
+      String tagsListRaw = rs.getString("tags_list");
+      if (StringUtils.isNotBlank(tagsListRaw)) {
+        String[] tagsList = Arrays.stream(StringUtils.stripAll(tagsListRaw.split(",")))
+            .filter(StringUtils::isNotBlank)
+            .toArray(String[]::new);
+        if (tagsList.length > 0) {
+          record.setTagsList(tagsList);
+        }
+      }
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjax.java
@@ -98,6 +98,16 @@ public class CalendarEventAjax extends GenericWidget {
       if (calendarEvent.getVideoUrl() != null) {
         sb.append("\"videoUrl\":\"").append(JsonCommand.toJson(calendarEvent.getVideoUrl())).append("\",");
       }
+      if (calendarEvent.getTagsList() != null && calendarEvent.getTagsList().length > 0) {
+        sb.append("\"tagsList\":[");
+        for (int i = 0; i < calendarEvent.getTagsList().length; i++) {
+          if (i > 0) {
+            sb.append(",");
+          }
+          sb.append("\"").append(JsonCommand.toJson(calendarEvent.getTagsList()[i])).append("\"");
+        }
+        sb.append("],");
+      }
       if (StringUtils.isNotEmpty(calendarEvent.getSummary())) {
         sb.append("\"description\":\"").append(JsonCommand.toJson(calendarEvent.getSummary())).append("\",");
       }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarWidget.java
@@ -111,6 +111,20 @@ public class CalendarWidget extends GenericWidget {
     } else {
       calendarEventBean.setPublished(null);
     }
+    String tagsListParam = context.getParameter("tagsList");
+    if (StringUtils.isNotBlank(tagsListParam)) {
+      String[] parsedTags = tagsListParam.split(",");
+      java.util.List<String> tagsList = new java.util.ArrayList<>();
+      for (String tag : parsedTags) {
+        String trimmed = tag.trim();
+        if (!trimmed.isEmpty()) {
+          tagsList.add(trimmed);
+        }
+      }
+      calendarEventBean.setTagsList(tagsList.isEmpty() ? null : tagsList.toArray(new String[0]));
+    } else {
+      calendarEventBean.setTagsList(null);
+    }
     calendarEventBean.setCreatedBy(context.getUserId());
     calendarEventBean.setModifiedBy(context.getUserId());
 

--- a/src/main/webapp/WEB-INF/jsp/calendar/calendar-event-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/calendar-event-details.jsp
@@ -96,6 +96,13 @@
     <c:if test="${!empty calendarEvent.location}">
       <p class="platform-calendar-event-location"><i class="fa fa-map-marker fa-fw"></i> <c:out value="${calendarEvent.location}" /></p>
     </c:if>
+    <c:if test="${!empty calendarEvent.tagsList}">
+      <div class="cell auto">
+        <c:forEach items="${calendarEvent.tagsList}" var="tag">
+          <span class="label secondary"><c:out value="${tag}"/></span>
+        </c:forEach>
+      </div>
+    </c:if>
     <div class="add-to-calendar" style="margin-left: 24px">
       <span class="icon">far fa-calendar-plus</span>
       <span class="timezone"><c:out value="${timezone}"/></span>

--- a/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/full-calendar.jsp
@@ -196,6 +196,11 @@
               if (data.hasOwnProperty('videoUrl')) {
                 document.getElementById('videoUrl').value = data.videoUrl;
               }
+              if (data.hasOwnProperty('tagsList')) {
+                document.getElementById('tagsList').value = data.tagsList.join(', ');
+              } else {
+                document.getElementById('tagsList').value = '';
+              }
               if (data.hasOwnProperty('published')) {
                 $('#enabled')[0].checked = true;
               } else {
@@ -382,6 +387,10 @@
         <input type="text" placeholder="https://..." name="videoUrl" id="videoUrl" value="">
       </label>
       <p class="help-text">Paste a link to a video or live meeting (Teams, Zoom, Google Meet, a YouTube stream, etc). Shown as a "Join" button on the event's page.</p>
+      <label>Tags
+        <input type="text" placeholder="conference, quarterly, all-hands" name="tagsList" id="tagsList" value="" maxlength="255">
+      </label>
+      <p class="help-text">Comma-separated list of tags for this event (e.g. "conference, quarterly, all-hands"). Limited to 255 characters total.</p>
       <input id="enabled" type="checkbox" name="enabled" value="true" checked/><label for="enabled">Publish it?</label>
       <p class="help-text">Unchecked saves this event as a draft, hidden from the public calendar.</p>
       <div class="button-container">

--- a/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjaxTest.java
@@ -83,6 +83,75 @@ class CalendarEventAjaxTest extends WidgetBase {
   }
 
   @Test
+  void jsonIncludesTagsListWhenSet() {
+    addQueryParameter(widgetContext, "id", "1");
+
+    CalendarEvent event = new CalendarEvent();
+    event.setId(1L);
+    event.setCalendarId(1L);
+    event.setTitle("Team Sync");
+    event.setStartDate(new Timestamp(0L));
+    event.setEndDate(new Timestamp(3600000L));
+    event.setTagsList(new String[] { "conference", "quarterly" });
+
+    try (MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      events.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(List.of(event));
+
+      CalendarEventAjax widget = new CalendarEventAjax();
+      widget.execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertTrue(json.contains("\"tagsList\":[\"conference\",\"quarterly\"]"),
+        "tagsList must be present as a JSON array in the JSON: " + json);
+  }
+
+  @Test
+  void jsonOmitsTagsListWhenNull() {
+    addQueryParameter(widgetContext, "id", "1");
+
+    CalendarEvent event = new CalendarEvent();
+    event.setId(1L);
+    event.setCalendarId(1L);
+    event.setTitle("Team Sync");
+    event.setStartDate(new Timestamp(0L));
+    event.setEndDate(new Timestamp(3600000L));
+
+    try (MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      events.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(List.of(event));
+
+      CalendarEventAjax widget = new CalendarEventAjax();
+      widget.execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertFalse(json.contains("tagsList"), "tagsList must be omitted when not set: " + json);
+  }
+
+  @Test
+  void jsonOmitsTagsListWhenEmpty() {
+    addQueryParameter(widgetContext, "id", "1");
+
+    CalendarEvent event = new CalendarEvent();
+    event.setId(1L);
+    event.setCalendarId(1L);
+    event.setTitle("Team Sync");
+    event.setStartDate(new Timestamp(0L));
+    event.setEndDate(new Timestamp(3600000L));
+    event.setTagsList(new String[0]);
+
+    try (MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      events.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(List.of(event));
+
+      CalendarEventAjax widget = new CalendarEventAjax();
+      widget.execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertFalse(json.contains("tagsList"), "tagsList must be omitted when empty: " + json);
+  }
+
+  @Test
   void jsonIncludesPublishedWhenSet() {
     addQueryParameter(widgetContext, "id", "1");
 


### PR DESCRIPTION
## Summary

Stacked on #705 (draft/publish) -- part of the same calendar capability work prompted by #525. `CalendarEvent.tagsList` (a `String[]` backed by a comma-separated `tags_list VARCHAR(255)` column) has existed since 2018 with zero implementation: no form field, no repository read/write, no display.

Unlike the two prior PRs in this stack, there was no working precedent to copy here. `BlogPost` has the identical field shape and even has working *display* code for it, but turns out to have no write path either -- so it was equally non-functional, just with leftover dead-end display markup. The comma-join/split conversion between the DB column and the Java array is new in this PR, not copied from elsewhere.

## Changes

- `CalendarEventRepository.java`: `add()`/`update()` persist `tags_list` as a comma-joined, length-guarded string; `buildRecord()` splits and trims it back into a `String[]`, dropping blanks.
- `SaveCalendarEventCommand.java`: copies `tagsList` onto the persisted entity.
- `full-calendar.jsp`: a "Tags" field (comma-separated, `maxlength=255`) in the event modal with help text; edit-modal JS populates/clears it correctly.
- `CalendarWidget.java`: explicitly parses the raw request param (split/trim/drop-blanks) after `BeanUtils.populate`, since BeanUtils alone would leave a single unsplit string in the array.
- `CalendarEventAjax.java`: includes `tagsList` as a properly JSON-escaped array in the single-event response.
- `calendar-event-details.jsp`: renders tags as HTML-escaped pills, matching `BlogPost`'s existing (if unreachable) markup exactly.

## Built with adversarial review

Implemented, then two independent reviews (correctness lens, security/regression lens), then a fix pass. Both reviewers independently flagged the same two real gaps:
1. `buildRecord()` split tags but didn't filter blanks after trimming, asymmetric with the write path
2. No `VARCHAR(255)` length guard -- an oversized tag list would throw inside `DB.insertInto`/`update`, which swallows the exception and fails the *entire* event save with a generic error, not just the tags

Both fixed here (the length guard now truncates instead, matching the same idiom `ItemRepository` already uses elsewhere in this codebase). Also added a client-side `maxlength` to match, and a code comment documenting that the comma-join/split has no escaping for a literal comma inside a tag -- not reachable through the shipped UI (which pre-splits on comma before persisting), but flagged for any future non-UI writer.

## Test plan

- [x] `ant -lib lib/war clean compile-jsp` -- passes
- [x] `ant -lib lib/tests ci-test` -- full suite passes, including new `CalendarEventAjaxTest` cases
- [x] Live verification via `curl`: created an event with tags containing spaces around commas, confirmed the DB stores them correctly trimmed and comma-joined; confirmed the JSON endpoint returns a proper array with each tag individually escaped; confirmed the public page renders one pill per tag; tested a tag containing `<script>alert(1)</script>` and confirmed it renders HTML-escaped publicly and JSON-escaped in the API, not as live markup; tested a 349-character tag list and confirmed it truncates to 255 and the event still saves, rather than the whole save failing