### PR TITLE
Add temporary/expiring direct capability grants (#702)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/LoadUserCommand.java
+++ b/src/main/java/com/simisinc/platform/application/LoadUserCommand.java
@@ -17,9 +17,11 @@
 package com.simisinc.platform.application;
 
 import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
 import com.simisinc.platform.infrastructure.persistence.CapabilityRepository;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
@@ -29,7 +31,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Loads a user object and related information
@@ -78,13 +83,41 @@ public class LoadUserCommand {
     // Get the list of roles the user has
     List<Role> roleList = RoleRepository.findAllByUserId(user.getId());
     user.setRoleList(roleList);
-    // Get the capabilities granted by those roles (issue #701 walking skeleton)
-    List<Capability> capabilityList = CapabilityRepository.findAllByUserId(user.getId());
-    user.setCapabilityList(capabilityList);
+    // Get the capabilities granted by those roles (issue #701), plus any active direct grants
+    // (issue #702) - a capability can be held either way, so merge them into one effective list.
+    user.setCapabilityList(loadEffectiveCapabilityList(user.getId()));
     // Get the list of user groups the user belongs to
     List<Group> groupList = GroupRepository.findAllByUserId(user.getId());
     user.setGroupList(groupList);
     // Retrieve the last login
     user.setLastLogin(UserLoginRepository.queryLastLogin(user.getId()));
+  }
+
+  private static List<Capability> loadEffectiveCapabilityList(long userId) {
+    List<Capability> capabilityList = CapabilityRepository.findAllByUserId(userId);
+    List<CapabilityGrant> activeGrantList = CapabilityGrantRepository.findActiveByUserId(userId);
+    if (activeGrantList == null || activeGrantList.isEmpty()) {
+      return capabilityList;
+    }
+    Map<String, Capability> capabilityByCode = new HashMap<>();
+    if (capabilityList != null) {
+      for (Capability capability : capabilityList) {
+        capabilityByCode.put(capability.getCode(), capability);
+      }
+    }
+    List<Capability> allCapabilityList = CapabilityRepository.findAll();
+    Map<Long, Capability> capabilityById = new HashMap<>();
+    if (allCapabilityList != null) {
+      for (Capability capability : allCapabilityList) {
+        capabilityById.put(capability.getId(), capability);
+      }
+    }
+    for (CapabilityGrant capabilityGrant : activeGrantList) {
+      Capability capability = capabilityById.get(capabilityGrant.getCapabilityId());
+      if (capability != null) {
+        capabilityByCode.putIfAbsent(capability.getCode(), capability);
+      }
+    }
+    return new ArrayList<>(capabilityByCode.values());
   }
 }

--- a/src/main/java/com/simisinc/platform/application/admin/SaveCapabilityGrantCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/SaveCapabilityGrantCommand.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Grants/revokes direct, individually-trackable capabilities to a user (issue #702) - the
+ * per-user counterpart to SaveRoleCapabilitiesCommand's per-role grants (#704). Expiration of a
+ * granted-with-an-expiresAt grant is enforced by CapabilityGrantExpirationJob's scheduled sweep,
+ * not here.
+ *
+ * @author elizabeth houser
+ */
+public class SaveCapabilityGrantCommand {
+
+  public static CapabilityGrant grant(WidgetContext context, User targetUser, Capability capability,
+      long grantedByUserId, String reason, java.sql.Timestamp expiresAt) throws DataException {
+    if (StringUtils.isBlank(reason)) {
+      throw new DataException("A reason is required when granting a capability");
+    }
+
+    // A friendlier refusal than letting the DB's unique-active-grant index surface a raw
+    // constraint violation - revoke (or wait for expiry) before granting the same one again.
+    List<CapabilityGrant> activeGrantList = CapabilityGrantRepository.findActiveByUserId(targetUser.getId());
+    if (activeGrantList != null) {
+      for (CapabilityGrant existing : activeGrantList) {
+        if (existing.getCapabilityId().equals(capability.getId())) {
+          throw new DataException(
+              targetUser.getUsername() + " already has an active grant of \"" + capability.getCode() +
+                  "\" - revoke it first if you want to change its reason or expiration");
+        }
+      }
+    }
+
+    CapabilityGrant record = new CapabilityGrant();
+    record.setUserId(targetUser.getId());
+    record.setCapabilityId(capability.getId());
+    record.setGrantedBy(grantedByUserId);
+    record.setReason(reason);
+    record.setExpiresAt(expiresAt);
+    CapabilityGrant savedRecord = CapabilityGrantRepository.add(record);
+    if (savedRecord == null) {
+      throw new DataException("The capability grant could not be saved");
+    }
+
+    // targetLabel = targetUser.getUsername() so a per-user History link (targetLabel-filtered,
+    // matching the role_capability convention where targetLabel = role code) surfaces every
+    // direct-grant change made for this user.
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "capability_grant.grant",
+        AuditEventCommand.SUCCESS, "capability_grant", capability.getCode(), targetUser.getUsername(), reason);
+    return savedRecord;
+  }
+
+  /**
+   * capabilityGrant must have been loaded through CapabilityGrantRepository (findById/
+   * findAllByUserId/etc) so its capabilityCode is already populated for the audit event.
+   */
+  public static void revoke(WidgetContext context, CapabilityGrant capabilityGrant, User targetUser, String reason)
+      throws DataException {
+    if (StringUtils.isBlank(reason)) {
+      throw new DataException("A reason is required when revoking a capability grant");
+    }
+    boolean wasRevoked = CapabilityGrantRepository.revoke(capabilityGrant.getId());
+    if (!wasRevoked) {
+      throw new DataException("The capability grant could not be revoked");
+    }
+    AuditEventCommand.record(context, AuditEventCommand.AUTHORIZATION, "capability_grant.revoke",
+        AuditEventCommand.SUCCESS, "capability_grant", capabilityGrant.getCapabilityCode(),
+        targetUser.getUsername(), reason);
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/CapabilityGrant.java
+++ b/src/main/java/com/simisinc/platform/domain/model/CapabilityGrant.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model;
+
+import java.sql.Timestamp;
+
+/**
+ * A direct, individually-trackable capability grant to a specific user (issue #702) - independent
+ * of role_capabilities. expiresAt null means permanent. See CapabilityGrantExpirationJob for how
+ * expiration is enforced (a scheduled sweep, not a live per-check evaluation).
+ *
+ * @author elizabeth houser
+ */
+public class CapabilityGrant extends Entity {
+
+  private Long id = -1L;
+  private Long userId = -1L;
+  private Long capabilityId = -1L;
+  private Long grantedBy = -1L;
+  private Timestamp granted = null;
+  private String reason = null;
+  private Timestamp expiresAt = null;
+  private Timestamp revokedAt = null;
+  private Timestamp expirationNotifiedAt = null;
+
+  // Populated by CapabilityGrantRepository's join queries for display - not a stored column.
+  private String capabilityCode = null;
+
+  public CapabilityGrant() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public Long getCapabilityId() {
+    return capabilityId;
+  }
+
+  public void setCapabilityId(Long capabilityId) {
+    this.capabilityId = capabilityId;
+  }
+
+  public Long getGrantedBy() {
+    return grantedBy;
+  }
+
+  public void setGrantedBy(Long grantedBy) {
+    this.grantedBy = grantedBy;
+  }
+
+  public Timestamp getGranted() {
+    return granted;
+  }
+
+  public void setGranted(Timestamp granted) {
+    this.granted = granted;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public Timestamp getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(Timestamp expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public Timestamp getRevokedAt() {
+    return revokedAt;
+  }
+
+  public void setRevokedAt(Timestamp revokedAt) {
+    this.revokedAt = revokedAt;
+  }
+
+  public Timestamp getExpirationNotifiedAt() {
+    return expirationNotifiedAt;
+  }
+
+  public void setExpirationNotifiedAt(Timestamp expirationNotifiedAt) {
+    this.expirationNotifiedAt = expirationNotifiedAt;
+  }
+
+  public String getCapabilityCode() {
+    return capabilityCode;
+  }
+
+  public void setCapabilityCode(String capabilityCode) {
+    this.capabilityCode = capabilityCode;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/CapabilityGrantRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/CapabilityGrantRepository.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves direct capability grants (issue #702) - the individually-trackable,
+ * possibly time-limited counterpart to role_capabilities (#701).
+ *
+ * @author elizabeth houser
+ */
+public class CapabilityGrantRepository {
+
+  private static Log LOG = LogFactory.getLog(CapabilityGrantRepository.class);
+
+  private static String TABLE_NAME = "capability_grants";
+  private static String[] PRIMARY_KEY = new String[]{"capability_grant_id"};
+
+  /**
+   * A user's active (not revoked, not yet expired) direct grants, for both the effective-
+   * capability resolution at login and the per-user admin UI.
+   */
+  public static List<CapabilityGrant> findActiveByUserId(long userId) {
+    if (userId == -1) {
+      return null;
+    }
+    SqlUtils where = new SqlUtils()
+        .add("user_id = ?", userId)
+        .add("revoked_at IS NULL")
+        .add("(expires_at IS NULL OR expires_at > NOW())");
+    return query(where);
+  }
+
+  /**
+   * Every grant for a user, active or not, for the admin UI's history view.
+   */
+  public static List<CapabilityGrant> findAllByUserId(long userId) {
+    if (userId == -1) {
+      return null;
+    }
+    SqlUtils where = new SqlUtils().add("user_id = ?", userId);
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME, where, new DataConstraints().setDefaultColumnToSortBy("granted DESC"),
+        CapabilityGrantRepository::buildRecord);
+    return withCapabilityCodes(result.hasRecords() ? (List<CapabilityGrant>) result.getRecords() : null);
+  }
+
+  public static CapabilityGrant findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    CapabilityGrant record = (CapabilityGrant) DB.selectRecordFrom(
+        TABLE_NAME, new SqlUtils().add("capability_grant_id = ?", id),
+        CapabilityGrantRepository::buildRecord);
+    if (record == null) {
+      return null;
+    }
+    withCapabilityCodes(List.of(record));
+    return record;
+  }
+
+  /**
+   * Active grants whose expiration has already passed - CapabilityGrantExpirationJob's revoke
+   * sweep.
+   */
+  public static List<CapabilityGrant> findExpired() {
+    SqlUtils where = new SqlUtils()
+        .add("revoked_at IS NULL")
+        .add("expires_at IS NOT NULL")
+        .add("expires_at <= NOW()");
+    return query(where);
+  }
+
+  /**
+   * Active grants expiring within the given number of days that haven't already been notified -
+   * CapabilityGrantExpirationJob's notification sweep.
+   */
+  public static List<CapabilityGrant> findExpiringWithinDaysNotYetNotified(int days) {
+    SqlUtils where = new SqlUtils()
+        .add("revoked_at IS NULL")
+        .add("expires_at IS NOT NULL")
+        .add("expires_at > NOW()")
+        .add("expires_at <= (NOW() + (? || ' days')::interval)", String.valueOf(days))
+        .add("expiration_notified_at IS NULL");
+    return query(where);
+  }
+
+  private static List<CapabilityGrant> query(SqlUtils where) {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME, where, new DataConstraints().setDefaultColumnToSortBy("granted DESC").setUseCount(false),
+        CapabilityGrantRepository::buildRecord);
+    return withCapabilityCodes(result.hasRecords() ? (List<CapabilityGrant>) result.getRecords() : null);
+  }
+
+  public static CapabilityGrant add(CapabilityGrant record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("user_id", record.getUserId())
+        .add("capability_id", record.getCapabilityId())
+        .add("granted_by", record.getGrantedBy())
+        .add("reason", record.getReason())
+        .add("expires_at", record.getExpiresAt());
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  public static boolean revoke(long id) {
+    SqlUtils updateValues = new SqlUtils().add("revoked_at", new Timestamp(System.currentTimeMillis()));
+    return DB.update(TABLE_NAME, updateValues, new SqlUtils().add("capability_grant_id = ?", id));
+  }
+
+  public static boolean markExpirationNotified(long id) {
+    SqlUtils updateValues = new SqlUtils().add("expiration_notified_at", new Timestamp(System.currentTimeMillis()));
+    return DB.update(TABLE_NAME, updateValues, new SqlUtils().add("capability_grant_id = ?", id));
+  }
+
+  /**
+   * The capabilities table is tiny (a handful of rows) - fetching it once per query and mapping
+   * in memory is simpler than a join for every call site here, and cheap enough not to matter.
+   */
+  private static List<CapabilityGrant> withCapabilityCodes(List<CapabilityGrant> grants) {
+    if (grants == null || grants.isEmpty()) {
+      return grants;
+    }
+    List<Capability> allCapabilities = CapabilityRepository.findAll();
+    Map<Long, String> codesById = new HashMap<>();
+    if (allCapabilities != null) {
+      for (Capability capability : allCapabilities) {
+        codesById.put(capability.getId(), capability.getCode());
+      }
+    }
+    for (CapabilityGrant grant : grants) {
+      grant.setCapabilityCode(codesById.get(grant.getCapabilityId()));
+    }
+    return grants;
+  }
+
+  private static CapabilityGrant buildRecord(ResultSet rs) {
+    try {
+      CapabilityGrant record = new CapabilityGrant();
+      record.setId(rs.getLong("capability_grant_id"));
+      record.setUserId(rs.getLong("user_id"));
+      record.setCapabilityId(rs.getLong("capability_id"));
+      long grantedBy = rs.getLong("granted_by");
+      record.setGrantedBy(rs.wasNull() ? null : grantedBy);
+      record.setGranted(rs.getTimestamp("granted"));
+      record.setReason(rs.getString("reason"));
+      record.setExpiresAt(rs.getTimestamp("expires_at"));
+      record.setRevokedAt(rs.getTimestamp("revoked_at"));
+      record.setExpirationNotifiedAt(rs.getTimestamp("expiration_notified_at"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.infrastructure.scheduler;
 
 import com.simisinc.platform.infrastructure.database.DataSource;
 import com.simisinc.platform.infrastructure.instance.InstanceManager;
+import com.simisinc.platform.infrastructure.scheduler.admin.CapabilityGrantExpirationJob;
 import com.simisinc.platform.infrastructure.scheduler.admin.DatasetsDownloadAndSyncJob;
 import com.simisinc.platform.infrastructure.scheduler.audit.AuditLogIntegrityJob;
 import com.simisinc.platform.infrastructure.scheduler.audit.AuditLogRetentionJob;
@@ -88,6 +89,7 @@ public class SchedulerManager {
   public static final String SESSIONS_PII_SCRUB_JOB = "SessionsPiiScrub";
   public static final String AUDIT_LOG_RETENTION_JOB = "AuditLogRetention";
   public static final String AUDIT_LOG_INTEGRITY_JOB = "AuditLogIntegrity";
+  public static final String CAPABILITY_GRANT_EXPIRATION_JOB = "CapabilityGrantExpiration";
   public static final String EMAIL_CLASSIFICATION_JOB = "EmailClassification";
   public static final String MAILING_LIST_QUARANTINE_JOB = "MailingListQuarantine";
   public static final String FORM_SUBMISSION_FAILURE_RETENTION_JOB = "FormSubmissionFailureRetention";
@@ -175,6 +177,8 @@ public class SchedulerManager {
         BackgroundJob.scheduleRecurrently(SESSIONS_PII_SCRUB_JOB, Cron.daily(4, 45), SessionsPiiScrubJob::execute);
         BackgroundJob.scheduleRecurrently(AUDIT_LOG_RETENTION_JOB, Cron.daily(4, 15), AuditLogRetentionJob::execute);
         BackgroundJob.scheduleRecurrently(AUDIT_LOG_INTEGRITY_JOB, Cron.daily(4, 30), AuditLogIntegrityJob::execute);
+        BackgroundJob.scheduleRecurrently(CAPABILITY_GRANT_EXPIRATION_JOB, Cron.hourly(),
+            CapabilityGrantExpirationJob::execute);
         // Once daily is plenty for a backlog job, and keeps it off ZeroBounce's real per-lookup API
         // billing except when there's actually unvalidated backlog; runs ahead of the 4am cluster above
         // so it isn't competing with those jobs for DB/API time.

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/admin/CapabilityGrantExpirationJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/admin/CapabilityGrantExpirationJob.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.admin;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jobrunr.jobs.annotations.Job;
+
+import com.simisinc.platform.application.admin.SendAdminEmailCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+
+/**
+ * Enforces expiration of direct capability grants (issue #702) via a scheduled sweep rather than
+ * a live per-check evaluation - the same staleness the rest of the permission model already
+ * accepts (a role or grant change only takes effect at a user's next login). Two independent
+ * passes: revoke anything already past its expiresAt, and send one batched admin-email digest
+ * for grants expiring soon so an admin can renew or deliberately let them lapse.
+ *
+ * @author elizabeth houser
+ */
+public class CapabilityGrantExpirationJob {
+
+  private static Log LOG = LogFactory.getLog(CapabilityGrantExpirationJob.class);
+
+  private static final int EXPIRING_SOON_DAYS = 7;
+
+  @Job(name = "Expire and warn on capability grants")
+  public static void execute() {
+    // Distributed lock so only one node runs the sweep
+    String lock = LockManager.lock(SchedulerManager.CAPABILITY_GRANT_EXPIRATION_JOB, Duration.ofHours(1));
+    if (lock == null) {
+      return;
+    }
+
+    revokeExpiredGrants();
+    notifyExpiringGrants();
+  }
+
+  private static void revokeExpiredGrants() {
+    List<CapabilityGrant> expiredGrantList = CapabilityGrantRepository.findExpired();
+    if (expiredGrantList == null || expiredGrantList.isEmpty()) {
+      return;
+    }
+    int revokedCount = 0;
+    for (CapabilityGrant capabilityGrant : expiredGrantList) {
+      if (!CapabilityGrantRepository.revoke(capabilityGrant.getId())) {
+        continue;
+      }
+      ++revokedCount;
+      User user = UserRepository.findByUserId(capabilityGrant.getUserId());
+      SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.AUTHORIZATION, "capability_grant.expire",
+          AuditEventCommand.SUCCESS, -1L, "system", null, null, "capability_grant",
+          capabilityGrant.getCapabilityCode(), user != null ? user.getUsername() : null,
+          "Grant expired at " + capabilityGrant.getExpiresAt());
+    }
+    if (revokedCount > 0) {
+      LOG.info("Capability grant expiration: revoked " + revokedCount + " expired grant(s)");
+    }
+  }
+
+  private static void notifyExpiringGrants() {
+    List<CapabilityGrant> expiringGrantList =
+        CapabilityGrantRepository.findExpiringWithinDaysNotYetNotified(EXPIRING_SOON_DAYS);
+    if (expiringGrantList == null || expiringGrantList.isEmpty()) {
+      return;
+    }
+
+    StringBuilder html = new StringBuilder(
+        "<p>The following capability grants expire within " + EXPIRING_SOON_DAYS + " days:</p><ul>");
+    StringBuilder text = new StringBuilder(
+        "The following capability grants expire within " + EXPIRING_SOON_DAYS + " days:\n\n");
+    for (CapabilityGrant capabilityGrant : expiringGrantList) {
+      User user = UserRepository.findByUserId(capabilityGrant.getUserId());
+      String username = user != null ? user.getUsername() : ("user #" + capabilityGrant.getUserId());
+      String line = username + " - " + capabilityGrant.getCapabilityCode() +
+          " (expires " + capabilityGrant.getExpiresAt() + ")";
+      html.append("<li>").append(StringEscapeUtils.escapeHtml4(line)).append("</li>");
+      text.append(line).append("\n");
+    }
+    html.append("</ul>");
+
+    // One digest for the whole batch, not one email per grant
+    SendAdminEmailCommand.sendMessage("Capability grants expiring soon", html.toString(), text.toString());
+
+    for (CapabilityGrant capabilityGrant : expiringGrantList) {
+      CapabilityGrantRepository.markExpirationNotified(capabilityGrant.getId());
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/CapabilityGrantsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/CapabilityGrantsWidget.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.SaveCapabilityGrantCommand;
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.infrastructure.persistence.CapabilityRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Lists and manages one user's direct capability grants (issue #702) - the minimal grant/revoke
+ * UI for temporary/expiring permissions, the per-user counterpart to RoleCapabilitiesForm/
+ * ListWidget's per-role UI (#704). No risk badges, search, or bulk operations - that richer UX
+ * layer is #703's job.
+ *
+ * @author elizabeth houser
+ */
+public class CapabilityGrantsWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908897L;
+
+  static String JSP = "/admin/capability-grants.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    if (!context.hasPermission("admin:manage")) {
+      LOG.warn("No access to capability grants");
+      return null;
+    }
+
+    User user = loadUser(context);
+    if (user == null) {
+      return null;
+    }
+
+    List<Capability> allCapabilities = CapabilityRepository.findAll();
+    List<CapabilityGrant> grantList = CapabilityGrantRepository.findAllByUserId(user.getId());
+
+    context.getRequest().setAttribute("targetUser", user);
+    context.getRequest().setAttribute("capabilityList", allCapabilities);
+    context.getRequest().setAttribute("grantList", grantList);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+    if (!context.hasPermission("admin:manage")) {
+      LOG.warn("No access to save capability grants");
+      return context;
+    }
+
+    User user = loadUser(context);
+    if (user == null) {
+      return context;
+    }
+
+    context.setRedirect("/admin/capability-grants?userId=" + user.getId());
+
+    String command = context.getParameter("command");
+    try {
+      if ("add".equals(command)) {
+        add(context, user);
+      } else if ("revoke".equals(command)) {
+        revoke(context, user);
+      }
+    } catch (DataException e) {
+      context.setErrorMessage(e.getMessage());
+    }
+
+    return context;
+  }
+
+  private void add(WidgetContext context, User user) throws DataException {
+    long capabilityId = context.getParameterAsLong("capabilityId", -1);
+    Capability capability = findCapability(capabilityId);
+    if (capability == null) {
+      throw new DataException("Capability was not found");
+    }
+    String reason = context.getParameter("reason");
+    Timestamp expiresAt = parseExpiresAt(context.getParameter("expiresAt"));
+
+    SaveCapabilityGrantCommand.grant(context, user, capability, context.getUserId(), reason, expiresAt);
+    context.setSuccessMessage("Granted \"" + capability.getCode() + "\" to " + user.getUsername());
+  }
+
+  private void revoke(WidgetContext context, User user) throws DataException {
+    long capabilityGrantId = context.getParameterAsLong("capabilityGrantId", -1);
+    CapabilityGrant capabilityGrant = CapabilityGrantRepository.findById(capabilityGrantId);
+    if (capabilityGrant == null || !capabilityGrant.getUserId().equals(user.getId())) {
+      throw new DataException("Capability grant was not found for this user");
+    }
+    String reason = context.getParameter("reason");
+
+    SaveCapabilityGrantCommand.revoke(context, capabilityGrant, user, reason);
+    context.setSuccessMessage("Revoked \"" + capabilityGrant.getCapabilityCode() + "\" from " + user.getUsername());
+  }
+
+  private Capability findCapability(long capabilityId) {
+    List<Capability> allCapabilities = CapabilityRepository.findAll();
+    if (allCapabilities == null) {
+      return null;
+    }
+    for (Capability capability : allCapabilities) {
+      if (capability.getId() == capabilityId) {
+        return capability;
+      }
+    }
+    return null;
+  }
+
+  /** Parses a yyyy-MM-dd date input as expiring at the start of the following day (inclusive of the
+   *  selected day); null when blank/invalid, meaning a permanent grant. */
+  private Timestamp parseExpiresAt(String value) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    try {
+      LocalDate date = LocalDate.parse(value.trim()).plusDays(1);
+      return Timestamp.valueOf(date.atStartOfDay());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private User loadUser(WidgetContext context) {
+    long userId = context.getParameterAsLong("userId", -1);
+    User user = UserRepository.findByUserId(userId);
+    if (user == null) {
+      context.setErrorMessage("User was not found");
+    }
+    return user;
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -411,6 +411,33 @@ CREATE TABLE user_roles (
 CREATE INDEX user_roles_rol_idx ON user_roles(role_id);
 CREATE INDEX user_roles_usr_idx ON user_roles(user_id);
 
+-- Direct, individually-trackable capability grants (issue #702) - independent of role_capabilities.
+-- A user can hold a capability two ways: through a role (role_capabilities, #701) or through a
+-- direct grant here (e.g. a temporary contractor who shouldn't get a whole role). expires_at is
+-- nullable - null means permanent, matching a direct grant with no time limit.
+CREATE TABLE capability_grants (
+  capability_grant_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES users (user_id),
+  capability_id BIGINT NOT NULL REFERENCES capabilities (capability_id),
+  granted_by BIGINT REFERENCES users (user_id),
+  granted TIMESTAMP DEFAULT NOW(),
+  reason VARCHAR(500),
+  expires_at TIMESTAMP,
+  revoked_at TIMESTAMP,
+  expiration_notified_at TIMESTAMP
+);
+
+CREATE INDEX idx_capability_grants_user_id ON capability_grants (user_id);
+CREATE INDEX idx_capability_grants_capability_id ON capability_grants (capability_id);
+
+-- Only one *active* grant of a given capability per user at a time - prevents silently stacking
+-- duplicate grants; revoke (or let expire) the existing one before granting again.
+CREATE UNIQUE INDEX idx_capability_grants_active_unique ON capability_grants (user_id, capability_id)
+  WHERE revoked_at IS NULL;
+
+-- Sweep queries (CapabilityGrantExpirationJob) filter on both columns together.
+CREATE INDEX idx_capability_grants_expires_at ON capability_grants (expires_at) WHERE revoked_at IS NULL;
+
 
 CREATE TABLE groups (
   group_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260729.2005__capability_grants.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260729.2005__capability_grants.sql
@@ -1,0 +1,26 @@
+-- Direct, individually-trackable capability grants (issue #702) - independent of role_capabilities.
+-- A user can hold a capability two ways: through a role (role_capabilities, #701) or through a
+-- direct grant here (e.g. a temporary contractor who shouldn't get a whole role). expires_at is
+-- nullable - null means permanent, matching a direct grant with no time limit.
+CREATE TABLE capability_grants (
+  capability_grant_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES users (user_id),
+  capability_id BIGINT NOT NULL REFERENCES capabilities (capability_id),
+  granted_by BIGINT REFERENCES users (user_id),
+  granted TIMESTAMP DEFAULT NOW(),
+  reason VARCHAR(500),
+  expires_at TIMESTAMP,
+  revoked_at TIMESTAMP,
+  expiration_notified_at TIMESTAMP
+);
+
+CREATE INDEX idx_capability_grants_user_id ON capability_grants (user_id);
+CREATE INDEX idx_capability_grants_capability_id ON capability_grants (capability_id);
+
+-- Only one *active* grant of a given capability per user at a time - prevents silently stacking
+-- duplicate grants; revoke (or let expire) the existing one before granting again.
+CREATE UNIQUE INDEX idx_capability_grants_active_unique ON capability_grants (user_id, capability_id)
+  WHERE revoked_at IS NULL;
+
+-- Sweep queries (CapabilityGrantExpirationJob) filter on both columns together.
+CREATE INDEX idx_capability_grants_expires_at ON capability_grants (expires_at) WHERE revoked_at IS NULL;

--- a/src/main/webapp/WEB-INF/jsp/admin/capability-grants.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/capability-grants.jsp
@@ -1,0 +1,144 @@
+<%--
+  ~ Copyright 2022 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="user" uri="/WEB-INF/tlds/user-functions.tld" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="targetUser" class="com.simisinc.platform.domain.model.User" scope="request"/>
+<jsp:useBean id="capabilityList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="grantList" class="java.util.ArrayList" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+</c:if>
+<h4><c:out value="${targetUser.fullName}" /></h4>
+<p class="help-text">Direct grants give this specific user a capability without changing their role - useful for a
+  temporary need (set an expiration) or a one-off exception (leave it permanent). See
+  <a href="${ctx}/admin/role-capabilities">Role Capabilities</a> for what this user already has through their
+  role(s). Every grant or revoke here is recorded in the platform's audit log. A session already logged in as this
+  user won't see the change take effect until they log in again.</p>
+<%@include file="../page_messages.jspf" %>
+<form method="post">
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <input type="hidden" name="command" value="add"/>
+  <input type="hidden" name="userId" value="${targetUser.id}"/>
+  <div class="grid-x grid-padding-x">
+    <div class="cell medium-4">
+      <label>Capability
+        <select name="capabilityId" required>
+          <option value="">Select...</option>
+          <c:forEach items="${capabilityList}" var="capability">
+            <option value="${capability.id}"><c:out value="${capability.code}" /> - <c:out value="${capability.description}" /></option>
+          </c:forEach>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-3">
+      <label>Expires (optional)
+        <input type="date" name="expiresAt">
+      </label>
+    </div>
+    <div class="cell medium-5">
+      <label>Reason (required)
+        <input type="text" name="reason" placeholder="Why is this being granted?" required>
+      </label>
+    </div>
+  </div>
+  <div class="button-container">
+    <input type="submit" class="button radius success" value="Grant"/>
+  </div>
+</form>
+<table class="unstriped stack">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th>Granted</th>
+      <th>Granted By</th>
+      <th>Reason</th>
+      <th>Expires</th>
+      <th>Status</th>
+      <th width="70">History</th>
+      <th width="70">Revoke</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${grantList}" var="grant">
+      <tr>
+        <td><code><c:out value="${grant.capabilityCode}" /></code></td>
+        <td><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${grant.granted}" /></td>
+        <td><c:out value="${user:name(grant.grantedBy)}" /></td>
+        <td><c:out value="${grant.reason}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty grant.expiresAt}"><fmt:formatDate pattern="yyyy-MM-dd" value="${grant.expiresAt}" /></c:when>
+            <c:otherwise><small class="subheader">Never</small></c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty grant.revokedAt}"><span class="label alert">Revoked</span></c:when>
+            <c:otherwise><span class="label success">Active</span></c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:url var="historyUrl" value="/admin/audit-log">
+            <c:param name="targetType" value="capability_grant"/>
+            <c:param name="targetLabel" value="${targetUser.username}"/>
+          </c:url>
+          <a href="${historyUrl}" title="View audit history for this user's grants">History</a>
+        </td>
+        <td>
+          <c:if test="${empty grant.revokedAt}">
+            <a href="#" title="Revoke this grant" onclick="openRevokeCapabilityGrantReveal(${grant.id}); return false;"><i class="fa fa-trash"></i></a>
+          </c:if>
+        </td>
+      </tr>
+    </c:forEach>
+    <c:if test="${empty grantList}">
+      <tr>
+        <td colspan="8">No direct grants for this user</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<p><a href="${ctx}/admin/user-details?userId=${targetUser.id}"><i class="fa fa-angle-double-left"></i> Back to user</a></p>
+<div class="reveal" id="revokeCapabilityGrantReveal" role="dialog" aria-modal="true" aria-labelledby="revokeCapabilityGrantTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="revokeCapabilityGrantTitle">Revoke Capability Grant</h4>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="revoke"/>
+    <input type="hidden" name="userId" value="${targetUser.id}"/>
+    <input type="hidden" name="capabilityGrantId" id="revokeCapabilityGrantId" value=""/>
+    <label>Reason (required)
+      <input type="text" name="reason" placeholder="Why is this being revoked?" required>
+    </label>
+    <input type="submit" class="button radius alert" value="Revoke"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<script nonce="${cspNonce}">
+  function openRevokeCapabilityGrantReveal(capabilityGrantId) {
+    document.getElementById('revokeCapabilityGrantId').value = capabilityGrantId;
+    $('#revokeCapabilityGrantReveal').foundation('open');
+  }
+</script>

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -49,6 +49,7 @@
 </script>
 <div style="margin-top: 6px;background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;">
   <div class="button-container float-right">
+    <a class="button small radius float-right" href="${ctx}/admin/capability-grants?userId=${user.id}">Capability Grants</a>
     <a class="button small radius float-right" href="${ctx}/admin/modify-user?userId=${user.id}">Modify User</a>
     <ul class="dropdown menu" style="padding-right: 15px;" data-dropdown-menu>
       <li>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1597,6 +1597,16 @@
     </section>
   </page>
 
+  <page name="/admin/capability-grants{?userId}" role="admin" title="Capability Grants">
+    <section>
+      <column class="small-12 medium-8 large-6 cell">
+        <widget name="capabilityGrants">
+          <title>Capability Grants</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/activity" role="admin,content-manager,community-manager,ecommerce-manager" title="Activity">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -218,6 +218,7 @@
   <widget name="allowedIPListForm" class="com.simisinc.platform.presentation.widgets.admin.AllowedIPFormWidget" />
   <widget name="roleCapabilitiesList" class="com.simisinc.platform.presentation.widgets.admin.RoleCapabilitiesListWidget" />
   <widget name="roleCapabilitiesForm" class="com.simisinc.platform.presentation.widgets.admin.RoleCapabilitiesFormWidget" />
+  <widget name="capabilityGrants" class="com.simisinc.platform.presentation.widgets.admin.CapabilityGrantsWidget" />
   <widget name="socialMediaLinkList" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkListWidget" />
   <widget name="socialMediaLinkForm" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkFormWidget" />
   <widget name="formDataList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormDataListWidget" />

--- a/src/test/java/com/simisinc/platform/application/LoadUserCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/LoadUserCommandTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.infrastructure.persistence.CapabilityRepository;
+import com.simisinc.platform.infrastructure.persistence.GroupRepository;
+import com.simisinc.platform.infrastructure.persistence.RoleRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
+
+/**
+ * Issue #702 adds direct capability grants alongside #701's role-derived ones; a user can hold
+ * a capability either way, so LoadUserCommand.populateUserRecord must merge both sources into one
+ * effective, de-duplicated capabilityList before hasPermission() ever sees it. These tests are the
+ * only coverage of that merge - hasPermission() itself just checks list membership, so getting the
+ * merge right here is the entire correctness burden of #702's runtime authorization path.
+ *
+ * @author elizabeth houser
+ */
+class LoadUserCommandTest {
+
+  private static Capability capability(String code, long id) {
+    Capability capability = new Capability();
+    capability.setId(id);
+    capability.setCode(code);
+    return capability;
+  }
+
+  private static CapabilityGrant grant(long capabilityId) {
+    CapabilityGrant grant = new CapabilityGrant();
+    grant.setCapabilityId(capabilityId);
+    return grant;
+  }
+
+  private static User user(long id) {
+    User user = new User();
+    user.setId(id);
+    return user;
+  }
+
+  @Test
+  void mergesRoleDerivedAndDirectlyGrantedCapabilities() {
+    Capability contentManage = capability("content:manage", 1L);
+    Capability reportsExport = capability("reports:export", 3L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(user(10L));
+      roleRepo.when(() -> RoleRepository.findAllByUserId(10L)).thenReturn(null);
+      groupRepo.when(() -> GroupRepository.findAllByUserId(10L)).thenReturn(null);
+      userLoginRepo.when(() -> UserLoginRepository.queryLastLogin(10L)).thenReturn(null);
+      capabilityRepo.when(() -> CapabilityRepository.findAllByUserId(10L)).thenReturn(List.of(contentManage));
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(contentManage, reportsExport));
+      grantRepo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(List.of(grant(3L)));
+
+      User result = LoadUserCommand.loadUser(10L);
+
+      Set<String> codes = result.getCapabilityList().stream().map(Capability::getCode).collect(Collectors.toSet());
+      assertEquals(Set.of("content:manage", "reports:export"), codes);
+    }
+  }
+
+  @Test
+  void aCapabilityHeldBothWaysAppearsOnlyOnce() {
+    Capability adminManage = capability("admin:manage", 5L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(user(10L));
+      roleRepo.when(() -> RoleRepository.findAllByUserId(10L)).thenReturn(null);
+      groupRepo.when(() -> GroupRepository.findAllByUserId(10L)).thenReturn(null);
+      userLoginRepo.when(() -> UserLoginRepository.queryLastLogin(10L)).thenReturn(null);
+      // Held via role AND via a redundant direct grant of the same capability
+      capabilityRepo.when(() -> CapabilityRepository.findAllByUserId(10L)).thenReturn(List.of(adminManage));
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(adminManage));
+      grantRepo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(List.of(grant(5L)));
+
+      User result = LoadUserCommand.loadUser(10L);
+
+      assertEquals(1, result.getCapabilityList().size());
+      assertTrue(result.hasPermission("admin:manage"));
+    }
+  }
+
+  @Test
+  void aDirectGrantAloneIsSufficientWithoutAnyRole() {
+    Capability reportsExport = capability("reports:export", 3L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(user(10L));
+      roleRepo.when(() -> RoleRepository.findAllByUserId(10L)).thenReturn(null);
+      groupRepo.when(() -> GroupRepository.findAllByUserId(10L)).thenReturn(null);
+      userLoginRepo.when(() -> UserLoginRepository.queryLastLogin(10L)).thenReturn(null);
+      // No roles at all, so the role-derived capability list is empty/null
+      capabilityRepo.when(() -> CapabilityRepository.findAllByUserId(10L)).thenReturn(null);
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(reportsExport));
+      grantRepo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(List.of(grant(3L)));
+
+      User result = LoadUserCommand.loadUser(10L);
+
+      assertTrue(result.hasPermission("reports:export"));
+    }
+  }
+
+  @Test
+  void noActiveGrantsLeavesTheRoleDerivedListUntouched() {
+    Capability contentManage = capability("content:manage", 1L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(user(10L));
+      roleRepo.when(() -> RoleRepository.findAllByUserId(10L)).thenReturn(null);
+      groupRepo.when(() -> GroupRepository.findAllByUserId(10L)).thenReturn(null);
+      userLoginRepo.when(() -> UserLoginRepository.queryLastLogin(10L)).thenReturn(null);
+      capabilityRepo.when(() -> CapabilityRepository.findAllByUserId(10L)).thenReturn(List.of(contentManage));
+      grantRepo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(null);
+
+      User result = LoadUserCommand.loadUser(10L);
+
+      assertEquals(List.of(contentManage), result.getCapabilityList());
+      capabilityRepo.verify(CapabilityRepository::findAll, never());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/admin/SaveCapabilityGrantCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/admin/SaveCapabilityGrantCommandTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+
+/**
+ * The only runtime path that mutates capability_grants (issue #702) - covers the required-reason
+ * validation, the friendlier duplicate-active-grant refusal (vs. letting the DB's unique index
+ * surface a raw constraint violation), and that both grant/revoke produce an audit event.
+ *
+ * @author elizabeth houser
+ */
+class SaveCapabilityGrantCommandTest {
+
+  private static User user(String username, long id) {
+    User user = new User();
+    user.setId(id);
+    user.setUsername(username);
+    return user;
+  }
+
+  private static Capability capability(String code, long id) {
+    Capability capability = new Capability();
+    capability.setId(id);
+    capability.setCode(code);
+    return capability;
+  }
+
+  private static CapabilityGrant grant(long id, long userId, long capabilityId, String capabilityCode) {
+    CapabilityGrant grant = new CapabilityGrant();
+    grant.setId(id);
+    grant.setUserId(userId);
+    grant.setCapabilityId(capabilityId);
+    grant.setCapabilityCode(capabilityCode);
+    return grant;
+  }
+
+  @Test
+  void grantRequiresAReason() {
+    User targetUser = user("jsmith", 10L);
+    Capability capability = capability("reports:export", 3L);
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class)) {
+      DataException e = assertThrows(DataException.class,
+          () -> SaveCapabilityGrantCommand.grant(null, targetUser, capability, 1L, "  ", null));
+      assertEquals("A reason is required when granting a capability", e.getMessage());
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void grantRefusesADuplicateActiveGrant() {
+    User targetUser = user("jsmith", 10L);
+    Capability capability = capability("reports:export", 3L);
+    CapabilityGrant existing = grant(1L, 10L, 3L, "reports:export");
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class)) {
+      repo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(List.of(existing));
+
+      DataException e = assertThrows(DataException.class,
+          () -> SaveCapabilityGrantCommand.grant(null, targetUser, capability, 1L, "Contractor access", null));
+      assertEquals(true, e.getMessage().contains("already has an active grant"));
+      repo.verify(() -> CapabilityGrantRepository.add(any()), never());
+    }
+  }
+
+  @Test
+  void grantSavesAndRecordsAnAuditEvent() throws Exception {
+    User targetUser = user("jsmith", 10L);
+    Capability capability = capability("reports:export", 3L);
+    Timestamp expiresAt = Timestamp.valueOf("2026-08-01 00:00:00");
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      repo.when(() -> CapabilityGrantRepository.findActiveByUserId(10L)).thenReturn(null);
+      repo.when(() -> CapabilityGrantRepository.add(any()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      CapabilityGrant saved = SaveCapabilityGrantCommand.grant(null, targetUser, capability, 1L,
+          "Temporary contractor access", expiresAt);
+
+      assertEquals(10L, saved.getUserId());
+      assertEquals(3L, saved.getCapabilityId());
+      assertEquals(1L, saved.getGrantedBy());
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.AUTHORIZATION),
+          eq("capability_grant.grant"), eq(AuditEventCommand.SUCCESS), eq("capability_grant"),
+          eq("reports:export"), eq("jsmith"), eq("Temporary contractor access")));
+    }
+  }
+
+  @Test
+  void revokeRequiresAReason() {
+    User targetUser = user("jsmith", 10L);
+    CapabilityGrant existing = grant(1L, 10L, 3L, "reports:export");
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class)) {
+      DataException e = assertThrows(DataException.class,
+          () -> SaveCapabilityGrantCommand.revoke(null, existing, targetUser, " "));
+      assertEquals("A reason is required when revoking a capability grant", e.getMessage());
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void revokeUpdatesTheRecordAndRecordsAnAuditEvent() throws Exception {
+    User targetUser = user("jsmith", 10L);
+    CapabilityGrant existing = grant(1L, 10L, 3L, "reports:export");
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      repo.when(() -> CapabilityGrantRepository.revoke(1L)).thenReturn(true);
+
+      SaveCapabilityGrantCommand.revoke(null, existing, targetUser, "No longer needed");
+
+      repo.verify(() -> CapabilityGrantRepository.revoke(1L));
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.AUTHORIZATION),
+          eq("capability_grant.revoke"), eq(AuditEventCommand.SUCCESS), eq("capability_grant"),
+          eq("reports:export"), eq("jsmith"), eq("No longer needed")));
+    }
+  }
+
+  @Test
+  void revokeThrowsWhenTheUpdateFails() {
+    User targetUser = user("jsmith", 10L);
+    CapabilityGrant existing = grant(1L, 10L, 3L, "reports:export");
+
+    try (MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class)) {
+      repo.when(() -> CapabilityGrantRepository.revoke(anyLong())).thenReturn(false);
+
+      assertThrows(DataException.class,
+          () -> SaveCapabilityGrantCommand.revoke(null, existing, targetUser, "No longer needed"));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/admin/CapabilityGrantExpirationJobTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/admin/CapabilityGrantExpirationJobTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.SendAdminEmailCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Verifies the two independent sweeps in {@link CapabilityGrantExpirationJob#execute} (issue
+ * #702): past-due grants are revoked and audited one event each, and grants expiring soon are
+ * batched into a single admin-email digest (not one email per grant) and marked notified so the
+ * next hourly run doesn't re-send. Everything reached is statically mocked, so nothing here
+ * touches a database or sends real mail.
+ *
+ * @author elizabeth houser
+ */
+class CapabilityGrantExpirationJobTest {
+
+  private static CapabilityGrant grant(long id, long userId, String capabilityCode) {
+    CapabilityGrant grant = new CapabilityGrant();
+    grant.setId(id);
+    grant.setUserId(userId);
+    grant.setCapabilityCode(capabilityCode);
+    return grant;
+  }
+
+  private static User user(long id, String username) {
+    User user = new User();
+    user.setId(id);
+    user.setUsername(username);
+    return user;
+  }
+
+  @Test
+  void executeSkipsEntirelyWhenTheLockIsHeldByAnotherNode() {
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.CAPABILITY_GRANT_EXPIRATION_JOB), any(Duration.class)))
+          .thenReturn(null);
+
+      CapabilityGrantExpirationJob.execute();
+
+      repo.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeRevokesExpiredGrantsAndRecordsAnAuditEventPerGrant() {
+    CapabilityGrant expired = grant(1L, 10L, "reports:export");
+
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class);
+        MockedStatic<SendAdminEmailCommand> adminEmail = mockStatic(SendAdminEmailCommand.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.CAPABILITY_GRANT_EXPIRATION_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      repo.when(CapabilityGrantRepository::findExpired).thenReturn(List.of(expired));
+      repo.when(() -> CapabilityGrantRepository.revoke(1L)).thenReturn(true);
+      repo.when(() -> CapabilityGrantRepository.findExpiringWithinDaysNotYetNotified(anyInt())).thenReturn(null);
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(user(10L, "jsmith"));
+
+      CapabilityGrantExpirationJob.execute();
+
+      repo.verify(() -> CapabilityGrantRepository.revoke(1L));
+      auditEvent.verify(() -> SaveAuditEventCommand.recordAdminEvent(anyString(), eq("capability_grant.expire"),
+          anyString(), eq(-1L), eq("system"), isNull(), isNull(), eq("capability_grant"),
+          eq("reports:export"), eq("jsmith"), contains("expired")), times(1));
+      adminEmail.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeDoesNothingWhenNoGrantsAreExpiredOrExpiring() {
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class);
+        MockedStatic<SendAdminEmailCommand> adminEmail = mockStatic(SendAdminEmailCommand.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.CAPABILITY_GRANT_EXPIRATION_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      repo.when(CapabilityGrantRepository::findExpired).thenReturn(null);
+      repo.when(() -> CapabilityGrantRepository.findExpiringWithinDaysNotYetNotified(anyInt())).thenReturn(null);
+
+      CapabilityGrantExpirationJob.execute();
+
+      auditEvent.verifyNoInteractions();
+      adminEmail.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeSendsOneBatchedDigestForAllExpiringGrantsAndMarksEachNotified() {
+    CapabilityGrant expiringA = grant(2L, 11L, "reports:export");
+    CapabilityGrant expiringB = grant(3L, 12L, "billing:manage");
+
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<CapabilityGrantRepository> repo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<SendAdminEmailCommand> adminEmail = mockStatic(SendAdminEmailCommand.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.CAPABILITY_GRANT_EXPIRATION_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      repo.when(CapabilityGrantRepository::findExpired).thenReturn(null);
+      repo.when(() -> CapabilityGrantRepository.findExpiringWithinDaysNotYetNotified(7))
+          .thenReturn(List.of(expiringA, expiringB));
+      userRepo.when(() -> UserRepository.findByUserId(11L)).thenReturn(user(11L, "asmith"));
+      userRepo.when(() -> UserRepository.findByUserId(12L)).thenReturn(user(12L, "bsmith"));
+
+      CapabilityGrantExpirationJob.execute();
+
+      adminEmail.verify(() -> SendAdminEmailCommand.sendMessage(anyString(), anyString(), anyString()), times(1));
+      repo.verify(() -> CapabilityGrantRepository.markExpirationNotified(2L));
+      repo.verify(() -> CapabilityGrantRepository.markExpirationNotified(3L));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/CapabilityGrantsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/CapabilityGrantsWidgetTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.SaveCapabilityGrantCommand;
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.CapabilityGrant;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.CapabilityGrantRepository;
+import com.simisinc.platform.infrastructure.persistence.CapabilityRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class CapabilityGrantsWidgetTest extends WidgetBase {
+
+  private static User targetUser(long id, String username) {
+    User user = new User();
+    user.setId(id);
+    user.setUsername(username);
+    return user;
+  }
+
+  private static Capability capability(String code, long id) {
+    Capability capability = new Capability();
+    capability.setId(id);
+    capability.setCode(code);
+    return capability;
+  }
+
+  private static CapabilityGrant grant(long id, long userId, long capabilityId, String capabilityCode) {
+    CapabilityGrant grant = new CapabilityGrant();
+    grant.setId(id);
+    grant.setUserId(userId);
+    grant.setCapabilityId(capabilityId);
+    grant.setCapabilityCode(capabilityCode);
+    return grant;
+  }
+
+  @Test
+  void executeIsRefusedWithoutAdminManagePermission() {
+    // WidgetBase's default session has no capability list populated at all (null)
+    addQueryParameter(widgetContext, "userId", "10");
+
+    WidgetContext result = new CapabilityGrantsWidget().execute(widgetContext);
+
+    assertNull(result);
+  }
+
+  @Test
+  void executeShowsTheUsersGrantsAndAllCapabilities() {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "10");
+
+    Capability reportsExport = capability("reports:export", 3L);
+    CapabilityGrant existingGrant = grant(1L, 10L, 3L, "reports:export");
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(targetUser(10L, "jsmith"));
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(reportsExport));
+      grantRepo.when(() -> CapabilityGrantRepository.findAllByUserId(10L)).thenReturn(List.of(existingGrant));
+
+      WidgetContext result = new CapabilityGrantsWidget().execute(widgetContext);
+
+      assertEquals(CapabilityGrantsWidget.JSP, result.getJsp());
+      assertEquals("jsmith", ((User) result.getRequest().getAttribute("targetUser")).getUsername());
+      assertEquals(1, ((List<?>) result.getRequest().getAttribute("grantList")).size());
+    }
+  }
+
+  @Test
+  void executeReturnsNullWhenTheUserIsNotFound() {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "999");
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(999L)).thenReturn(null);
+
+      WidgetContext result = new CapabilityGrantsWidget().execute(widgetContext);
+
+      assertNull(result);
+    }
+  }
+
+  @Test
+  void postIsRefusedWithoutAdminManagePermission() {
+    addQueryParameter(widgetContext, "userId", "10");
+    addQueryParameter(widgetContext, "command", "add");
+
+    try (MockedStatic<SaveCapabilityGrantCommand> saveCommand = mockStatic(SaveCapabilityGrantCommand.class)) {
+      new CapabilityGrantsWidget().post(widgetContext);
+
+      saveCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postAddsAGrant() throws Exception {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "10");
+    addQueryParameter(widgetContext, "command", "add");
+    addQueryParameter(widgetContext, "capabilityId", "3");
+    addQueryParameter(widgetContext, "reason", "Temporary contractor access");
+
+    Capability reportsExport = capability("reports:export", 3L);
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<SaveCapabilityGrantCommand> saveCommand = mockStatic(SaveCapabilityGrantCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(targetUser(10L, "jsmith"));
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(reportsExport));
+
+      WidgetContext result = new CapabilityGrantsWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveCapabilityGrantCommand.grant(any(), any(), eq(reportsExport), anyLong(),
+          eq("Temporary contractor access"), isNull()));
+      assertEquals("/admin/capability-grants?userId=10", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postRevokesAGrantBelongingToTheSameUser() throws Exception {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "10");
+    addQueryParameter(widgetContext, "command", "revoke");
+    addQueryParameter(widgetContext, "capabilityGrantId", "1");
+    addQueryParameter(widgetContext, "reason", "No longer needed");
+
+    CapabilityGrant existingGrant = grant(1L, 10L, 3L, "reports:export");
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<SaveCapabilityGrantCommand> saveCommand = mockStatic(SaveCapabilityGrantCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(targetUser(10L, "jsmith"));
+      grantRepo.when(() -> CapabilityGrantRepository.findById(1L)).thenReturn(existingGrant);
+
+      new CapabilityGrantsWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveCapabilityGrantCommand.revoke(any(), eq(existingGrant), any(), eq("No longer needed")));
+    }
+  }
+
+  @Test
+  void postRefusesToRevokeAGrantBelongingToADifferentUser() throws Exception {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "10");
+    addQueryParameter(widgetContext, "command", "revoke");
+    addQueryParameter(widgetContext, "capabilityGrantId", "1");
+    addQueryParameter(widgetContext, "reason", "No longer needed");
+
+    // Belongs to user 99, not the user 10 in this request
+    CapabilityGrant otherUsersGrant = grant(1L, 99L, 3L, "reports:export");
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<CapabilityGrantRepository> grantRepo = mockStatic(CapabilityGrantRepository.class);
+        MockedStatic<SaveCapabilityGrantCommand> saveCommand = mockStatic(SaveCapabilityGrantCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(targetUser(10L, "jsmith"));
+      grantRepo.when(() -> CapabilityGrantRepository.findById(1L)).thenReturn(otherUsersGrant);
+
+      WidgetContext result = new CapabilityGrantsWidget().post(widgetContext);
+
+      saveCommand.verifyNoInteractions();
+      assertEquals("Capability grant was not found for this user", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void postShowsTheErrorWhenTheCommandRefuses() throws Exception {
+    widgetContext.getUserSession().setCapabilityList(List.of(capability("admin:manage", 5L)));
+    addQueryParameter(widgetContext, "userId", "10");
+    addQueryParameter(widgetContext, "command", "add");
+    addQueryParameter(widgetContext, "capabilityId", "3");
+    addQueryParameter(widgetContext, "reason", "Temporary contractor access");
+
+    Capability reportsExport = capability("reports:export", 3L);
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<CapabilityRepository> capabilityRepo = mockStatic(CapabilityRepository.class);
+        MockedStatic<SaveCapabilityGrantCommand> saveCommand = mockStatic(SaveCapabilityGrantCommand.class)) {
+      userRepo.when(() -> UserRepository.findByUserId(10L)).thenReturn(targetUser(10L, "jsmith"));
+      capabilityRepo.when(CapabilityRepository::findAll).thenReturn(List.of(reportsExport));
+      saveCommand.when(() -> SaveCapabilityGrantCommand.grant(any(), any(), any(), anyLong(), any(), any()))
+          .thenThrow(new DataException("jsmith already has an active grant of \"reports:export\""));
+
+      WidgetContext result = new CapabilityGrantsWidget().post(widgetContext);
+
+      assertEquals("jsmith already has an active grant of \"reports:export\"", result.getErrorMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #702. Builds on #701's role-derived capabilities (`capabilities` + `role_capabilities`) and #704's minimal grant/revoke UI pattern.

- `capability_grants`: a new table for direct, individually-trackable, per-user capability grants - independent of role membership. A user can hold a capability either through a role or through a direct grant; `expires_at` is nullable (permanent when absent).
- `LoadUserCommand` now merges active direct grants into the same effective `capabilityList` that `hasPermission()` already checks, de-duplicated by code - no changes needed to `hasPermission()` itself.
- `SaveCapabilityGrantCommand`: grant (required reason, optional expiration) / revoke (required reason), each producing an `authorization` audit event. A friendlier refusal (checked before insert) replaces a raw DB constraint violation if the same user+capability is already actively granted.
- `CapabilityGrantExpirationJob` (hourly, JobRunr, distributed-lock guarded): revokes past-due grants (one audit event per revocation) and sends a single batched admin-email digest for grants expiring within 7 days, marking each notified so it isn't re-sent.
- A minimal per-user grants UI (`/admin/capability-grants?userId=`) - list, add, revoke, with a History link into the existing audit log - reachable from a new link on `user-details.jsp`. Intentionally minimal, matching #704's scope; no risk badges/search/bulk-ops (that's #703).

## Scope note

Per #493's original ask, this covers **Permanent** and **Temporary/expiring** grant types. **One-time-use** (revoked after first use) was deferred - there's no existing precedent in this codebase for "consume on use" semantics, and no current caller that would exercise it, so it isn't included here.

## Known limitation (shared with #701/#704, not introduced here)

Like role-derived capabilities, a direct grant's effective permission is resolved once at login and cached on the session - a grant, revoke, or expiration doesn't take effect for an already-active session until that user logs in again. The scheduled sweep only prevents *future* logins from picking up an expired grant; it does not force-expire an active session.

## Test plan

- [x] `ant compile` / `ant -lib lib/war compile-jsp` / `tools/check-unescaped-el.py` / `ant -lib lib/tests ci-test` all clean
- [x] Live-verified in a docker-compose rehearsal against real Postgres: grant → real-time UI + DB row + audit event; revoke → status flips, audit event, action link disappears; History link filters correctly by `targetLabel`; the unique-active-grant partial index rejects a real duplicate; `findExpired()`/`findExpiringWithinDaysNotYetNotified()`'s raw SQL (including the `days`-interval cast) verified directly against Postgres with seeded past-due/soon-expiring/outside-window rows
- [x] New unit tests: `LoadUserCommandTest` (the capabilityList merge itself), `SaveCapabilityGrantCommandTest`, `CapabilityGrantExpirationJobTest`, `CapabilityGrantsWidgetTest`