### PR TITLE
Fix: MenuWidget's rendered Log Out link is missing its CSRF token

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/MenuWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/MenuWidget.java
@@ -40,6 +40,7 @@ import com.simisinc.platform.domain.model.cms.TableOfContentsLink;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
 import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.UserSession;
 import com.simisinc.platform.presentation.controller.WebComponentCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -181,7 +182,7 @@ public class MenuWidget extends GenericWidget {
         // menu.jsp renders this straight into href="${ctx}${link['link']}" without escaping.
         // LinkWidget already runs its equivalent through sanitizeUrl (LinkWidget.java:64); this
         // path did not, so a link attribute in the page-layout XML reached the page verbatim.
-        addProperty(context, properties, "link", UrlCommand.sanitizeUrl(link));
+        addProperty(context, properties, "link", withLogoutToken(context, UrlCommand.sanitizeUrl(link)));
         addProperty(context, properties, "class", menuItemClass);
         addProperty(context, properties, "container", container);
         addProperty(context, properties, "icon", icon);
@@ -363,11 +364,28 @@ public class MenuWidget extends GenericWidget {
     // Prepare the link
     Map<String, String> properties = new HashMap<>();
     addProperty(context, properties, "name", name);
-    addProperty(context, properties, "link", link);
+    addProperty(context, properties, "link", withLogoutToken(context, link));
     addProperty(context, properties, "container", container);
     addProperty(context, properties, "icon", icon);
     //addProperty(context, properties, "icon-only", valueMap.get("icon-only"));
     linkList.add(properties);
+  }
+
+  /**
+   * WebRequestFilter requires a matching CSRF token on /logout (GH-359); the standard header
+   * JSP appends it inline, but menu.jsp renders link['link'] as-is, so any "/logout" entry
+   * reaching this widget (site-configured header links, the admin-dropdown Logout item) needs
+   * the current session's token appended here or it silently fails to log the user out.
+   */
+  private static String withLogoutToken(WidgetContext context, String link) {
+    if (!"/logout".equals(link)) {
+      return link;
+    }
+    UserSession userSession = context.getUserSession();
+    if (userSession == null) {
+      return link;
+    }
+    return link + "?token=" + userSession.getFormToken();
   }
 
   private static void addDivider(WidgetContext context, List<Map<String, String>> linkList, String container, String roleValue) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebRequestFilterTest.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.controller;
 
 import static com.simisinc.platform.application.cms.HostnameCommand.HOSTNAME_ALLOW_LIST;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -336,6 +337,101 @@ class WebRequestFilterTest {
 
       logout.verify(() -> LogoutCommand.logout(request, response));
       verify(response).setHeader("Location", "/login");
+      verify(chain, never()).doFilter(request, response);
+    }
+  }
+
+  // --- /logout CSRF token check (GH-359) ---
+  // MenuWidget renders the "Log Out" link (see MenuWidgetTest) with "?token=" + the session's
+  // formToken; these prove the filter side of that contract: the exact link the page now renders
+  // actually logs the user out, and a request missing/forging that token does not.
+
+  private HttpServletRequest logoutRequest(HttpSession session, String token) {
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getContextPath()).thenReturn("");
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getScheme()).thenReturn("http");
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getServletContext()).thenReturn(servletContext);
+    when(request.getRequestURI()).thenReturn("/logout");
+    when(request.getRemoteAddr()).thenReturn("203.0.113.9");
+    when(request.getServerName()).thenReturn("www.example.com");
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://www.example.com/logout"));
+    when(request.getSession(false)).thenReturn(session);
+    when(request.getParameter("token")).thenReturn(token);
+    when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+    return request;
+  }
+
+  @Test
+  void logoutWithTheTokenTheRenderedLinkCarriesActuallyInvalidatesTheSession() throws Exception {
+    User user = new User();
+    user.setId(30L);
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+    // This is exactly what MenuWidget now appends to the rendered "Log Out" link
+    String renderedToken = userSession.getFormToken();
+
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+
+    HttpServletRequest request = logoutRequest(session, renderedToken);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class);
+        MockedStatic<OAuthRequestCommand> oauth = mockStatic(OAuthRequestCommand.class);
+        MockedStatic<LogoutCommand> logout = mockStatic(LogoutCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+      // Force an early return right after the logout call (the SSL redirect below it) so this
+      // test doesn't have to stub the rest of the per-request pipeline (cookies, visitor
+      // tracking, etc.) that has nothing to do with the CSRF token check being verified here.
+      siteProperties.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn(SITE_URL);
+
+      WebRequestFilter filter = filterRequiringSSL(siteProperties);
+      filter.doFilter(request, response, chain);
+
+      logout.verify(() -> LogoutCommand.logout(request, response));
+    }
+  }
+
+  @Test
+  void logoutWithAMissingOrWrongTokenDoesNotInvalidateTheSession() throws Exception {
+    // The behavior this whole check exists to prevent: a forged/tokenless /logout (the CSRF
+    // attack GH-359 fixed) must NOT log the user out -- it should just bounce to "/" and leave
+    // the session alone.
+    User user = new User();
+    user.setId(31L);
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+
+    HttpServletRequest request = logoutRequest(session, null);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperties = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<LoadRedirectsCommand> redirects = mockStatic(LoadRedirectsCommand.class);
+        MockedStatic<LoadBlockedIPListCommand> blockedIPList = mockStatic(LoadBlockedIPListCommand.class);
+        MockedStatic<BlockedIPListCommand> blockedIPs = mockStatic(BlockedIPListCommand.class);
+        MockedStatic<LogoutCommand> logout = mockStatic(LogoutCommand.class)) {
+
+      redirects.when(LoadRedirectsCommand::load).thenReturn(null);
+      blockedIPs.when(() -> BlockedIPListCommand.passesCheck(anyString(), anyString())).thenReturn(true);
+
+      WebRequestFilter filter = filterWithoutSSL(siteProperties);
+      filter.doFilter(request, response, chain);
+
+      logout.verify(() -> LogoutCommand.logout(any(), any()), never());
+      verify(response).setHeader("Location", "/");
       verify(chain, never()).doFilter(request, response);
     }
   }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/MenuWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/MenuWidgetTest.java
@@ -94,4 +94,54 @@ class MenuWidgetTest extends WidgetBase {
       }
     }
   }
+
+  @Test
+  void logoutLinkFromTheHeaderLayoutXmlIncludesTheCsrfToken() {
+    // WebRequestFilter requires a "token" query param matching the session's formToken before it
+    // will process /logout (GH-359). menu.jsp renders link['link'] verbatim into href, so a plain
+    // "/logout" reaching the page here would silently fail to log anyone out.
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"menu\">\n" +
+            "  <links>\n" +
+            "    <link name=\"Log Out\" link=\"/logout\" role=\"users\" />\n" +
+            "  </links>\n" +
+            "</widget>");
+
+    request.setAttribute(RequestConstants.WEB_PAGE_PATH, "/");
+    String expectedToken = widgetContext.getUserSession().getFormToken();
+
+    MenuWidget widget = new MenuWidget();
+    widget.execute(widgetContext);
+    List<Map<String, String>> linkList = (List) widgetContext.getRequest().getAttribute("linkList");
+
+    Assertions.assertEquals(1, linkList.size());
+    Assertions.assertEquals("/logout?token=" + expectedToken, linkList.get(0).get("link"));
+  }
+
+  @Test
+  void adminDropdownLogoutLinkAlsoIncludesTheCsrfToken() {
+    // The Admin dropdown's Logout entry is injected internally (MenuWidget.execute(), the
+    // "type=admin" branch) rather than read from widget preferences -- it needs the same token.
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"menu\">\n" +
+            "  <links>\n" +
+            "    <link name=\"Settings\" icon=\"fa-cog\" icon-only=\"true\" type=\"admin\" />\n" +
+            "  </links>\n" +
+            "</widget>");
+
+    request.setAttribute(RequestConstants.WEB_PAGE_PATH, "/");
+    setRoles(widgetContext, ADMIN);
+    String expectedToken = widgetContext.getUserSession().getFormToken();
+
+    MenuWidget widget = new MenuWidget();
+    widget.execute(widgetContext);
+    List<Map<String, String>> linkList = (List) widgetContext.getRequest().getAttribute("linkList");
+
+    Map<String, String> logoutLink = linkList.stream()
+        .filter(link -> "Logout".equals(link.get("name")))
+        .findFirst()
+        .orElse(null);
+    Assertions.assertNotNull(logoutLink, "Logout link missing from the admin dropdown");
+    Assertions.assertEquals("/logout?token=" + expectedToken, logoutLink.get("link"));
+  }
 }


### PR DESCRIPTION
## Summary
GH-359 fixed logout CSRF by having `WebRequestFilter` require a `token` query parameter matching the session's `formToken` on `/logout`, and updated the four hardcoded logout anchors in `layout-header-standard.jspf` to include it. However, that JSPF is only one of the header rendering paths in this app: a site's active header is just as often the widget-driven layout defined in `header-layout.xml` (the default for a fresh install), rendered via `MenuWidget`/`menu.jsp`. That path was missed by the original fix -- both the `header-layout.xml`-configured "Log Out" links and the Admin dropdown's internally-added "Logout" entry still emitted a bare `/logout` with no token.

Since `WebRequestFilter` silently no-ops (redirects to `/` without invalidating the session) on any `/logout` request with a missing or mismatched token, a user on an affected header who clicks "Log Out" appears to sign out (they land back on the homepage, same as a real logout) but remains fully authenticated. Confirmed live: after "logging out" this way, an admin session could still load `/admin/users` and `/my-page` with full authenticated content. This is a real risk on shared or public computers.

## Fix
`MenuWidget` now appends the current session's `formToken` to any link that is exactly `/logout` before it's stored for `menu.jsp` to render, covering both the XML-configured links and the internally-added Admin dropdown entry.

## Test plan
- [x] `MenuWidgetTest`: new tests assert the `header-layout.xml`-style `/logout` link and the Admin dropdown's `Logout` entry both carry `?token=<session formToken>`
- [x] `WebRequestFilterTest`: new tests assert (a) a `/logout` request carrying the token `MenuWidget` now renders actually invokes `LogoutCommand.logout()`, and (b) a `/logout` request with a missing/wrong token still does not
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` passes in full
- [x] Live-verified end-to-end against a freshly built container: logged in, fetched `/admin/users`, extracted the exact rendered `Log Out` href, followed it, then confirmed a follow-up request with the same cookies to `/admin/users` and `/my-page` both now 404 (session invalidated) -- reproduced the bug on the pre-fix build and confirmed it's resolved post-fix