### PR TITLE
Fix: a pending draft on a live page takes it offline for the public

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -225,13 +225,11 @@ public class PageServlet extends HttpServlet {
       WebPage webPage = LoadWebPageCommand.loadByLink(pagePath);
       if (webPage != null) {
         // Determine if this is a draft page
-        if (webPage.getDraft()) {
-          if (!userSession.hasRole("admin") && !userSession.hasRole("content-manager")) {
-            LOG.error("DRAFT FOUND, no access: " + pagePath + " " + request.getRemoteAddr());
-            controllerSession.clearAllWidgetData();
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
-          }
+        if (isDraftBlockedFromPublicAccess(webPage, userSession)) {
+          LOG.error("DRAFT FOUND, no access: " + pagePath + " " + request.getRemoteAddr());
+          controllerSession.clearAllWidgetData();
+          response.sendError(HttpServletResponse.SC_NOT_FOUND);
+          return;
         }
         // Enforce publish schedule and expiry for non-editors
         if (!userSession.hasRole("admin") && !userSession.hasRole("content-manager")) {
@@ -1351,6 +1349,21 @@ public class PageServlet extends HttpServlet {
    */
   static boolean isFormTokenValid(String requestToken, String sessionToken) {
     return StringUtils.isNotEmpty(requestToken) && sessionToken != null && sessionToken.equals(requestToken);
+  }
+
+  /**
+   * A pending draft (draftPageXml) must not take an already-published page offline for the
+   * public: retrievePageForRequest() below always renders from pageXml, and draftPageXml is only
+   * ever substituted in for a layout builder previewing in edit mode (see the pageEditMode block
+   * further down) -- so a non-blank pageXml means there is still valid, unaffected published
+   * content to serve. Only a page that has never been published (pageXml blank) should 404 here
+   * for a non-editor while draft is true.
+   */
+  static boolean isDraftBlockedFromPublicAccess(WebPage webPage, UserSession userSession) {
+    if (!webPage.getDraft() || StringUtils.isNotBlank(webPage.getPageXml())) {
+      return false;
+    }
+    return !userSession.hasRole("admin") && !userSession.hasRole("content-manager");
   }
 
   private static int intParam(HttpServletRequest request, String name, int defaultValue) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -37,7 +37,9 @@ import org.mockito.MockedStatic;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
+import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.SocialMediaLink;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.FaqQuestion;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.items.Collection;
@@ -456,5 +458,84 @@ class PageServletTest {
 
     assertEquals("https://example.org/items/staff/jane-doe",
         PageServlet.computeCanonicalUrl("https://example.org", "/items/staff/jane-doe", null, item, collection));
+  }
+
+  /** A logged-in session whose user holds exactly the given role codes. */
+  private UserSession sessionWithRoles(String... roleCodes) {
+    List<Role> roles = new ArrayList<>();
+    for (String code : roleCodes) {
+      roles.add(new Role(code, code));
+    }
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(roles);
+    user.setGroupList(new ArrayList<>());
+    UserSession session = new UserSession();
+    session.login(user);
+    return session;
+  }
+
+  /** A not-logged-in (guest) session. */
+  private UserSession guestSession() {
+    return new UserSession();
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessAllowsAGuestToKeepSeeingAnAlreadyPublishedPageWithAPendingDraft() {
+    // Regression test: an editor drafting layout changes on a live page (SaveDraftLayoutCommand /
+    // MutateLayoutCommand) sets draft=true on the SAME row that still holds the published pageXml.
+    // That pending draft must not take the live page offline for the public.
+    WebPage webPage = new WebPage();
+    webPage.setDraft(true);
+    webPage.setPageXml("<page><section/></page>");
+
+    assertFalse(PageServlet.isDraftBlockedFromPublicAccess(webPage, guestSession()));
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessBlocksAGuestFromABrandNewNeverPublishedPage() {
+    // A page that has never been published (no pageXml yet) has nothing valid to serve publicly,
+    // so it must still 404 for a non-editor while it's draft-only.
+    WebPage webPage = new WebPage();
+    webPage.setDraft(true);
+    webPage.setPageXml(null);
+
+    assertTrue(PageServlet.isDraftBlockedFromPublicAccess(webPage, guestSession()));
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessBlocksAGuestFromABrandNewPageWithBlankPageXml() {
+    WebPage webPage = new WebPage();
+    webPage.setDraft(true);
+    webPage.setPageXml("   ");
+
+    assertTrue(PageServlet.isDraftBlockedFromPublicAccess(webPage, guestSession()));
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessNeverBlocksAnAdminRegardlessOfPageXml() {
+    WebPage neverPublished = new WebPage();
+    neverPublished.setDraft(true);
+    neverPublished.setPageXml(null);
+
+    assertFalse(PageServlet.isDraftBlockedFromPublicAccess(neverPublished, sessionWithRoles("admin")));
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessNeverBlocksAContentManagerRegardlessOfPageXml() {
+    WebPage neverPublished = new WebPage();
+    neverPublished.setDraft(true);
+    neverPublished.setPageXml(null);
+
+    assertFalse(PageServlet.isDraftBlockedFromPublicAccess(neverPublished, sessionWithRoles("content-manager")));
+  }
+
+  @Test
+  void isDraftBlockedFromPublicAccessReturnsFalseWhenThePageIsNotADraft() {
+    WebPage webPage = new WebPage();
+    webPage.setDraft(false);
+    webPage.setPageXml(null);
+
+    assertFalse(PageServlet.isDraftBlockedFromPublicAccess(webPage, guestSession()));
   }
 }


### PR DESCRIPTION
## Summary

- Making any draft-layout edit to an already-published, live page (add/remove a section/column/widget, or a Save Layout drag-reorder via the P4 composition canvas) sets `draft=true` on the same row that still holds the published `page_xml` — `SaveDraftLayoutCommand.saveDraftLayout()` and `MutateLayoutCommand`'s mutation helpers both do this unconditionally, regardless of whether the page was previously published.
- `PageServlet`'s direct-URL-access check only looked at `webPage.getDraft()`. If true, it 404'd the entire page for every anonymous/non-editor visitor, without checking whether `page_xml` still held valid published content. So the moment an editor makes any draft-layout change to a live page, that page goes offline for the public until the draft is published or discarded.
- `WebPageXmlLayoutCommand.retrievePageForRequest()` always renders from `pageXml`; the draft override (`parseFreshDraft`) only ever substitutes in for a layout builder previewing in edit mode (`pageEditMode && canBuildLayout`). So once the over-eager 404 check is relaxed, the existing render path already does the right thing for both audiences: non-editors keep seeing the last-published content, editors previewing in edit mode see the draft.

Found while auditing #419 (a separate, unimplemented "draft preview mode" feature request) — this is a correctness bug in the existing draft-layout-editing feature shipped as part of #259 (P4), not something #419 itself would fix.

## Fix

- `PageServlet.java`: the draft-page 404 check now also requires `pageXml` to be blank — i.e., only a page that has never been published (no `page_xml` yet) 404s for a non-editor while `draft` is true. An already-published page with a pending draft keeps serving its live content.
- Extracted the check into a new package-private static `isDraftBlockedFromPublicAccess(WebPage, UserSession)` method, matching this file's existing convention for testable decision logic (`isFormTokenValid`, `computeCanonicalUrl`, etc.) — the original check was inline in `service()`, which isn't unit-testable directly.

## Test plan

- [x] New `PageServletTest` coverage (7 cases, none existed for draft handling before this): an already-published page with a pending draft is not blocked for a guest (the regression case); a brand-new draft-only page with null or blank `pageXml` is still blocked for a guest; admin and content-manager roles are never blocked regardless of `pageXml`; a non-draft page is never blocked.
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green (225 test classes, zero failures/errors), rebased onto current `upstream/main` tip before the final run.
- [x] `ant -lib lib/war clean compile` and `ant -lib lib/war compile-jsp` — both clean.
