### PR TITLE
Fix mailing list CSV upload redirecting to Users admin page

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
@@ -167,7 +167,7 @@ public class MailingListMembersWidget extends GenericWidget {
       context.setErrorMessage(e.getMessage());
     }
     // Determine the page to return to
-    context.setRedirect("/admin/users");
+    context.setRedirect("/admin/mailing-list-members?mailingListId=" + mailingList.getId());
     return context;
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.SaveBlockedIPCommand;
+import com.simisinc.platform.application.mailinglists.ProcessEmailCSVFileCommand;
 import com.simisinc.platform.domain.model.BlockedIP;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
@@ -191,6 +193,43 @@ class MailingListMembersWidgetTest extends WidgetBase {
       new MailingListMembersWidget().post(widgetContext);
 
       memberRepo.verify(() -> MailingListMemberRepository.remove(any(), any()), never());
+    }
+  }
+
+  @Test
+  void uploadCSVFileRedirectsBackToTheMailingListMembersPage() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "uploadCSVFile");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      processCsv.when(() -> ProcessEmailCSVFileCommand.processCSV(any(), any())).thenReturn(3);
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      assertEquals("/admin/mailing-list-members?mailingListId=1", result.getRedirect());
+      assertEquals("3 emails added", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void uploadCSVFileRedirectsBackToTheMailingListMembersPageEvenWhenProcessingFails() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "uploadCSVFile");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      processCsv.when(() -> ProcessEmailCSVFileCommand.processCSV(any(), any()))
+          .thenThrow(new DataException("Valid file not found"));
+
+      WidgetContext result = new MailingListMembersWidget().post(widgetContext);
+
+      assertEquals("/admin/mailing-list-members?mailingListId=1", result.getRedirect());
+      assertEquals("Valid file not found", result.getErrorMessage());
     }
   }
 


### PR DESCRIPTION
## Summary
- `uploadCSVFileAction()` in `MailingListMembersWidget` redirected admins to `/admin/users` after a CSV import, instead of back to the mailing list they just imported into.
- Every other action in this widget (add email, block IP, delete, download) redirects to `/admin/mailing-list-members?mailingListId=...`. This one line didn't match — almost certainly a copy-paste leftover.
- Fix is one line: redirect to the mailing list members page, consistent with the rest of the widget.

Found while auditing #462. See also the follow-up in #763.

## Test plan
- [x] Added `MailingListMembersWidgetTest` coverage for `uploadCSVFile` (no test previously covered this action) — verifies the redirect on both the success path and when `ProcessEmailCSVFileCommand.processCSV` throws.
- [x] Confirmed both new tests fail against the old `/admin/users` redirect and pass against the fix.
- [x] `ant -lib lib/war clean compile` — clean
- [x] `ant -lib lib/war compile-test` + full `MailingListMembersWidgetTest` run via the vendored JUnit console launcher — 8/8 passing
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `ant -lib lib/war package` — WAR builds successfully