### PR TITLE
Fix unsafe-migration gate: recursive discovery of dated-subdirectory migrations

### DIFF
--- a/tools/detect_unsafe_migrations.py
+++ b/tools/detect_unsafe_migrations.py
@@ -119,7 +119,7 @@ def check_migrations(repo_root):
         print(f"Migrations directory not found: {migrations_dir}", file=sys.stderr)
         return violations
 
-    sql_files = sorted(migrations_dir.glob('UPGRADE_*.sql'))
+    sql_files = sorted(migrations_dir.rglob('UPGRADE_*.sql'))
 
     # Group by version (date.time)
     migrations_by_version = defaultdict(list)

--- a/tools/tests/test_detect_unsafe_migrations.py
+++ b/tools/tests/test_detect_unsafe_migrations.py
@@ -4,11 +4,10 @@ Unlike the other five tools/tests/*.py files, this one is git-based (issue #399)
 it exercises the tool through real commits in a synthetic tmp_path repo, since the
 Java-removal side of the check reads `git diff`, not the working tree.
 
-Migration files below are written directly under
-src/main/resources/database/upgrade/ (not a dated subdirectory like the real repo's
-upgrade/2026/) to match check_migrations()'s current glob, which is not recursive.
-Real migrations one level deeper are a separate, pre-existing bug from the one this
-file covers (the shallow-clone / git-diff fix) and are out of scope here.
+Migration files below are written under a dated subdirectory
+(src/main/resources/database/upgrade/2026/), matching how real migrations are laid
+out in this repo, to exercise check_migrations()'s recursive discovery
+(migrations_dir.rglob(...)) rather than a synthetic top-level-only placement.
 """
 
 import subprocess
@@ -18,7 +17,7 @@ from conftest import run_tool, write
 
 TOOL = "detect_unsafe_migrations.py"
 
-MIGRATION_DIR = "src/main/resources/database/upgrade"
+MIGRATION_DIR = "src/main/resources/database/upgrade/2026"
 JAVA_FILE = "src/main/java/com/simisinc/platform/domain/model/Order.java"
 
 JAVA_BEFORE = (
@@ -59,6 +58,8 @@ def _commit_all(root: Path, message: str) -> None:
 
 
 def test_destructive_migration_with_matching_java_removal_is_flagged(repo):
+    """Also covers recursive discovery: MIGRATION_DIR is a dated subdirectory,
+    like real migrations, not the top-level upgrade/ directory."""
     _init_repo(repo)
     write(repo, JAVA_FILE, JAVA_BEFORE)
     _commit_all(repo, "initial state")


### PR DESCRIPTION
## What

`check_migrations()` in `tools/detect_unsafe_migrations.py` discovered SQL migration files with a non-recursive `Path.glob('UPGRADE_*.sql')`. Almost all real migrations live one directory deeper, under `src/main/resources/database/upgrade/<year>/` — so the glob only ever found stray top-level files (1, in the current tree) instead of the real ~69. The destructive-SQL-pattern side of the expand/contract gate (#399) was effectively blind to nearly the entire migration history.

Fix: switch to `rglob()`.

## Why this is stacked on #756

`tools/tests/test_detect_unsafe_migrations.py` doesn't exist on `main` yet — it's added by #756. This PR edits that file, so it has to build on top of #756's branch rather than `main`. **Merge #756 first.**

## Testing

- `tools/tests/test_detect_unsafe_migrations.py`: moved `MIGRATION_DIR` to a dated subdirectory (`upgrade/2026/`) to match real repo layout, so the existing "destructive migration + matching Java removal is flagged" test now also exercises recursive discovery. Confirmed this test (and the multi-commit regression test, which shares the same constant) fails against the old non-recursive `glob()` and passes with `rglob()`.
- Verified directly against this repo's real migration tree: `rglob` now finds all ~69 real `UPGRADE_*.sql` files (vs. 1 with the old `glob`).
- `python3 -m pytest tools/tests -q` — 21 passed.

## Context

Found while working on #756 (a separate, already-shipped bug in the same function); kept out of that PR to stay scoped to one defect. Flagged as a known follow-up in the #399 comment and in the relocated runbook (`SimisRnD/simis-cms-runbooks/expand-contract-migrations.md`).

Refs #399, #756.
