### PR TITLE
Fix stale edit-mode UI leaking across a re-login on the same session

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/LogoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/LogoutCommand.java
@@ -54,6 +54,9 @@ public class LogoutCommand {
         userId = userSession.getUserId();
       }
       request.getSession().removeAttribute(SessionConstants.USER);
+      // A per-user toggle (e.g. the visual editor's edit mode) must not survive to whichever
+      // identity, if any, authenticates next on this same HttpSession.
+      request.getSession().removeAttribute(SessionConstants.PAGE_EDIT_MODE);
       // Prevent other sessions
       UserTokenRepository.removeAll(userId);
     }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -293,9 +293,12 @@ public class PageServlet extends HttpServlet {
       // WebContainerCommand.processWidgets()'s per-widget loop -- their names must stay in sync
       // with WebContainerCommand.PAGE_LEVEL_ATTRIBUTE_NAMES, which exempts them from that loop's
       // per-widget request attribute reset.
-      if (pageEditMode) {
-        request.setAttribute("pageEditMode", "true");
-      }
+      //
+      // pageEditMode must be published unconditionally, like pageLayoutMode below -- leaving it
+      // unset on the false path lets JSP EL's implicit page/request/session/application scope
+      // search fall through to the raw session attribute read above, which can still be "true"
+      // from a previously-authenticated, more-privileged user on this same HttpSession.
+      request.setAttribute("pageEditMode", pageEditMode ? "true" : "false");
       boolean hasDraft = pageLayoutMode && webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml());
       request.setAttribute("pageLayoutMode", pageLayoutMode ? "true" : "false");
       request.setAttribute("hasDraft", hasDraft ? "true" : "false");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/login/LoginWidget.java
@@ -182,6 +182,9 @@ public class LoginWidget extends GenericWidget {
     // Rotate the servlet session id now that the user has authenticated: any session id an
     // attacker may have fixed on the browser before login is invalidated (session-fixation defense).
     context.getRequest().changeSessionId();
+    // A per-user toggle (e.g. the visual editor's edit mode) set earlier on this same HttpSession
+    // by whichever identity was logged in before must not carry over to the new identity.
+    context.getRequest().getSession().removeAttribute(SessionConstants.PAGE_EDIT_MODE);
     userSession.login(user);
 
     // Track the login

--- a/src/test/java/com/simisinc/platform/application/login/LogoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/login/LogoutCommandTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.login;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.oauth.OAuthRequestCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
+import com.simisinc.platform.presentation.controller.SessionConstants;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Verifies logout() clears every per-user session flag it owns, not just the UserSession itself --
+ * a flag left behind (e.g. the visual editor's edit mode) must not survive to whichever identity,
+ * if any, authenticates next on this same HttpSession.
+ *
+ * @author elizabeth houser
+ */
+class LogoutCommandTest {
+
+  @Test
+  void logoutClearsThePageEditModeFlagAlongsideTheUserSession() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    HttpSession session = mock(HttpSession.class);
+    when(request.getSession()).thenReturn(session);
+
+    UserSession userSession = new UserSession();
+    userSession.login(new User());
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+
+    try (MockedStatic<OAuthRequestCommand> oauth = mockStatic(OAuthRequestCommand.class);
+        MockedStatic<UserTokenRepository> userTokenRepo = mockStatic(UserTokenRepository.class)) {
+      oauth.when(OAuthRequestCommand::isEnabled).thenReturn(false);
+      userTokenRepo.when(() -> UserTokenRepository.removeAll(anyLong())).thenAnswer(invocation -> null);
+
+      LogoutCommand.logout(request, response);
+    }
+
+    verify(session).removeAttribute(SessionConstants.USER);
+    verify(session).removeAttribute(SessionConstants.PAGE_EDIT_MODE);
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/login/LoginWidgetTest.java
@@ -223,6 +223,37 @@ class LoginWidgetTest extends WidgetBase {
   }
 
   @Test
+  void finalizingLoginClearsAStalePageEditModeFlagLeftByAPreviousUser() {
+    // Simulates a previously-authenticated, more-privileged user (e.g. an admin who turned on the
+    // visual editor) leaving this flag set on the HttpSession, then logging out without an
+    // explicit editMode=false -- or simply a second, different user authenticating on top of the
+    // same session without an intervening /logout call at all.
+    session.setAttribute(SessionConstants.PAGE_EDIT_MODE, "true");
+    session.setAttribute(SessionConstants.USER, new UserSession());
+    addQueryParameter(widgetContext, "email", "user@example.com");
+    addQueryParameter(widgetContext, "password", "hunter2hunter2");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    User user = new User();
+    user.setId(7L);
+    user.setMfaEnabled(false);
+
+    LoginWidget widget = new LoginWidget();
+    try (MockedStatic<AuthenticateLoginCommand> auth = mockStatic(AuthenticateLoginCommand.class);
+        MockedStatic<UserLoginRepository> userLoginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      auth.when(() -> AuthenticateLoginCommand.getAuthenticatedUser(anyString(), anyString(), anyString()))
+          .thenReturn(user);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("site.online")).thenReturn(true);
+      widget.post(widgetContext);
+    }
+
+    // Whichever user now owns this session, a previous user's edit-mode toggle must not carry over.
+    verify(session).removeAttribute(SessionConstants.PAGE_EDIT_MODE);
+  }
+
+  @Test
   void badPasswordShowsAnErrorAndDoesNotAuthenticate() {
     addQueryParameter(widgetContext, "email", "user@example.com");
     addQueryParameter(widgetContext, "password", "wrong");


### PR DESCRIPTION
## Summary
- A previous, more-privileged user's visual-editor edit-mode toggle (`SessionConstants.PAGE_EDIT_MODE`) could survive a different, lower-privileged user logging in on top of the same `HttpSession` without an intervening `/logout`.
- `PageServlet` only published the freshly re-derived `pageEditMode` value to request scope when `true`. When it was `false` for the new user, no request attribute existed, so JSP EL's implicit page/request/session/application scope search fell through to the stale session attribute and rendered the composition-canvas toolbar (`#sc-editor-toolbar`) and `body.page-edit-mode` for a user with no edit permission.
- The backing read/write actions (`getWidgetContent`, `saveWidgetContent`, etc.) already re-check permission independently and correctly return 404 for such a user — this is a UI/authorization-state disclosure, not a data leak. `data-layout-mode`, `data-widget-names`, and the per-widget edit-pencil affordance were all already correctly gated and unaffected.

## Fix
- `PageServlet.java`: publish `pageEditMode` to request scope unconditionally (`true`/`false`), mirroring the already-correct `pageLayoutMode` line right next to it, instead of only setting it when true.
- `LoginWidget.java`: clear the stale session attribute when a login is finalized, at the same point the session id itself is rotated for session-fixation defense.
- `LogoutCommand.java`: clear the same attribute on explicit logout, so it can't outlive any identity boundary, not just a same-session re-login.

## Test plan
- [x] Unit tests: new `LoginWidgetTest` case asserts a stale `PAGE_EDIT_MODE` flag is cleared when a different user completes login; new `LogoutCommandTest` asserts `logout()` clears it too.
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` green (full suite, no regressions).
- [x] Live-verified via a local docker-compose rehearsal against a real seeded page (`/legal/privacy`): reproduced the exact reported sequence (admin login → `editMode=true` → log in as a genuine no-role user on the same cookie jar, no logout → GET the page with no `editMode` param).
  - Pre-fix build: `body class="page-edit-mode"` + `#sc-editor-toolbar` render for the no-role user.
  - Post-fix build, identical sequence: neither renders; `/admin/users` still correctly 404s for that user, confirming it's genuinely the low-privileged identity and not a masked admin session.