### PR TITLE
Fix inverted privileged-role check in web page content search

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
@@ -85,7 +85,7 @@ public class WebPageSearchResultsWidget extends GenericWidget {
     // Determine the web pages that can be searched
     UserSession userSession = context.getUserSession();
     WebPageSpecification webPageSpecification = new WebPageSpecification();
-    if (!context.hasRole("admin") || context.hasRole("content-manager")) {
+    if (shouldRestrictToPublishedSearchableWebPages(context)) {
       webPageSpecification.setSearchable(true);
       webPageSpecification.setDraft(false);
     }
@@ -164,6 +164,11 @@ public class WebPageSearchResultsWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("searchResultList", resultsMap.values());
     return finishRequest(context, resultsMap);
+  }
+
+  // Mirrors isPageInTheNavigation's privileged bypass below.
+  static boolean shouldRestrictToPublishedSearchableWebPages(WidgetContext context) {
+    return !context.hasRole("admin") && !context.hasRole("content-manager");
   }
 
   private boolean isPageInTheNavigation(WidgetContext context, String link, List<MenuTab> menuTabList, List<TableOfContents> tableOfContentsList) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
@@ -42,4 +42,38 @@ class WebPageSearchResultsWidgetTest extends WidgetBase {
     // Mock the results
 //    Assertions.assertEquals(JSP, widgetContext.getJsp());
   }
+
+  // --- shouldRestrictToPublishedSearchableWebPages: mirrors isPageInTheNavigation's privileged
+  // bypass (hasRole("admin") || hasRole("content-manager") means "skip restrictions") ---
+
+  @Test
+  void restrictsAPlainLoggedInUser() {
+    Assertions.assertTrue(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext));
+  }
+
+  @Test
+  void restrictsAGuest() {
+    logout(widgetContext);
+    Assertions.assertTrue(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext));
+  }
+
+  @Test
+  void doesNotRestrictAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+    Assertions.assertFalse(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext));
+  }
+
+  @Test
+  void doesNotRestrictAContentManager() {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    Assertions.assertFalse(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext),
+        "a content-manager is privileged, like isPageInTheNavigation treats it, and must not be restricted");
+  }
+
+  @Test
+  void doesNotRestrictAnAdminWhoIsAlsoAContentManager() {
+    setRoles(widgetContext, ADMIN, CONTENT_MANAGER);
+    Assertions.assertFalse(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext),
+        "an admin+content-manager combination is still privileged");
+  }
 }


### PR DESCRIPTION
## Summary
`WebPageSearchResultsWidget` (the "content" tab of site search) decides which web pages are eligible to appear in results with:

```java
if (!context.hasRole("admin") || context.hasRole("content-manager")) {
  webPageSpecification.setSearchable(true);
  webPageSpecification.setDraft(false);
}
```

That condition is not the negation of this file's own privileged-role pattern (`hasRole("admin") || hasRole("content-manager")`, used a few lines below in `isPageInTheNavigation` to mean "skip restrictions"). Worked out by truth table, the current condition incorrectly applies the restrictive filter to:
- a plain content-manager (no admin role)
- a user who holds **both** admin and content-manager

Only a pure admin with no content-manager role gets the intended unrestricted view. Everyone else privileged is wrongly limited to searchable, non-draft pages.

## Fix
Extracted the check into `shouldRestrictToPublishedSearchableWebPages(WidgetContext)` and corrected it to `!hasRole("admin") && !hasRole("content-manager")`, matching the pattern already used elsewhere in this file and codebase.

## Test plan
- [x] New unit tests cover all four role combinations (guest, plain user, admin, content-manager, admin+content-manager) against the extracted method directly
- [x] Confirmed the two content-manager cases fail against the original condition and pass after the fix
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` green (full suite, no regressions)
- [x] `ant -lib lib/war compile-jsp` green
