### PR TITLE
Add /admin/analytics-retention page and nav entry for analyticsRetention widget

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -492,6 +492,7 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/blocked-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/blocked-ip-list"><i class="${font:far()} fa-shield-halved fa-fw"></i> <span>Blocked IPs</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/allowed-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/allowed-ip-list"><i class="${font:far()} fa-shield fa-fw"></i> <span>Allowed IPs</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/audit-log')}"> class="is-active"</c:if>><a href="${ctx}/admin/audit-log"><i class="${font:far()} fa-clipboard-list fa-fw"></i> <span>Audit Log</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/analytics-retention')}"> class="is-active"</c:if>><a href="${ctx}/admin/analytics-retention"><i class="${font:far()} fa-trash-can fa-fw"></i> <span>Analytics Retention</span></a></li>
             </ul>
           </c:if>
           <%-- Settings menu --%>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1603,4 +1603,15 @@
     </section>
   </page>
 
+  <page name="/admin/analytics-retention" role="admin" title="Analytics Retention">
+    <section>
+      <column class="small-12 cell">
+        <widget name="analyticsRetention">
+          <icon>fa-trash-can</icon>
+          <title>Analytics Retention</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
 </pages>


### PR DESCRIPTION
## Bug

Issue #673: `AnalyticsRetentionWidget` (registered in `widget-library.xml` as `analyticsRetention`) is a complete, role-gated admin console — it reports how many session records still hold visitor PII and lets an admin trigger an immediate purge instead of waiting for the nightly job. It was never placed on any admin page and has no nav entry, so it's unreachable from the admin UI entirely.

## Fix

- Added a new `/admin/analytics-retention` page in `admin-layout.xml`, hosting the `analyticsRetention` widget. Structure (single section/column) mirrors the existing `/admin/audit-log` page. The widget's `icon` and `title` preferences (both read by `AnalyticsRetentionWidget.execute()` and rendered in its JSP) are set, matching the pattern used for the similarly-shaped `/admin/web-vitals` page.
- Added a nav `<li>` for the new page in the Access section of `main.jsp`, directly after the Audit Log entry, copying its exact markup pattern (`fn:startsWith` active-state check, `${ctx}`-relative href, icon + label). Used `fa-trash-can`, not otherwise used in that section, labeled "Analytics Retention".

## Verification

- `ant -lib lib/war clean package` — `BUILD SUCCESSFUL`, including a clean Jasper JSP-compile pass (`Generation completed with [0] errors`).
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green, no failures.

Fixes #673
