### PR TITLE
maint: De-duplicate the two JDK-version fail-fast guards

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -81,16 +81,6 @@
 
   <!-- Creates build directories -->
   <target name="prepare" depends="version">
-    <condition property="jdk.version.ok">
-      <equals arg1="${java.specification.version}" arg2="${jdk}"/>
-    </condition>
-    <fail unless="jdk.version.ok">
-This build requires JDK ${jdk} (found JDK ${java.specification.version} at ${java.home}).
-lib/compile/lombok/lombok-1.18.30.jar does not generate annotation-based methods (@Getter/@Setter/etc.)
-on other JDK versions in this Ant/javac setup -- it fails silently, so a JDK mismatch shows up later
-as a misleading "cannot find symbol" compile error instead of a clear version error. Point JAVA_HOME
-at a JDK ${jdk} installation and retry.
-    </fail>
     <mkdir dir="${build.dir}"/>
     <mkdir dir="${target.dir}"/>
     <tstamp />
@@ -402,7 +392,7 @@ at a JDK ${jdk} installation and retry.
     <echo message="Finished: ${end.val}" />
   </target>
 
-  <target name="checkstyle" depends="prepare">
+  <target name="checkstyle" depends="check-jdk-version,prepare">
     <mkdir dir="${target.dir}/checkstyle"/>
     <checkstyle config="checkstyle.xml"
                 failureProperty="checkstyle.failure"


### PR DESCRIPTION
## Summary
- PR #778 and PR #780 merged ~10 minutes apart today from two concurrent sessions, each independently adding a fail-fast JDK-version check for the same reason (Lombok silently no-ops its annotation processor on a JDK/javac mismatch, which otherwise surfaces later as a confusing "cannot find symbol" compile error).
- #778 added a check inside `prepare` comparing `java.specification.version`; #780 added a standalone `check-jdk-version` target comparing `ant.java.version`, wired ahead of `compile`/`compile-test`. Both merged cleanly since they touched different parts of the file, leaving two overlapping guards.
- Keeps the standalone `check-jdk-version` target (composable via `depends`) and removes the duplicate check from `prepare`.
- `checkstyle` depended on `prepare` without also depending on `check-jdk-version`, so it would have silently lost fail-fast JDK checking once `prepare`'s copy was removed — added `check-jdk-version` to its `depends` directly. Every other target that could previously reach either guard (`compile`, `compile-jsp`, `jar`, `package`, `webapp`, `compile-test`, `ci-test`, `run-test`, `test`) already depends on `check-jdk-version` directly or transitively via `compile`.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean compile-test` under JDK 21 (`JAVA_HOME=/opt/homebrew/opt/openjdk@21/...`) → `BUILD SUCCESSFUL`
- [x] Same command with `JAVA_HOME` unset (falls back to Homebrew's unversioned JDK 26) → fails immediately (`Total time: 0 seconds`) with `This build requires JDK 21 (found 26 at ...). Export JAVA_HOME to your JDK 21 install before running ant.`
- [x] `ant checkstyle` under JDK 21 → passes the JDK guard, runs checkstyle (pre-existing, unrelated lint findings in the tree are out of scope here)
- [x] `ant checkstyle` with `JAVA_HOME` unset → fails immediately at `check-jdk-version`, same message