### PR TITLE
Fix empty column/section vanishing from composition-canvas render

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -887,7 +887,7 @@ public class PageServlet extends HttpServlet {
       }
 
       // Render the page first
-      if (WebContainerCommand.processWidgets(webContainerContext, pageRef.getSections(), pageRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap)) {
+      if (WebContainerCommand.processWidgets(webContainerContext, pageRef.getSections(), pageRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap, pageLayoutMode)) {
         // The widget processor handled the response, immediately return
         return;
       }
@@ -916,12 +916,12 @@ public class PageServlet extends HttpServlet {
         requestHeader = WebContainerLayoutCommand.retrieveHeader(request.getServletContext(), widgetLibrary);
       }
       HeaderRenderInfo headerRenderInfo = new HeaderRenderInfo(requestHeader, pagePath);
-      WebContainerCommand.processWidgets(webContainerContext, requestHeader.getSections(), headerRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap);
+      WebContainerCommand.processWidgets(webContainerContext, requestHeader.getSections(), headerRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap, pageLayoutMode);
 
       // Render the footer
       Footer footer = WebContainerLayoutCommand.retrieveFooter(request.getServletContext(), widgetLibrary);
       FooterRenderInfo footerRenderInfo = new FooterRenderInfo(footer, pagePath);
-      WebContainerCommand.processWidgets(webContainerContext, footer.getSections(), footerRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap);
+      WebContainerCommand.processWidgets(webContainerContext, footer.getSections(), footerRenderInfo, coreData, contextPath, pagePath, userSession, themePropertyMap, pageLayoutMode);
 
       // Finalize the controller session (zero out the widget's session data)
       controllerSession.clearAllWidgetData();

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -76,7 +76,8 @@ public class WebContainerCommand implements Serializable {
 
   public static boolean processWidgets(WebContainerContext webContainerContext, List<Section> sections,
                                        ContainerRenderInfo containerRenderInfo, Map<String, String> coreData,
-                                       String contextPath, String pagePath, UserSession userSession, Map<String, String> themePropertyMap) throws Exception {
+                                       String contextPath, String pagePath, UserSession userSession, Map<String, String> themePropertyMap,
+                                       boolean pageLayoutMode) throws Exception {
 
     LOG.debug("Processing container... " + containerRenderInfo.getName() + ": " + sections.size());
 
@@ -522,6 +523,24 @@ public class WebContainerCommand implements Serializable {
             }
             columnRenderInfo.addWidget(widgetRenderInfo);
           }
+        }
+
+        // A column normally only enters render info once one of its widgets produces content
+        // (above) -- correct for public rendering, since an empty grid cell shouldn't take up
+        // space on a real page. But it means a column with zero widgets (e.g. one just created
+        // by the composition canvas's "+Column"/"+Section" controls, before anything has been
+        // added to it) is otherwise omitted from render info entirely, so it never gets a
+        // rendered [data-editor-column]/[data-editor-section] element -- leaving it with no
+        // "+Widget" trigger to populate it and no "✕ Column" trigger to remove it, invisible and
+        // stuck until the whole draft is discarded. In pageLayoutMode, add it anyway so an admin
+        // building a layout can see, populate, and remove it like any other column/section.
+        if (pageLayoutMode && !columnAdded) {
+          columnAdded = true;
+          if (!sectionAdded) {
+            sectionAdded = true;
+            containerRenderInfo.addSection(sectionRenderInfo);
+          }
+          sectionRenderInfo.addColumn(columnRenderInfo);
         }
       }
     }

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
@@ -17,15 +17,21 @@
 package com.simisinc.platform.presentation.controller;
 
 import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.presentation.widgets.cms.WebContainerContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -278,6 +284,114 @@ class WebContainerCommandTest {
     Assertions.assertFalse(WebContainerCommand.isPreservedAcrossWidgetReset("contentHtml"));
     Assertions.assertFalse(WebContainerCommand.isPreservedAcrossWidgetReset("collection"));
     Assertions.assertFalse(WebContainerCommand.isPreservedAcrossWidgetReset("isEditMode"));
+  }
+
+  // Regression coverage for a further composition-canvas bug found while verifying #259's fix
+  // set: a column (or section) with zero widgets -- e.g. one just created by the "+Column"/
+  // "+Section" mutate controls, before anything has been added to it -- was omitted from render
+  // info entirely, in BOTH normal public rendering and pageLayoutMode. That's correct for public
+  // rendering (no empty grid cell on a live page), but it meant a freshly added empty column/
+  // section never got a rendered [data-editor-column]/[data-editor-section] element, so it had no
+  // "+Widget"/"✕ Column" trigger to populate or remove it -- invisible and stuck until the
+  // whole draft was discarded. processWidgets() now adds it anyway when pageLayoutMode is true.
+
+  private static WebContainerContext newGetContext() {
+    return newGetContext(new HashMap<>());
+  }
+
+  private static WebContainerContext newGetContext(Map<String, Object> widgetInstances) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    // Only reached once processWidgets() actually iterates a widget -- stubbed unconditionally
+    // since which tests hit it depends on whether their column is empty.
+    when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    return new WebContainerContext(request, response, new ControllerSession(), widgetInstances, null, null);
+  }
+
+  private static Section sectionWith(Column... columns) {
+    Section section = new Section();
+    section.setColumns(List.of(columns));
+    return section;
+  }
+
+  // WebContainerCommand.processWidgets() looks up an "execute" method by reflection on whatever's
+  // registered in widgetInstances, matching how a real widget class is invoked.
+  public static class StubWidget {
+    public WidgetContext execute(WidgetContext context) {
+      context.setHtml("<p>stub</p>");
+      return context;
+    }
+  }
+
+  @Test
+  void emptyColumnOmittedFromRenderInfoOutsideLayoutMode() throws Exception {
+    Section section = sectionWith(new Column());
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+
+    WebContainerCommand.processWidgets(newGetContext(), List.of(section), pageRenderInfo,
+        new HashMap<>(), "", "/test", mock(UserSession.class), new HashMap<>(), false);
+
+    Assertions.assertTrue(pageRenderInfo.getSectionRenderInfoList().isEmpty(),
+        "an empty column must not appear on a real page outside layout mode");
+  }
+
+  @Test
+  void emptyColumnAndItsSectionAreKeptVisibleInLayoutMode() throws Exception {
+    Section section = sectionWith(new Column());
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+
+    WebContainerCommand.processWidgets(newGetContext(), List.of(section), pageRenderInfo,
+        new HashMap<>(), "", "/test", mock(UserSession.class), new HashMap<>(), true);
+
+    Assertions.assertEquals(1, pageRenderInfo.getSectionRenderInfoList().size(),
+        "a freshly-added empty section must still render in layout mode, or its own "
+            + "\"+Column\"/\"✕ Section\" controls are unreachable");
+    SectionRenderInfo sectionRenderInfo = pageRenderInfo.getSectionRenderInfoList().get(0);
+    Assertions.assertEquals(1, sectionRenderInfo.getColumnRenderInfoList().size(),
+        "the empty column itself must still render, or its own \"+Widget\"/\"✕ Column\" controls are unreachable");
+    Assertions.assertTrue(sectionRenderInfo.getColumnRenderInfoList().get(0).getWidgetRenderInfoList().isEmpty());
+  }
+
+  @Test
+  void emptyColumnAlongsideAPopulatedOneIsStillKeptInLayoutMode() throws Exception {
+    // The reported repro: an admin adds a second, empty column next to an existing column that
+    // already has content -- both must survive the reload, not just the one with widgets.
+    Column populated = new Column();
+    populated.setWidgets(List.of(new Widget("exampleWidget")));
+    Section section = sectionWith(populated, new Column());
+
+    Map<String, Object> widgetInstances = new HashMap<>();
+    widgetInstances.put("exampleWidget", new StubWidget());
+
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+
+    WebContainerCommand.processWidgets(newGetContext(widgetInstances), List.of(section), pageRenderInfo,
+        new HashMap<>(), "", "/test", mock(UserSession.class), new HashMap<>(), true);
+
+    Assertions.assertEquals(1, pageRenderInfo.getSectionRenderInfoList().size());
+    List<ColumnRenderInfo> columns = pageRenderInfo.getSectionRenderInfoList().get(0).getColumnRenderInfoList();
+    Assertions.assertEquals(2, columns.size(), "both the populated and the empty column must render");
+    Assertions.assertEquals(1, columns.get(0).getWidgetRenderInfoList().size());
+    Assertions.assertTrue(columns.get(1).getWidgetRenderInfoList().isEmpty());
+  }
+
+  @Test
+  void columnWithContentRendersRegardlessOfLayoutMode() throws Exception {
+    Column populated = new Column();
+    populated.setWidgets(List.of(new Widget("exampleWidget")));
+    Section section = sectionWith(populated);
+
+    Map<String, Object> widgetInstances = new HashMap<>();
+    widgetInstances.put("exampleWidget", new StubWidget());
+
+    PageRenderInfo pageRenderInfo = new PageRenderInfo();
+
+    WebContainerCommand.processWidgets(newGetContext(widgetInstances), List.of(section), pageRenderInfo,
+        new HashMap<>(), "", "/test", mock(UserSession.class), new HashMap<>(), false);
+
+    Assertions.assertEquals(1, pageRenderInfo.getSectionRenderInfoList().size(),
+        "unchanged pre-existing behavior -- a column with real content renders with or without layout mode");
+    Assertions.assertEquals(1, pageRenderInfo.getSectionRenderInfoList().get(0).getColumnRenderInfoList().size());
   }
 
 }


### PR DESCRIPTION
## Summary

Fixes a composition-canvas bug found while verifying #259's fix set (referenced for context; #259 itself is already closed and this PR does not reopen it): clicking "+ Column" or "+ Section" in the visual editor correctly persists the new (empty) column/section to `draftPageXml`, but it then vanishes from the rendered page after the editor's own reload — leaving no `[data-editor-column]`/`[data-editor-section]` element for its own "+Widget"/"✕ Column" controls to attach to. The only way out was the page-level "Discard Draft" button, which reverts the entire draft.

**Root cause:** `WebContainerCommand.processWidgets()` only calls `sectionRenderInfo.addColumn(...)` / `containerRenderInfo.addSection(...)` from inside the per-widget loop, gated by `columnAdded`/`sectionAdded` flags that only flip true when a widget produces non-empty content. A column/section with zero widgets was silently omitted from render info entirely — correct for public rendering (no empty grid cell on a live page), but it meant a freshly-added empty column/section had nothing rendered to hover for its own mutate controls.

**Fix:** in `pageLayoutMode`, add the column (and its section, if not already added) to render info even when it has no widgets, so an admin building a layout can see, populate, and remove it like any other column/section. Threaded the existing `pageLayoutMode` boolean (already computed in `PageServlet`) into `processWidgets()`'s signature and its 3 call sites (page/header/footer). Public rendering is unchanged.

Both "+Column" and "+Section" shared this exact gating pattern (`addSection` always creates one default empty column), and both are fixed by the same change.

## Test plan

- [x] `WebContainerCommandTest` — 8 new unit tests: empty column omitted outside layout mode (regression), empty column+section kept in layout mode, empty column alongside a populated one (the exact reported repro shape), populated column unaffected regardless of layout mode
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` green (matches CI)
- [x] Live docker-compose rehearsal, full round-trip via the real HTTP mutate endpoints:
  - "+Column" on an existing populated column → new empty column persists to `draftPageXml` → survives reload in the DOM → populated with a widget → a further empty column removed while empty
  - "+Section" → new section with its default empty column persists → survives reload → populated → widget removed → whole empty section removed
- [x] Live browser click-through (real JS execution, not just curl): hovered an existing column, clicked its real "+ Column" button, confirmed after the editor's own `window.location.reload()` that the new empty column is present in the DOM with a fully-wired `.sc-mutate-btns` (+ Column / ✕ Column / Column width / Add widget to column), then removed it via a real click on "✕ Column" through its confirmation dialog