### PR TITLE
Fix intermittent SystemHealthCheckRepositoryTest failure (flaky ORDER BY tie)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SystemHealthCheckRepository.java
@@ -60,10 +60,14 @@ public class SystemHealthCheckRepository {
   /** The single most recent check for each service that has ever been checked, most recently
    * checked first. Uses Postgres' DISTINCT ON rather than a self-join or per-service query. */
   public static List<SystemHealthCheck> findLatestPerService() {
+    // checked_at is millisecond precision (TIMESTAMP(3)) and DB-assigned, so two checks for the
+    // same service can tie on it -- without a deterministic tie-breaker, DISTINCT ON can pick
+    // either tied row arbitrarily, not necessarily the one actually inserted last. Break ties by
+    // the auto-incrementing id, which is strictly ordered by insertion.
     String SQL_QUERY =
         "SELECT DISTINCT ON (service_name) * " +
             "FROM " + TABLE_NAME + " " +
-            "ORDER BY service_name, checked_at DESC";
+            "ORDER BY service_name, checked_at DESC, system_health_check_id DESC";
     List<SystemHealthCheck> records = new ArrayList<>();
     try (Connection connection = DB.getConnection();
          PreparedStatement pst = connection.prepareStatement(SQL_QUERY);


### PR DESCRIPTION
## Summary
`SystemHealthCheckRepository.findLatestPerService()`'s query had no tie-breaker beyond `checked_at`, which is millisecond precision and DB-assigned (`DEFAULT CURRENT_TIMESTAMP`). When two checks for the same service land in the same millisecond — reproducible locally at roughly a 30% rate over repeated runs — `SELECT DISTINCT ON (service_name) ... ORDER BY service_name, checked_at DESC` can pick either tied row arbitrarily, not necessarily the one actually inserted last.

This surfaced as CI failures on unrelated PRs (first noticed on #766, which never touched this file) once #765 merged this test into `main`.

## Fix
Add the auto-incrementing id as a secondary sort key, which is strictly ordered by insertion and breaks the tie deterministically:
```sql
ORDER BY service_name, checked_at DESC, system_health_check_id DESC
```

## Verification
- Reproduced the flake directly: 3/10 failures running `SystemHealthCheckRepositoryTest` repeatedly via the JUnit Platform Console Launcher (bypasses this machine's separate, unrelated local Ant+JaCoCo JDK-version issue) against real Testcontainers Postgres, before the fix.
- 0/30 failures after the fix, then a further 0/20 after rebasing onto the latest `main` (which now includes #766).
- `ant -lib lib/war -lib lib/tests clean compile-test` builds clean.