### PR TITLE
Restore stranded PR #592: Wire up bot-traffic summary tiles into Site Analytics page (#561)

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -620,6 +620,27 @@
         </widget>
       </column>
       <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-user</icon>
+          <title>Real Sessions Today</title>
+          <report>real-sessions-today</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-robot</icon>
+          <title>Bot Sessions Today</title>
+          <report>bot-sessions-today-total</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-percentage</icon>
+          <title>Bot Traffic %</title>
+          <report>bot-traffic-percentage</report>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
         <widget name="communityStats">
           <icon>fa-mail-bulk</icon>
           <title>Mailing List Subscribers</title>


### PR DESCRIPTION
## What this is

This is a mechanical restoration of PR #592 ("Wire up bot-traffic summary tiles into Site Analytics page (#561)"), whose content never actually reached `main` despite GitHub showing it as merged.

**Root cause:** PR #592 was a stacked PR based on another PR's feature branch (not `main`). That base-branch PR merged into `main` *before* PR #592 merged into the base branch's branch, so PR #592's commits landed on a branch that was never itself merged into `main` — an orphaned merge, despite the GitHub UI showing "Merged". This is a recurring stacked-PR merge-order race in this repo.

**Evidence:**
- Original PR: #592
- Its merge commit: `e2016f04649b08bf38c0d8f0adc54b7a025f0eca` (real, reviewed content)
- Confirmed unreachable from `origin/main` via `git merge-base --is-ancestor e2016f04649b08bf38c0d8f0adc54b7a025f0eca origin/main` (fails)

## What changed

Cherry-picked the merge commit's diff (`git cherry-pick -m 1 e2016f04649b08bf38c0d8f0adc54b7a025f0eca`) cleanly onto current `main`, with no conflicts. The change is limited to `src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml`, wiring three already-existing `siteStats` report keys (`real-sessions-today`, `bot-sessions-today-total`, `bot-traffic-percentage` — implemented earlier by #561 and already present in `SiteStatsWidget.java` on `main`) into the Site Analytics admin page as callout tiles.

**The code itself is unchanged from what was already reviewed and approved in #592.** No migration renumbering was needed (no Flyway files in this PR's diff, and no version collisions found in `src/main/resources/database/upgrade/2026/`). This is not new unreviewed work.

## Verification

`ant -lib lib/war -lib lib/tests ci-test` run clean: 218 test classes, 1204 tests, 0 failures, BUILD SUCCESSFUL. This PR's own change (a layout XML file) has no dedicated unit test; the report keys it wires up already have coverage via `SiteStatsWidgetTest`-adjacent suites which passed unchanged.