### PR TITLE
Show Access-section admin nav links to capability-granted users (#733)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -485,15 +485,19 @@
             </c:if>
           </c:if>
           <%-- API, Apps, etc. --%>
-          <c:if test="${userSession.hasRole('admin')}">
+          <c:if test="${userSession.hasRole('admin') || userSession.hasPermission('admin:manage')}">
             <ul class="vertical menu">
               <li class="section-title">Access</li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/api')}"> class="is-active"</c:if>><a href="${ctx}/admin/apis"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>APIs</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/app')}"> class="is-active"</c:if>><a href="${ctx}/admin/apps"><i class="${font:far()} fa-mobile fa-fw"></i> <span>Apps</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/blocked-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/blocked-ip-list"><i class="${font:far()} fa-shield-halved fa-fw"></i> <span>Blocked IPs</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/allowed-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/allowed-ip-list"><i class="${font:far()} fa-shield fa-fw"></i> <span>Allowed IPs</span></a></li>
+              <c:if test="${userSession.hasRole('admin')}">
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/api')}"> class="is-active"</c:if>><a href="${ctx}/admin/apis"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>APIs</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/app')}"> class="is-active"</c:if>><a href="${ctx}/admin/apps"><i class="${font:far()} fa-mobile fa-fw"></i> <span>Apps</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/blocked-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/blocked-ip-list"><i class="${font:far()} fa-shield-halved fa-fw"></i> <span>Blocked IPs</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/allowed-ip-list')}"> class="is-active"</c:if>><a href="${ctx}/admin/allowed-ip-list"><i class="${font:far()} fa-shield fa-fw"></i> <span>Allowed IPs</span></a></li>
+              </c:if>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/role-capabilities')}"> class="is-active"</c:if>><a href="${ctx}/admin/role-capabilities"><i class="${font:far()} fa-user-lock fa-fw"></i> <span>Role Capabilities</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/audit-log')}"> class="is-active"</c:if>><a href="${ctx}/admin/audit-log"><i class="${font:far()} fa-clipboard-list fa-fw"></i> <span>Audit Log</span></a></li>
+              <c:if test="${userSession.hasRole('admin')}">
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/audit-log')}"> class="is-active"</c:if>><a href="${ctx}/admin/audit-log"><i class="${font:far()} fa-clipboard-list fa-fw"></i> <span>Audit Log</span></a></li>
+              </c:if>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/analytics-retention')}"> class="is-active"</c:if>><a href="${ctx}/admin/analytics-retention"><i class="${font:far()} fa-trash-can fa-fw"></i> <span>Analytics Retention</span></a></li>
             </ul>
           </c:if>


### PR DESCRIPTION
## Stacked on #739 — do not merge until #739 merges

PR #739 taught the page-container gate to accept `capability="admin:manage"` on `/admin/role-capabilities`, `/admin/role-capabilities-form`, and `/admin/analytics-retention`, closing the container-level half of #733. This is the sibling gap noted in that issue: `main.jsp` renders the admin nav via its own hardcoded `hasRole('admin')` checks, entirely separate from `WebComponentCommand`'s gate, so a user reachable via `admin:manage` alone still couldn't *see* the links to get there.

## Scope

Audited every `hasRole()`-gated nav block in `main.jsp` against which linked pages actually carry `capability=` (checked the whole `web-layouts/` tree, not just `admin-layout.xml`). Only the **Access** section links to capability-enabled pages today (Role Capabilities, Analytics Retention). The Content/Community/Data/E-Commerce/Settings sections map suggestively onto capability codes that already exist in the DB (`content:manage`, `data:manage`, etc.), but none of their pages have a `capability=` attribute wired yet — extending those sections now would make links visible that still 404, so this PR deliberately leaves them untouched.

## Change

- Access section's outer gate: `hasRole('admin')` → `hasRole('admin') || hasPermission('admin:manage')`
- APIs / Apps / Blocked IPs / Allowed IPs / Audit Log (still role-only, no `capability=`) nested in their own inner `hasRole('admin')` check so they stay hidden for a capability-only user
- Role Capabilities / Analytics Retention left open under the outer condition

Mirrors the nested-`c:if` pattern already used in this same file for Web Vitals / User Groups inside the Community section — no new idiom introduced.

## Verification

- `ant -lib lib/war clean compile-jsp` — passes
- Live-verified in a docker rehearsal built off this PR's own base branch: granted `admin:manage` to the content-manager role, created a real user with content-manager only (no admin role), logged in as them.
  - Access section renders with **only** Role Capabilities + Analytics Retention, both return `200`
  - APIs / Apps / Blocked IPs / Allowed IPs / Audit Log are absent from the rendered nav **and** still `404` on direct hit — no visible-but-unreachable mismatch introduced
  - Full-admin baseline unchanged (still sees all 7 links)

## Test plan

- [ ] Merge #739 first
- [ ] Confirm a legacy-admin-role user still sees the full Access section
- [ ] Confirm a capability-only (no admin role) user sees only Role Capabilities + Analytics Retention, and both load