### PR TITLE
Route dataset pagination fetches through the guarded SSRF wrapper

### DIFF
--- a/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommand.java
@@ -93,7 +93,7 @@ public class DatasetDownloadRemoteFileCommand {
           }
         } else {
           // Download a single JSON file
-          if (!HttpDownloadFileCommand.execute(dataset.getSourceUrl(), tempFile)) {
+          if (!HttpDownloadFileCommand.executeUserUrl(dataset.getSourceUrl(), tempFile)) {
             throw new DataException("File download error from: " + dataset.getSourceUrl());
           }
         }
@@ -173,7 +173,9 @@ public class DatasetDownloadRemoteFileCommand {
   public static boolean downloadPagedFile(String url, String jsonPagingPath, String jsonRecordsPath, File tempFile) {
 
     // Download the first file, as a string
-    String content = HttpGetCommand.execute(url);
+    // [SSRF] executeUserUrl() validates url before fetching, so this method is safe to call
+    // directly rather than depending on the caller having already checked it.
+    String content = HttpGetCommand.executeUserUrl(url);
     if (StringUtils.isBlank(content)) {
       return false;
     }
@@ -242,14 +244,11 @@ public class DatasetDownloadRemoteFileCommand {
       LOG.debug("Next url: " + nextUrl);
 
       // [SSRF] nextUrl comes from the fetched response, so it is fully controlled by whoever
-      // runs the source server -- validate it before following, exactly like the source url.
-      if (!RemoteUrlValidationCommand.isFetchAllowed(nextUrl)) {
-        throw new IOException("Blocked a paging url that is not permitted: " + nextUrl);
-      }
-
-      String content = HttpGetCommand.execute(nextUrl);
+      // runs the source server -- executeUserUrl() validates it before following, exactly
+      // like the source url.
+      String content = HttpGetCommand.executeUserUrl(nextUrl);
       if (StringUtils.isBlank(content)) {
-        throw new IOException("Content is blank");
+        throw new IOException("Blocked or empty content for paging url: " + nextUrl);
       }
 
       JsonNode nextJson = JsonLoader.fromString(content);

--- a/src/test/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/datasets/DatasetDownloadRemoteFileCommandTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.datasets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jackson.JsonLoader;
+import com.simisinc.platform.application.http.HttpGetCommand;
+
+/**
+ * Proves that a "next page" url discovered mid-pagination -- fully controlled by whoever runs
+ * the source server, not by the admin who configured the dataset -- is routed through the
+ * guarded {@link HttpGetCommand#executeUserUrl(String)} entry point and never reaches the raw,
+ * unguarded {@link HttpGetCommand#execute(String)}. Mirrors the static-mocking pattern already
+ * established in {@code RemoteContentWidgetTest} for the same class of concern: the guard's own
+ * address classification is covered directly by {@code RemoteUrlValidationCommandTest}, so this
+ * is a call-site routing proof, not a re-test of the guard logic itself.
+ *
+ * @author Elizabeth Houser
+ * @created 2026-07-31
+ */
+class DatasetDownloadRemoteFileCommandTest {
+
+  private static final String FIRST_PAGE_URL = "http://93.184.216.34/page1";
+
+  // Loopback: the SSRF guard blocks this regardless of whether anything listens there --
+  // exactly the shape of a malicious "next" url a hostile/compromised source server could
+  // hand back mid-pagination to reach the app's own internal network.
+  private static final String MALICIOUS_NEXT_URL = "http://127.0.0.1:65535/internal-page2";
+
+  @Test
+  void maliciousNextPageUrlIsRejectedAndNeverFetchedUnguarded(@TempDir File tempDir) {
+    File tempFile = new File(tempDir, "out.json");
+    String firstPageJson = "{\"records\":[{\"id\":1}],\"next\":\"" + MALICIOUS_NEXT_URL + "\"}";
+
+    try (MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      httpGet.when(() -> HttpGetCommand.executeUserUrl(FIRST_PAGE_URL)).thenReturn(firstPageJson);
+      // MALICIOUS_NEXT_URL is deliberately left unstubbed: the guard inside executeUserUrl()
+      // is what's responsible for refusing it (proven for real in RemoteUrlValidationCommandTest).
+
+      boolean result = DatasetDownloadRemoteFileCommand.downloadPagedFile(FIRST_PAGE_URL, "next", "records", tempFile);
+
+      assertFalse(result, "a malicious mid-pagination url must abort the download");
+      assertFalse(tempFile.exists(), "no partial/merged output should be written");
+
+      // The malicious url was routed through the guarded entry point...
+      httpGet.verify(() -> HttpGetCommand.executeUserUrl(MALICIOUS_NEXT_URL));
+      // ...and the raw, unguarded fetch was never reached at all -- for any url.
+      httpGet.verify(() -> HttpGetCommand.execute(anyString()), never());
+    }
+  }
+
+  @Test
+  void maliciousSourceUrlIsRejectedWithoutRelyingOnTheCaller(@TempDir File tempDir) {
+    // downloadPagedFile() is public static and must not depend on a caller having already
+    // validated the url -- calling it directly with a malicious url must still route through
+    // the guard itself rather than merely failing to connect (a real, unmocked loopback call
+    // would return false either way, since nothing listens there -- that would pass both
+    // before and after the fix and prove nothing, so this verifies routing explicitly instead).
+    File tempFile = new File(tempDir, "out.json");
+
+    try (MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      boolean result = DatasetDownloadRemoteFileCommand.downloadPagedFile(MALICIOUS_NEXT_URL, "next", "records", tempFile);
+
+      assertFalse(result);
+      assertFalse(tempFile.exists());
+      httpGet.verify(() -> HttpGetCommand.executeUserUrl(MALICIOUS_NEXT_URL));
+      httpGet.verify(() -> HttpGetCommand.execute(anyString()), never());
+    }
+  }
+
+  @Test
+  void legitimatePagingStillMerges(@TempDir File tempDir) throws Exception {
+    File tempFile = new File(tempDir, "out.json");
+    String secondPageUrl = "http://93.184.216.34/page2";
+    String firstPageJson = "{\"records\":[{\"id\":1}],\"next\":\"" + secondPageUrl + "\"}";
+    String secondPageJson = "{\"records\":[{\"id\":2}],\"next\":null}";
+
+    try (MockedStatic<HttpGetCommand> httpGet = mockStatic(HttpGetCommand.class)) {
+      httpGet.when(() -> HttpGetCommand.executeUserUrl(FIRST_PAGE_URL)).thenReturn(firstPageJson);
+      httpGet.when(() -> HttpGetCommand.executeUserUrl(secondPageUrl)).thenReturn(secondPageJson);
+
+      boolean result = DatasetDownloadRemoteFileCommand.downloadPagedFile(FIRST_PAGE_URL, "next", "records", tempFile);
+
+      assertTrue(result);
+      JsonNode written = JsonLoader.fromFile(tempFile);
+      JsonNode records = written.get("records");
+      assertEquals(2, records.size());
+      assertEquals(1, records.get(0).get("id").asInt());
+      assertEquals(2, records.get(1).get("id").asInt());
+
+      // Both the source page and the discovered paging url went through the guarded entry
+      // point, and the raw, unguarded fetch was never reached.
+      httpGet.verify(() -> HttpGetCommand.executeUserUrl(FIRST_PAGE_URL));
+      httpGet.verify(() -> HttpGetCommand.executeUserUrl(secondPageUrl));
+      httpGet.verify(() -> HttpGetCommand.execute(anyString()), never());
+    }
+  }
+}


### PR DESCRIPTION
## Background

`DatasetDownloadRemoteFileCommand` fetches dataset content server-side from an admin-configured source URL, optionally following "next page" URLs pulled out of the fetched response itself (`appendNextUrls`). PR #236 originally guarded both the source url and the paging url by calling `RemoteUrlValidationCommand.isFetchAllowed()` manually before fetching. PR #381 later added `executeUserUrl()` wrappers to `HttpGetCommand`/`HttpDownloadFileCommand` specifically to centralize that guard so callers wouldn't need to hand-roll it — but this file's call sites were never migrated onto them.

Found while reading this code during the #760 SSRF workflow; out of scope for that issue, so filed as its own fix per usual practice.

## The gap

All three fetch call sites in this file called the raw, unguarded `execute()` overloads instead of `executeUserUrl()`:

- `handleRemoteFileDownload()` validated the source url once, then called `HttpDownloadFileCommand.execute(...)` directly for the single-file case.
- `downloadPagedFile()` called `HttpGetCommand.execute(url)` for the first page with **no validation inside the method at all** — it's `public static` and was relying entirely on its one current caller having already checked the url first. Calling it directly with an unvalidated url was unsafe.
- `appendNextUrls()` did call `isFetchAllowed()` on each discovered "next" url before fetching, so it wasn't literally unguarded today — but by hand-rolling validate-then-raw-fetch instead of using `executeUserUrl()`, it both duplicates the guard logic and won't automatically inherit whatever DNS-rebinding fix eventually lands in `executeUserUrl()` for #760.

## The fix

Route all three call sites through `executeUserUrl()` (the pattern this codebase already documents as the intended one for "URLs derived from fetched responses" — see the `HttpGetCommand`/`HttpDownloadFileCommand` class javadoc). `downloadPagedFile()` is now self-guarding regardless of caller behavior, and every fetch in this file will pick up future guard improvements automatically instead of needing a second migration.

## Tests

New `DatasetDownloadRemoteFileCommandTest`:
- `maliciousNextPageUrlIsRejectedAndNeverFetchedUnguarded` — a "next" url discovered mid-pagination is routed through `executeUserUrl()` and the download aborts with no output written.
- `maliciousSourceUrlIsRejectedWithoutRelyingOnTheCaller` — calling `downloadPagedFile()` directly with a malicious url is safe without a pre-validating caller.
- `legitimatePagingStillMerges` — a normal two-page paginated fetch still merges records correctly (no regression to the legitimate path).

Verified all three fail against the pre-fix code and pass against the fix (manual red/green check, not just written-then-trusted). Full `ant -lib lib/war -lib lib/tests clean ci-test`, `check-security-coverage.sh`, `compile-jsp`, and `package` all pass.
