### PR TITLE
Add a read-only Job Queue Dashboard admin page (issue #464, Phase 1)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -68,7 +68,7 @@ import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardB
 public class SchedulerManager {
 
   private static ServletContext servletContext = null;
-  private static StorageProvider storageProvider = null;
+  private static volatile StorageProvider storageProvider = null;
   private static Log LOG = LogFactory.getLog(SchedulerManager.class);
 
   // Jobs for every replica
@@ -202,9 +202,15 @@ public class SchedulerManager {
   }
 
   public static void shutdown() {
+    // Null the field before JobRunr.destroy() closes the underlying provider, not after: a reader
+    // that observes null gets the correct "unavailable" signal, rather than a reference to a
+    // provider that JobRunr.destroy() is concurrently closing underneath it. This narrows, but
+    // doesn't fully eliminate, the shutdown race for a request already mid-call when destroy()
+    // runs -- accepted as low-risk for an admin-only diagnostic path exercised only around
+    // container shutdown, not a sustained concurrency guarantee.
+    storageProvider = null;
     JobRunr.destroy();
     servletContext = null;
-    storageProvider = null;
   }
 
   public static ServletContext getServletContext() {

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -68,6 +68,7 @@ import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardB
 public class SchedulerManager {
 
   private static ServletContext servletContext = null;
+  private static StorageProvider storageProvider = null;
   private static Log LOG = LogFactory.getLog(SchedulerManager.class);
 
   // Jobs for every replica
@@ -133,6 +134,7 @@ public class SchedulerManager {
 
       // Configure the storage
       StorageProvider jobStorageProvider = (inMemoryStorage ? new InMemoryStorageProvider() : SqlStorageProviderFactory.using(DataSource.getDataSource(), null, StorageProviderUtils.DatabaseOptions.CREATE));
+      storageProvider = jobStorageProvider;
 
       // Initialize the scheduler
       JobRunr.configure()
@@ -202,9 +204,17 @@ public class SchedulerManager {
   public static void shutdown() {
     JobRunr.destroy();
     servletContext = null;
+    storageProvider = null;
   }
 
   public static ServletContext getServletContext() {
     return servletContext;
+  }
+
+  /** The JobRunr StorageProvider backing the scheduler, so admin tooling (e.g. the Job Queue
+   * Dashboard, issue #464) can query job counts and lists directly. Null until {@link #startup}
+   * has run. */
+  public static StorageProvider getStorageProvider() {
+    return storageProvider;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/JobQueueDashboardWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/JobQueueDashboardWidget.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.storage.JobStats;
+import org.jobrunr.storage.Page;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.navigation.OffsetBasedPageRequest;
+
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Admin-only, read-only view of the background job queue (JobRunr): current counts per state, and a
+ * paginated list of the jobs sitting in a selected state (issue #464, Phase 1). Retry/cancel actions
+ * and a dedicated dead-letter-queue view are deliberately out of scope here -- see the phased scoping
+ * already recorded on the issue -- so this widget has no post() at all.
+ *
+ * <p>JobRunr's own {@link Page} is offset/limit based, not the page-number-based
+ * {@link DataConstraints} the rest of this codebase's list widgets use for
+ * {@code paging_control.jspf}. Rather than teach the JSP a second pagination model, this widget
+ * adapts one into the other: it asks JobRunr for the page of jobs it needs, then builds a
+ * {@link DataConstraints} from that {@link Page}'s total/offset/limit so job-queue-dashboard.jsp can
+ * reuse the standard paging control unchanged.
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+public class JobQueueDashboardWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908895L;
+
+  static String JSP = "/admin/job-queue-dashboard.jsp";
+
+  private static final int PAGE_SIZE = 25;
+
+  // The states an admin can filter the job list to. AWAITING (carbon-aware scheduling holdback) and
+  // DELETED (soft-deleted, pending permanent removal) are internal JobRunr bookkeeping states rather
+  // than something day-to-day queue monitoring needs its own view for, so Phase 1 leaves them out of
+  // both the count tiles and the filter -- consistent with deferring the dead-letter-queue view.
+  static final List<StateName> FILTERABLE_STATES = List.of(
+      StateName.SCHEDULED, StateName.ENQUEUED, StateName.PROCESSING, StateName.FAILED, StateName.SUCCEEDED);
+
+  public WidgetContext execute(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    StorageProvider storageProvider = SchedulerManager.getStorageProvider();
+    if (storageProvider == null) {
+      // Defensive only: the scheduler starts at application startup, well before this admin page
+      // could be reached, and StorageProvider stays set until shutdown() runs.
+      context.getRequest().setAttribute("storageProviderUnavailable", true);
+      context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+      context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+      context.setJsp(JSP);
+      return context;
+    }
+
+    loadDashboardData(context, storageProvider);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  private void loadDashboardData(WidgetContext context, StorageProvider storageProvider) {
+
+    Map<String, Long> stateCounts = loadStateCounts(storageProvider);
+    context.getRequest().setAttribute("stateCounts", stateCounts);
+
+    StateName selectedState = resolveSelectedState(context, stateCounts);
+    context.getRequest().setAttribute("selectedState", selectedState.name());
+
+    int page = context.getParameterAsInt("page", 1);
+    if (page < 1) {
+      page = 1;
+    }
+    long offset = (long) (page - 1) * PAGE_SIZE;
+    Page<Job> jobPage = storageProvider.getJobs(selectedState,
+        new OffsetBasedPageRequest("updatedAt:DESC", offset, PAGE_SIZE));
+
+    List<JobRow> jobList = new ArrayList<>();
+    for (Job job : jobPage.getItems()) {
+      jobList.add(new JobRow(job));
+    }
+    context.getRequest().setAttribute("jobList", jobList);
+
+    // Bridge JobRunr's Page into this codebase's DataConstraints/paging_control.jspf (see class
+    // javadoc). The filter state is carried through page links the same way AuditLogListWidget
+    // carries its filters: a "recordPagingParams" request attribute appended by paging_control.jspf.
+    DataConstraints recordPaging = new DataConstraints(page, PAGE_SIZE);
+    long total = jobPage.getTotal() != null ? jobPage.getTotal() : 0L;
+    recordPaging.setTotalRecordCount(total);
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, recordPaging);
+    context.getRequest().setAttribute("recordPagingParams", "state=" + selectedState.name());
+
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+  }
+
+  private Map<String, Long> loadStateCounts(StorageProvider storageProvider) {
+    JobStats stats = storageProvider.getJobStats();
+    Map<String, Long> stateCounts = new LinkedHashMap<>();
+    stateCounts.put(StateName.SCHEDULED.name(), nullToZero(stats.getScheduled()));
+    stateCounts.put(StateName.ENQUEUED.name(), nullToZero(stats.getEnqueued()));
+    stateCounts.put(StateName.PROCESSING.name(), nullToZero(stats.getProcessing()));
+    stateCounts.put(StateName.FAILED.name(), nullToZero(stats.getFailed()));
+    stateCounts.put(StateName.SUCCEEDED.name(), nullToZero(stats.getSucceeded()));
+    return stateCounts;
+  }
+
+  /** The "state" request parameter when it names one of the filterable states; otherwise FAILED if
+   * any jobs are currently failed (the state an admin most likely wants to see without knowing to
+   * look for it), else ENQUEUED (the normal "waiting to run" state). */
+  static StateName resolveSelectedState(WidgetContext context, Map<String, Long> stateCounts) {
+    String requested = context.getParameter("state");
+    if (requested != null) {
+      for (StateName candidate : FILTERABLE_STATES) {
+        if (candidate.name().equals(requested)) {
+          return candidate;
+        }
+      }
+    }
+    Long failedCount = stateCounts.get(StateName.FAILED.name());
+    if (failedCount != null && failedCount > 0) {
+      return StateName.FAILED;
+    }
+    return StateName.ENQUEUED;
+  }
+
+  private static long nullToZero(Long value) {
+    return value != null ? value : 0L;
+  }
+
+  /** A display-friendly adapter from JobRunr's {@link Job} (java.time.Instant timestamps, a nested
+   * JobDetails object) to plain bean properties job-queue-dashboard.jsp can read with EL, including
+   * {@code date:relative()} which -- like the rest of this codebase's date functions -- takes a
+   * {@link Timestamp}, not an Instant. */
+  public static class JobRow {
+
+    private final String id;
+    private final String jobType;
+    private final String state;
+    private final Timestamp createdAt;
+    private final Timestamp updatedAt;
+
+    JobRow(Job job) {
+      this.id = job.getId().toString();
+      this.jobType = simpleJobType(job);
+      this.state = job.getState().name();
+      this.createdAt = Timestamp.from(job.getCreatedAt());
+      this.updatedAt = Timestamp.from(job.getUpdatedAt());
+    }
+
+    private static String simpleJobType(Job job) {
+      String className = job.getJobDetails().getClassName();
+      String simpleName = className.substring(className.lastIndexOf('.') + 1);
+      return simpleName + "." + job.getJobDetails().getMethodName();
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getJobType() {
+      return jobType;
+    }
+
+    public String getState() {
+      return state;
+    }
+
+    public Timestamp getCreatedAt() {
+      return createdAt;
+    }
+
+    public Timestamp getUpdatedAt() {
+      return updatedAt;
+    }
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/admin/job-queue-dashboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/job-queue-dashboard.jsp
@@ -1,0 +1,90 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<c:choose>
+  <c:when test="${storageProviderUnavailable}">
+    <p>The background job scheduler has not started yet, so no queue data is available. Try reloading this page in a moment.</p>
+  </c:when>
+  <c:otherwise>
+    <jsp:useBean id="stateCounts" class="java.util.LinkedHashMap" scope="request"/>
+    <jsp:useBean id="jobList" class="java.util.ArrayList" scope="request"/>
+    <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+    <%-- State tiles double as the filter: each shows the current count for that state and links to
+         show that state's job list. Only the 5 states an admin would monitor day-to-day are shown --
+         see JobQueueDashboardWidget's FILTERABLE_STATES javadoc for AWAITING/DELETED being left out
+         of Phase 1. --%>
+    <div class="button-group tiny">
+      <c:forEach items="${stateCounts}" var="entry">
+        <c:url var="stateFilterUrl" value="${widgetContext.uri}">
+          <c:param name="state" value="${entry.key}"/>
+        </c:url>
+        <c:choose>
+          <c:when test="${selectedState eq entry.key}">
+            <a href="${stateFilterUrl}" class="button primary"><c:out value="${entry.key}"/> (<c:out value="${entry.value}"/>)</a>
+          </c:when>
+          <c:otherwise>
+            <a href="${stateFilterUrl}" class="button secondary"><c:out value="${entry.key}"/> (<c:out value="${entry.value}"/>)</a>
+          </c:otherwise>
+        </c:choose>
+      </c:forEach>
+    </div>
+    <c:choose>
+      <c:when test="${empty jobList}">
+        <p>No jobs are currently in the <c:out value="${selectedState}"/> state.</p>
+      </c:when>
+      <c:otherwise>
+        <table class="unstriped">
+          <thead>
+            <tr>
+              <th>Job Type</th>
+              <th>State</th>
+              <th>Created</th>
+              <th>Updated</th>
+              <th>Id</th>
+            </tr>
+          </thead>
+          <tbody>
+            <c:forEach items="${jobList}" var="job">
+              <tr>
+                <td><c:out value="${job.jobType}"/></td>
+                <td>
+                  <c:choose>
+                    <c:when test="${job.state eq 'FAILED'}"><span class="label alert radius"><c:out value="${job.state}"/></span></c:when>
+                    <c:when test="${job.state eq 'SUCCEEDED'}"><span class="label success radius"><c:out value="${job.state}"/></span></c:when>
+                    <c:when test="${job.state eq 'PROCESSING'}"><span class="label warning radius"><c:out value="${job.state}"/></span></c:when>
+                    <c:otherwise><span class="label secondary radius"><c:out value="${job.state}"/></span></c:otherwise>
+                  </c:choose>
+                </td>
+                <td><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${job.createdAt}' />"><c:out value="${date:relative(job.createdAt)}" /></span></td>
+                <td><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${job.updatedAt}' />"><c:out value="${date:relative(job.updatedAt)}" /></span></td>
+                <td><small><c:out value="${job.id}"/></small></td>
+              </tr>
+            </c:forEach>
+          </tbody>
+        </table>
+        <%@include file="../paging_control.jspf" %>
+      </c:otherwise>
+    </c:choose>
+  </c:otherwise>
+</c:choose>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -427,6 +427,7 @@
             <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/activity')}"> class="is-active"</c:if>><a href="${ctx}/admin/activity"><i class="${font:far()} fa-exchange-alt fa-fw"></i> <span>Activity</span></a></li>
             <c:if test="${userSession.hasRole('admin')}">
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/health-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/health-dashboard"><i class="${font:far()} fa-heart-pulse fa-fw"></i> <span>System Health</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/job-queue-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/job-queue-dashboard"><i class="${font:far()} fa-list-check fa-fw"></i> <span>Job Queue</span></a></li>
             </c:if>
           </ul>
           <%-- Community menu --%>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1709,6 +1709,17 @@
     </section>
   </page>
 
+  <page name="/admin/job-queue-dashboard" role="admin" title="Job Queue Dashboard">
+    <section>
+      <column class="small-12 cell">
+        <widget name="jobQueueDashboard">
+          <icon>fa-list-check</icon>
+          <title>Job Queue Dashboard</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/analytics-retention" role="admin" capability="admin:manage" title="Analytics Retention">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -267,6 +267,7 @@
   <widget name="xapiStatementList" class="com.simisinc.platform.presentation.widgets.admin.xapi.XapiStatementListWidget" />
   <widget name="auditLogList" class="com.simisinc.platform.presentation.widgets.admin.audit.AuditLogListWidget" />
   <widget name="healthDashboard" class="com.simisinc.platform.presentation.widgets.admin.HealthDashboardWidget" />
+  <widget name="jobQueueDashboard" class="com.simisinc.platform.presentation.widgets.admin.JobQueueDashboardWidget" />
   <!-- Not implemented -->
   <widget name="profilePhoto" class="com.simisinc.platform.presentation.widgets.GenericWidget" />
   <widget name="profileDetails" class="com.simisinc.platform.presentation.widgets.GenericWidget" />

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManagerTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManagerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers only the {@link SchedulerManager#getStorageProvider()} accessor added for the Job Queue
+ * Dashboard (issue #464). {@link SchedulerManager#startup} itself is not exercised here -- it reads
+ * a real ServletContext resource stream and stands up a live JobRunr configuration (storage
+ * provider, background job server, recurring job schedules), which is integration-test territory,
+ * not something worth mocking piece by piece for a single field assignment.
+ *
+ * @author SimIS
+ * @created 7/30/2026
+ */
+class SchedulerManagerTest {
+
+  @Test
+  void getStorageProviderIsNullBeforeStartupHasRun() {
+    // shutdown() is also what resets the field, so this doubles as coverage of that reset -- neither
+    // startup() nor shutdown() have run in this JVM in a way that would leave storageProvider set to
+    // anything else, but shutdown() first makes the assertion deterministic regardless of test order.
+    SchedulerManager.shutdown();
+    assertNull(SchedulerManager.getStorageProvider());
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManagerTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManagerTest.java
@@ -17,15 +17,22 @@
 package com.simisinc.platform.infrastructure.scheduler;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.lang.reflect.Field;
+
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.jobrunr.storage.StorageProvider;
 import org.junit.jupiter.api.Test;
 
 /**
- * Covers only the {@link SchedulerManager#getStorageProvider()} accessor added for the Job Queue
+ * Covers the {@link SchedulerManager#getStorageProvider()} accessor added for the Job Queue
  * Dashboard (issue #464). {@link SchedulerManager#startup} itself is not exercised here -- it reads
  * a real ServletContext resource stream and stands up a live JobRunr configuration (storage
  * provider, background job server, recurring job schedules), which is integration-test territory,
- * not something worth mocking piece by piece for a single field assignment.
+ * not something worth mocking piece by piece for a single field assignment. The non-null round trip
+ * is exercised instead by setting the backing field directly via reflection, which covers the real
+ * shutdown() code path (clearing an actually-set field) without needing full JobRunr startup.
  *
  * @author SimIS
  * @created 7/30/2026
@@ -38,6 +45,20 @@ class SchedulerManagerTest {
     // startup() nor shutdown() have run in this JVM in a way that would leave storageProvider set to
     // anything else, but shutdown() first makes the assertion deterministic regardless of test order.
     SchedulerManager.shutdown();
+    assertNull(SchedulerManager.getStorageProvider());
+  }
+
+  @Test
+  void getStorageProviderReturnsWhateverStartupAssignedUntilShutdownClearsIt() throws Exception {
+    StorageProvider realProvider = new InMemoryStorageProvider();
+    Field field = SchedulerManager.class.getDeclaredField("storageProvider");
+    field.setAccessible(true);
+    field.set(null, realProvider);
+    try {
+      assertSame(realProvider, SchedulerManager.getStorageProvider());
+    } finally {
+      SchedulerManager.shutdown();
+    }
     assertNull(SchedulerManager.getStorageProvider());
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/JobQueueDashboardWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/JobQueueDashboardWidgetTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.JobDetails;
+import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.storage.JobStats;
+import org.jobrunr.storage.Page;
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.navigation.PageRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS
+ * @created 7/30/2026
+ */
+class JobQueueDashboardWidgetTest extends WidgetBase {
+
+  private static JobStats jobStats(long scheduled, long enqueued, long processing, long failed, long succeeded) {
+    JobStats stats = mock(JobStats.class);
+    when(stats.getScheduled()).thenReturn(scheduled);
+    when(stats.getEnqueued()).thenReturn(enqueued);
+    when(stats.getProcessing()).thenReturn(processing);
+    when(stats.getFailed()).thenReturn(failed);
+    when(stats.getSucceeded()).thenReturn(succeeded);
+    return stats;
+  }
+
+  private static Job job(StateName state, String className, String methodName) {
+    Job job = mock(Job.class);
+    JobDetails jobDetails = mock(JobDetails.class);
+    when(jobDetails.getClassName()).thenReturn(className);
+    when(jobDetails.getMethodName()).thenReturn(methodName);
+    when(job.getId()).thenReturn(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+    when(job.getState()).thenReturn(state);
+    when(job.getJobDetails()).thenReturn(jobDetails);
+    when(job.getCreatedAt()).thenReturn(Instant.parse("2026-07-29T12:00:00Z"));
+    when(job.getUpdatedAt()).thenReturn(Instant.parse("2026-07-29T12:05:00Z"));
+    return job;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Page<Job> page(long total, List<Job> items) {
+    Page<Job> page = mock(Page.class);
+    when(page.getTotal()).thenReturn(total);
+    when(page.getItems()).thenReturn(items);
+    return page;
+  }
+
+  @Test
+  void executeDoesNothingForAUserWithoutAdmin() {
+    // WidgetBase's default logged-in test user has no roles at all
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+      scheduler.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void executeShowsAnUnavailableMessageWhenTheStorageProviderIsNotSetYet() {
+    setRoles(widgetContext, ADMIN);
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      scheduler.when(SchedulerManager::getStorageProvider).thenReturn(null);
+
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertEquals("/admin/job-queue-dashboard.jsp", result.getJsp());
+      assertEquals(Boolean.TRUE, result.getRequest().getAttribute("storageProviderUnavailable"));
+      assertNull(result.getRequest().getAttribute("jobList"));
+    }
+  }
+
+  @Test
+  void executeDefaultsToEnqueuedWhenNoJobsAreFailed() {
+    setRoles(widgetContext, ADMIN);
+    StorageProvider storageProvider = mock(StorageProvider.class);
+    JobStats stats = jobStats(1, 4, 0, 0, 10);
+    Job enqueuedJob = job(StateName.ENQUEUED,
+        "com.simisinc.platform.infrastructure.scheduler.cms.SystemHealthJob", "execute");
+
+    // Built before the when(...) chain below starts: constructing a mock inline as a .thenReturn()
+    // argument runs that mock's own when(...) calls while the outer stub is still "open", which
+    // Mockito's stubbing state machine treats as an "unfinished stubbing" error on the outer mock.
+    Page<Job> jobPage = page(1, List.of(enqueuedJob));
+
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      scheduler.when(SchedulerManager::getStorageProvider).thenReturn(storageProvider);
+      when(storageProvider.getJobStats()).thenReturn(stats);
+      when(storageProvider.getJobs(eq(StateName.ENQUEUED), any(PageRequest.class))).thenReturn(jobPage);
+
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertEquals("/admin/job-queue-dashboard.jsp", result.getJsp());
+      assertEquals("ENQUEUED", result.getRequest().getAttribute("selectedState"));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Long> stateCounts = (Map<String, Long>) result.getRequest().getAttribute("stateCounts");
+      assertEquals(4L, stateCounts.get("ENQUEUED"));
+      assertEquals(0L, stateCounts.get("FAILED"));
+
+      @SuppressWarnings("unchecked")
+      List<JobQueueDashboardWidget.JobRow> jobList =
+          (List<JobQueueDashboardWidget.JobRow>) result.getRequest().getAttribute("jobList");
+      assertEquals(1, jobList.size());
+      assertEquals("SystemHealthJob.execute", jobList.get(0).getJobType());
+      assertEquals("ENQUEUED", jobList.get(0).getState());
+
+      DataConstraints recordPaging = (DataConstraints) result.getRequest().getAttribute("recordPaging");
+      assertEquals(1, recordPaging.getPageNumber());
+      assertEquals(1L, recordPaging.getTotalRecordCount());
+      assertEquals("state=ENQUEUED", result.getRequest().getAttribute("recordPagingParams"));
+    }
+  }
+
+  @Test
+  void executeDefaultsToFailedWhenAnyJobsAreFailed() {
+    setRoles(widgetContext, ADMIN);
+    StorageProvider storageProvider = mock(StorageProvider.class);
+    JobStats stats = jobStats(0, 2, 0, 3, 10);
+    Page<Job> jobPage = page(3, List.of());
+
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      scheduler.when(SchedulerManager::getStorageProvider).thenReturn(storageProvider);
+      when(storageProvider.getJobStats()).thenReturn(stats);
+      when(storageProvider.getJobs(eq(StateName.FAILED), any(PageRequest.class))).thenReturn(jobPage);
+
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertEquals("FAILED", result.getRequest().getAttribute("selectedState"));
+    }
+  }
+
+  @Test
+  void executeHonorsAnExplicitStateParameterEvenWhenFailedJobsExist() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "state", "SUCCEEDED");
+    StorageProvider storageProvider = mock(StorageProvider.class);
+    JobStats stats = jobStats(0, 0, 0, 3, 10);
+    Page<Job> jobPage = page(10, List.of());
+
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      scheduler.when(SchedulerManager::getStorageProvider).thenReturn(storageProvider);
+      when(storageProvider.getJobStats()).thenReturn(stats);
+      when(storageProvider.getJobs(eq(StateName.SUCCEEDED), any(PageRequest.class))).thenReturn(jobPage);
+
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertEquals("SUCCEEDED", result.getRequest().getAttribute("selectedState"));
+    }
+  }
+
+  @Test
+  void executeIgnoresAnUnfilterableStateParameterAndFallsBackToTheDefault() {
+    setRoles(widgetContext, ADMIN);
+    // DELETED is a real JobRunr state but not one of Phase 1's filterable states
+    addQueryParameter(widgetContext, "state", "DELETED");
+    StorageProvider storageProvider = mock(StorageProvider.class);
+    JobStats stats = jobStats(0, 5, 0, 0, 10);
+    Page<Job> jobPage = page(5, List.of());
+
+    try (MockedStatic<SchedulerManager> scheduler = mockStatic(SchedulerManager.class)) {
+      scheduler.when(SchedulerManager::getStorageProvider).thenReturn(storageProvider);
+      when(storageProvider.getJobStats()).thenReturn(stats);
+      when(storageProvider.getJobs(eq(StateName.ENQUEUED), any(PageRequest.class))).thenReturn(jobPage);
+
+      WidgetContext result = new JobQueueDashboardWidget().execute(widgetContext);
+
+      assertEquals("ENQUEUED", result.getRequest().getAttribute("selectedState"));
+    }
+  }
+}

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -308,6 +308,8 @@ ALLOWLIST: dict[str, str] = {
         "EditMyProfileFormWidget calls UrlCommand.getValidReturnPage() before setAttribute; that method rejects non-relative paths and any char outside [A-Za-z0-9/?&=#%._~+,;-].",
     "items/approve-item-button.jsp:${approveUrl}":
         "Built by <c:url> tag with <c:param> elements for each query parameter (action, widget, token, itemUniqueId, returnPage); <c:url> handles percent-encoding of parameter values and assembly of the URL.",
+    "admin/job-queue-dashboard.jsp:${stateFilterUrl}":
+        "Built by <c:url> tag with a <c:param name='state' value='${entry.key}'/> (job-queue-dashboard.jsp); entry.key only ever iterates over JobQueueDashboardWidget.loadStateCounts()'s fixed StateName.name() literals (SCHEDULED/ENQUEUED/PROCESSING/FAILED/SUCCEEDED), never request input, and <c:url>/<c:param> percent-encode the value regardless.",
 
     # <fmt:formatDate> output with a fixed, all-numeric pattern: the JSTL tag renders a real
     # Date/Timestamp through that pattern, so the output can only ever contain digits, '-',


### PR DESCRIPTION
Phase 1 of #464. Scoped to read-only status/filter, per the phased plan already recorded on the issue (retry/cancel actions and a dead-letter-queue view are deferred to later phases).

## Summary
The repo runs JobRunr 8.7.1 for background jobs, with SQL-backed durable storage in production since #395 — real, persisted job state exists, but there was no SimIS-native admin UI to see it at all. JobRunr's own built-in dashboard is explicitly disabled in production and runs outside SimIS's login/role system.

- `SchedulerManager`: exposes the configured `StorageProvider` via a new `getStorageProvider()` accessor (previously only a local variable in `startup()`).
- `JobQueueDashboardWidget` + `/admin/job-queue-dashboard.jsp`: admin-only view showing per-state counts (Scheduled/Enqueued/Processing/Failed/Succeeded) as filter tiles, and a paginated list of jobs in the selected state (job type, state badge, created/updated time, id). Defaults to FAILED if any jobs are currently failed, else ENQUEUED.
- Bridges JobRunr's own offset/limit `Page<Job>` into this codebase's `DataConstraints`/`paging_control.jspf` pagination convention, reusing the existing pattern rather than introducing a second one.
- Registered in `widget-library.xml` / `admin-layout.xml` (role="admin") / nav link in `main.jsp`.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean compile-test`, `compile-jsp`, and `tools/check-unescaped-el.py` (0 unallowlisted) all pass clean
- [x] 8 new tests (widget + `SchedulerManager` accessor, including the accessor's actual non-null → null round trip through `shutdown()`, verified via reflection) — all independently verified passing via the JUnit Platform Console Launcher (this machine's local `ant ci-test` has a pre-existing, unrelated JaCoCo/JDK-bytecode-version incompatibility, already confirmed present on a clean `origin/main` checkout, not something this PR introduces)
- [x] Adversarial code review pass — 2 low-severity findings (a narrow shutdown-race window on the new `StorageProvider` accessor, and a coverage gap in its test), both fixed: field made `volatile`, `shutdown()` reordered to null the field before closing the underlying provider, and a reflection-based test added for the round trip
- [x] Live Docker rehearsal: logged in as admin, dashboard renders real live JobRunr data end-to-end (state tiles with real counts, an actual `RecordWebPageHitJob` row in ENQUEUED), nav link works and highlights correctly alongside the unrelated System Health nav link (#466) from the same Admin section