### PR TITLE
Fail fast with a clear error when Ant runs on the wrong JDK

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -69,6 +69,16 @@
 
   <!-- Creates build directories -->
   <target name="prepare" depends="version">
+    <condition property="jdk.version.ok">
+      <equals arg1="${java.specification.version}" arg2="${jdk}"/>
+    </condition>
+    <fail unless="jdk.version.ok">
+This build requires JDK ${jdk} (found JDK ${java.specification.version} at ${java.home}).
+lib/compile/lombok/lombok-1.18.30.jar does not generate annotation-based methods (@Getter/@Setter/etc.)
+on other JDK versions in this Ant/javac setup -- it fails silently, so a JDK mismatch shows up later
+as a misleading "cannot find symbol" compile error instead of a clear version error. Point JAVA_HOME
+at a JDK ${jdk} installation and retry.
+    </fail>
     <mkdir dir="${build.dir}"/>
     <mkdir dir="${target.dir}"/>
     <tstamp />


### PR DESCRIPTION
## Summary
- `lib/compile/lombok/lombok-1.18.30.jar` silently stops generating `@Getter`/`@Setter`/etc. methods when this Ant build runs under a JDK other than the one `build.xml` declares (`jdk` property, currently 21) — reproduced under JDK 26.
- Previously this surfaced many minutes into `compile-test` as a misleading `cannot find symbol getFoo()` error in an unrelated test file, with no indication the real cause was a JDK mismatch.
- `prepare` now checks `java.specification.version` against the `jdk` property and fails immediately with a clear message pointing at the actual cause, before any compilation happens.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean compile-test` under JDK 26 now fails in <1s with a clear "This build requires JDK 21" message instead of the misleading Lombok symbol error.
- [x] Same command under JDK 21 is unaffected: `BUILD SUCCESSFUL`, all test source files compile.
- [x] `ant -lib lib/war clean package` under JDK 21 still builds the WAR successfully.