### PR TITLE
Fix dragstart event bubbling corrupting composition-canvas drag state

### DIFF
--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -624,6 +624,10 @@
   // Attach HTML5 drag events to a draggable element (section or widget)
   function makeDraggable(el, type) {
     el.addEventListener('dragstart', function (e) {
+      // dragstart bubbles: a widget's dragstart also reaches its enclosing section's
+      // listener. Ignore any dragstart that didn't originate on this exact element, or
+      // the bubbled event overwrites dragSrcEl/dragSrcType with the wrong element/type.
+      if (e.target !== el) return;
       dragSrcEl = el;
       dragSrcType = type;
       e.dataTransfer.effectAllowed = 'move';


### PR DESCRIPTION
## Summary

`makeDraggable()` in `platform-editor.js` registers a `dragstart` listener on each draggable element (both sections and widgets) that unconditionally overwrites shared module state (`dragSrcEl`/`dragSrcType`) with no check that the event actually originated on that element.

`dragstart` is a normal bubbling DOM event, and widgets are nested inside sections (section → column → widget), so both a widget and its enclosing section have their own `dragstart` listener. Dragging a widget fires the widget's own listener first (correctly setting state to the widget), then the *same* event bubbles up and the enclosing section's listener fires again, unconditionally overwriting `dragSrcEl`/`dragSrcType` back to the section.

Every subsequent `dragover`/`drop` on a widget target then fails its `dragSrcType !== type` guard (state says `'section'`, not `'widget'`), so **all widget-to-widget drag-and-drop is blocked** -- not just cross-column moves, same-column reordering too.

## Fix

Add an `e.target !== el` guard at the top of the `dragstart` handler so a bubbled event from a descendant's own drag is ignored, and only a `dragstart` that truly originated on that element updates the shared state.

## Verification

This is a pure client-side DOM event-bubbling bug, so it was verified with a standalone browser harness (real `DragEvent`/`DataTransfer` dispatch against the actual `platform-editor.js`, not a mock) rather than the full app stack:

- **Before fix (unpatched `main`):** same-column widget drag reproduced the bug live -- `dragover` never got `preventDefault()`, no drop indicator appeared, and the DOM order was unchanged after "drop."
- **After fix:** same-column widget reorder works end-to-end (dragover prevented, indicator shown, DOM order correctly updated).
- **Composed with the pending same-column-only guard from #259's layout-mode fix:** re-ran the same harness with both fixes applied together -- same-column reorder still works, and cross-column drop is now correctly rejected (DOM unchanged after the blocked attempt). Confirms the two fixes compose correctly.

This bug is pre-existing and independent of any other in-flight change (`makeDraggable` itself isn't touched by other open PRs) -- it's called out here because it was found while live-testing the composition canvas for #259, where it was masking whether a different new guard worked.

Related: #259