### PR TITLE
Fix web page content search hiding published pages with a pending draft

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
@@ -84,12 +84,7 @@ public class WebPageSearchResultsWidget extends GenericWidget {
 
     // Determine the web pages that can be searched
     UserSession userSession = context.getUserSession();
-    WebPageSpecification webPageSpecification = new WebPageSpecification();
-    if (!context.hasRole("admin") || context.hasRole("content-manager")) {
-      webPageSpecification.setSearchable(true);
-      webPageSpecification.setDraft(false);
-    }
-    webPageSpecification.setHasRedirect(false);
+    WebPageSpecification webPageSpecification = buildWebPageSearchSpecification(context);
     List<WebPage> webPageList = WebPageRepository.findAll(webPageSpecification, null);
 
     // Now search the web pages for a matching unique id
@@ -164,6 +159,19 @@ public class WebPageSearchResultsWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("searchResultList", resultsMap.values());
     return finishRequest(context, resultsMap);
+  }
+
+  // Draft is deliberately not filtered here: a page keeps its published page_xml when draft=true
+  // (draft only means it also has a pending edit -- see WebPageRepository.publish(), the only place
+  // that clears page_xml, which always flips draft back to false in the same statement). The
+  // blank-pageXml check later in execute() is what correctly excludes a page that was never published.
+  static WebPageSpecification buildWebPageSearchSpecification(WidgetContext context) {
+    WebPageSpecification webPageSpecification = new WebPageSpecification();
+    if (!context.hasRole("admin") || context.hasRole("content-manager")) {
+      webPageSpecification.setSearchable(true);
+    }
+    webPageSpecification.setHasRedirect(false);
+    return webPageSpecification;
   }
 
   private boolean isPageInTheNavigation(WidgetContext context, String link, List<MenuTab> menuTabList, List<TableOfContents> tableOfContentsList) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
@@ -17,6 +17,8 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
+import com.simisinc.platform.presentation.controller.DataConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -41,5 +43,48 @@ class WebPageSearchResultsWidgetTest extends WidgetBase {
 
     // Mock the results
 //    Assertions.assertEquals(JSP, widgetContext.getJsp());
+  }
+
+  // --- buildWebPageSearchSpecification: draft must never be filtered at the specification level.
+  // A page with draft=true can still be published -- WebPageRepository.publish() is the only thing
+  // that clears page_xml, and it always runs alongside draft going back to false, so an
+  // already-published page's page_xml stays valid regardless of a later pending draft edit. Excluding
+  // draft=true here silently hid a live, published page the moment an editor made any layout tweak to
+  // it. The existing blank-pageXml check further down execute() already excludes pages that have
+  // genuinely never been published, so no replacement filter is needed -- see PR #768/#770 for the
+  // same conflation fixed elsewhere in this codebase. ---
+
+  @Test
+  void doesNotFilterByDraftForANonPrivilegedViewer() {
+    WebPageSpecification specification = WebPageSearchResultsWidget.buildWebPageSearchSpecification(widgetContext);
+    Assertions.assertEquals(DataConstants.UNDEFINED, specification.getDraft(),
+        "a published page can have draft=true (a pending edit) and must still be searchable");
+  }
+
+  @Test
+  void doesNotFilterByDraftForAGuest() {
+    logout(widgetContext);
+    WebPageSpecification specification = WebPageSearchResultsWidget.buildWebPageSearchSpecification(widgetContext);
+    Assertions.assertEquals(DataConstants.UNDEFINED, specification.getDraft());
+  }
+
+  @Test
+  void stillRestrictsToSearchablePagesForANonPrivilegedViewer() {
+    WebPageSpecification specification = WebPageSearchResultsWidget.buildWebPageSearchSpecification(widgetContext);
+    Assertions.assertEquals(DataConstants.TRUE, specification.getSearchable());
+  }
+
+  @Test
+  void doesNotRestrictSearchableForAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+    WebPageSpecification specification = WebPageSearchResultsWidget.buildWebPageSearchSpecification(widgetContext);
+    Assertions.assertEquals(DataConstants.UNDEFINED, specification.getSearchable());
+  }
+
+  @Test
+  void alwaysExcludesRedirects() {
+    setRoles(widgetContext, ADMIN);
+    WebPageSpecification specification = WebPageSearchResultsWidget.buildWebPageSearchSpecification(widgetContext);
+    Assertions.assertEquals(DataConstants.FALSE, specification.getHasRedirect());
   }
 }


### PR DESCRIPTION
## Summary
`WebPageSearchResultsWidget` (the "content" tab of site search) builds its web-page query with:

```java
if (!context.hasRole("admin") || context.hasRole("content-manager")) {
  webPageSpecification.setSearchable(true);
  webPageSpecification.setDraft(false);
}
```

`setDraft(false)` excludes any page with `draft=true` from the specification-level query. But `draft=true` does not mean "unpublished" -- `WebPageRepository.publish()` is the only place that clears `page_xml`, and it always flips `draft` back to `false` in that same statement. So a page that is **already live**, with a **pending draft edit** on top of it, still has valid `page_xml` while `draft=true`. Filtering on `draft=false` here silently removed an already-published page from content search results the instant an editor made any layout tweak to it (`SaveDraftLayoutCommand`/`MutateLayoutCommand` set `draft=true` without touching `page_xml`).

This is the same conflation already fixed in `PageServlet` (#768) and `ValidateUserAccessToWebPageCommand` (#770) -- draft-in-progress was being treated as never-published. It can't be fixed the same way here since this filter runs at the specification/SQL level rather than as a post-load check on an already-loaded page.

## Fix
Removed the `setDraft(false)` call. No replacement filter is needed: `execute()` already has a blank-`pageXml` check further down (used to confirm the page's content actually contains the matching `uniqueId`) that correctly excludes pages that have genuinely never been published, since those have blank `pageXml` regardless of `draft`. Extracted the specification-building block into `buildWebPageSearchSpecification(WidgetContext)` for direct unit testing.

Out of scope for this PR: the role-check condition on the same line (`!hasRole("admin") || hasRole("content-manager")`) has an unrelated, independent bug -- see #775.

## Test plan
- [x] New unit tests assert the built specification never sets `draft` (confirmed red against the original code: expected `UNDEFINED`, got `FALSE`)
- [x] Confirmed `searchable`/`hasRedirect` behavior is unchanged
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` green (full suite, no regressions)
- [x] `ant -lib lib/war compile-jsp` green
