### PR TITLE
ci: surface container-level test failures in ci-test's CI log

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -438,6 +438,7 @@
           <jvmarg value="-javaagent:${lib.test.dir}/byte-buddy-agent-1.14.10.jar"/>
           <jvmarg value="-Djava.awt.headless=true"/>
         </fork>
+        <listener classname="com.simisinc.platform.ContainerFailureReportingListener"/>
       </testclasses>
     </junitlauncher>
     <fail if="hasFailingTest" />

--- a/src/test/java/com/simisinc/platform/ContainerFailureReportingListener.java
+++ b/src/test/java/com/simisinc/platform/ContainerFailureReportingListener.java
@@ -1,0 +1,31 @@
+package com.simisinc.platform;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+/**
+ * Ant's junitlauncher prints each class's "Tests run: N, Failures: M" line using
+ * TestExecutionSummary#getTestsFailedCount() (test-level only), but sets the
+ * failureproperty that fails the build using #getTotalFailureCount() (test+container
+ * level). A container failure -- a @BeforeAll/@AfterAll or extension callback throwing --
+ * can fail the build while every printed per-class line still reads "Failures: 0", making
+ * ci-test fail with no visible cause anywhere in the log. This listener prints the
+ * container, its source, and the exception whenever that gap would otherwise hide it.
+ */
+public class ContainerFailureReportingListener implements TestExecutionListener {
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
+        if (!testIdentifier.isContainer() || result.getStatus() != TestExecutionResult.Status.FAILED) {
+            return;
+        }
+        System.out.println("================================================================================");
+        System.out.println("CONTAINER-LEVEL TEST FAILURE (invisible to any class's \"Tests run\" summary line)");
+        System.out.println("Container: " + testIdentifier.getDisplayName());
+        System.out.println("Source:    " + testIdentifier.getSource().map(Object::toString).orElse("<unknown>"));
+        System.out.println("================================================================================");
+        result.getThrowable().ifPresent(t -> t.printStackTrace(System.out));
+        System.out.println("================================================================================");
+    }
+}


### PR DESCRIPTION
## Problem

`ci-test` (the `build` job in `.github/workflows/ant.yml`) has repeatedly failed at `build.xml:443: if=hasFailingTest` with **zero** visible evidence anywhere in the log -- every one of the ~218 test classes' printed `Tests run: N, Failures: M, Aborted: K` line reads `Failures: 0, Aborted: 0`. Confirmed independently on two unrelated PRs (#706, #738), both locally and on GitHub Actions CI, by grepping the complete raw log for any nonzero Failures/Aborted count and finding none. This makes the CI check untrustworthy: reviewers can't tell a real failure from this one without a from-scratch investigation each time.

## Root cause

Ant's `junitlauncher` task (`LauncherSupport.java`) uses two *different* JUnit Platform `TestExecutionSummary` counters for two different purposes:

- The printed per-class summary line uses `summary.getTestsFailedCount()` -- **test-level failures only**.
- The `failureproperty` (`hasFailingTest`) is set from `summary.getTotalFailureCount()` -- **test + container-level failures** (e.g. a `@BeforeAll`/`@AfterAll` or extension callback throwing).

When a *container* fails -- as opposed to an individual `@Test` method -- the build fails, but the printed summary line for that class shows all zeros (`Tests run: 0, Failures: 0, Aborted: 0, Skipped: 0`), indistinguishable from a class with nothing to report. This is a real gap in Ant's own reporting, not a flake -- no amount of grepping the per-class line can ever surface it.

I reproduced this directly: `ci-test`'s `<testclasses>` runs all ~218 test classes in a single forked JVM (no `forkmode` set), so I wired a temporary `TestExecutionListener` into a worktree of PR #738's branch and re-ran `ant -lib lib/war -lib lib/tests clean ci-test`. It caught the real cause -- `DatabaseMigrationTest` and `WebVitalsMigrationTest` both fail at `@BeforeAll` with:

```
org.flywaydb.core.api.FlywayException: Found more than one migration with version 20260730.1000
Offenders:
-> UPGRADE_20260730.1000__unsuspend_approval_workflow.sql
-> UPGRADE_20260730.1000__mailchimp_campaign_id.sql
```

Two branches independently picked the same next-available migration version. That's a genuine, correct failure -- Flyway is right to refuse an ambiguous version -- but it was completely invisible in the CI log, which is what actually made this feel like a mystery each time it recurred.

## Fix

Add `ContainerFailureReportingListener`, a `TestExecutionListener` wired into `ci-test`'s `<testclasses>` block, that prints the failing container's name, source, and full exception whenever a container-level failure occurs -- the exact case the existing per-class summary line can't show.

**Verified:**
- Clean tree: `BUILD SUCCESSFUL`, listener produces zero extra output (no noise added to the normal path).
- With the PR #738 migration collision reproduced locally: `BUILD FAILED`, and the log now contains a clearly-marked block identifying `DatabaseMigrationTest` / `WebVitalsMigrationTest` and the exact `FlywayException`, instead of silence.

## Scope note

This fixes the CI-log visibility gap only. It does not touch pass/fail semantics (still `haltOnFailure="false"` + `failureproperty="hasFailingTest"` + `<fail if="hasFailingTest"/>`, unchanged) and does not fix PR #738's specific migration-version collision, which is content on an actively-worked, unrelated branch -- flagged separately.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` on a clean tree: green, no new output
- [x] Same command with the PR #738 migration collision reproduced locally: fails as before, but now with a clear diagnostic block naming the failing container and the underlying exception
- [x] This PR's own `build` CI check: passed on real GitHub Actions (3m29s), confirming the fix is a no-op on the normal green path in the actual CI environment, not just locally