### PR TITLE
Fix AFD session affinity: sessionAffinitySettings doesn't exist in the real Azure schema

### DIFF
--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -246,10 +246,9 @@ az webapp config appsettings set \
 Azure Front Door uses session affinity to pin authenticated users to the same backend instance. Without affinity, a multi-instance deployment (scale-out or rolling update) would log out users mid-session because Tomcat stores sessions in JVM-local memory.
 
 **Affinity behavior:**
-- AFD sets a routing cookie on the first request
-- Subsequent requests from the same browser are routed to the same backend
-- Cookie duration: 24 hours (default; non-configurable per route in Bicep)
-- SameSite=Lax: cookie sent on same-site navigation and external links; protects against cross-site request forgery
+- Session affinity is a property of the **origin group** (not the route) — a plain `Enabled`/`Disabled` toggle. There is no route-level session-affinity setting in the Azure Front Door schema.
+- When enabled, AFD sets a routing cookie on the first request and routes subsequent requests from the same browser to the same backend.
+- Azure manages the cookie's characteristics (name, attributes like `SameSite`) and its duration internally. Neither is exposed as a Bicep-configurable setting for Standard/Premium Front Door, so this document does not state specific values for them — check the current [Azure Front Door documentation](https://learn.microsoft.com/azure/frontdoor/) if the exact cookie behavior matters for a given investigation.
 
 **Failover behavior (when a pinned backend becomes unhealthy):**
 - AFD health checks detect the instance is DOWN (probes fail 3× in a row)
@@ -261,9 +260,11 @@ Azure Front Door uses session affinity to pin authenticated users to the same ba
 **Expected frequency:** Rare. Health probes every 30 seconds; instance must fail 3× to be marked unhealthy. Transient blips don't trigger failover.
 
 **Configuration:**
-- Enabled in `infra/modules/frontdoor.bicep` (route resource, `sessionAffinitySettings`)
-- Applied to all routes (/*) — affects the whole site
-- Cannot be tuned per route in Azure Portal (Bicep is source of truth)
+- Enabled in `infra/modules/frontdoor.bicep` (`originGroup` resource, `sessionAffinityState: 'Enabled'`)
+- Applies to all traffic routed through that origin group — affects the whole site
+- Cannot be tuned in the Azure Portal outside of Bicep (Bicep is source of truth)
+
+**Current impact:** The App Service plan behind this origin group is currently pinned to a single instance (`capacity: 1`, pilot posture — see `infra/modules/appservice.bicep`). With one instance there is nowhere else a session could be routed, so this setting has no observable effect until the plan is actually scaled to multiple instances. It's configured now so multi-instance routing behaves correctly once that happens.
 
 ---
 

--- a/infra/modules/frontdoor.bicep
+++ b/infra/modules/frontdoor.bicep
@@ -118,6 +118,30 @@ resource originGroup 'Microsoft.Cdn/profiles/originGroups@2024-02-01' = {
       probeProtocol: 'Https'
       probeIntervalInSeconds: 30
     }
+    // Session affinity: pin authenticated users to the same backend instance
+    // for the duration of their session. In multi-instance deployments, Tomcat
+    // stores sessions in JVM-local memory; without affinity, a user routed to
+    // a different instance loses their session and must re-authenticate. AFD
+    // affinity solves this via a routing cookie.
+    //
+    // This is an origin-group-level property (AFDOriginGroupProperties), not a
+    // route-level one -- there is no per-route session-affinity setting in the
+    // Microsoft.Cdn resource schema. It is also a plain Enabled/Disabled toggle;
+    // Azure manages the cookie's characteristics (name, SameSite attribute) and
+    // TTL internally, and neither is Bicep-configurable for Standard/Premium
+    // Front Door. (An earlier version of this file set sessionAffinitySettings
+    // on the route resource with a cookie characteristic and a timeout field --
+    // that property does not exist on RouteProperties in any API version and
+    // was a no-op; see issue #397.)
+    //
+    // NOTE: the App Service plan backing this origin is currently pinned to
+    // capacity: 1 (single instance, pilot posture -- decision #8, see
+    // infra/modules/appservice.bicep). With only one instance there is only
+    // one place a session can live, so this setting has no observable effect
+    // today. It's here so multi-instance routing works correctly once the plan
+    // is actually scaled out; until then "it deploys cleanly" should not be
+    // read as "verified against a real multi-instance deployment."
+    sessionAffinityState: 'Enabled'
   }
 }
 
@@ -179,16 +203,6 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
         id: customDomain.id
       }
     ]
-    // Session affinity: pin authenticated users to the same backend instance
-    // for the duration of their session (default 24 hours). In multi-instance
-    // deployments, Tomcat stores sessions in JVM-local memory; without affinity,
-    // a user routed to a different instance loses their session and must
-    // re-authenticate. AFD affinity solves this via a routing cookie.
-    sessionAffinitySettings: {
-      affinityEnabled: 'Enabled'
-      affinityCookieCharacteristic: 'SameSite=Lax'
-      affintiyTimeoutInMinutes: 1440
-    }
     // Caching: honor application Cache-Control headers. Public pages (no session
     // context) return "public, max-age=300, stale-while-revalidate=3600" and are
     // cached at the edge. Authenticated/session pages return "no-cache, no-store"


### PR DESCRIPTION
## Bug

Closes #397.

`infra/modules/frontdoor.bicep`'s `route` resource
(`Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01`) set:

```bicep
sessionAffinitySettings: {
  affinityEnabled: 'Enabled'
  affinityCookieCharacteristic: 'SameSite=Lax'
  affintiyTimeoutInMinutes: 1440
}
```

Two problems:

1. **Wrong property, wrong resource.** `sessionAffinitySettings` does not exist
   anywhere in `RouteProperties` for this resource type, in any API version
   (checked against the Microsoft Learn ARM/Bicep schema reference, including
   2024-02-01). `RouteProperties` only has: `cacheConfiguration`,
   `customDomains`, `enabledState`, `forwardingProtocol`, `httpsRedirect`,
   `linkToDefaultDomain`, `originGroup`, `originPath`, `patternsToMatch`,
   `ruleSets`, `supportedProtocols`. This block was a silent no-op — it would
   have been dropped/ignored (or rejected) had it ever actually been deployed
   or run through `az bicep build`.
2. **Typo that nobody caught:** `affintiyTimeoutInMinutes` is missing letters.
   On its own, this is strong evidence the block was never actually validated
   against a compiler or the live schema — a real `bicep build` run would
   have flagged an unknown property here regardless of the typo, but the typo
   makes it doubly clear this was never exercised.

The real mechanism, per the live schema: for Front Door Standard/Premium,
session affinity is a plain two-state property, `sessionAffinityState:
'Enabled' | 'Disabled'`, on the **origin group**
(`AFDOriginGroupProperties`, `Microsoft.Cdn/profiles/originGroups@2024-02-01`)
— not the route. There is no Bicep-configurable cookie `SameSite` attribute
or TTL for this feature; Azure controls both internally and neither is
exposed as a settable property.

## Fix

- Removed the invalid `sessionAffinitySettings` block from the `route`
  resource.
- Added `sessionAffinityState: 'Enabled'` to the `og-app` `originGroup`
  resource's `properties`, alongside the existing `loadBalancingSettings` /
  `healthProbeSettings`.
- Rewrote the explanatory comment to describe the real mechanism (origin
  group, Enabled/Disabled toggle, Azure-managed cookie) instead of the
  fabricated per-route cookie/TTL customization, and left a note for future
  readers about the earlier incorrect version so nobody re-adds it.
- Corrected `infra/DEPLOYMENT.md` §5.3 ("Session Affinity (Multi-Instance)"):
  removed the fabricated "Cookie duration: 24 hours" and `SameSite=Lax`
  specifics (values that were never real — they were read off the invalid
  Bicep block, not off Azure), removed the "route resource,
  `sessionAffinitySettings`" configuration reference, and replaced it with
  the actual mechanism (origin-group-level toggle, Azure-managed cookie
  behavior, no per-route customization). I did not invent replacement
  concrete values (e.g. a "real" cookie TTL) since I can't verify those
  against Azure's actual current behavior from this environment — the doc
  now says that honestly rather than restating a different unverified
  number.
- Checked `docs/rolling-deploy-workflow.md` (grepped for "affinity"): its
  three mentions describe session affinity conceptually (pinned to an
  instance, re-auth on failover) and don't reference route-level specifics
  or the removed cookie/TTL fields, so they remain accurate as written — no
  changes made there.

## Caveat: no observable effect yet

The App Service plan behind this origin group is currently pinned to
`capacity: 1` (single instance, pilot posture — decision #8, see
`infra/modules/appservice.bicep`). With a single instance there is nowhere
else a session could be routed, so this fix has **no observable effect**
until the environment actually scales to multiple instances. It's there so
multi-instance routing behaves correctly once that happens — please don't
read "this compiles now" as "this was verified against a real
multi-instance deployment," because it hasn't been.

## Validation — honest status

Neither the `az` CLI nor a standalone `bicep` CLI is available in the
environment this fix was written in, so **I could not run `az bicep build`
or otherwise compile-check this change**. The fix is based on manually
reading the Microsoft Learn ARM/Bicep schema reference for
`Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01` (`RouteProperties`)
and `Microsoft.Cdn/profiles/originGroups@2024-02-01`
(`AFDOriginGroupProperties`) across API versions, not a compiler run. I also
confirmed by grep that no CI workflow in this repo touches `infra/` or
`.bicep` files at all, so this hasn't been validated by automation either,
before or after this change.

**Before merging, please have someone with Azure CLI access run the team's
own documented pre-flight check:**

```bash
az bicep build --file infra/main.bicep --stdout > /dev/null
```

from DEPLOYMENT.md, to confirm this compiles clean against the real Bicep
compiler before this is trusted as done.

## Files changed

- `infra/modules/frontdoor.bicep`
- `infra/DEPLOYMENT.md`