### PR TITLE
Restore stranded PR #708: Move MediaApiController off /api/* so RestRequestFilter stops blocking it

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -41,10 +41,10 @@ import java.util.UUID;
 /**
  * P5.2: Media Library API endpoints for the visual editor panel
  *
- * GET /api/media?search=query&limit=20&offset=0 - List media assets with pagination and search
- * POST /api/media - Create stub asset record
- * POST /api/media/upload - Handle file upload from drag-and-drop or file picker (not yet implemented)
- * POST /api/media/widget-update - Apply a selected asset to a widget's preference on a page's draft
+ * GET /visual-editor/media?search=query&limit=20&offset=0 - List media assets with pagination and search
+ * POST /visual-editor/media - Create stub asset record
+ * POST /visual-editor/media/upload - Handle file upload from drag-and-drop or file picker (not yet implemented)
+ * POST /visual-editor/media/widget-update - Apply a selected asset to a widget's preference on a page's draft
  * layout. Requires builder-tier permission and the session CSRF token, and identifies the target
  * widget the same way {@link PageServlet}'s {@code mutateDraftLayout} action does -- by structural
  * position, not by a render-time {@code widgetContext.uniqueId} -- so it can safely delegate to
@@ -54,7 +54,7 @@ import java.util.UUID;
  * @author claude
  * @created 7/26/26
  */
-@WebServlet(name = "MediaApi", urlPatterns = {"/api/media", "/api/media/*"})
+@WebServlet(name = "MediaApi", urlPatterns = {"/visual-editor/media", "/visual-editor/media/*"})
 public class MediaApiController extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(MediaApiController.class);

--- a/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
@@ -376,7 +376,7 @@
       params.append('search', search);
     }
 
-    fetch('/api/media?' + params)
+    fetch('/visual-editor/media?' + params)
       .then(r => r.json())
       .then(data => {
         filteredAssets = data.assets || [];

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -112,8 +112,8 @@
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>MediaApi</servlet-name>
-    <url-pattern>/api/media</url-pattern>
-    <url-pattern>/api/media/*</url-pattern>
+    <url-pattern>/visual-editor/media</url-pattern>
+    <url-pattern>/visual-editor/media/*</url-pattern>
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>StylesheetServlet</servlet-name>


### PR DESCRIPTION
## What this is

This is a mechanical restoration of PR #708, whose content never actually reached `main` despite GitHub showing it as merged.

**Root cause:** #708 was based on a feature branch (not `main`) that was itself part of a stacked-PR chain. That base branch's own PR merged into `main` *before* #708 merged into the base branch. As a result, #708's merge commit exists and is real, reviewed, already-tested content — but it landed on a branch that was never reachable from `main`. This is a recurring stacked-PR merge-order race in this repo.

**Evidence:**
- Original PR: #708
- Its merge commit: `174ccc5bad5e74e1f18d955403a2a3b3aa1b33e0` (merge of `fix/media-api-move-off-rest-filter-path`)
- Confirmed unreachable from `origin/main`: `git merge-base --is-ancestor 174ccc5bad5e74e1f18d955403a2a3b3aa1b33e0 origin/main` fails

**What this PR does:** cherry-picks `174ccc5bad5e74e1f18d955403a2a3b3aa1b33e0` (via `git cherry-pick -m 1`, i.e. the diff relative to its main-side parent) onto current `main`. The cherry-pick applied cleanly with no conflicts — no file this PR touches has changed on `main` since the original merge, so nothing needed reconciling.

**The code itself is unchanged from what was already reviewed and approved in #708.** No migration renumbering was needed (there were no migration files in this change). This is not new unreviewed work; it is restoring work that already went through review.

## Original changes (from #708)

Moves `MediaApiController`'s servlet mapping and all references from `/api/*` to `/visual-editor/*`, so `RestRequestFilter` (which gates all `/api/*` traffic behind an API key + toggle) stops blocking the visual editor's media library panel, which is meant to be an authenticated in-app UI, not a public REST API.

- `MediaApiController.java`: `@WebServlet` urlPatterns and javadoc updated from `/api/media` to `/visual-editor/media`
- `web.xml`: matching `<url-pattern>` updates
- `media-library-panel.jsp`: fetch call updated to the new path

## Verification

- `git cherry-pick -m 1 174ccc5bad5e74e1f18d955403a2a3b3aa1b33e0` — clean, no conflicts
- `ant -lib lib/war -lib lib/tests ci-test` — BUILD SUCCESSFUL, zero real test failures
- `MediaApiControllerTest` (pre-existing test class covering this controller) explicitly confirmed passing: `Tests run: 11, Failures: 0`
- Confirmed no leftover `/api/media` references anywhere in the tree after the cherry-pick
- Confirmed no Flyway migration version collisions were introduced (no migrations in this change)