### PR TITLE
Fix: draft layout edits hide published pages from nav menu and search

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommand.java
@@ -45,11 +45,10 @@ public class ValidateUserAccessToWebPageCommand {
     if (webPage == null) {
       return false;
     }
-    // The page is a draft
-    if (webPage.getDraft()) {
-      return false;
-    }
-    // The page is empty
+    // The page has no published content -- either it has never been published, or its content
+    // was cleared. The draft flag alone doesn't mean this: a published page can have draft=true
+    // while pageXml still holds its last-published, still-valid content (see
+    // SaveDraftLayoutCommand/MutateLayoutCommand, which set draft=true without touching pageXml).
     if (StringUtils.isBlank(webPage.getPageXml())) {
       return false;
     }

--- a/src/test/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ValidateUserAccessToWebPageCommandTest.java
@@ -40,9 +40,12 @@ import static org.mockito.Mockito.mockStatic;
  * <p>
  * The role/group primitive this gate leans on ({@code WebComponentCommand.allowsUser}) is covered by
  * WebComponentCommandTest. These tests cover what {@code hasAccess} adds on top of it: the privileged-role
- * bypass, and the checks that a page is loadable, published (not draft), non-empty, and reachable. The
- * data-loading boundary ({@code LoadWebPageCommand}, {@code WebPageXmlLayoutCommand}) is mocked so the real
- * authorization logic runs against controlled page structures.
+ * bypass, and the checks that a page is loadable, has published content, and is reachable. Note that
+ * "has published content" means non-blank {@code pageXml} -- NOT {@code draft == false}. A page can be
+ * published (non-blank {@code pageXml}) while also having an unrelated pending draft layout edit
+ * ({@code draft == true}); that combination must still be accessible. The data-loading boundary
+ * ({@code LoadWebPageCommand}, {@code WebPageXmlLayoutCommand}) is mocked so the real authorization logic
+ * runs against controlled page structures.
  * </p>
  *
  * @author Elizabeth Houser
@@ -115,13 +118,33 @@ class ValidateUserAccessToWebPageCommandTest {
   }
 
   @Test
-  void deniedWhenPageIsDraft() {
-    // Security property: an unpublished draft must never be served to a non-privileged user.
-    WebPage draft = publishedPage("<page/>");
-    draft.setDraft(true);
+  void deniedWhenPageHasNeverBeenPublished() {
+    // Security property: a page with no published content must never be served to a
+    // non-privileged user, even though a draft layout exists for it (draftPageXml is set, but
+    // pageXml -- the only thing ever shown to a non-editor -- is blank).
+    WebPage unpublishedDraft = new WebPage();
+    unpublishedDraft.setDraft(true);
+    unpublishedDraft.setDraftPageXml("<page/>");
     try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class)) {
-      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(draft);
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(unpublishedDraft);
       Assertions.assertFalse(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
+    }
+  }
+
+  @Test
+  void grantedWhenPublishedPageHasAPendingDraftEdit() {
+    // A page that is already published (non-blank pageXml) must stay reachable even while an
+    // editor has an unrelated draft layout change pending. SaveDraftLayoutCommand and
+    // MutateLayoutCommand both set draft=true for this case without ever touching the
+    // already-published pageXml, so draft=true here does NOT mean "unpublished."
+    WebPage webPage = publishedPage("<page/>");
+    webPage.setDraft(true);
+    Page structure = pageStructure(new ArrayList<>()); // no roles required -> public
+    try (MockedStatic<LoadWebPageCommand> load = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageXmlLayoutCommand> layout = mockStatic(WebPageXmlLayoutCommand.class)) {
+      load.when(() -> LoadWebPageCommand.loadByLink(LINK)).thenReturn(webPage);
+      layout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(webPage, LINK)).thenReturn(structure);
+      Assertions.assertTrue(ValidateUserAccessToWebPageCommand.hasAccess(LINK, guestSession()));
     }
   }
 


### PR DESCRIPTION
## Summary
- `ValidateUserAccessToWebPageCommand.hasAccess()` denied access to any page with `draft == true`, without checking whether `pageXml` (the last-published, still-valid content) was non-blank.
- `SaveDraftLayoutCommand` and `MutateLayoutCommand` set `draft=true` for any pending layout edit (add/remove a widget, drag-reorder a section, etc.) without touching `pageXml` -- so a single structural edit to an already-live page silently removed it from the main nav menu (`MainMenuWidget`) and site search results (`WebPageTitleSearchResultsWidget`) for every non-privileged visitor, even though the page still rendered fine by direct URL.
- Same bug shape as the direct-URL-access fix already applied to `PageServlet`. This scopes the equivalent fix to the menu/search access gate.
- Now only denies access when the page has no published content at all (blank `pageXml`), regardless of whether a draft edit happens to be pending.

## Test plan
- [x] Split the existing `deniedWhenPageIsDraft()` test (whose own fixture built a *published* page and only asserted the draft-flag conflation) into two cases: a brand-new, never-published draft (`draftPageXml` set, `pageXml` blank -- still denied) and an already-published page with a pending draft edit (`pageXml` non-blank, `draft=true` -- now granted).
- [x] `ant -lib lib/war -lib lib/tests ci-test` -- full suite green, `ValidateUserAccessToWebPageCommandTest` 10/10 passing
- [x] `ant -lib lib/war compile-jsp` -- JSP syntax gate green
- [x] `.github/scripts/check-security-coverage.sh` -- `ValidateUserAccessToWebPageCommand` at 87.1% (floor 50%)