### PR TITLE
Add "Add Event" link on the calendar detail page and wire up calendarId

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventFormWidget.java
@@ -19,10 +19,12 @@ package com.simisinc.platform.presentation.widgets.admin.cms;
 import com.simisinc.platform.application.AppException;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.SaveCalendarEventCommand;
+import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.domain.model.cms.CalendarEvent;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -44,6 +46,13 @@ public class CalendarEventFormWidget extends GenericWidget {
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
     context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
+    // This page can return to different places
+    String returnPage = context.getSharedRequestValue("returnPage");
+    if (returnPage == null) {
+      returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));
+    }
+    context.getRequest().setAttribute("returnPage", returnPage);
+
     // Form bean
     if (context.getRequestObject() != null) {
       context.getRequest().setAttribute("calendarEvent", context.getRequestObject());
@@ -52,6 +61,12 @@ public class CalendarEventFormWidget extends GenericWidget {
 //      int calendarEventId = context.getParameterAsInt("calendarEventId");
 //      CalendarEvent calendarEvent = CalendarEventRepository.findById(calendarEventId);
 //      context.getRequest().setAttribute("calendarEvent", calendarEvent);
+      long calendarId = context.getParameterAsLong("calendarId");
+      if (calendarId > -1) {
+        CalendarEvent calendarEvent = new CalendarEvent();
+        calendarEvent.setCalendarId(calendarId);
+        context.getRequest().setAttribute("calendarEvent", calendarEvent);
+      }
     }
 
     // Show the editor
@@ -67,6 +82,9 @@ public class CalendarEventFormWidget extends GenericWidget {
     calendarEventBean.setCreatedBy(context.getUserId());
     calendarEventBean.setModifiedBy(context.getUserId());
 
+    // Determine additional settings
+    String returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));
+
     // Save the record
     CalendarEvent calendarEvent = null;
     try {
@@ -77,12 +95,17 @@ public class CalendarEventFormWidget extends GenericWidget {
     } catch (DataException | AppException e) {
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(calendarEventBean);
+      context.addSharedRequestValue("returnPage", returnPage);
       return context;
     }
 
     // Determine the page to return to
     context.setSuccessMessage("Event was saved");
-    context.setRedirect("/admin/calendars");
+    if (StringUtils.isNotBlank(returnPage)) {
+      context.setRedirect(returnPage);
+    } else {
+      context.setRedirect("/admin/calendars");
+    }
     return context;
 
   }

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-event-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-event-form.jsp
@@ -24,6 +24,7 @@
   <input type="hidden" name="token" value="${userSession.formToken}"/>
   <%-- Form values --%>
   <input type="hidden" name="id" value="${calendarEvent.id}"/>
+  <input type="hidden" name="calendarId" value="${calendarEvent.calendarId}"/>
   <c:if test="${!empty returnPage}">
     <input type="hidden" name="returnPage" value="<c:out value="${returnPage}"/>"/>
   </c:if>
@@ -37,7 +38,7 @@
     <input type="text" placeholder="Name of event" name="title" value="<c:out value="${calendarEvent.title}"/>">
   </label>
   <label>Description
-    <input type="text" placeholder="Describe it..." name="description" value="<c:out value="${calendarEvent.description}"/>">
+    <input type="text" placeholder="Describe it..." name="summary" value="<c:out value="${calendarEvent.summary}"/>">
   </label>
   <label>All day?
     <div class="switch large">

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-form.jsp
@@ -22,7 +22,10 @@
 <script src="${ctx}/javascript/spectrum-1.8.1/spectrum.js"></script>
 <c:choose>
   <c:when test="${calendar.id eq -1}"><h4>New Calendar</h4></c:when>
-  <c:otherwise><h4>Update Calendar</h4></c:otherwise>
+  <c:otherwise>
+    <h4>Update Calendar</h4>
+    <a class="button small radius primary" href="${ctx}/admin/calendar-event?calendarId=${calendar.id}&returnPage=/admin/calendar?calendarId=${calendar.id}">Add Event <i class="fa fa-arrow-circle-right"></i></a>
+  </c:otherwise>
 </c:choose>
 <form method="post">
   <%-- Required by controller --%>


### PR DESCRIPTION
## Summary
- Follow-up to #720: that PR gave `CalendarEventFormWidget` a real URL (`/admin/calendar-event`), but nothing in the app linked to it, and the widget never set `calendarId` on the saved event, so every save failed validation ("A calendar must be set").
- Adds an "Add Event" button to the calendar detail page (`calendar-form.jsp`), scoped to the calendar being edited, mirroring the existing "Add a Calendar" button pattern on `calendar-list.jsp`.
- `CalendarEventFormWidget` now reads `calendarId` from the request to prefill the hidden form field, and honors `returnPage` the same way `CalendarFormWidget` already does, so Cancel/Save return to the calendar you came from.
- Along the way, found and fixed a second, independent bug: `calendar-event-form.jsp` referenced `calendarEvent.description`, a property that doesn't exist on `CalendarEvent` (it's `summary`). That threw a JSP EL exception and rendered the page blank on every load, regardless of the calendarId issue. Fixed by binding the field to `summary`, which is the property already used everywhere else in the app (event details, upcoming events, search results, JSON APIs) to render an event's description.

## Test plan
- [x] `ant -lib lib/war clean package` — BUILD SUCCESSFUL, 0 Jasper errors
- [x] Verified live via `docker compose`: created a calendar, clicked "Add Event" from its detail page, filled out and saved a new event, confirmed it saved with the correct `calendar_id` (previously would have failed with "A calendar must be set"), and confirmed Cancel/Save both redirect back to the calendar detail page
- [x] Confirmed the "Add Event" button is hidden while creating a brand new (unsaved) calendar, since there's no calendarId to scope events to yet