### PR TITLE
Add a System Health Dashboard admin page (issue #466)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/HealthCommand.java
+++ b/src/main/java/com/simisinc/platform/application/HealthCommand.java
@@ -18,6 +18,8 @@ package com.simisinc.platform.application;
 
 import java.io.File;
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.servlet.ServletContext;
 
@@ -46,6 +48,9 @@ public class HealthCommand {
     // Static utility
   }
 
+  public static final String DATABASE_SERVICE = "database";
+  public static final String FILESYSTEM_SERVICE = "filesystem";
+
   /** True only when every readiness check passes. Never throws. */
   public static boolean isReady(ServletContext context) {
     return startedUp(context) && databaseReachable() && fileStoreWritable();
@@ -58,24 +63,90 @@ public class HealthCommand {
 
   /** A pooled connection is obtainable and valid (the DB has not gone away since startup). */
   static boolean databaseReachable() {
-    try (Connection connection = DB.getConnection()) {
-      return connection != null && connection.isValid(2);
-    } catch (Exception e) {
-      return false;
-    }
+    return checkDatabase().isUp();
   }
 
   /** The file store (CMS_PATH / Azure Files mount) exists and is writable. */
   static boolean fileStoreWritable() {
+    return checkFileStore().isUp();
+  }
+
+  /**
+   * The database check, with timing and an error message on failure -- used by SystemHealthJob to
+   * populate the admin Health Dashboard (issue #466). Behaviorally identical to
+   * {@link #databaseReachable()}, just with the detail that a plain boolean throws away.
+   */
+  public static CheckResult checkDatabase() {
+    long start = System.currentTimeMillis();
+    try (Connection connection = DB.getConnection()) {
+      boolean up = connection != null && connection.isValid(2);
+      return new CheckResult(DATABASE_SERVICE, up, System.currentTimeMillis() - start,
+          up ? null : "Connection could not be validated");
+    } catch (Exception e) {
+      return new CheckResult(DATABASE_SERVICE, false, System.currentTimeMillis() - start, e.getMessage());
+    }
+  }
+
+  /**
+   * The file store check, with timing and an error message on failure -- used by SystemHealthJob to
+   * populate the admin Health Dashboard (issue #466). Behaviorally identical to
+   * {@link #fileStoreWritable()}, just with the detail that a plain boolean throws away.
+   */
+  public static CheckResult checkFileStore() {
+    long start = System.currentTimeMillis();
     try {
       String root = FileSystemCommand.getFileServerRootPath();
       if (StringUtils.isBlank(root)) {
-        return false;
+        return new CheckResult(FILESYSTEM_SERVICE, false, System.currentTimeMillis() - start,
+            "File store root path is not configured");
       }
       File dir = new File(root);
-      return dir.isDirectory() && dir.canWrite();
+      boolean up = dir.isDirectory() && dir.canWrite();
+      return new CheckResult(FILESYSTEM_SERVICE, up, System.currentTimeMillis() - start,
+          up ? null : "File store root is missing or not writable: " + root);
     } catch (Exception e) {
-      return false;
+      return new CheckResult(FILESYSTEM_SERVICE, false, System.currentTimeMillis() - start, e.getMessage());
+    }
+  }
+
+  /** The individually-checkable results, for anything that needs per-service detail rather than the
+   * single ANDed {@link #isReady(ServletContext)} boolean. Never throws. */
+  public static List<CheckResult> runAllChecks() {
+    List<CheckResult> results = new ArrayList<>();
+    results.add(checkDatabase());
+    results.add(checkFileStore());
+    return results;
+  }
+
+  /** The outcome of a single readiness check: which service, whether it passed, how long it took,
+   * and (on failure) why. */
+  public static class CheckResult {
+    private final String serviceName;
+    private final boolean up;
+    private final long responseTimeMs;
+    private final String errorMessage;
+
+    public CheckResult(String serviceName, boolean up, long responseTimeMs, String errorMessage) {
+      this.serviceName = serviceName;
+      this.up = up;
+      this.responseTimeMs = responseTimeMs;
+      this.errorMessage = errorMessage;
+    }
+
+    public String getServiceName() {
+      return serviceName;
+    }
+
+    public boolean isUp() {
+      return up;
+    }
+
+    public long getResponseTimeMs() {
+      return responseTimeMs;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
     }
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/cms/SystemHealthCheck.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/SystemHealthCheck.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import com.simisinc.platform.domain.model.Entity;
+
+import java.sql.Timestamp;
+
+/**
+ * One row per health check run, recorded by SystemHealthJob for a single service (database,
+ * filesystem). See issue #466.
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+public class SystemHealthCheck extends Entity {
+
+  public static final String STATUS_UP = "UP";
+  public static final String STATUS_DOWN = "DOWN";
+
+  private long id = -1;
+  private String serviceName = null;
+  private String status = null;
+  private int responseTimeMs = 0;
+  private String errorMessage = null;
+  private Timestamp checkedAt = null;
+
+  public SystemHealthCheck() {
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  /** A display-friendly label for the admin dashboard, since serviceName is a stable identifier
+   * ("filesystem") rather than something meant to be shown to a user as-is ("File Store"). */
+  public String getServiceLabel() {
+    if ("database".equals(serviceName)) {
+      return "Database";
+    }
+    if ("filesystem".equals(serviceName)) {
+      return "File Store";
+    }
+    return serviceName;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public boolean isUp() {
+    return STATUS_UP.equals(status);
+  }
+
+  public int getResponseTimeMs() {
+    return responseTimeMs;
+  }
+
+  public void setResponseTimeMs(int responseTimeMs) {
+    this.responseTimeMs = responseTimeMs;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public Timestamp getCheckedAt() {
+    return checkedAt;
+  }
+
+  public void setCheckedAt(Timestamp checkedAt) {
+    this.checkedAt = checkedAt;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepository.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Persists and retrieves system health check history (issue #466).
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+public class SystemHealthCheckRepository {
+
+  private static Log LOG = LogFactory.getLog(SystemHealthCheckRepository.class);
+
+  private static String TABLE_NAME = "system_health_checks";
+  private static String[] PRIMARY_KEY = new String[]{"system_health_check_id"};
+
+  public static SystemHealthCheck save(SystemHealthCheck record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("service_name", record.getServiceName(), 50)
+        .add("status", record.getStatus(), 10)
+        .add("response_time_ms", record.getResponseTimeMs())
+        .add("error_message", record.getErrorMessage(), 500);
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  /** The single most recent check for each service that has ever been checked, most recently
+   * checked first. Uses Postgres' DISTINCT ON rather than a self-join or per-service query. */
+  public static List<SystemHealthCheck> findLatestPerService() {
+    String SQL_QUERY =
+        "SELECT DISTINCT ON (service_name) * " +
+            "FROM " + TABLE_NAME + " " +
+            "ORDER BY service_name, checked_at DESC";
+    List<SystemHealthCheck> records = new ArrayList<>();
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+         ResultSet rs = pst.executeQuery()) {
+      while (rs.next()) {
+        records.add(buildRecord(rs));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return records;
+  }
+
+  /** Percent of checks for the given service that passed over the last {@code hours} hours, or null
+   * if the service has no checks in that window. hours is an int, so placing it in the interval
+   * cannot inject SQL. */
+  public static Double findUptimePercent(String serviceName, int hours) {
+    String SQL_QUERY =
+        "SELECT COUNT(*) AS total, COUNT(*) FILTER (WHERE status = 'UP') AS up_count " +
+            "FROM " + TABLE_NAME + " " +
+            "WHERE service_name = ? AND checked_at > NOW() - INTERVAL '" + hours + " hours'";
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY)) {
+      pst.setString(1, serviceName);
+      try (ResultSet rs = pst.executeQuery()) {
+        if (rs.next()) {
+          long total = rs.getLong("total");
+          if (total == 0) {
+            return null;
+          }
+          long up = rs.getLong("up_count");
+          return (up * 100.0) / total;
+        }
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return null;
+  }
+
+  /** Prunes check history older than 30 days, mirroring the raw web_vitals retention window. */
+  public static void deleteOld() {
+    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("checked_at < NOW() - INTERVAL '30 days'"));
+  }
+
+  private static SystemHealthCheck buildRecord(ResultSet rs) throws SQLException {
+    SystemHealthCheck record = new SystemHealthCheck();
+    record.setId(rs.getLong("system_health_check_id"));
+    record.setServiceName(rs.getString("service_name"));
+    record.setStatus(rs.getString("status"));
+    record.setResponseTimeMs(rs.getInt("response_time_ms"));
+    record.setErrorMessage(rs.getString("error_message"));
+    Timestamp checkedAt = rs.getTimestamp("checked_at");
+    record.setCheckedAt(checkedAt);
+    return record;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.infrastructure.scheduler.cms.LoadSystemFilesJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.RecordWebPageHitJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.SearchAnalyticsCleanupJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.SessionsPiiScrubJob;
+import com.simisinc.platform.infrastructure.scheduler.cms.SystemHealthCheckCleanupJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.SystemHealthJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.WebPageHitSnapshotJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.WebPageHitsCleanupJob;
@@ -70,11 +71,12 @@ public class SchedulerManager {
   private static Log LOG = LogFactory.getLog(SchedulerManager.class);
 
   // Jobs for every replica
-  public static final String SYSTEM_HEALTH_JOB = "SystemHealth";
   public static final String LOAD_SYSTEM_FILES_JOB = "LoadSystemFiles";
   public static final String RECORD_WEB_PAGE_HITS_JOB = "RecordWebPageHits";
 
   // Jobs to be run once across many replicas
+  public static final String SYSTEM_HEALTH_JOB = "SystemHealth";
+  public static final String SYSTEM_HEALTH_CHECK_CLEANUP_JOB = "SystemHealthCheckCleanup";
   public static final String WEB_PAGE_HIT_SNAPSHOT_JOB = "WebPageHitSnapshot";
   public static final String WEB_PAGE_HITS_CLEANUP_JOB = "WebPageHitsCleanup";
   public static final String SEARCH_ANALYTICS_CLEANUP_JOB = "SearchAnalyticsCleanup";
@@ -156,12 +158,15 @@ public class SchedulerManager {
           .initialize();
 
       // These background jobs are run by every node
-      // BackgroundJob.scheduleRecurrently(SYSTEM_HEALTH_JOB, Cron.every15seconds(), SystemHealthJob::execute);
       BackgroundJob.scheduleRecurrently(LOAD_SYSTEM_FILES_JOB, Cron.every5minutes(), LoadSystemFilesJob::execute);
       BackgroundJob.scheduleRecurrently(RECORD_WEB_PAGE_HITS_JOB, Cron.every15seconds(), RecordWebPageHitJob::execute);
 
       // These jobs need to be run by at least 1 node, preferably not the web-only nodes
       if (canRunClusterJobs) {
+        // Distributed-locked (LockManager) so exactly one node writes each interval's checks --
+        // see SystemHealthJob's own javadoc for why this isn't a per-replica "every node" job.
+        BackgroundJob.scheduleRecurrently(SYSTEM_HEALTH_JOB, Cron.minutely(), SystemHealthJob::execute);
+        BackgroundJob.scheduleRecurrently(SYSTEM_HEALTH_CHECK_CLEANUP_JOB, Cron.daily(4, 20), SystemHealthCheckCleanupJob::execute);
         BackgroundJob.scheduleRecurrently(WEB_PAGE_HIT_SNAPSHOT_JOB, Cron.every5minutes(), WebPageHitSnapshotJob::execute);
         BackgroundJob.scheduleRecurrently(WEB_PAGE_HITS_CLEANUP_JOB, Cron.daily(4), WebPageHitsCleanupJob::execute);
         // Offset from the other 4am-ish cleanup jobs so they aren't all competing for DB time at once

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthCheckCleanupJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthCheckCleanupJob.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.cms;
+
+import java.time.Duration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jobrunr.jobs.annotations.Job;
+
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.cms.SystemHealthCheckRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Deletes old system health check history (issue #466).
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+public class SystemHealthCheckCleanupJob {
+
+  private static Log LOG = LogFactory.getLog(SystemHealthCheckCleanupJob.class);
+
+  @Job(name = "Delete old system health check history")
+  public static void execute() {
+    String lock = LockManager.lock(SchedulerManager.SYSTEM_HEALTH_CHECK_CLEANUP_JOB, Duration.ofHours(4));
+    if (lock == null) {
+      return;
+    }
+
+    SystemHealthCheckRepository.deleteOld();
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthJob.java
@@ -16,12 +16,22 @@
 
 package com.simisinc.platform.infrastructure.scheduler.cms;
 
+import com.simisinc.platform.application.HealthCommand;
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.cms.SystemHealthCheckRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jobrunr.jobs.annotations.Job;
 
+import java.time.Duration;
+
 /**
- * Used for logging health information
+ * Runs HealthCommand's individual readiness checks (database, filesystem) and persists each result,
+ * so the admin Health Dashboard has real current status and history to show (issue #466). Uses a
+ * distributed lock so exactly one node writes each interval's checks, giving a single unambiguous
+ * cluster-wide history rather than one row per replica.
  *
  * @author matt rajkowski
  * @created 3/26/2023 7:47 AM
@@ -30,10 +40,27 @@ public class SystemHealthJob {
 
   private static Log LOG = LogFactory.getLog(SystemHealthJob.class);
 
-  @Job(name = "System Health")
+  @Job(name = "System Health Check")
   public static void execute() {
-    if (LOG.isDebugEnabled()) {
-      LOG.info("Healthy");
+    String lock = LockManager.lock(SchedulerManager.SYSTEM_HEALTH_JOB, Duration.ofMinutes(5));
+    if (lock == null) {
+      return;
+    }
+
+    try {
+      for (HealthCommand.CheckResult result : HealthCommand.runAllChecks()) {
+        SystemHealthCheck record = new SystemHealthCheck();
+        record.setServiceName(result.getServiceName());
+        record.setStatus(result.isUp() ? SystemHealthCheck.STATUS_UP : SystemHealthCheck.STATUS_DOWN);
+        record.setResponseTimeMs((int) result.getResponseTimeMs());
+        record.setErrorMessage(result.getErrorMessage());
+        SystemHealthCheckRepository.save(record);
+        if (!result.isUp()) {
+          LOG.warn("Health check failed for " + result.getServiceName() + ": " + result.getErrorMessage());
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error running system health checks", e);
     }
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/HealthDashboardWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/HealthDashboardWidget.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import com.simisinc.platform.application.HealthCommand;
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.persistence.cms.SystemHealthCheckRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Admin-only view of current and recent system health check status (database, filesystem), backed
+ * by the history SystemHealthJob persists every minute. Also offers a manual "Run Check Now" action
+ * for an admin who wants a fresh reading without waiting for the next scheduled run (issue #466).
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+public class HealthDashboardWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/admin/health-dashboard.jsp";
+
+  private static final int UPTIME_WINDOW_HOURS = 24;
+
+  public WidgetContext execute(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    loadDashboardData(context);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("runCheckNow".equals(command)) {
+      for (HealthCommand.CheckResult result : HealthCommand.runAllChecks()) {
+        SystemHealthCheck record = new SystemHealthCheck();
+        record.setServiceName(result.getServiceName());
+        record.setStatus(result.isUp() ? SystemHealthCheck.STATUS_UP : SystemHealthCheck.STATUS_DOWN);
+        record.setResponseTimeMs((int) result.getResponseTimeMs());
+        record.setErrorMessage(result.getErrorMessage());
+        SystemHealthCheckRepository.save(record);
+      }
+    }
+
+    context.setRedirect("/admin/health-dashboard");
+    return context;
+  }
+
+  private void loadDashboardData(WidgetContext context) {
+    List<SystemHealthCheck> latestChecks = SystemHealthCheckRepository.findLatestPerService();
+    context.getRequest().setAttribute("latestChecks", latestChecks);
+
+    Map<String, Double> uptimeByService = new HashMap<>();
+    for (SystemHealthCheck check : latestChecks) {
+      Double uptime = SystemHealthCheckRepository.findUptimePercent(check.getServiceName(), UPTIME_WINDOW_HOURS);
+      uptimeByService.put(check.getServiceName(), uptime);
+    }
+    context.getRequest().setAttribute("uptimeByService", uptimeByService);
+    context.getRequest().setAttribute("uptimeWindowHours", UPTIME_WINDOW_HOURS);
+
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+  }
+}

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -294,6 +294,21 @@ CREATE TABLE search_analytics (
 CREATE INDEX search_analytics_created_idx ON search_analytics(created);
 CREATE INDEX search_analytics_query_idx ON search_analytics(query);
 
+-- System health check history: one row per (service, check run), populated by SystemHealthJob
+-- (issue #466). service_name is currently 'database' or 'filesystem' -- the two HealthCommand
+-- checks that can flip from healthy to unhealthy after startup; see system_health_checks's own
+-- upgrade migration for why 'startup' isn't tracked here.
+CREATE TABLE system_health_checks (
+  system_health_check_id BIGSERIAL PRIMARY KEY,
+  service_name VARCHAR(50) NOT NULL,
+  status VARCHAR(10) NOT NULL,
+  response_time_ms INTEGER,
+  error_message VARCHAR(500),
+  checked_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX system_health_checks_checked_at_idx ON system_health_checks(checked_at);
+CREATE INDEX system_health_checks_service_name_idx ON system_health_checks(service_name);
+
 --
 -- CREATE TABLE content_hits (
 --   hit_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260730.1003__system_health_checks.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260730.1003__system_health_checks.sql
@@ -1,0 +1,25 @@
+-- System health check history (issue #466). HealthCommand already gates the /healthz readiness
+-- probe on three checks ANDed together (startup flag, database reachability, file store
+-- writability), but nothing persists the individual results, so admins have no way to see current
+-- or historical per-service status.
+--
+-- Only 'database' and 'filesystem' are tracked here, not 'startup' -- the startup flag is a
+-- one-time fact set once by the ContextListener and never flips back to false, so re-checking it
+-- on a recurring schedule (SystemHealthJob, which only starts after startup already succeeded)
+-- has no signal value. The dashboard shows application startup as a separate static fact instead
+-- of a row in this history table.
+--
+-- One row per check run rather than a single upserted "current status" row, so the dashboard can
+-- show a real uptime percentage / history, not just the latest sample. Pruned by
+-- SystemHealthCheckCleanupJob after 30 days, mirroring the raw web_vitals retention window.
+CREATE TABLE system_health_checks (
+  system_health_check_id BIGSERIAL PRIMARY KEY,
+  service_name VARCHAR(50) NOT NULL,
+  status VARCHAR(10) NOT NULL,
+  response_time_ms INTEGER,
+  error_message VARCHAR(500),
+  checked_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX system_health_checks_checked_at_idx ON system_health_checks(checked_at);
+CREATE INDEX system_health_checks_service_name_idx ON system_health_checks(service_name);

--- a/src/main/webapp/WEB-INF/jsp/admin/health-dashboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/health-dashboard.jsp
@@ -1,0 +1,80 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="latestChecks" class="java.util.ArrayList" scope="request"/>
+<meta http-equiv="refresh" content="30">
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="text-right">
+  <small class="subheader">This page refreshes automatically every 30 seconds.</small>
+  <a href="#" onclick="return confirmPostAction('Run all health checks now?', '${widgetContext.uri}?command=runCheckNow&widget=${widgetContext.uniqueId}&token=${userSession.formToken}');" class="button tiny">
+    <i class="fa fa-rotate"></i> Run Check Now
+  </a>
+</p>
+<c:choose>
+  <c:when test="${empty latestChecks}">
+    <p>No health checks have run yet. The scheduled check runs every minute -- use "Run Check Now" above for an immediate reading.</p>
+  </c:when>
+  <c:otherwise>
+    <table class="unstriped">
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>Status</th>
+          <th>Response Time</th>
+          <th>Last Checked</th>
+          <th>Uptime (last <c:out value="${uptimeWindowHours}"/>h)</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <c:forEach items="${latestChecks}" var="check">
+          <tr>
+            <td><c:out value="${check.serviceLabel}"/></td>
+            <td>
+              <c:choose>
+                <c:when test="${check.up}"><span class="label success radius">UP</span></c:when>
+                <c:otherwise><span class="label alert radius">DOWN</span></c:otherwise>
+              </c:choose>
+            </td>
+            <td><c:out value="${check.responseTimeMs}"/> ms</td>
+            <td><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${check.checkedAt}' />"><c:out value="${date:relative(check.checkedAt)}" /></span></td>
+            <td>
+              <c:set var="uptime" value="${uptimeByService[check.serviceName]}"/>
+              <c:choose>
+                <c:when test="${empty uptime}">&#8212;</c:when>
+                <c:otherwise><fmt:formatNumber value="${uptime}" maxFractionDigits="1"/>%</c:otherwise>
+              </c:choose>
+            </td>
+            <td><c:out value="${check.errorMessage}"/></td>
+          </tr>
+        </c:forEach>
+      </tbody>
+    </table>
+  </c:otherwise>
+</c:choose>
+<p class="small">
+  Checks readiness for the two dependencies that can go unhealthy after startup (database, file store) --
+  see the <code>/healthz</code> endpoint for the combined readiness probe used by load balancers and
+  container orchestration. History is kept for 30 days.
+</p>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -425,6 +425,9 @@
             <li<c:if test="${pageRenderInfo.name eq '/admin'}"> class="is-active"</c:if>><a href="${ctx}/admin"><i class="${font:far()} fa-home fa-fw"></i> <span>Welcome</span></a></li>
             <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/documentation')}"> class="is-active"</c:if>><a href="${ctx}/admin/documentation/wiki/Home"><i class="${font:far()} fa-book fa-fw"></i> <span>Documentation</span></a></li>
             <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/activity')}"> class="is-active"</c:if>><a href="${ctx}/admin/activity"><i class="${font:far()} fa-exchange-alt fa-fw"></i> <span>Activity</span></a></li>
+            <c:if test="${userSession.hasRole('admin')}">
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/health-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/health-dashboard"><i class="${font:far()} fa-heart-pulse fa-fw"></i> <span>System Health</span></a></li>
+            </c:if>
           </ul>
           <%-- Community menu --%>
           <c:if test="${userSession.hasRole('admin') || userSession.hasRole('community-manager')}">

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1690,6 +1690,17 @@
     </section>
   </page>
 
+  <page name="/admin/health-dashboard" role="admin" title="System Health">
+    <section>
+      <column class="small-12 cell">
+        <widget name="healthDashboard">
+          <icon>fa-heart-pulse</icon>
+          <title>System Health</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/analytics-retention" role="admin" capability="admin:manage" title="Analytics Retention">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -266,6 +266,7 @@
   <widget name="salesTaxNexusAddressForm" class="com.simisinc.platform.presentation.widgets.admin.ecommerce.SalesTaxNexusAddressFormWidget" />
   <widget name="xapiStatementList" class="com.simisinc.platform.presentation.widgets.admin.xapi.XapiStatementListWidget" />
   <widget name="auditLogList" class="com.simisinc.platform.presentation.widgets.admin.audit.AuditLogListWidget" />
+  <widget name="healthDashboard" class="com.simisinc.platform.presentation.widgets.admin.HealthDashboardWidget" />
   <!-- Not implemented -->
   <widget name="profilePhoto" class="com.simisinc.platform.presentation.widgets.GenericWidget" />
   <widget name="profileDetails" class="com.simisinc.platform.presentation.widgets.GenericWidget" />

--- a/src/test/java/com/simisinc/platform/application/HealthCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/HealthCommandTest.java
@@ -16,7 +16,9 @@
 
 package com.simisinc.platform.application;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -25,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 
 import jakarta.servlet.ServletContext;
 
@@ -105,6 +108,56 @@ class HealthCommandTest {
       assertTrue(HealthCommand.isReady(contextWithStartup("true")));
       // A single failing check (here: startup not complete) makes the whole probe report DOWN
       assertFalse(HealthCommand.isReady(contextWithStartup(null)));
+    }
+  }
+
+  @Test
+  void checkDatabaseReportsUpWithNoErrorMessage() throws SQLException {
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(true);
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      db.when(DB::getConnection).thenReturn(connection);
+      HealthCommand.CheckResult result = HealthCommand.checkDatabase();
+      assertEquals(HealthCommand.DATABASE_SERVICE, result.getServiceName());
+      assertTrue(result.isUp());
+      assertNull(result.getErrorMessage());
+      assertTrue(result.getResponseTimeMs() >= 0);
+    }
+  }
+
+  @Test
+  void checkDatabaseReportsDownWithTheExceptionMessage() throws SQLException {
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      db.when(DB::getConnection).thenThrow(new SQLException("db is gone"));
+      HealthCommand.CheckResult result = HealthCommand.checkDatabase();
+      assertFalse(result.isUp());
+      assertEquals("db is gone", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void checkFileStoreReportsDownWithAReasonWhenUnconfigured() {
+    try (MockedStatic<FileSystemCommand> fs = mockStatic(FileSystemCommand.class)) {
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn("");
+      HealthCommand.CheckResult result = HealthCommand.checkFileStore();
+      assertEquals(HealthCommand.FILESYSTEM_SERVICE, result.getServiceName());
+      assertFalse(result.isUp());
+      assertEquals("File store root path is not configured", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void runAllChecksReturnsOneResultPerService() throws SQLException {
+    Connection connection = mock(Connection.class);
+    when(connection.isValid(anyInt())).thenReturn(true);
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<FileSystemCommand> fs = mockStatic(FileSystemCommand.class)) {
+      db.when(DB::getConnection).thenReturn(connection);
+      fs.when(FileSystemCommand::getFileServerRootPath).thenReturn(System.getProperty("java.io.tmpdir"));
+
+      List<HealthCommand.CheckResult> results = HealthCommand.runAllChecks();
+      assertEquals(2, results.size());
+      assertTrue(results.stream().allMatch(HealthCommand.CheckResult::isUp));
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepositoryTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies the latest-per-service and uptime-percentage queries against a real PostgreSQL instance,
+ * since DISTINCT ON and interval-window aggregation cannot be exercised meaningfully with a mock.
+ * Skipped automatically when Docker is not available, matching SearchAnalyticsRepositoryTest's
+ * pattern. deleteOld() is a single unconditional DB.deleteFrom call with a fixed interval (no site
+ * property lookup, unlike SearchAnalyticsRepository.deleteOld()), so it is exercised directly here.
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+class SystemHealthCheckRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping SystemHealthCheckRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE system_health_checks RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset system_health_checks table", se);
+    }
+  }
+
+  @Test
+  void saveInsertsARetrievableRow() {
+    SystemHealthCheck saved = addCheck("database", true, 12, null);
+
+    assertTrue(saved.getId() > 0);
+  }
+
+  @Test
+  void findLatestPerServiceReturnsOnlyTheMostRecentRowForEachService() {
+    addCheck("database", true, 10, null);
+    SystemHealthCheck latestDatabase = addCheck("database", false, 999, "connection refused");
+    addCheck("filesystem", true, 5, null);
+
+    List<SystemHealthCheck> latest = SystemHealthCheckRepository.findLatestPerService();
+
+    assertEquals(2, latest.size());
+    SystemHealthCheck databaseResult = latest.stream()
+        .filter(c -> "database".equals(c.getServiceName())).findFirst().orElseThrow();
+    assertEquals(latestDatabase.getId(), databaseResult.getId());
+    assertEquals("connection refused", databaseResult.getErrorMessage());
+  }
+
+  @Test
+  void findUptimePercentComputesThePassRateWithinTheWindow() {
+    addCheck("database", true, 10, null);
+    addCheck("database", true, 10, null);
+    addCheck("database", false, 10, "timeout");
+
+    Double uptime = SystemHealthCheckRepository.findUptimePercent("database", 24);
+
+    assertEquals(66.67, uptime, 0.01);
+  }
+
+  @Test
+  void findUptimePercentIsNullWhenNoChecksExistInTheWindow() {
+    Double uptime = SystemHealthCheckRepository.findUptimePercent("database", 24);
+
+    assertNull(uptime);
+  }
+
+  @Test
+  void findUptimePercentExcludesChecksOutsideTheWindow() {
+    SystemHealthCheck old = addCheck("database", false, 10, "old failure");
+    backdate(old.getId(), 48);
+    addCheck("database", true, 10, null);
+
+    Double uptime = SystemHealthCheckRepository.findUptimePercent("database", 24);
+
+    assertEquals(100.0, uptime, 0.01);
+  }
+
+  @Test
+  void deleteOldKeepsChecksWithinThirtyDaysAndRemovesOlderOnes() {
+    // Two different service_names on purpose: findLatestPerService()'s DISTINCT ON collapses to
+    // one row per service regardless of how many raw rows exist for it, so asserting against that
+    // method cannot detect whether deleteOld() actually deleted anything. A direct row count can.
+    SystemHealthCheck justInsideRetention = addCheck("database", true, 10, null);
+    backdate(justInsideRetention.getId(), 29 * 24);
+    SystemHealthCheck justOutsideRetention = addCheck("filesystem", true, 5, null);
+    backdate(justOutsideRetention.getId(), 31 * 24);
+
+    SystemHealthCheckRepository.deleteOld();
+
+    assertEquals(1, countRows());
+    List<SystemHealthCheck> remaining = SystemHealthCheckRepository.findLatestPerService();
+    assertEquals(1, remaining.size());
+    assertEquals("database", remaining.get(0).getServiceName());
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS system_health_checks CASCADE");
+      statement.execute("CREATE TABLE system_health_checks ("
+          + "system_health_check_id BIGSERIAL PRIMARY KEY, "
+          + "service_name VARCHAR(50) NOT NULL, "
+          + "status VARCHAR(10) NOT NULL, "
+          + "response_time_ms INTEGER, "
+          + "error_message VARCHAR(500), "
+          + "checked_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the system_health_checks schema", se);
+    }
+  }
+
+  private static SystemHealthCheck addCheck(String serviceName, boolean up, int responseTimeMs, String errorMessage) {
+    SystemHealthCheck record = new SystemHealthCheck();
+    record.setServiceName(serviceName);
+    record.setStatus(up ? SystemHealthCheck.STATUS_UP : SystemHealthCheck.STATUS_DOWN);
+    record.setResponseTimeMs(responseTimeMs);
+    record.setErrorMessage(errorMessage);
+    return SystemHealthCheckRepository.save(record);
+  }
+
+  private static long countRows() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT COUNT(*) FROM system_health_checks")) {
+      rs.next();
+      return rs.getLong(1);
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not count system_health_checks rows", se);
+    }
+  }
+
+  private static void backdate(long id, int hoursAgo) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "UPDATE system_health_checks SET checked_at = NOW() - INTERVAL '" + hoursAgo + " hours' "
+                + "WHERE system_health_check_id = ?")) {
+      pst.setLong(1, id);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not backdate row " + id, se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthJobTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/cms/SystemHealthJobTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.HealthCommand;
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.cms.SystemHealthCheckRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Verifies {@link SystemHealthJob#execute}'s control flow: the lock guard, and that every
+ * HealthCommand check result gets persisted with the right status mapping. {@link LockManager},
+ * {@link HealthCommand}, and {@link SystemHealthCheckRepository} are all statically mocked, so
+ * nothing here touches a database.
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+class SystemHealthJobTest {
+
+  @Test
+  void executeSavesOneRecordPerCheckResult() {
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<HealthCommand> healthCommand = mockStatic(HealthCommand.class);
+        MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.SYSTEM_HEALTH_JOB), any(Duration.class)))
+          .thenReturn("lock-uuid");
+      healthCommand.when(HealthCommand::runAllChecks).thenReturn(List.of(
+          new HealthCommand.CheckResult(HealthCommand.DATABASE_SERVICE, true, 12, null),
+          new HealthCommand.CheckResult(HealthCommand.FILESYSTEM_SERVICE, false, 5, "not writable")));
+
+      SystemHealthJob.execute();
+
+      repository.verify(() -> SystemHealthCheckRepository.save(argThat(
+          record -> HealthCommand.DATABASE_SERVICE.equals(record.getServiceName())
+              && record.isUp() && record.getResponseTimeMs() == 12 && record.getErrorMessage() == null)));
+      repository.verify(() -> SystemHealthCheckRepository.save(argThat(
+          record -> HealthCommand.FILESYSTEM_SERVICE.equals(record.getServiceName())
+              && !record.isUp() && "not writable".equals(record.getErrorMessage()))));
+      repository.verify(() -> SystemHealthCheckRepository.save(any(SystemHealthCheck.class)), times(2));
+    }
+  }
+
+  @Test
+  void executeSkipsEntirelyWhenTheLockIsHeldByAnotherNode() {
+    try (MockedStatic<LockManager> lockManager = mockStatic(LockManager.class);
+        MockedStatic<HealthCommand> healthCommand = mockStatic(HealthCommand.class)) {
+      lockManager.when(() -> LockManager.lock(eq(SchedulerManager.SYSTEM_HEALTH_JOB), any(Duration.class)))
+          .thenReturn(null);
+
+      SystemHealthJob.execute();
+
+      healthCommand.verifyNoInteractions();
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/HealthDashboardWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/HealthDashboardWidgetTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.HealthCommand;
+import com.simisinc.platform.domain.model.cms.SystemHealthCheck;
+import com.simisinc.platform.infrastructure.persistence.cms.SystemHealthCheckRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS
+ * @created 7/30/2026
+ */
+class HealthDashboardWidgetTest extends WidgetBase {
+
+  private static SystemHealthCheck check(String serviceName, boolean up) {
+    SystemHealthCheck record = new SystemHealthCheck();
+    record.setServiceName(serviceName);
+    record.setStatus(up ? SystemHealthCheck.STATUS_UP : SystemHealthCheck.STATUS_DOWN);
+    record.setResponseTimeMs(10);
+    return record;
+  }
+
+  @Test
+  void executeLoadsLatestChecksAndUptimeForAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+    List<SystemHealthCheck> latest = List.of(check("database", true), check("filesystem", false));
+
+    try (MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      repository.when(SystemHealthCheckRepository::findLatestPerService).thenReturn(latest);
+      repository.when(() -> SystemHealthCheckRepository.findUptimePercent("database", 24)).thenReturn(100.0);
+      repository.when(() -> SystemHealthCheckRepository.findUptimePercent("filesystem", 24)).thenReturn(50.0);
+
+      WidgetContext result = new HealthDashboardWidget().execute(widgetContext);
+
+      assertEquals("/admin/health-dashboard.jsp", result.getJsp());
+      assertEquals(latest, result.getRequest().getAttribute("latestChecks"));
+      @SuppressWarnings("unchecked")
+      Map<String, Double> uptimeByService = (Map<String, Double>) result.getRequest().getAttribute("uptimeByService");
+      assertEquals(100.0, uptimeByService.get("database"));
+      assertEquals(50.0, uptimeByService.get("filesystem"));
+    }
+  }
+
+  @Test
+  void executeHandlesNoChecksHavingRunYet() {
+    // The real state right after a fresh install/deploy, before SystemHealthJob's first
+    // Cron.minutely() run has persisted anything -- health-dashboard.jsp has a dedicated
+    // "No health checks have run yet" branch for exactly this.
+    setRoles(widgetContext, ADMIN);
+
+    try (MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      repository.when(SystemHealthCheckRepository::findLatestPerService).thenReturn(List.of());
+
+      WidgetContext result = new HealthDashboardWidget().execute(widgetContext);
+
+      assertEquals("/admin/health-dashboard.jsp", result.getJsp());
+      assertEquals(List.of(), result.getRequest().getAttribute("latestChecks"));
+      @SuppressWarnings("unchecked")
+      Map<String, Double> uptimeByService = (Map<String, Double>) result.getRequest().getAttribute("uptimeByService");
+      assertTrue(uptimeByService.isEmpty());
+      repository.verify(() -> SystemHealthCheckRepository.findUptimePercent(anyString(), anyInt()), never());
+    }
+  }
+
+  @Test
+  void executeDoesNothingForAUserWithoutAdmin() {
+    // WidgetBase's default logged-in test user has no roles at all
+    try (MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      WidgetContext result = new HealthDashboardWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+      repository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postRunCheckNowSavesEveryCheckResultAndRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "runCheckNow");
+
+    try (MockedStatic<HealthCommand> healthCommand = mockStatic(HealthCommand.class);
+        MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      healthCommand.when(HealthCommand::runAllChecks).thenReturn(List.of(
+          new HealthCommand.CheckResult(HealthCommand.DATABASE_SERVICE, true, 8, null),
+          new HealthCommand.CheckResult(HealthCommand.FILESYSTEM_SERVICE, true, 3, null)));
+
+      WidgetContext result = new HealthDashboardWidget().post(widgetContext);
+
+      repository.verify(() -> SystemHealthCheckRepository.save(any(SystemHealthCheck.class)), times(2));
+      assertEquals("/admin/health-dashboard", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postDoesNothingForAUserWithoutAdmin() {
+    addQueryParameter(widgetContext, "command", "runCheckNow");
+
+    try (MockedStatic<HealthCommand> healthCommand = mockStatic(HealthCommand.class)) {
+      WidgetContext result = new HealthDashboardWidget().post(widgetContext);
+
+      assertNull(result.getRedirect());
+      healthCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postIgnoresAnUnrecognizedCommandButStillRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "somethingElse");
+
+    try (MockedStatic<HealthCommand> healthCommand = mockStatic(HealthCommand.class);
+        MockedStatic<SystemHealthCheckRepository> repository = mockStatic(SystemHealthCheckRepository.class)) {
+      WidgetContext result = new HealthDashboardWidget().post(widgetContext);
+
+      healthCommand.verify(HealthCommand::runAllChecks, never());
+      repository.verify(() -> SystemHealthCheckRepository.save(any()), never());
+      assertEquals("/admin/health-dashboard", result.getRedirect());
+    }
+  }
+}


### PR DESCRIPTION
Closes #466.

## Summary
`HealthCommand`'s `/healthz` readiness probe already checks database reachability and file-store writability (`isReady()`), but nothing surfaced the individual results anywhere — admins had no way to see current or historical per-service health. This adds an admin-only dashboard backed by real, persisted check history.

- Extended `HealthCommand` with per-check timing/error detail (`checkDatabase()`/`checkFileStore()`/`runAllChecks()`), refactored from the existing logic without changing `isReady()`'s behavior — the production readiness probe is unaffected.
- New `system_health_checks` table, populated every minute by a rewritten `SystemHealthJob` (previously a disabled no-op, `SchedulerManager.java:159`) and pruned after 30 days by a new `SystemHealthCheckCleanupJob`. Both run under the existing `LockManager`-guarded "once across replicas" scheduling section.
- New `/admin/health-dashboard` page (`HealthDashboardWidget` + JSP): per-service UP/DOWN status, response time, relative last-checked time, 24h uptime %, and a manual "Run Check Now" action (reusing the existing `confirmPostAction()` + CSRF-token pattern). 30-second auto-refresh via `<meta http-equiv="refresh">`.
- Registered in `widget-library.xml` / `admin-layout.xml` (role="admin") / a new nav link in the top-level Admin section of `main.jsp`.

**Deliberately out of scope** (flagged as lower-value in the originating ticket audit, not required for this issue): a true separate liveness endpoint, admin alerting on unhealthy state, and additional checks beyond database/filesystem (no other real dependency — e.g. no Redis/external cache — exists in this deployment to check).

## Test plan
- [x] `HealthCommandTest` extended (new `CheckResult`/`runAllChecks()` coverage) — existing `isReady()`/`databaseReachable()`/`fileStoreWritable()` tests pass unchanged, confirming the refactor preserves behavior
- [x] New `SystemHealthCheckRepositoryTest` (Testcontainers Postgres) — including a mutation-tested 30-day retention boundary test (verified it fails against a deliberately broken `deleteOld()`, then confirmed the real implementation passes)
- [x] New `SystemHealthJobTest` / `HealthDashboardWidgetTest` (Mockito) — 23 new/changed tests total, all independently verified passing via the JUnit Platform Console Launcher (this machine's local `ant ci-test` has a pre-existing, unrelated JaCoCo/JDK-bytecode-version incompatibility that produces false failures with no real stack trace on tests mocking JDK classes — confirmed present on a clean `origin/main` checkout too, not something this PR introduced or something present in real CI)
- [x] `compile-jsp` gate and `tools/check-unescaped-el.py` gate both pass clean (0 unallowlisted EL sites)
- [x] Adversarial code review pass (Workflow, 3 dimensions × verification) — 2 real findings, both fixed: a test-coverage gap where the retention-boundary test couldn't actually detect a broken `deleteOld()`, and missing coverage for the dashboard's empty-state (no checks run yet) path
- [x] Live Docker rehearsal: logged in as admin, dashboard renders real end-to-end data (job → repository → widget → JSP), nav link highlights correctly, "Run Check Now" POST endpoint verified correct (command/token wiring inspected directly; the confirm() dialog itself is out-of-scope shared infra already used elsewhere in this codebase)