### PR TITLE
maint: Fail fast when Ant runs on the wrong JDK

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,18 @@
     <format property="val" pattern="yyyy-MM-dd h:mm aa" />
   </tstamp>
 
+  <!-- Fails fast if Ant is not running on the JDK this build requires. Must run before the
+       Lombok-dependent compile step: lib/compile/lombok's annotation processor does not hook
+       into javac under other JDKs, so a JAVA_HOME mismatch here would otherwise surface many
+       steps later as a confusing "cannot find symbol" on Lombok-generated accessors instead
+       of as an immediate, legible error. -->
+  <target name="check-jdk-version">
+    <condition property="jdk.version.ok">
+      <equals arg1="${ant.java.version}" arg2="${jdk}"/>
+    </condition>
+    <fail unless="jdk.version.ok">This build requires JDK ${jdk} (found ${ant.java.version} at ${java.home}). Export JAVA_HOME to your JDK ${jdk} install before running ant.</fail>
+  </target>
+
   <!-- Version for scripts to use -->
   <target name="version">
     <echo message="Project: ${ant.project.name}"/>
@@ -92,7 +104,7 @@
   </target>
 
   <!-- Compiles the source code -->
-  <target name="compile" depends="prepare">
+  <target name="compile" depends="check-jdk-version,prepare">
     <javac srcdir="${src.dir}" source="${jdk}" target="${jdk}"
            destdir="${build.dir}"
            debug="on" debuglevel="lines,source"
@@ -390,7 +402,7 @@
     </checkstyle>
   </target>
 
-  <target name="compile-test" depends="jar">
+  <target name="compile-test" depends="check-jdk-version,jar">
     <!-- Stage ONLY the SQL migrations onto the test classpath. The package target copies them
          into the WAR, but compile does not stage them, so build.dir has no database/ directory
          and the migration test resolves "classpath:database/install" to nothing - finding just


### PR DESCRIPTION
## Summary
- `build.xml` declares `jdk=21`, but nothing enforced it — running Ant under a different JDK compiled successfully except that Lombok's annotation processor silently produced no accessors, so the *first* symptom was a `cannot find symbol getFoo()` deep in test compilation, indistinguishable from a real code bug.
- Adds a `check-jdk-version` target (`<condition>` + `<fail>` comparing `${ant.java.version}` to the `jdk` property) wired in ahead of `compile` and `compile-test`, so a JDK mismatch fails immediately with a clear message instead of a confusing downstream error.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests compile-test` under JDK 26 → fails immediately at `check-jdk-version` with: `This build requires JDK 21 (found 26 at ...). Export JAVA_HOME to your JDK 21 install before running ant.`
- [x] Same command under JDK 21 → `BUILD SUCCESSFUL`, no code changes needed
- [x] `clean compile`, `-lib lib/war compile-jsp`, and `-lib lib/war package` also verified green under JDK 21 on this branch