### PR TITLE
Let page-level access gates accept a capability, not just a role (#733)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/Page.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/Page.java
@@ -40,6 +40,9 @@ public class Page {
   private List<Section> sections = new ArrayList<Section>();
   private List<String> roles = new ArrayList<String>();
   private List<String> groups = new ArrayList<String>();
+  // Capability codes (issue #701's hasPermission() system) that also satisfy this page's access
+  // check, alongside roles -- see WebComponentCommand.allowsUser(). Optional; most pages only use role=.
+  private List<String> capabilities = new ArrayList<String>();
 
   public Page() {
   }
@@ -104,6 +107,14 @@ public class Page {
 
   public void setGroups(List<String> groups) {
     this.groups = groups;
+  }
+
+  public List<String> getCapabilities() {
+    return capabilities;
+  }
+
+  public void setCapabilities(List<String> capabilities) {
+    this.capabilities = capabilities;
   }
 
   public String getCollectionUniqueId() {

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebComponentCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebComponentCommand.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -34,8 +35,12 @@ public class WebComponentCommand implements Serializable {
   private static Log LOG = LogFactory.getLog(WebComponentCommand.class);
 
   // Open-by-default: CMS pages/sections/columns/widgets are public unless roles/groups are declared.
+  // Pages (only) additionally accept a capability= list (issue #701's hasPermission() system,
+  // issue #733) -- a user satisfies the role/capability side of the check by holding EITHER a
+  // listed role OR a listed capability, so existing role="..." pages are unaffected until a
+  // capability="..." attribute is deliberately added alongside them.
   public static boolean allowsUser(Page page, UserSession userSession) {
-    return allowsUser(page.getRoles(), page.getGroups(), userSession, false);
+    return allowsUser(page.getRoles(), page.getGroups(), page.getCapabilities(), userSession, false);
   }
 
   public static boolean allowsUser(Section section, UserSession userSession) {
@@ -63,12 +68,21 @@ public class WebComponentCommand implements Serializable {
    *                      New resources that require explicit authorisation should pass {@code true}.
    */
   public static boolean allowsUser(List<String> roles, List<String> groups, UserSession userSession, boolean denyWhenEmpty) {
-    if (roles.isEmpty() && groups.isEmpty()) {
+    return allowsUser(roles, groups, Collections.emptyList(), userSession, denyWhenEmpty);
+  }
+
+  /**
+   * As above, plus an optional capability= list (issue #733): the role side of the check is
+   * satisfied by holding EITHER a listed role OR a listed capability (hasPermission()), not both.
+   */
+  public static boolean allowsUser(List<String> roles, List<String> groups, List<String> capabilities,
+      UserSession userSession, boolean denyWhenEmpty) {
+    if (roles.isEmpty() && groups.isEmpty() && capabilities.isEmpty()) {
       return !denyWhenEmpty;
     }
 
     // Roles can be for a user that is either logged in/out
-    boolean roleAllowed = roles.isEmpty();
+    boolean roleAllowed = roles.isEmpty() && capabilities.isEmpty();
     for (String role : roles) {
       if ("guest".equals(role) && !userSession.isLoggedIn()) {
         roleAllowed = true;
@@ -77,6 +91,11 @@ public class WebComponentCommand implements Serializable {
         roleAllowed = true;
       }
       if (userSession.hasRole(role)) {
+        roleAllowed = true;
+      }
+    }
+    for (String capability : capabilities) {
+      if (userSession.hasPermission(capability)) {
         roleAllowed = true;
       }
     }

--- a/src/main/java/com/simisinc/platform/presentation/controller/XMLPageLoader.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/XMLPageLoader.java
@@ -234,6 +234,15 @@ public class XMLPageLoader implements Serializable {
         page.setGroups(groups);
       }
     }
+    if (e.hasAttribute("capability")) {
+      String aCapabilities = e.getAttribute("capability");
+      if (aCapabilities.length() > 0) {
+        List<String> capabilities = Stream.of(aCapabilities.split(","))
+            .map(String::trim)
+            .collect(toList());
+        page.setCapabilities(capabilities);
+      }
+    }
     if (e.hasAttribute("class")) {
       if (e.hasAttribute("endpoint")) {
         /* @deprecated */

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1577,7 +1577,7 @@
     </section>
   </page>
 
-  <page name="/admin/role-capabilities" role="admin" title="Role Capabilities">
+  <page name="/admin/role-capabilities" role="admin" capability="admin:manage" title="Role Capabilities">
     <section>
       <column class="small-12 cell">
         <widget name="roleCapabilitiesList">
@@ -1587,7 +1587,7 @@
     </section>
   </page>
 
-  <page name="/admin/role-capabilities-form" role="admin" title="Edit Role Capabilities">
+  <page name="/admin/role-capabilities-form" role="admin" capability="admin:manage" title="Edit Role Capabilities">
     <section>
       <column class="small-12 medium-8 large-6 cell">
         <widget name="roleCapabilitiesForm">
@@ -1649,7 +1649,7 @@
     </section>
   </page>
 
-  <page name="/admin/analytics-retention" role="admin" title="Analytics Retention">
+  <page name="/admin/analytics-retention" role="admin" capability="admin:manage" title="Analytics Retention">
     <section>
       <column class="small-12 cell">
         <widget name="analyticsRetention">

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.controller;
 
+import com.simisinc.platform.domain.model.Capability;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -361,5 +363,101 @@ class WebComponentCommandTest {
     // Any of these: testers, researchers
     groups.add("researchers");
     Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession));
+  }
+
+  // --- capability= (issue #733: a page-level role="..." gate previously had no hasPermission()
+  // path at all, so a user granted a capability directly -- but holding no matching legacy role --
+  // was blocked by the page container before the widget's own hasPermission() check ever ran) ---
+
+  private static UserSession sessionWithCapability(String code) {
+    Capability capability = new Capability();
+    capability.setCode(code);
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(new ArrayList<>());
+    user.setGroupList(new ArrayList<>());
+    user.setCapabilityList(List.of(capability));
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+    return userSession;
+  }
+
+  @Test
+  void userWithCapabilityButNoMatchingRoleIsAllowed() {
+    UserSession userSession = sessionWithCapability("admin:manage");
+
+    List<String> roles = List.of("admin");
+    List<String> groups = Collections.emptyList();
+    List<String> capabilities = List.of("admin:manage");
+
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, userSession),
+        "the 3-arg overload has no capability path -- confirms this user genuinely lacks the role");
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, capabilities, userSession, false),
+        "a listed capability the user holds must satisfy the check even without a matching role");
+  }
+
+  @Test
+  void userWithNeitherRoleNorMatchingCapabilityIsDenied() {
+    UserSession userSession = sessionWithCapability("some-other:capability");
+
+    List<String> roles = List.of("admin");
+    List<String> groups = Collections.emptyList();
+    List<String> capabilities = List.of("admin:manage");
+
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, capabilities, userSession, false));
+  }
+
+  @Test
+  void userWithTheRoleIsStillAllowedWhenACapabilityIsAlsoListed() {
+    List<Role> roleList = new ArrayList<>();
+    roleList.add(new Role("System Administrator", "admin"));
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(roleList);
+    user.setGroupList(new ArrayList<>());
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+
+    List<String> roles = List.of("admin");
+    List<String> groups = Collections.emptyList();
+    List<String> capabilities = List.of("admin:manage");
+
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, capabilities, userSession, false),
+        "adding a capability= list must not break the existing role-only path");
+  }
+
+  @Test
+  void capabilityOnlyPageDeniesAUserWithoutIt() {
+    UserSession userSession = sessionWithCapability("some-other:capability");
+
+    // No role= or group= at all -- capability= alone must still gate access (not open-by-default).
+    List<String> roles = Collections.emptyList();
+    List<String> groups = Collections.emptyList();
+    List<String> capabilities = List.of("admin:manage");
+
+    Assertions.assertFalse(WebComponentCommand.allowsUser(roles, groups, capabilities, userSession, false));
+  }
+
+  @Test
+  void capabilityOnlyPageAllowsAUserWithIt() {
+    UserSession userSession = sessionWithCapability("admin:manage");
+
+    List<String> roles = Collections.emptyList();
+    List<String> groups = Collections.emptyList();
+    List<String> capabilities = List.of("admin:manage");
+
+    Assertions.assertTrue(WebComponentCommand.allowsUser(roles, groups, capabilities, userSession, false));
+  }
+
+  @Test
+  void pageOverloadReadsCapabilitiesFromThePageItself() {
+    UserSession userSession = sessionWithCapability("admin:manage");
+
+    Page page = new Page("/admin/role-capabilities", null, null);
+    page.setRoles(List.of("admin"));
+    page.setCapabilities(List.of("admin:manage"));
+
+    Assertions.assertTrue(WebComponentCommand.allowsUser(page, userSession),
+        "the Page-specific overload must read page.getCapabilities(), not just page.getRoles()");
   }
 }


### PR DESCRIPTION
Fixes #733.

## The gap

Every admin page is gated in `PageServlet` via `WebComponentCommand.allowsUser()`, which checked only `hasRole()`/`hasGroup()` — no `hasPermission()` path at all. This runs **before** the widget itself is invoked. A user granted a capability — directly, or via a role-derived grant (#701/#704) — had zero way to reach a `hasPermission()`-gated page unless they *also* held a legacy role listed in that page's `role="..."` attribute: the container 404'd them before the widget's own `hasPermission()` check ever ran, making the capability system currently redundant with the role system it's meant to eventually replace.

## The fix

Adds an optional `capability="..."` attribute to `<page>` elements (parsed identically to `role=`/`group=`). `WebComponentCommand.allowsUser()` now grants the role/capability side of its check on **either** a listed role **or** a listed capability (`hasPermission()`). This is purely additive:

- None of the other ~117 `role="..."` pages across the layout XML files carry a `capability=` attribute, so their behavior is completely unchanged.
- Wired `capability="admin:manage"` onto the 3 pages that already internally gate on `hasPermission("admin:manage")`: `/admin/role-capabilities`, `/admin/role-capabilities-form`, `/admin/analytics-retention`.
- `ValidateUserAccessToWebPageCommand.hasAccess()` (dynamic CMS page menu-visibility checks) delegates through the same `WebComponentCommand.allowsUser(Page, UserSession)` call and inherits the fix automatically — no code change needed there.

## Test plan

- [x] New unit tests in `WebComponentCommandTest` covering: capability-only access (no role), neither-role-nor-capability denial, role-only access unaffected by an also-listed capability, capability-only page (no role= at all), and the `Page`-specific overload reading `getCapabilities()`
- [x] Full `ant ci-test` — all green
- [x] `tools/check-unescaped-el.py --strict` — 0 unallowlisted sites
- [x] **Live Docker rehearsal reproducing the exact reported scenario**: created a fresh user with no legacy role, granted `admin:manage` via a role-derived capability grant (not the `admin` role), logged in as them — `/admin/role-capabilities` and `/admin/analytics-retention` both return a real `200` with actual page content (was `404` before this fix). A control user with neither role nor capability still correctly gets `404`.

## Out of scope, filed as a follow-up

`main.jsp`'s admin nav menu hides the Role Capabilities / Analytics Retention links behind its own hardcoded `hasRole('admin')` check — entirely separate from `WebComponentCommand`. After this fix, a capability-only user can reach those pages directly by URL but won't see the menu link to find them. Flagged separately rather than bundled into this fix, since it touches a different, unrelated code path (JSP-level hardcoded checks throughout `main.jsp`, not the `Page`/`WebComponentCommand` gate this PR addresses).