### PR TITLE
Fix blank Mailing List Spam Rate / Quality Score dashboard tiles

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
@@ -208,6 +208,19 @@ public class SiteStatsWidget extends GenericWidget {
         context.getRequest().setAttribute("asOfDate", new SimpleDateFormat("MMM d, yyyy h:mm a").format(lastClassifiedAt));
       }
       return TABLE_JSP;
+    } else if ("mailing-list-quality-score".equalsIgnoreCase(report)) {
+      double score = MailingListMemberRepository.findQualityScorePercent();
+      context.getRequest().setAttribute("numberValue", String.format("%.1f", score));
+      return CARD_JSP;
+    } else if ("mailing-list-spam-rate-alert".equalsIgnoreCase(report)) {
+      // Same underlying metric as mailing-list-quality-score, just its complement -- one query,
+      // two presentations, so the two tiles can never drift out of sync with each other.
+      double spamRatePercent = 100 - MailingListMemberRepository.findQualityScorePercent();
+      int thresholdPercent = MailingListMemberRepository.resolveQuarantineAlertThresholdPercent(
+          LoadSitePropertyCommand.loadByName("mailing-list.quarantine.alertThresholdPercent"));
+      context.getRequest().setAttribute("numberValue", String.format("%.1f", spamRatePercent));
+      context.getRequest().setAttribute("severity", spamRatePercent > thresholdPercent ? "warning" : "ok");
+      return ALERT_CARD_JSP;
     } else if ("enabled-accounts".equalsIgnoreCase(report)) {
       long count = UserRepository.countEnabledAccounts();
       context.getRequest().setAttribute("numberValue", String.valueOf(count));

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
@@ -676,6 +676,78 @@ class SiteStatsWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeMailingListQualityScore() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>Mailing List Quality Score</title>\n" +
+            "  <report>mailing-list-quality-score</report>\n" +
+            "</widget>");
+
+    try (MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      repository.when(MailingListMemberRepository::findQualityScorePercent).thenReturn(87.5);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("87.5", request.getAttribute("numberValue"));
+  }
+
+  @Test
+  void executeMailingListSpamRateAlertIsOkBelowThreshold() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>Mailing List Spam Rate</title>\n" +
+            "  <report>mailing-list-spam-rate-alert</report>\n" +
+            "</widget>");
+
+    try (MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      // 95% quality -> 5% spam rate, below the default 10% threshold
+      repository.when(MailingListMemberRepository::findQualityScorePercent).thenReturn(95.0);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.quarantine.alertThresholdPercent"))
+          .thenReturn("10");
+      repository.when(() -> MailingListMemberRepository.resolveQuarantineAlertThresholdPercent("10")).thenReturn(10);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("5.0", request.getAttribute("numberValue"));
+    Assertions.assertEquals("ok", request.getAttribute("severity"));
+  }
+
+  @Test
+  void executeMailingListSpamRateAlertIsWarningAboveThreshold() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>Mailing List Spam Rate</title>\n" +
+            "  <report>mailing-list-spam-rate-alert</report>\n" +
+            "</widget>");
+
+    try (MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      // 70% quality -> 30% spam rate, above the default 10% threshold
+      repository.when(MailingListMemberRepository::findQualityScorePercent).thenReturn(70.0);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.quarantine.alertThresholdPercent"))
+          .thenReturn("10");
+      repository.when(() -> MailingListMemberRepository.resolveQuarantineAlertThresholdPercent("10")).thenReturn(10);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("30.0", request.getAttribute("numberValue"));
+    Assertions.assertEquals("warning", request.getAttribute("severity"));
+  }
+
+  @Test
   void executeConversionRate() {
     addPreferencesFromWidgetXml(widgetContext,
         "<widget name=\"siteStats\" class=\"stats card\">\n" +


### PR DESCRIPTION
## Problem

Two admin dashboard tiles render blank:
- **Mailing List Spam Rate** (`/admin` dashboard, `admin-layout.xml`)
- **Mailing List Quality Score** (Site Stats admin page, `admin-layout.xml`)

Both reference report names in `<report>` tags that `SiteStatsWidget.runReport()` no longer handles, so the dispatch falls through to `return null`, `execute()` never calls `context.setJsp(...)`, and the widget silently renders nothing.

## Root cause

`eb43cb40` ("Add automated mailing list quarantine job (issue #564)") added `mailing-list-quality-score` and `mailing-list-spam-rate-alert` branches to `runReport()`, plus regression tests for both. The very next commit, `f9286a21` ("Merge branch 'main' into feature/mailing-list-quarantine-564"), resolved a real conflict at that same insertion point — `main` had concurrently added a `mailing-list-classification-breakdown` branch there via a different PR — by keeping only `main`'s side and silently dropping the feature branch's two `else if` blocks and their tests entirely, with no conflict markers and no build error.

The `MailingListMemberRepository` methods these branches call (`findQualityScorePercent()`, `resolveQuarantineAlertThresholdPercent()`) were separately restored in #655, but nothing called them afterward, so the tiles kept rendering blank.

Corroborating evidence: `SiteStatsWidget.java` still imported `LoadSitePropertyCommand` (now unused — only the dropped branch used it), and `SiteStatsWidgetTest.java` still imported it too despite having no tests for either report name.

## Fix

Restores the two `runReport()` branches and their three regression tests verbatim from `eb43cb40`, positioned alongside the other mailing-list report branches.

## Test plan
- [x] `ant -lib lib/war clean compile` — clean
- [x] `ant -lib lib/war -lib lib/tests ci-test` — full suite green, `SiteStatsWidgetTest` 35/35 passing (32 existing + 3 restored)
- [x] Verified against current `origin/main` before starting (bug confirmed present, methods confirmed present in `MailingListMemberRepository`)