### PR TITLE
Prevent account takeover via client-supplied id on New User creation

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -216,6 +216,11 @@ public class UsersListWidget extends GenericWidget {
     // Populate the fields
     User userBean = new User();
     BeanUtils.populate(userBean, context.getParameterMap());
+    // This action only ever creates a new user -- the New User form never renders an id field, but
+    // populate() maps ANY request parameter matching a bean property, so a crafted "id" parameter would
+    // otherwise be mass-assigned here and route SaveUserCommand.saveUser() into overwriting an existing
+    // account (by id) instead of creating one. Force create semantics regardless of what was submitted.
+    userBean.setId(-1L);
     userBean.setCreatedBy(context.getUserId());
     userBean.setModifiedBy(context.getUserId());
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetTest.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.presentation.widgets.admin.login;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.Collections;
@@ -28,7 +29,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.register.SaveUserCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
@@ -36,6 +39,8 @@ import com.simisinc.platform.infrastructure.persistence.RoleRepository;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.UserSpecification;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.DataConstants;
 
 /**
@@ -154,5 +159,42 @@ class UsersListWidgetTest extends WidgetBase {
   void agingPasswordFilterIsUnsetByDefault() {
     UserSpecification spec = captureSpecification(() -> { });
     assertEquals(-1, spec.getPasswordOlderThanDays());
+  }
+
+  @Test
+  void addUserActionForcesCreateEvenWithClientSuppliedId() throws Exception {
+    // The New User form (users-list.jsp) never renders an id field, but addUserAction() populates
+    // userBean via BeanUtils.populate() against the raw, unfiltered parameter map -- so a crafted "id"
+    // targeting an existing user would otherwise be mass-assigned and route SaveUserCommand.saveUser()
+    // into overwriting that account (email/username/roles) instead of creating a new one.
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "firstName", "Attacker");
+    addQueryParameter(widgetContext, "lastName", "Controlled");
+    addQueryParameter(widgetContext, "email", "attacker@example.com");
+
+    User saved = new User();
+    saved.setId(42L);
+    saved.setEmail("attacker@example.com");
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(Collections.emptyList());
+      groupRepo.when(GroupRepository::findAll).thenReturn(Collections.emptyList());
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(saved);
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(null);
+
+      new UsersListWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      assertEquals(-1L, captor.getValue().getId(),
+          "a client-supplied id must never reach SaveUserCommand as a positive id from the New User action");
+      assertEquals("attacker@example.com", captor.getValue().getEmail());
+    }
   }
 }


### PR DESCRIPTION
## Summary

`UsersListWidget.addUserAction()` (the "New User" action on `/admin/users`, reachable by `admin` and `community-manager`) populates the user bean straight from the raw, unfiltered request parameter map:

```java
User userBean = new User();
BeanUtils.populate(userBean, context.getParameterMap());
```

The New User form (`users-list.jsp`) never renders an `id` field, but `BeanUtils.populate()` maps any request parameter matching a bean property name, and `User.setId(Long)` is a normal public setter. `SaveUserCommand.saveUser()` branches purely on `userBean.getId() > -1`: a crafted POST with `id=<existing user id>` routes into the update-existing-record branch instead of create, and unconditionally copies the attacker-supplied email/username/role list onto that record.

Overwriting the victim's email lets the attacker complete a password reset via the normal "forgot password" flow and fully take over the account — full account takeover, not just role tampering, and no crafted role IDs are even needed for it to work.

## Fix

Reset `userBean`'s id to `-1` immediately after `BeanUtils.populate()`, since this action's entire contract is creating a new user — mirrors the pattern of never trusting client input for something the action's own semantics already determine.

## Test plan

- [x] Added `addUserActionForcesCreateEvenWithClientSuppliedId` to `UsersListWidgetTest`, posting a crafted `id` for an existing user and asserting `SaveUserCommand.saveUser()` is never invoked with a positive id
- [x] Verified the new test fails without the fix (`expected: <-1> but was: <5>`) and passes with it
- [x] `ant -lib lib/war package` — clean
- [x] `ant -lib lib/tests ci-test` — full suite green, 205/206 test classes run (the 206th, `SaveSessionCommandTest`, is a pre-existing `@Disabled` case unrelated to this change), zero failures