### PR TITLE
Fix structural layout mutations silently failing to persist

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
@@ -98,13 +98,14 @@ public class MutateLayoutCommand {
    *                        sections
    * @param sectionClass    optional Foundation CSS class for the new section element; null or blank
    *                        means no class attribute
+   * @param modifiedBy      user id of the person making this change
    */
-  public static void addSection(WebPage webPage, int afterSectionIdx, String sectionClass)
+  public static void addSection(WebPage webPage, int afterSectionIdx, String sectionClass, long modifiedBy)
       throws DataException {
     if (StringUtils.isNotBlank(sectionClass)) {
       validateCssClass(sectionClass);
     }
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       Element pageEl = doc.getDocumentElement();
       List<Element> sections = childElements(pageEl, "section");
       if (afterSectionIdx < -1 || afterSectionIdx >= sections.size()) {
@@ -125,8 +126,8 @@ public class MutateLayoutCommand {
    * Removes the section at {@code sectionIdx}. Fails if the section contains any widgets (in any
    * column) — the caller must remove all widgets first.
    */
-  public static void removeSection(WebPage webPage, int sectionIdx) throws DataException {
-    mutate(webPage, doc -> {
+  public static void removeSection(WebPage webPage, int sectionIdx, long modifiedBy) throws DataException {
+    mutate(webPage, modifiedBy, doc -> {
       Element pageEl = doc.getDocumentElement();
       List<Element> sections = childElements(pageEl, "section");
       checkSectionIdx(sections, sectionIdx);
@@ -143,13 +144,13 @@ public class MutateLayoutCommand {
   /**
    * Replaces the {@code class} attribute on the section at {@code sectionIdx}.
    */
-  public static void setSectionClass(WebPage webPage, int sectionIdx, String sectionClass)
+  public static void setSectionClass(WebPage webPage, int sectionIdx, String sectionClass, long modifiedBy)
       throws DataException {
     if (StringUtils.isBlank(sectionClass)) {
       throw new DataException("Section class is required");
     }
     validateCssClass(sectionClass);
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       sections.get(sectionIdx).setAttribute("class", sectionClass);
@@ -164,12 +165,13 @@ public class MutateLayoutCommand {
    * @param afterColumnIdx index within the section to insert after; {@code -1} prepends
    * @param columnClass    Foundation grid class for the new column; defaults to {@code "small-12 cell"}
    *                       if blank
+   * @param modifiedBy     user id of the person making this change
    */
-  public static void addColumn(WebPage webPage, int sectionIdx, int afterColumnIdx, String columnClass)
-      throws DataException {
+  public static void addColumn(WebPage webPage, int sectionIdx, int afterColumnIdx, String columnClass,
+      long modifiedBy) throws DataException {
     String effectiveClass = StringUtils.isNotBlank(columnClass) ? columnClass : "small-12 cell";
     validateCssClass(effectiveClass);
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       Element sectionEl = sections.get(sectionIdx);
@@ -187,8 +189,9 @@ public class MutateLayoutCommand {
    * Removes the column at {@code sectionIdx}:{@code columnIdx}. Fails if the column contains any
    * widgets.
    */
-  public static void removeColumn(WebPage webPage, int sectionIdx, int columnIdx) throws DataException {
-    mutate(webPage, doc -> {
+  public static void removeColumn(WebPage webPage, int sectionIdx, int columnIdx, long modifiedBy)
+      throws DataException {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       Element sectionEl = sections.get(sectionIdx);
@@ -205,13 +208,13 @@ public class MutateLayoutCommand {
   /**
    * Replaces the {@code class} attribute on the column at {@code sectionIdx}:{@code columnIdx}.
    */
-  public static void setColumnClass(WebPage webPage, int sectionIdx, int columnIdx, String columnClass)
-      throws DataException {
+  public static void setColumnClass(WebPage webPage, int sectionIdx, int columnIdx, String columnClass,
+      long modifiedBy) throws DataException {
     if (StringUtils.isBlank(columnClass)) {
       throw new DataException("Column class is required");
     }
     validateCssClass(columnClass);
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       List<Element> columns = childElements(sections.get(sectionIdx), "column");
@@ -229,9 +232,10 @@ public class MutateLayoutCommand {
    * @param widgetName     widget name; must exist in the widget library
    * @param prefsJson      optional JSON object of initial preference key/value pairs, e.g.
    *                       {@code {"uniqueId":"my-content"}}; null or blank means no preferences
+   * @param modifiedBy     user id of the person making this change
    */
   public static void addWidget(WebPage webPage, int sectionIdx, int columnIdx, int afterWidgetIdx,
-      String widgetName, String prefsJson) throws DataException {
+      String widgetName, String prefsJson, long modifiedBy) throws DataException {
     if (StringUtils.isBlank(widgetName)) {
       throw new DataException("Widget name is required");
     }
@@ -240,7 +244,7 @@ public class MutateLayoutCommand {
     }
     Map<String, String> prefs = parsePrefsJson(prefsJson);
     validateWidgetPreferenceValues(widgetName, prefs);
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       List<Element> columns = childElements(sections.get(sectionIdx), "column");
@@ -264,9 +268,9 @@ public class MutateLayoutCommand {
   /**
    * Removes the widget at {@code sectionIdx}:{@code columnIdx}:{@code widgetIdx}.
    */
-  public static void removeWidget(WebPage webPage, int sectionIdx, int columnIdx, int widgetIdx)
-      throws DataException {
-    mutate(webPage, doc -> {
+  public static void removeWidget(WebPage webPage, int sectionIdx, int columnIdx, int widgetIdx,
+      long modifiedBy) throws DataException {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       List<Element> columns = childElements(sections.get(sectionIdx), "column");
@@ -283,15 +287,16 @@ public class MutateLayoutCommand {
    * {@code widgetIdx}. Existing keys are updated; new keys are appended. Keys not in
    * {@code prefsJson} are left unchanged.
    *
-   * @param prefsJson JSON object of preference key/value pairs to merge
+   * @param prefsJson  JSON object of preference key/value pairs to merge
+   * @param modifiedBy user id of the person making this change
    */
   public static void setWidgetPreferences(WebPage webPage, int sectionIdx, int columnIdx,
-      int widgetIdx, String prefsJson) throws DataException {
+      int widgetIdx, String prefsJson, long modifiedBy) throws DataException {
     Map<String, String> prefs = parsePrefsJson(prefsJson);
     if (prefs.isEmpty()) {
       throw new DataException("At least one preference is required");
     }
-    mutate(webPage, doc -> {
+    mutate(webPage, modifiedBy, doc -> {
       List<Element> sections = childElements(doc.getDocumentElement(), "section");
       checkSectionIdx(sections, sectionIdx);
       List<Element> columns = childElements(sections.get(sectionIdx), "column");
@@ -321,7 +326,7 @@ public class MutateLayoutCommand {
     void apply(Document doc) throws DataException;
   }
 
-  private static void mutate(WebPage webPage, DomMutation mutation) throws DataException {
+  private static void mutate(WebPage webPage, long modifiedBy, DomMutation mutation) throws DataException {
     if (webPage == null || webPage.getId() == -1) {
       throw new DataException("Page not found");
     }
@@ -351,7 +356,10 @@ public class MutateLayoutCommand {
 
       webPage.setDraftPageXml(sw.toString().trim());
       webPage.setDraft(true);
-      WebPageRepository.save(webPage);
+      webPage.setModifiedBy(modifiedBy);
+      if (WebPageRepository.save(webPage) == null) {
+        throw new DataException("Could not save layout changes for " + webPage.getLink());
+      }
       WebPageXmlLayoutCommand.removeCustomPage(webPage.getLink());
     } catch (DataException e) {
       throw e;

--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -297,7 +297,8 @@ public class MediaApiController extends HttpServlet {
       Map<String, String> prefs = new HashMap<>();
       prefs.put(prefKey, asset.getStoragePath());
       String prefsJson = objectMapper.writeValueAsString(prefs);
-      MutateLayoutCommand.setWidgetPreferences(webPage, sectionIdx, columnIdx, widgetIdx, prefsJson);
+      MutateLayoutCommand.setWidgetPreferences(webPage, sectionIdx, columnIdx, widgetIdx, prefsJson,
+          userSession.getUserId());
     } catch (DataException e) {
       LOG.warn("widget-update failed for " + pagePath + " " + sectionIdx + ":" + columnIdx + ":" + widgetIdx
           + ": " + e.getMessage());

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -599,32 +599,32 @@ public class PageServlet extends HttpServlet {
           int after = intParam(request, "after", -1);
           switch (mutateAction) {
             case "addSection":
-              MutateLayoutCommand.addSection(webPage, after, request.getParameter("class"));
+              MutateLayoutCommand.addSection(webPage, after, request.getParameter("class"), userSession.getUserId());
               break;
             case "removeSection":
-              MutateLayoutCommand.removeSection(webPage, s);
+              MutateLayoutCommand.removeSection(webPage, s, userSession.getUserId());
               break;
             case "setSectionClass":
-              MutateLayoutCommand.setSectionClass(webPage, s, request.getParameter("class"));
+              MutateLayoutCommand.setSectionClass(webPage, s, request.getParameter("class"), userSession.getUserId());
               break;
             case "addColumn":
-              MutateLayoutCommand.addColumn(webPage, s, after, request.getParameter("class"));
+              MutateLayoutCommand.addColumn(webPage, s, after, request.getParameter("class"), userSession.getUserId());
               break;
             case "removeColumn":
-              MutateLayoutCommand.removeColumn(webPage, s, c);
+              MutateLayoutCommand.removeColumn(webPage, s, c, userSession.getUserId());
               break;
             case "setColumnClass":
-              MutateLayoutCommand.setColumnClass(webPage, s, c, request.getParameter("class"));
+              MutateLayoutCommand.setColumnClass(webPage, s, c, request.getParameter("class"), userSession.getUserId());
               break;
             case "addWidget":
               MutateLayoutCommand.addWidget(webPage, s, c, after,
-                  request.getParameter("widgetName"), request.getParameter("prefs"));
+                  request.getParameter("widgetName"), request.getParameter("prefs"), userSession.getUserId());
               break;
             case "removeWidget":
-              MutateLayoutCommand.removeWidget(webPage, s, c, w);
+              MutateLayoutCommand.removeWidget(webPage, s, c, w, userSession.getUserId());
               break;
             case "setWidgetPreferences":
-              MutateLayoutCommand.setWidgetPreferences(webPage, s, c, w, request.getParameter("prefs"));
+              MutateLayoutCommand.setWidgetPreferences(webPage, s, c, w, request.getParameter("prefs"), userSession.getUserId());
               break;
             default:
               response.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandIntegrationTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandIntegrationTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+
+/**
+ * Verifies {@link MutateLayoutCommand}'s structural mutations against a real PostgreSQL instance.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises {@code MutateLayoutCommand} through the real {@code WebPageRepository}/JDBC stack,
+ * including the {@code web_pages_modified_by_fkey} foreign key that a mock-based test (see
+ * {@link MutateLayoutCommandTest}) cannot exercise -- a mock never rejects an invalid id. It is
+ * skipped automatically when Docker is not available, so it does not break the build on hosts
+ * without a Docker daemon.
+ * </p>
+ *
+ * @author Elizabeth Houser
+ * @created 7/30/26
+ */
+class MutateLayoutCommandIntegrationTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+  private static final String PAGE_XML =
+      "<page><section class=\"first\"><column class=\"small-12 cell\" /></section></page>";
+
+  private static GenericContainer<?> postgres;
+  private static long validUserId;
+
+  @BeforeAll
+  static void startDatabase() {
+    // Only run when a Docker daemon is reachable; otherwise mark the whole class as skipped
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping MutateLayoutCommand integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    // Point the application's shared DataSource at the container
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+    validUserId = insertUser("editor1");
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetPages() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_pages table", se);
+    }
+  }
+
+  @Test
+  void structuralMutationPersistsToTheDatabase() throws Exception {
+    WebPage page = insertPage("/integration-test-page");
+
+    MutateLayoutCommand.addSection(page, 0, "new-section", validUserId);
+
+    WebPage reloaded = WebPageRepository.findById(page.getId());
+    assertNotNull(reloaded.getDraftPageXml(),
+        "draftPageXml should be persisted to the row, not just returned to the in-memory caller");
+    assertTrue(reloaded.getDraftPageXml().contains("new-section"));
+    assertTrue(reloaded.getDraft(), "draft flag should be persisted");
+    assertEquals(validUserId, reloaded.getModifiedBy());
+  }
+
+  @Test
+  void structuralMutationWithInvalidModifiedByThrowsAndDoesNotPersist() throws Exception {
+    WebPage page = insertPage("/integration-test-page-2");
+    long noSuchUserId = validUserId + 999;
+
+    assertThrows(DataException.class,
+        () -> MutateLayoutCommand.addSection(page, 0, "new-section", noSuchUserId),
+        "modified_by referencing a nonexistent user must violate web_pages_modified_by_fkey and "
+            + "surface as a real error, not a silent no-op");
+
+    WebPage reloaded = WebPageRepository.findById(page.getId());
+    assertNull(reloaded.getDraftPageXml(),
+        "the mutation must not silently succeed: draftPageXml must remain unset when the save was rejected");
+    assertFalse(reloaded.getDraft(), "draft flag must not be set either, since nothing was actually saved");
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // `users` is a focused subset -- just enough to satisfy web_pages' created_by/modified_by
+    // foreign keys (the real table's `geom` column needs PostGIS, which this test has no need
+    // for). `web_pages` is the full real column set: WebPageRepository.update() writes every one
+    // of these columns in a single UPDATE, so a narrower subset would fail with an unrelated
+    // "column does not exist" instead of exercising the modified_by fkey this test targets.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
+      statement.execute("DROP TABLE IF EXISTS users CASCADE");
+      statement.execute("CREATE TABLE users ("
+          + "user_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "username VARCHAR(255) UNIQUE NOT NULL, "
+          + "password VARCHAR(255) NOT NULL)");
+      statement.execute("CREATE TABLE web_pages ("
+          + "web_page_id BIGSERIAL PRIMARY KEY, "
+          + "link VARCHAR(255) UNIQUE NOT NULL, "
+          + "redirect_url VARCHAR(255), "
+          + "page_title VARCHAR(255), "
+          + "page_keywords VARCHAR(255), "
+          + "page_description VARCHAR(255), "
+          + "draft BOOLEAN DEFAULT false, "
+          + "enabled BOOLEAN DEFAULT true, "
+          + "created_by BIGINT REFERENCES users(user_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT REFERENCES users(user_id), "
+          + "role_id_list VARCHAR(100) DEFAULT NULL, "
+          + "template VARCHAR(255), "
+          + "page_xml TEXT, "
+          + "comments TEXT, "
+          + "draft_page_xml TEXT, "
+          + "page_image_url VARCHAR(255), "
+          + "searchable BOOLEAN DEFAULT true, "
+          + "show_in_sitemap BOOLEAN DEFAULT true, "
+          + "has_redirect BOOLEAN DEFAULT false, "
+          + "sitemap_priority NUMERIC(2,1) DEFAULT 0.5, "
+          + "sitemap_changefreq VARCHAR(20), "
+          + "publish_at TIMESTAMP, "
+          + "expires_at TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_pages/users schema", se);
+    }
+  }
+
+  private static long insertUser(String uniqueId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO users (unique_id, username, password) VALUES (?, ?, ?) RETURNING user_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      pst.setString(3, "not-a-real-hash");
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert test user", se);
+    }
+  }
+
+  private static WebPage insertPage(String link) {
+    WebPage page = new WebPage();
+    page.setLink(link);
+    page.setPageXml(PAGE_XML);
+    page.setCreatedBy(validUserId);
+    WebPage saved = WebPageRepository.save(page);
+    if (saved == null) {
+      throw new IllegalStateException("Test setup failed: could not insert page " + link);
+    }
+    return saved;
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 import java.util.Map;
 
@@ -99,10 +101,13 @@ class MutateLayoutCommandTest {
   }
 
   // Helper: run a mutation with mocked repository/cache, then return the resulting draftPageXml.
+  // WebPageRepository.save() answers with the same record it was given, mirroring the real
+  // repository's success return (the record, or null on failure) -- see
+  // mutationThrowsWhenSaveFails below for the null/failure path.
   private static String mutate(WebPage page, ThrowingRunnable mutation) throws DataException {
     try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
          MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
-      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> null);
+      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
       cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
       cmd.when(WebPageXmlLayoutCommand::getWidgetLibrary)
           .thenReturn(Map.of("content", "ContentWidget", "menu", "MenuWidget", "dataTable", "TableWidget"));
@@ -121,7 +126,7 @@ class MutateLayoutCommandTest {
   @Test
   void addSectionAppendsAtEnd() throws DataException {
     WebPage page = pageWithXml(TWO_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 1, "new-section"));
+    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 1, "new-section", 42L));
     // Three sections after the operation; new one is last.
     long sectionCount = result.chars().filter(c -> c == '<').mapToObj(c -> "").count();
     assertTrue(result.contains("class=\"new-section\""), "new class should be present");
@@ -135,7 +140,7 @@ class MutateLayoutCommandTest {
   @Test
   void addSectionPrependsWhenAfterMinusOne() throws DataException {
     WebPage page = pageWithXml(TWO_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, -1, "prepended"));
+    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, -1, "prepended", 42L));
     int prependedIdx = result.indexOf("class=\"prepended\"");
     int firstIdx = result.indexOf("class=\"first\"");
     assertTrue(prependedIdx < firstIdx, "prepended section should come before existing sections");
@@ -144,7 +149,7 @@ class MutateLayoutCommandTest {
   @Test
   void addSectionWithoutClassHasNoClassAttribute() throws DataException {
     WebPage page = pageWithXml(EMPTY_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 0, null));
+    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 0, null, 42L));
     // The new section element should appear; it may or may not have a class.
     // Verify the existing section's class is unchanged and the result is valid XML.
     assertTrue(result.contains("class=\"empty\""));
@@ -153,7 +158,7 @@ class MutateLayoutCommandTest {
   @Test
   void addSectionDefaultColumnHasSmall12CellClass() throws DataException {
     WebPage page = pageWithXml(EMPTY_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "new"));
+    String result = mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "new", 42L));
     // The new section's auto-generated column should be small-12 cell.
     // Both sections are in the result, so count occurrences of the default class.
     int count = 0;
@@ -169,18 +174,18 @@ class MutateLayoutCommandTest {
   void addSectionRejectsInvalidIndex() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 5, "x")));
+        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 5, "x", 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, -2, "x")));
+        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, -2, "x", 42L)));
   }
 
   @Test
   void addSectionRejectsInvalidCssClass() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "x\"><script>alert(1)</script>")));
+        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "x\"><script>alert(1)</script>", 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "bad'class")));
+        () -> mutate(page, () -> MutateLayoutCommand.addSection(page, 0, "bad'class", 42L)));
   }
 
   // ── removeSection ────────────────────────────────────────────────────────
@@ -188,7 +193,7 @@ class MutateLayoutCommandTest {
   @Test
   void removeSectionDeletesEmptySection() throws DataException {
     WebPage page = pageWithXml(TWO_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.removeSection(page, 1));
+    String result = mutate(page, () -> MutateLayoutCommand.removeSection(page, 1, 42L));
     assertTrue(result.contains("class=\"first\""), "first section should survive");
     assertTrue(!result.contains("class=\"second\""), "second section should be removed");
   }
@@ -197,16 +202,16 @@ class MutateLayoutCommandTest {
   void removeSectionFailsWhenSectionHasWidgets() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, 0)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, 0, 42L)));
   }
 
   @Test
   void removeSectionRejectsInvalidIndex() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, 99)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, 99, 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, -1)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeSection(page, -1, 42L)));
   }
 
   // ── setSectionClass ──────────────────────────────────────────────────────
@@ -214,7 +219,7 @@ class MutateLayoutCommandTest {
   @Test
   void setSectionClassUpdatesTheAttribute() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, "updated-class"));
+    String result = mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, "updated-class", 42L));
     assertTrue(result.contains("class=\"updated-class\""), "class should be updated");
     assertTrue(!result.contains("class=\"first\""), "old class should be gone");
   }
@@ -223,9 +228,9 @@ class MutateLayoutCommandTest {
   void setSectionClassRejectsBlank() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, "")));
+        () -> mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, "", 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, null)));
+        () -> mutate(page, () -> MutateLayoutCommand.setSectionClass(page, 0, null, 42L)));
   }
 
   // ── addColumn ────────────────────────────────────────────────────────────
@@ -233,7 +238,7 @@ class MutateLayoutCommandTest {
   @Test
   void addColumnAppendsToSection() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addColumn(page, 0, 0, "medium-6 cell"));
+    String result = mutate(page, () -> MutateLayoutCommand.addColumn(page, 0, 0, "medium-6 cell", 42L));
     assertTrue(result.contains("class=\"medium-6 cell\""), "new column class should be present");
     assertTrue(result.contains("class=\"small-12 cell\""), "original column should survive");
   }
@@ -241,7 +246,7 @@ class MutateLayoutCommandTest {
   @Test
   void addColumnUsesDefaultClassWhenBlank() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addColumn(page, 0, 0, null));
+    String result = mutate(page, () -> MutateLayoutCommand.addColumn(page, 0, 0, null, 42L));
     // Should still add a column with default class
     int count = 0;
     int idx = 0;
@@ -256,7 +261,7 @@ class MutateLayoutCommandTest {
   void addColumnRejectsInvalidSectionIndex() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addColumn(page, 99, 0, null)));
+        () -> mutate(page, () -> MutateLayoutCommand.addColumn(page, 99, 0, null, 42L)));
   }
 
   // ── removeColumn ─────────────────────────────────────────────────────────
@@ -265,7 +270,7 @@ class MutateLayoutCommandTest {
   void removeColumnFailsWhenColumnHasWidgets() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeColumn(page, 0, 0)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeColumn(page, 0, 0, 42L)));
   }
 
   // ── setColumnClass ───────────────────────────────────────────────────────
@@ -273,7 +278,7 @@ class MutateLayoutCommandTest {
   @Test
   void setColumnClassUpdatesTheAttribute() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.setColumnClass(page, 0, 0, "medium-4 cell"));
+    String result = mutate(page, () -> MutateLayoutCommand.setColumnClass(page, 0, 0, "medium-4 cell", 42L));
     assertTrue(result.contains("class=\"medium-4 cell\""), "class should be updated");
     assertTrue(!result.contains("class=\"small-12 cell\""), "old class should be gone");
   }
@@ -282,7 +287,7 @@ class MutateLayoutCommandTest {
   void setColumnClassRejectsScriptInjection() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setColumnClass(page, 0, 0, "x\" onload=\"evil()")));
+        () -> mutate(page, () -> MutateLayoutCommand.setColumnClass(page, 0, 0, "x\" onload=\"evil()", 42L)));
   }
 
   // ── addWidget ────────────────────────────────────────────────────────────
@@ -290,7 +295,7 @@ class MutateLayoutCommandTest {
   @Test
   void addWidgetInsertsWidgetAtEnd() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "menu", null));
+    String result = mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "menu", null, 42L));
     assertTrue(result.contains("name=\"menu\""), "new widget should be present");
     assertTrue(result.contains("name=\"content\""), "original widget should survive");
     // menu should come after content (afterWidgetIdx=0 means after index 0)
@@ -304,7 +309,7 @@ class MutateLayoutCommandTest {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     String result = mutate(page, () ->
         MutateLayoutCommand.addWidget(page, 0, 0, -1, "menu",
-            "{\"title\":\"My Menu\",\"class\":\"vertical\"}"));
+            "{\"title\":\"My Menu\",\"class\":\"vertical\"}", 42L));
     assertTrue(result.contains("<title>My Menu</title>"), "title pref should be present");
     assertTrue(result.contains("<class>vertical</class>"), "class pref should be present");
   }
@@ -313,7 +318,7 @@ class MutateLayoutCommandTest {
   void addWidgetRejectsUnknownWidgetName() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "notAWidget", null)));
+        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "notAWidget", null, 42L)));
   }
 
   @Test
@@ -322,19 +327,19 @@ class MutateLayoutCommandTest {
     // A key with angle brackets would inject a tag name into the XML element.
     assertThrows(DataException.class,
         () -> mutate(page, () ->
-            MutateLayoutCommand.addWidget(page, 0, 0, 0, "content", "{\"bad<key>\":\"val\"}")));
+            MutateLayoutCommand.addWidget(page, 0, 0, 0, "content", "{\"bad<key>\":\"val\"}", 42L)));
     assertThrows(DataException.class,
         () -> mutate(page, () ->
-            MutateLayoutCommand.addWidget(page, 0, 0, 0, "content", "{\"0startsWithDigit\":\"val\"}")));
+            MutateLayoutCommand.addWidget(page, 0, 0, 0, "content", "{\"0startsWithDigit\":\"val\"}", 42L)));
   }
 
   @Test
   void addWidgetRejectsBlankWidgetName() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "", null)));
+        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, "", null, 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, null, null)));
+        () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, 0, null, null, 42L)));
   }
 
   // ── removeWidget ─────────────────────────────────────────────────────────
@@ -342,7 +347,7 @@ class MutateLayoutCommandTest {
   @Test
   void removeWidgetDeletesTheWidget() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
-    String result = mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, 0));
+    String result = mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, 0, 42L));
     assertTrue(!result.contains("name=\"content\""), "widget should be removed");
   }
 
@@ -350,9 +355,9 @@ class MutateLayoutCommandTest {
   void removeWidgetRejectsInvalidIndex() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, 5)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, 5, 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, -1)));
+        () -> mutate(page, () -> MutateLayoutCommand.removeWidget(page, 0, 0, -1, 42L)));
   }
 
   // ── setWidgetPreferences ─────────────────────────────────────────────────
@@ -361,7 +366,7 @@ class MutateLayoutCommandTest {
   void setWidgetPreferencesUpdatesExistingKey() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     String result = mutate(page, () ->
-        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"uniqueId\":\"new-id\"}"));
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"uniqueId\":\"new-id\"}", 42L));
     assertTrue(result.contains("<uniqueId>new-id</uniqueId>"), "uniqueId should be updated");
     assertTrue(!result.contains("<uniqueId>my-content</uniqueId>"), "old value should be gone");
   }
@@ -370,7 +375,7 @@ class MutateLayoutCommandTest {
   void setWidgetPreferencesAddsNewKey() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     String result = mutate(page, () ->
-        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"title\":\"New Title\"}"));
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"title\":\"New Title\"}", 42L));
     assertTrue(result.contains("<title>New Title</title>"), "new pref element should be added");
     assertTrue(result.contains("<uniqueId>my-content</uniqueId>"), "existing pref should be preserved");
   }
@@ -379,9 +384,9 @@ class MutateLayoutCommandTest {
   void setWidgetPreferencesRejectsEmptyPrefs() {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{}")));
+        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{}", 42L)));
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, null)));
+        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, null, 42L)));
   }
 
   @Test
@@ -389,7 +394,7 @@ class MutateLayoutCommandTest {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
         () -> mutate(page, () ->
-            MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"</injection>\":\"val\"}")));
+            MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"</injection>\":\"val\"}", 42L)));
   }
 
   // ── setWidgetPreferences / addWidget: TableWidget's tableData is validated at this boundary ─────
@@ -398,7 +403,7 @@ class MutateLayoutCommandTest {
   void setWidgetPreferencesAcceptsWellFormedTableData() throws DataException {
     WebPage page = pageWithXml(TABLE_WIDGET_XML);
     String result = mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
-        "{\"tableData\":\"{\\\"headers\\\":[\\\"Name\\\",\\\"Age\\\"],\\\"rows\\\":[[\\\"Alice\\\",\\\"30\\\"]]}\"}"));
+        "{\"tableData\":\"{\\\"headers\\\":[\\\"Name\\\",\\\"Age\\\"],\\\"rows\\\":[[\\\"Alice\\\",\\\"30\\\"]]}\"}", 42L));
     assertTrue(result.contains("Alice"), "the new table data should be written");
   }
 
@@ -407,7 +412,7 @@ class MutateLayoutCommandTest {
     WebPage page = pageWithXml(TABLE_WIDGET_XML);
     assertThrows(DataException.class,
         () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
-            "{\"tableData\":\"{\\\"headers\\\":[\\\"A\\\"]}\"}")),
+            "{\"tableData\":\"{\\\"headers\\\":[\\\"A\\\"]}\"}", 42L)),
         "tableData without a 'rows' array must be rejected before it is persisted");
   }
 
@@ -416,7 +421,7 @@ class MutateLayoutCommandTest {
     WebPage page = pageWithXml(TABLE_WIDGET_XML);
     assertThrows(DataException.class,
         () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
-            "{\"tableData\":\"{\\\"headers\\\":\\\"not-an-array\\\",\\\"rows\\\":[]}\"}")));
+            "{\"tableData\":\"{\\\"headers\\\":\\\"not-an-array\\\",\\\"rows\\\":[]}\"}", 42L)));
   }
 
   @Test
@@ -431,7 +436,7 @@ class MutateLayoutCommandTest {
     }
     String prefsJson = "{\"tableData\":\"{\\\"headers\\\":[\\\"A\\\"],\\\"rows\\\":[" + rows + "]}\"}";
     assertThrows(DataException.class,
-        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, prefsJson)),
+        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, prefsJson, 42L)),
         "a row count over MAX_ROWS must be rejected before it is persisted");
   }
 
@@ -441,7 +446,7 @@ class MutateLayoutCommandTest {
     // class -- only the dataTable widget's value gets structurally validated.
     WebPage page = pageWithXml(ONE_SECTION_XML);
     String result = mutate(page, () ->
-        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"tableData\":\"not-json-at-all\"}"));
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"tableData\":\"not-json-at-all\"}", 42L));
     assertTrue(result.contains("<tableData>not-json-at-all</tableData>"));
   }
 
@@ -449,7 +454,7 @@ class MutateLayoutCommandTest {
   void addWidgetAcceptsWellFormedTableData() throws DataException {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     String result = mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, -1, "dataTable",
-        "{\"tableData\":\"{\\\"headers\\\":[\\\"A\\\"],\\\"rows\\\":[[\\\"1\\\"]]}\"}"));
+        "{\"tableData\":\"{\\\"headers\\\":[\\\"A\\\"],\\\"rows\\\":[[\\\"1\\\"]]}\"}", 42L));
     assertTrue(result.contains("name=\"dataTable\""));
   }
 
@@ -458,8 +463,47 @@ class MutateLayoutCommandTest {
     WebPage page = pageWithXml(ONE_SECTION_XML);
     assertThrows(DataException.class,
         () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, -1, "dataTable",
-            "{\"tableData\":\"{\\\"rows\\\":[]}\"}")),
+            "{\"tableData\":\"{\\\"rows\\\":[]}\"}", 42L)),
         "tableData missing 'headers' must be rejected before the widget is ever added");
+  }
+
+  // ── modifiedBy / persistence-failure propagation ─────────────────────────
+  // A structural mutation must record who made it and must not report success when the
+  // underlying save silently fails (e.g. a stale modified_by value tripping the
+  // web_pages_modified_by_fkey foreign key). See MutateLayoutCommandIntegrationTest for the same
+  // two properties proven against a real database instead of a mock.
+
+  @Test
+  void mutationSetsModifiedByBeforeSaving() throws DataException {
+    WebPage page = pageWithXml(ONE_SECTION_XML);
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+         MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
+      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
+      cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
+
+      MutateLayoutCommand.addSection(page, 0, "new-section", 42L);
+
+      repo.verify(() -> WebPageRepository.save(argThat(p -> p.getModifiedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void mutationThrowsWhenSaveFails() {
+    WebPage page = pageWithXml(ONE_SECTION_XML);
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+         MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
+      // A null return simulates WebPageRepository.update() failing (e.g. the FK violation logged
+      // by DB.update() when modified_by isn't a real user id) -- mutate() must not treat that as
+      // success.
+      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> null);
+      cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
+
+      assertThrows(DataException.class,
+          () -> MutateLayoutCommand.addSection(page, 0, "new-section", 42L),
+          "a null return from WebPageRepository.save() means persistence failed and must not be swallowed");
+
+      cmd.verify(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString()), never());
+    }
   }
 
   // ── Allowlist pattern constants are stable ───────────────────────────────

--- a/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -243,7 +244,7 @@ class MediaApiControllerTest {
 
       ArgumentCaptor<String> prefsJsonCaptor = ArgumentCaptor.forClass(String.class);
       mutate.verify(() -> MutateLayoutCommand.setWidgetPreferences(
-          eq(webPage), eq(0), eq(1), eq(2), prefsJsonCaptor.capture()));
+          eq(webPage), eq(0), eq(1), eq(2), prefsJsonCaptor.capture(), eq(userSession.getUserId())));
       JsonNode prefs = MAPPER.readTree(prefsJsonCaptor.getValue());
       assertEquals("/assets/photo.jpg", prefs.get("url").asText());
     }
@@ -265,7 +266,8 @@ class MediaApiControllerTest {
          MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
       assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
       pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
-      mutate.when(() -> MutateLayoutCommand.setWidgetPreferences(any(), anyInt(), anyInt(), anyInt(), anyString()))
+      mutate.when(() -> MutateLayoutCommand.setWidgetPreferences(
+          any(), anyInt(), anyInt(), anyInt(), anyString(), anyLong()))
           .thenThrow(new DataException("Widget index 2 at 0:1 out of range (1 widget(s))"));
 
       Recorded result = runWidgetUpdate(request);


### PR DESCRIPTION
Part of #259 (Visual Editor P4 -- composition canvas). Flagged as an out-of-scope follow-up in #734's "Out of scope / follow-up" section: *"Structural mutations (add/remove section/column) report `{\"success\":true}` but don't actually persist in some cases -- `MutateLayoutCommand.mutate()` doesn't set `modified_by` before save, causing a swallowed FK-constraint failure."*

## The bug

`MutateLayoutCommand.mutate()` applies a structural edit (add/remove section, column, or widget) to the in-memory `WebPage`, then calls `WebPageRepository.save(webPage)` -- but as a bare statement, discarding the return value:

```java
webPage.setDraftPageXml(sw.toString().trim());
webPage.setDraft(true);
WebPageRepository.save(webPage);   // return value never checked
WebPageXmlLayoutCommand.removeCustomPage(webPage.getLink());
```

Two things compound into a false-positive `200 {"success":true}`:

1. **`modified_by` is never set from the actual editor.** Whatever value the loaded `WebPage` object already carries in memory (e.g. `0` on older/seeded pages) gets written straight through. `web_pages.modified_by` has a `REFERENCES users(user_id)` foreign key, so if that value isn't a real user id, Postgres rejects the `UPDATE`.
2. **The failure never surfaces.** `WebPageRepository.update()` (called via `save()`) already does the right thing when `DB.update()` fails -- it logs and returns `null`. But `mutate()` never looks at that return value, so it neither retries nor throws. `PageServlet`'s `mutateDraftLayout` switch statement then falls through to `response.getWriter().print("{\"success\":true}")` regardless.

Net effect: every structural mutation in the composition canvas can silently no-op while the client reloads believing it worked. (Note: I initially assumed `WebPageRepository.update()` itself was missing the null-check too -- it isn't; it already returns `null` correctly. The gap is entirely in `MutateLayoutCommand.mutate()` discarding that signal.)

## The fix

- `MutateLayoutCommand.mutate()` (and all 9 public methods that delegate to it) now take a `modifiedBy` argument, set via `webPage.setModifiedBy(modifiedBy)` before saving.
- If `WebPageRepository.save()` returns `null`, `mutate()` now throws a `DataException` instead of continuing silently -- which `PageServlet`'s existing `catch (Exception e)` block already turns into a real `{"success":false,"error":"..."}` response, no servlet changes needed.
- `PageServlet`'s 9 `mutateDraftLayout` call sites and `MediaApiController.handleWidgetUpdate`'s 1 call site now pass `userSession.getUserId()`.

## Tests

- `MutateLayoutCommandTest`: updated all call sites for the new parameter (the shared mock helper was asserting behavior while mocking `WebPageRepository.save()` to always return `null` -- i.e. simulating failure on every single existing test -- because nothing previously checked that return value; fixed it to mirror a real success). Added two unit tests: `modifiedBy` reaches `WebPageRepository.save()`, and a `null` return now throws instead of being swallowed.
- **New `MutateLayoutCommandIntegrationTest`** (Testcontainers, real PostgreSQL, skipped when Docker is unavailable): reproduces the actual `web_pages_modified_by_fkey` violation against a real `users`/`web_pages` schema, matching a live docker-compose rehearsal of this exact bug. Confirms both that a valid `modifiedBy` really persists `draft_page_xml`/`draft`/`modified_by` to the row (not just that the in-memory object looks right), and that an invalid one throws and leaves the row untouched -- the two properties a mock can't prove.
- `MediaApiControllerTest`: updated its 3 `MutateLayoutCommand` mock/verify call sites for the new signature.

## Verification

`ant -lib lib/war -lib lib/tests clean ci-test`: BUILD SUCCESSFUL, full suite green (0 failures), including the new integration test's log showing the real constraint violation being caught:
```
ERROR ... violates foreign key constraint "web_pages_modified_by_fkey"
  Detail: Key (modified_by)=(1000) is not present in table "users".
ERROR ... WebPageRepository - The update failed!
```