### PR TITLE
Fix Quill inline editor: content disappears after Save Draft, orphaned toolbar left in DOM

### DIFF
--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -125,10 +125,22 @@
   function deactivateQuill(keepChanges) {
     if (!activeQuill) return;
     var container = activeQuill.container && activeQuill.container.closest('.sc-quill-editor-container');
-    if (!keepChanges && quillContentEl) {
+    // Always restore visibility -- keepChanges only reflects whether the caller already wrote
+    // new content into quillContentEl (save) or left it untouched (discard); either way the
+    // editor session is ending and the underlying element must reappear.
+    if (quillContentEl) {
       quillContentEl.style.display = '';
     }
-    if (container && container.parentNode) container.parentNode.removeChild(container);
+    if (container) {
+      // Quill auto-creates its own .ql-toolbar as container's previous sibling when the
+      // toolbar module is configured as an array rather than a container element; it isn't
+      // inside container, so removing container alone leaves it orphaned in the page.
+      var toolbarEl = container.previousElementSibling;
+      if (toolbarEl && toolbarEl.classList.contains('ql-toolbar') && toolbarEl.parentNode) {
+        toolbarEl.parentNode.removeChild(toolbarEl);
+      }
+      if (container.parentNode) container.parentNode.removeChild(container);
+    }
     if (quillActionsBar && quillActionsBar.parentNode) quillActionsBar.parentNode.removeChild(quillActionsBar);
     if (quillHost) quillHost.classList.remove('sc-quill-editing');
     activeQuill = null;


### PR DESCRIPTION
## Summary
The composition canvas's inline Quill rich-text editor for Content widgets (`platform-editor.js`) had two related bugs in its save/deactivate flow:

- **Content silently disappears after Save Draft.** `deactivateQuill(keepChanges)` only restored the original content element's visibility when `keepChanges` was `false`. `saveQuillDraft`'s success handler calls `deactivateQuill(true)` *after* already writing the freshly-saved HTML into that element, so the `display:none` set when the Quill session began was never cleared — the widget's content vanished right after a successful save, even though the save succeeded server-side (confirmed via direct DB query: `draft_content` was correctly persisted while the page showed nothing).
- **Orphaned `.ql-toolbar` left in the DOM.** Quill is constructed with `modules.toolbar` as a config array, so Quill auto-creates its own `.ql-toolbar` element as a sibling immediately before the editor container, rather than nesting it inside. `deactivateQuill` only ever removed the container, leaving a dead, non-functional toolbar stuck in the page on every edit session end — save or discard.

## Fix
- Restore `quillContentEl`'s visibility unconditionally in `deactivateQuill` — `keepChanges` only reflects whether the caller already wrote new content into the element (save) or left it untouched (discard); either way the element must reappear when the session ends.
- Locate and remove the auto-created `.ql-toolbar` sibling (`container.previousElementSibling`, guarded on the `ql-toolbar` class) alongside the container itself.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` green
- [x] Live-verified in a docker-compose rehearsal: activated Quill on an existing Content widget, typed text, clicked **Save Draft** — content stayed visible with the new text, `draft_content` correctly persisted in Postgres, zero `.ql-toolbar`/`.sc-quill-editor-container` elements left in the DOM
- [x] Live-verified the **Discard** path on the same widget — reverts to prior content, same clean-DOM check
- [x] Reloaded the page fresh (not just client-side state) and confirmed the saved draft renders correctly