### PR TITLE
Add PowerBI widget for embedding Power BI "Publish to web" reports

### DIFF
--- a/src/main/java/com/simisinc/platform/application/dashboards/PowerBiEmbedCommand.java
+++ b/src/main/java/com/simisinc/platform/application/dashboards/PowerBiEmbedCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.dashboards;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Validates a Power BI "Publish to web" embed URL before it's dropped into an iframe src.
+ * <p>
+ * Unlike Superset's guest-token flow or Metabase's static (signed) embedding, Power BI's publish-
+ * to-web URLs are already complete, self-contained, and public by design -- Power BI itself signs
+ * and hosts them, so there is no server-side secret to configure or token to generate here. This
+ * command's only job is confirming the URL a page author configured is actually a Power BI embed
+ * URL, not an arbitrary attacker-controlled address, before it's rendered.
+ *
+ * @author elizabeth houser
+ */
+public class PowerBiEmbedCommand {
+
+  private static Log LOG = LogFactory.getLog(PowerBiEmbedCommand.class);
+
+  private static final String REQUIRED_HOST = "app.powerbi.com";
+
+  public static String validateEmbedUrl(String embedUrl) {
+    if (StringUtils.isBlank(embedUrl)) {
+      LOG.debug("Missing embedUrl");
+      return null;
+    }
+    URI uri;
+    try {
+      uri = new URI(embedUrl.trim());
+    } catch (URISyntaxException e) {
+      LOG.warn("Power BI embedUrl is not a valid URL: " + embedUrl);
+      return null;
+    }
+    if (!"https".equalsIgnoreCase(uri.getScheme()) || !REQUIRED_HOST.equalsIgnoreCase(uri.getHost())) {
+      LOG.warn("Power BI embedUrl must be a https://" + REQUIRED_HOST + " address: " + embedUrl);
+      return null;
+    }
+    return uri.toString();
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/PowerBiWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/dashboard/PowerBiWidget.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.dashboard;
+
+import com.simisinc.platform.application.cms.NumberCommand;
+import com.simisinc.platform.application.dashboards.PowerBiEmbedCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Renders a Power BI report published via "Publish to web". The embed URL is complete and
+ * public as configured by Power BI itself -- this widget only validates it before rendering,
+ * it does not sign or generate anything (contrast SupersetWidget/MetabaseWidget).
+ *
+ * @author elizabeth houser
+ */
+public class PowerBiWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908895L;
+
+  public static String JSP = "/dashboard/powerbi-embedded.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+    String embedUrl = PowerBiEmbedCommand.validateEmbedUrl(context.getPreferences().get("embedUrl"));
+    if (embedUrl == null) {
+      return context;
+    }
+
+    context.getRequest().setAttribute("embedUrl", embedUrl);
+    // height is rendered into a style value, so require a CSS length
+    context.getRequest().setAttribute("height",
+        NumberCommand.filterCssLength(context.getPreferences().getOrDefault("height", "300px"), "300px"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/dashboard/powerbi-embedded.jsp
+++ b/src/main/webapp/WEB-INF/jsp/dashboard/powerbi-embedded.jsp
@@ -1,0 +1,19 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="embedUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="height" class="java.lang.String" scope="request"/>
+<iframe src="<c:out value="${embedUrl}"/>" frameborder="0" width="100%" style="min-height: <c:out value="${height}"/>;" allowFullScreen="true"></iframe>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -83,6 +83,7 @@
   <widget name="progressCard" class="com.simisinc.platform.presentation.widgets.dashboard.ProgressCardWidget" />
   <widget name="statisticCard" class="com.simisinc.platform.presentation.widgets.dashboard.StatisticCardWidget" />
   <widget name="superset" class="com.simisinc.platform.presentation.widgets.dashboard.SupersetWidget" />
+  <widget name="powerBi" class="com.simisinc.platform.presentation.widgets.dashboard.PowerBiWidget" />
   <!-- User Profile and Management -->
   <widget name="emailSubscribe" class="com.simisinc.platform.presentation.widgets.mailinglists.EmailSubscribeWidget" />
   <widget name="myInfo" class="com.simisinc.platform.presentation.widgets.userProfile.MyInfoWidget" />

--- a/src/test/java/com/simisinc/platform/application/dashboards/PowerBiEmbedCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/dashboards/PowerBiEmbedCommandTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.dashboards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class PowerBiEmbedCommandTest {
+
+  @Test
+  void acceptsARealPublishToWebUrl() {
+    String url = "https://app.powerbi.com/view?r=eyJrIjoiYWJjMTIzIn0%3D";
+
+    assertEquals(url, PowerBiEmbedCommand.validateEmbedUrl(url));
+  }
+
+  @Test
+  void rejectsAMissingUrl() {
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl(null));
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl(""));
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("   "));
+  }
+
+  @Test
+  void rejectsAMalformedUrl() {
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("not a url at all"));
+  }
+
+  @Test
+  void rejectsAnHttpUrl() {
+    // Publish-to-web URLs are always https -- refuse to embed a downgraded/spoofed variant.
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("http://app.powerbi.com/view?r=abc123"));
+  }
+
+  @Test
+  void rejectsANonPowerBiHost() {
+    // Guards against a page author (or a compromised page-layout XML edit) pointing this widget
+    // at an arbitrary attacker-controlled iframe target instead of a real Power BI embed.
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("https://evil.example.com/view?r=abc123"));
+  }
+
+  @Test
+  void rejectsALookalikeHost() {
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("https://app.powerbi.com.evil.com/view?r=abc123"));
+    assertNull(PowerBiEmbedCommand.validateEmbedUrl("https://notapp.powerbi.com/view?r=abc123"));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/dashboard/PowerBiWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/dashboard/PowerBiWidgetTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class PowerBiWidgetTest extends WidgetBase {
+
+  private static final String VALID_URL = "https://app.powerbi.com/view?r=eyJrIjoiYWJjMTIzIn0%3D";
+
+  @Test
+  void rendersTheIframeWhenConfigured() {
+    preferences.put("embedUrl", VALID_URL);
+
+    WidgetContext result = new PowerBiWidget().execute(widgetContext);
+
+    assertEquals(PowerBiWidget.JSP, result.getJsp());
+    assertEquals(VALID_URL, result.getRequest().getAttribute("embedUrl"));
+    assertEquals("300px", result.getRequest().getAttribute("height"));
+  }
+
+  @Test
+  void usesTheConfiguredHeight() {
+    preferences.put("embedUrl", VALID_URL);
+    preferences.put("height", "600px");
+
+    WidgetContext result = new PowerBiWidget().execute(widgetContext);
+
+    assertEquals("600px", result.getRequest().getAttribute("height"));
+  }
+
+  @Test
+  void doesNotRenderWhenTheUrlIsMissing() {
+    WidgetContext result = new PowerBiWidget().execute(widgetContext);
+
+    assertNull(result.getJsp());
+    assertNull(result.getRequest().getAttribute("embedUrl"));
+  }
+
+  @Test
+  void doesNotRenderWhenTheUrlIsNotARealPowerBiEmbed() {
+    preferences.put("embedUrl", "https://evil.example.com/view?r=abc123");
+
+    WidgetContext result = new PowerBiWidget().execute(widgetContext);
+
+    assertNull(result.getJsp());
+    assertNull(result.getRequest().getAttribute("embedUrl"));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `powerBi` widget that renders a configured Power BI "Publish to web" embed URL in an iframe, mirroring the existing `superset`/Metabase embedding widgets.
- `PowerBiEmbedCommand.validateEmbedUrl` restricts the configured URL to `https://app.powerbi.com/...` so a page-layout edit can't turn the widget into an arbitrary iframe injector (rejects http, other hosts, and lookalike hosts like `app.powerbi.com.evil.com`).
- Height is configurable via a `height` preference (default `300px`), reusing `NumberCommand.filterCssLength` for the same CSS-length sanitization the other dashboard widgets use.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests ci-test` — full suite green, including new `PowerBiEmbedCommandTest` (6 cases: accepts a real publish-to-web URL, rejects missing/malformed/http/non-PowerBI-host/lookalike-host URLs) and `PowerBiWidgetTest` (4 cases: renders, honors configured height, no-op when URL missing, no-op when URL fails validation).
- [x] Unescaped-EL gate clean.
- [x] Live Docker verification: inserted a page with `<widget name="powerBi"><embedUrl>https://app.powerbi.com/view?r=...</embedUrl><height>500px</height></widget>` and confirmed the rendered response contains the exact expected `<iframe src="https://app.powerbi.com/view?r=..." ... style="min-height: 500px;">`.
- [x] Live Docker negative check: a page pointing `embedUrl` at a non-PowerBI host renders no iframe at all.
- [ ] Verified against a real Power BI "Publish to web" URL from an actual account (only a realistically-shaped placeholder URL was available at build time) — noting this the same way PR #729 flagged the MailChimp `segment_opts` gap.