### PR TITLE
Fix sitemap.xml omitting published pages with a pending draft edit

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/SitemapServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SitemapServlet.java
@@ -277,13 +277,16 @@ public class SitemapServlet extends HttpServlet {
     try {
       WebPageSpecification spec = new WebPageSpecification();
       spec.setEnabled(1);
-      spec.setDraft(0);
       spec.setInSitemap(true);
       List<WebPage> pages = WebPageRepository.findAll(spec, null);
 
       if (pages != null) {
         for (WebPage page : pages) {
-          if (page != null && StringUtils.isNotBlank(page.getLink())) {
+          // Draft is deliberately not filtered here: a page keeps its published page_xml when
+          // draft=true (draft only means it also has a pending edit -- see WebPageRepository.publish(),
+          // the only place that clears page_xml, which always flips draft back to false in the same
+          // statement). Blank pageXml is what correctly excludes a page that has never been published.
+          if (page != null && StringUtils.isNotBlank(page.getLink()) && StringUtils.isNotBlank(page.getPageXml())) {
             String lastmod = page.getModified() != null ? formatDate(page.getModified()) : null;
             long modifiedTimestamp = page.getModified() != null ? page.getModified().getTime() : 0L;
             String changefreq = StringUtils.isNotBlank(page.getSitemapChangeFrequency())

--- a/src/test/java/com/simisinc/platform/presentation/controller/SitemapServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/SitemapServletTest.java
@@ -116,6 +116,9 @@ class SitemapServletTest {
       webPage.setSitemapPriority(priority);
     }
     webPage.setModified(Timestamp.valueOf("2026-03-15 12:30:00"));
+    // Every fixture defaults to published/live content -- tests that specifically need an
+    // unpublished page (blank page_xml) override this explicitly rather than relying on the default.
+    webPage.setPageXml("<page/>");
     return webPage;
   }
 
@@ -216,6 +219,68 @@ class SitemapServletTest {
     }
 
     assertEquals(DataConstants.TRUE, captor.getValue().getInSitemap());
+  }
+
+  // --- draft must never be filtered at the specification level: a page keeps its published
+  // page_xml when draft=true (draft only means it also has a pending edit -- see
+  // WebPageRepository.publish(), the only place that clears page_xml, which always flips draft
+  // back to false in the same statement). Filtering draft=false silently dropped an
+  // already-published page from the sitemap the instant an editor made any layout tweak to it.
+  // Same conflation already fixed for PageServlet (#768), nav/search visibility (#770), and
+  // content search (#776) -- here the specification-level filter has no downstream pageXml check
+  // to fall back on, so one is added below instead of simply deleting the filter. ---
+
+  @Test
+  void doGetDoesNotFilterBySpecificationLevelDraft() throws Exception {
+    List<WebPage> pages = new ArrayList<>();
+    pages.add(webPage("/about", null, null));
+
+    ArgumentCaptor<WebPageSpecification> captor = ArgumentCaptor.forClass(WebPageSpecification.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<ItemRepository> itemRepository = mockStatic(ItemRepository.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadAsMap("site")).thenReturn(siteProperties(true, true));
+      webPageRepository.when(() -> WebPageRepository.findAll(captor.capture(), any())).thenReturn(pages);
+      itemRepository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      new SitemapServlet().doGet(request, response);
+    }
+
+    assertEquals(DataConstants.UNDEFINED, captor.getValue().getDraft(),
+        "a published page can have draft=true (a pending edit) and must still appear in the sitemap");
+  }
+
+  @Test
+  void doGetIncludesAPublishedPageThatHasAPendingDraftEdit() throws Exception {
+    WebPage publishedWithPendingDraft = webPage("/about", null, null);
+    publishedWithPendingDraft.setDraft(true);
+    List<WebPage> pages = new ArrayList<>();
+    pages.add(publishedWithPendingDraft);
+
+    String body = runDoGet(siteProperties(true, true), pages, new ArrayList<>());
+
+    assertTrue(body.contains("<loc>https://example.org/about</loc>"),
+        "an already-published page with a pending draft edit must still appear in the sitemap: " + body);
+  }
+
+  @Test
+  void doGetExcludesAWebPageThatHasNeverBeenPublished() throws Exception {
+    // draft=true with a BLANK page_xml is the one case that must still be excluded: it means the
+    // page has never been published, unlike a live page with a merely-pending draft edit.
+    WebPage neverPublished = webPage("/coming-soon", null, null);
+    neverPublished.setDraft(true);
+    neverPublished.setPageXml(null);
+    List<WebPage> pages = new ArrayList<>();
+    pages.add(neverPublished);
+
+    String body = runDoGet(siteProperties(true, true), pages, new ArrayList<>());
+
+    assertFalse(body.contains("coming-soon"),
+        "a page that has never been published must not be linked from the public sitemap: " + body);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `SitemapServlet` (`/sitemap.xml`) queried web pages with `WebPageSpecification#setDraft(0)`, so any already-published page with a pending draft-layout edit (`draft=true`, but still holding valid `page_xml`) silently disappeared from the sitemap the moment an editor made any layout tweak to it.
- `draft=true` does not mean "never published" — `WebPageRepository.publish()` is the only place that clears `page_xml`, and it always flips `draft` back to `false` in the same statement. Same conflation already fixed for direct-URL access ([#768](https://github.com/SimisRnD/simis-cms/pull/768)) and nav/search visibility ([#770](https://github.com/SimisRnD/simis-cms/pull/770)).
- Unlike those fixes, this call site had no downstream blank-`page_xml` check to fall back on once the specification-level filter was removed, so one was added in the per-page loop to keep genuinely-never-published pages out of the public sitemap.

## Test plan
- [x] Added `SitemapServletTest` coverage: the built specification no longer restricts `draft` (`doGetDoesNotFilterBySpecificationLevelDraft`, fails without the fix), a never-published page (`draft=true`, blank `page_xml`) is still excluded (`doGetExcludesAWebPageThatHasNeverBeenPublished`, fails without the fix), and a published page with a pending draft edit is included (`doGetIncludesAPublishedPageThatHasAPendingDraftEdit`).
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — green
- [x] `ant -lib lib/war compile-jsp` — green
