### PR TITLE
Fix broken media library panel browse (toolbar, install schema, Jackson crash, silent errors, focus trap, clear-search)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -17,6 +17,8 @@
 package com.simisinc.platform.presentation.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
@@ -58,7 +60,14 @@ import java.util.UUID;
 public class MediaApiController extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(MediaApiController.class);
-  private static ObjectMapper objectMapper = new ObjectMapper();
+  // MediaAsset.createdAt/updatedAt/deletedAt are LocalDateTime; without the JSR-310 module
+  // registered, Jackson has no serializer for that type and throws InvalidDefinitionException
+  // the instant a response includes a MediaAsset with a non-null timestamp -- every list/create/
+  // widget-update response path below. WRITE_DATES_AS_TIMESTAMPS is disabled so the field comes
+  // out as a normal ISO-8601 string instead of a [year,month,day,...] array.
+  private static ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new JavaTimeModule())
+      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/src/main/resources/database/install/NEW_10125__new_media_assets.sql
+++ b/src/main/resources/database/install/NEW_10125__new_media_assets.sql
@@ -1,0 +1,43 @@
+-- Issue #771: media_assets/media_asset_usage (added by
+-- UPGRADE_20260726.1004__create_media_assets_table.sql) only ever existed as an upgrade/
+-- migration, so a fresh install never created these tables at all -- MediaAssetRepository's
+-- queries then failed with a SQLException that DB.java logs and swallows, returning an empty
+-- result that looks exactly like "no files yet" instead of a hard failure. Mirrors that upgrade
+-- migration's schema (including the media_asset_usage fix from a later, same-day migration) so a
+-- fresh install has this schema from day one.
+
+-- P5.1: Media Assets Library
+-- Stores uploaded media (images, PDFs) for insertion into content
+CREATE TABLE media_assets (
+  id BIGSERIAL PRIMARY KEY,
+  asset_id VARCHAR(128) NOT NULL UNIQUE,
+  asset_name VARCHAR(512) NOT NULL,
+  asset_type VARCHAR(32) NOT NULL,
+  mime_type VARCHAR(64),
+  file_size_bytes BIGINT NOT NULL,
+  storage_path TEXT NOT NULL,
+  alt_text TEXT NOT NULL,
+  tags TEXT,
+  created_by BIGINT NOT NULL REFERENCES users(user_id),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_media_asset_id ON media_assets(asset_id);
+CREATE INDEX idx_media_created_at ON media_assets(created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX idx_media_type ON media_assets(asset_type) WHERE deleted_at IS NULL;
+CREATE INDEX idx_media_created_by ON media_assets(created_by) WHERE deleted_at IS NULL;
+
+-- Track where media is used in content (enables orphan detection, usage audit)
+CREATE TABLE media_asset_usage (
+  media_usage_id BIGSERIAL PRIMARY KEY,
+  asset_id BIGINT NOT NULL REFERENCES media_assets(id) ON DELETE CASCADE,
+  content_id BIGINT NOT NULL REFERENCES content(content_id) ON DELETE CASCADE,
+  embed_type VARCHAR(32) NOT NULL,
+  used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(asset_id, content_id)
+);
+
+CREATE INDEX idx_usage_asset_id ON media_asset_usage(asset_id);
+CREATE INDEX idx_usage_content_id ON media_asset_usage(content_id);

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -401,6 +401,7 @@
          data-widget-names="<c:out value="${widgetLibraryJson}"/>">
       <span id="sc-editor-toolbar-title">Visual Editor</span>
       <a href="${ctx}/admin/web-page-designer?webPage=<c:out value="${pageRenderInfo.pagePath}"/>" class="button small hollow secondary"><i class="fa fa-fw fa-code"></i> XML</a>
+      <button type="button" id="sc-editor-media-library" class="button small hollow secondary"><i class="fa fa-fw fa-image"></i> Media Library</button>
       <a href="?editMode=false" id="sc-editor-exit" class="button small hollow secondary"><i class="fa fa-fw fa-times"></i> Exit</a>
       <span id="sc-editor-status" aria-live="polite"></span>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
@@ -48,6 +48,10 @@
     <div class="empty" style="display: none;">
       <p>No files found</p>
     </div>
+    <div class="error" style="display: none;" role="alert">
+      <i class="fa fa-exclamation-triangle"></i>
+      <p></p>
+    </div>
     <div class="files" role="presentation"></div>
   </div>
 
@@ -76,10 +80,15 @@
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    display: flex;
+    display: none;
     flex-direction: column;
     z-index: 1000;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  /* Closed by default (above); the toolbar's Media Library button toggles this class to open it. */
+  .media-library-panel.open {
+    display: flex;
   }
 
   .media-panel-header {
@@ -279,7 +288,7 @@
     cursor: not-allowed;
   }
 
-  .loading, .empty {
+  .loading, .empty, .error {
     text-align: center;
     padding: 32px 16px;
     color: #999;
@@ -291,6 +300,16 @@
     font-size: 24px;
     margin-bottom: 12px;
     animation: spin 1s linear infinite;
+  }
+
+  .error {
+    color: #c0392b;
+  }
+
+  .error i {
+    display: block;
+    font-size: 24px;
+    margin-bottom: 12px;
   }
 
   @keyframes spin {
@@ -322,19 +341,31 @@
   const uploadArea = document.getElementById('media-upload-area');
   const fileInput = document.getElementById('media-file-input');
   const pagination = document.getElementById('media-pagination');
+  const toggleBtn = document.getElementById('sc-editor-media-library');
 
   let currentPage = 0;
   const pageSize = 12;
   let allAssets = [];
   let filteredAssets = [];
+  let lastFocusedElement = null;
 
   // Load initial files
   loadFiles();
 
   // Event listeners
   closeBtn.addEventListener('click', () => {
-    panel.style.display = 'none';
+    hideMediaLibrary();
   });
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      if (isOpen()) {
+        hideMediaLibrary();
+      } else {
+        showMediaLibrary();
+      }
+    });
+  }
 
   searchInput.addEventListener('input', (e) => {
     currentPage = 0;
@@ -367,6 +398,7 @@
     loading.style.display = '';
     gridContent.style.display = 'none';
     empty.style.display = 'none';
+    hideErrorState();
 
     const params = new URLSearchParams({
       limit: pageSize,
@@ -377,7 +409,12 @@
     }
 
     fetch('/visual-editor/media?' + params)
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) {
+          throw new Error('Request failed with status ' + r.status);
+        }
+        return r.json();
+      })
       .then(data => {
         filteredAssets = data.assets || [];
         allAssets = data.assets || [];
@@ -391,10 +428,22 @@
         }
       })
       .catch(err => {
-        console.error('Error loading files:', err);
+        console.error('Error loading media library files:', err);
         loading.style.display = 'none';
-        empty.style.display = '';
+        gridContent.style.display = 'none';
+        empty.style.display = 'none';
+        showErrorState('Unable to load files. Please try again.');
       });
+  }
+
+  function showErrorState(message) {
+    const errorEl = grid.querySelector('.error');
+    errorEl.querySelector('p').textContent = message;
+    errorEl.style.display = '';
+  }
+
+  function hideErrorState() {
+    grid.querySelector('.error').style.display = 'none';
   }
 
   function renderFiles() {
@@ -474,14 +523,66 @@
     }
   }
 
-  // Expose panel control functions to global scope
-  window.showMediaLibrary = function() {
-    panel.style.display = 'flex';
-    searchInput.focus();
-  };
+  function isOpen() {
+    return panel.classList.contains('open');
+  }
 
-  window.hideMediaLibrary = function() {
-    panel.style.display = 'none';
-  };
+  function showMediaLibrary() {
+    lastFocusedElement = document.activeElement;
+    panel.classList.add('open');
+    searchInput.focus();
+  }
+
+  function hideMediaLibrary() {
+    panel.classList.remove('open');
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+      lastFocusedElement.focus();
+    }
+    lastFocusedElement = null;
+  }
+
+  // Expose panel control functions to global scope
+  window.showMediaLibrary = showMediaLibrary;
+  window.hideMediaLibrary = hideMediaLibrary;
+
+  // ── Keyboard operability: Escape closes the panel, Tab/Shift+Tab stay trapped inside it while
+  // open. Follows the same convention as platform-editor.js's width/widget pickers (document-level
+  // keydown, gated on the picker's own open state).
+  function getFocusableElements() {
+    const nodes = panel.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    return Array.prototype.filter.call(nodes, el => !el.disabled && el.offsetParent !== null);
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (!isOpen()) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      hideMediaLibrary();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (e.shiftKey) {
+      if (active === first || !panel.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last || !panel.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  });
 })();
 </script>

--- a/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
@@ -337,6 +337,7 @@
   const panel = document.getElementById('sc-media-panel');
   const grid = document.getElementById('media-grid');
   const searchInput = document.getElementById('media-search-input');
+  const searchClearBtn = document.getElementById('media-search-clear');
   const closeBtn = document.querySelector('.media-panel-close');
   const uploadArea = document.getElementById('media-upload-area');
   const fileInput = document.getElementById('media-file-input');
@@ -368,8 +369,16 @@
   }
 
   searchInput.addEventListener('input', (e) => {
+    searchClearBtn.style.display = e.target.value ? '' : 'none';
     currentPage = 0;
     loadFiles(e.target.value);
+  });
+
+  searchClearBtn.addEventListener('click', () => {
+    searchInput.value = '';
+    searchClearBtn.style.display = 'none';
+    currentPage = 0;
+    loadFiles();
   });
 
   uploadArea.addEventListener('click', () => fileInput.click());

--- a/src/test/java/com/simisinc/platform/infrastructure/database/DatabaseMigrationTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/database/DatabaseMigrationTest.java
@@ -217,6 +217,21 @@ class DatabaseMigrationTest {
             + "will fail on a fresh install");
   }
 
+  @Test
+  void tablesThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath() throws SQLException {
+    // Same class of gap as columnsThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath above,
+    // but for whole tables instead of columns: media_assets/media_asset_usage
+    // (UPGRADE_20260726.1004__create_media_assets_table.sql) were never mirrored into install/, so
+    // a fresh install had no media_assets table at all -- MediaAssetRepository's queries threw a
+    // SQLException that DB.java logs and swallows, silently returning an empty result that looks
+    // identical to "no files yet" (issue #771).
+    assertTrue(tableExists("media_assets"),
+        "media_assets is missing - MediaAssetRepository queries will silently fail on a fresh "
+            + "install (DB.java swallows the SQLException and returns an empty result)");
+    assertTrue(tableExists("media_asset_usage"),
+        "media_asset_usage is missing on a fresh install");
+  }
+
   private static boolean tableExists(String name) throws SQLException {
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement();

--- a/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +123,32 @@ class MediaApiControllerTest {
     }).when(response).setStatus(anyInt());
 
     new MediaApiController().doPost(request, response);
+    recorded.body = body.toString();
+    return recorded;
+  }
+
+  private static HttpServletRequest getRequestWithSession(UserSession userSession, Map<String, String> params) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    for (Map.Entry<String, String> e : params.entrySet()) {
+      when(request.getParameter(e.getKey())).thenReturn(e.getValue());
+    }
+    return request;
+  }
+
+  private static Recorded runGet(HttpServletRequest request) throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+    Recorded recorded = new Recorded();
+    doAnswer(inv -> {
+      recorded.status = inv.getArgument(0);
+      return null;
+    }).when(response).setStatus(anyInt());
+
+    new MediaApiController().doGet(request, response);
     recorded.body = body.toString();
     return recorded;
   }
@@ -298,6 +325,91 @@ class MediaApiControllerTest {
       new MediaApiController().doPost(request, response);
 
       verify(response, never()).setStatus(anyInt());
+    }
+  }
+
+  // ── Jackson JSR-310 regression coverage (issue #771) ───────────────────────────────────────
+  //
+  // None of the tests above ever set createdAt on a MediaAsset, so they never exercised Jackson
+  // actually serializing a LocalDateTime -- without the jsr310 module registered on the shared
+  // ObjectMapper, that throws InvalidDefinitionException the instant a non-null LocalDateTime
+  // hits the wire, which the surrounding catch(Exception) turns into a generic 500. These three
+  // cover every response path in this controller that can serialize a MediaAsset.
+
+  @Test
+  void listEndpointSerializesAssetsWithNonNullTimestampsWithoutThrowing() throws Exception {
+    UserSession userSession = loggedInSession("admin");
+    HttpServletRequest request = getRequestWithSession(userSession, new HashMap<>());
+
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setAssetName("photo.jpg");
+    asset.setCreatedAt(LocalDateTime.now());
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      assets.when(() -> MediaAssetRepository.findAll(null)).thenReturn(List.of(asset));
+
+      Recorded result = runGet(request);
+
+      assertEquals(200, result.status);
+      assertTrue(result.body.contains("\"success\":true"));
+      assertFalse(result.body.contains("Failed to retrieve media assets"));
+    }
+  }
+
+  @Test
+  void widgetUpdateSerializesAnAssetWithNonNullTimestampsWithoutThrowing() throws Exception {
+    UserSession userSession = loggedInSession("admin");
+    HttpServletRequest request = requestWithSession(userSession, baseParams(userSession.getFormToken()));
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setStoragePath("/assets/photo.jpg");
+    asset.setCreatedAt(LocalDateTime.now());
+    WebPage webPage = new WebPage();
+    webPage.setId(55);
+    webPage.setLink("/about");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class);
+         MockedStatic<LoadWebPageCommand> pages = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
+      pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(200, result.status);
+      assertTrue(result.body.contains("\"success\":true"));
+      assertFalse(result.body.contains("Failed to process request"));
+    }
+  }
+
+  @Test
+  void createAssetEndpointSerializesTheStampedCreatedAtWithoutThrowing() throws Exception {
+    // handleCreateAsset always stamps createdAt = LocalDateTime.now() on the new asset before
+    // saving, then echoes that same object back in the response -- so this path always hits the
+    // Jackson gap, with no test setup required to force a non-null timestamp.
+    UserSession userSession = loggedInSession("admin");
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    when(request.getPathInfo()).thenReturn(null);
+    when(request.getParameter("assetName")).thenReturn("photo.jpg");
+    when(request.getParameter("assetType")).thenReturn("image");
+    when(request.getParameter("mimeType")).thenReturn("image/jpeg");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      assets.when(() -> MediaAssetRepository.save(any())).thenAnswer(inv -> {
+        MediaAsset saved = inv.getArgument(0);
+        saved.setId(42);
+        return saved;
+      });
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(200, result.status);
+      assertTrue(result.body.contains("\"success\":true"));
+      assertFalse(result.body.contains("Failed to process request"));
     }
   }
 


### PR DESCRIPTION
## Summary
Part of #771 (media library panel "browse" fixes, split from #431):
- Wire the toolbar's Media Library button to `showMediaLibrary()`/`hideMediaLibrary()` (previously the panel auto-opened on every edit-mode page load instead)
- Mirror the `media_assets`/`media_asset_usage` migration into `database/install/` so a fresh install has the tables (was upgrade-only)
- Register Jackson's JSR-310 module in `MediaApiController` so any row with a real `createdAt` doesn't 500
- Client fetch now checks `response.ok` and surfaces a real error instead of silently rendering an empty list on 401/403/500
- Escape-to-close + a focus trap, matching the width/widget pickers' existing convention in `platform-editor.js`
- Wire the previously-dead `#media-search-clear` button: it now appears once the search box has a value, and clicking it clears the search, resets to page 0, and reloads the unfiltered list

## Test plan
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `ant -lib lib/tests ci-test` (existing `MediaApiControllerTest`/`ValidateUserAccessToWebPageCommandTest`/`DatabaseMigrationTest` additions)
- [x] Live docker rehearsal: logged in, opened the visual editor's Media Library panel, confirmed the clear-search button appears on input and correctly clears/reloads on click (verified via network log: `GET .../media?...&search=logo` then `GET .../media?...` with no `search` param, `offset=0`)