### PR TITLE
Fix nested widget/column/section hover toolbars pixel-overlapping

### DIFF
--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -431,8 +431,11 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-move-btns {
   padding: 2px;
 }
 
-body.page-edit-mode [data-editor-section]:hover > .sc-mutate-btns,
-body.page-edit-mode [data-editor-column]:hover > .sc-mutate-btns,
+/* An ancestor's toolbar defers to a nested descendant's own toolbar so the two
+   never compete for the same click when a widget/column nearly fills its parent
+   (issue #783). */
+body.page-edit-mode [data-editor-section]:hover:not(:has([data-editor-column]:hover)) > .sc-mutate-btns,
+body.page-edit-mode [data-editor-column]:hover:not(:has([data-editor-widget]:hover)) > .sc-mutate-btns,
 body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
   display: flex;
 }


### PR DESCRIPTION
## Summary
- `.sc-mutate-btns` (the per-widget/column/section hover toolbar in the composition-canvas editor) is shown via plain `:hover` bubbling — hovering a widget also satisfies `:hover` on its ancestor column and section, so all three toolbars become simultaneously eligible to display. Each is independently anchored `bottom: 0; right: 0` of its own box, so when a descendant nearly fills its ancestor, the toolbars land on the same pixels and the browser's hit-testing can resolve a click to the wrong (ancestor's) toolbar — including a column's destructive "✕ Column" ("Remove this column and all its widgets?") control.
- Fix: scope each level's hover-triggered display with `:has()` so an ancestor's toolbar hides whenever a nested descendant's own toolbar would show — mutually exclusive instead of competing for the same click, regardless of how closely the boxes' edges coincide.
- Fixes #783.

## Verification

No JS test runner exists in this repo, so this was verified two ways instead of a checked-in test:

**1. Isolated static-HTML harness** (real `platform-editor.css`, no server needed), driving genuine OS-level pointer hover (not synthetic DOM events, which don't set real CSS `:hover`) and reading `document.elementFromPoint`:
- Widget nearly filling its column: pre-fix, hovering the widget showed both toolbars and a click at the seam resolved to the column's "Add widget to column" button; post-fix, the same pixel resolves to the widget's own button, and the column's toolbar still correctly reappears when hovering the column's own area outside the widget.
- Column nearly filling its section (the sibling case below): same result, section vs. column.

**2. Real docker-compose rehearsal** (`ant -lib lib/war package` → `docker compose up`), logged in as admin, `/legal/privacy?editMode=true` — a real seeded page with one widget in one column in one section. This turned out to demonstrate the bug even more severely than expected: with a single-column section, hovering the widget shows **all three** toolbars stacked illegibly at once. At a pixel inside the widget's own "✕ Widget" button rectangle, `elementFromPoint` pre-fix resolved to the **section's** "Section style" button; post-fix, the identical pixel resolves correctly to the widget's own "✕ Widget" button, with the column's and section's toolbars both cleanly hidden while the widget is hovered.

**Manual repro** (for anyone re-checking by hand): open any page in edit mode, find a widget that's close to its column's height (a single-widget column is the simplest case), hover near the widget's bottom-right corner, and confirm only one toolbar row is visible/clickable at a time as you move the pointer between the widget and its column's own area.

## Note on scope

This is one CSS rule block (`.sc-mutate-btns`'s hover-trigger selector) shared by all three nesting levels — fixing the reported widget/column case correctly requires the identical treatment for the column/section pair one level up, since it's the same selector list. That sibling case (a column's "+ Widget" occluded by its ancestor section's "✕ Section") was previously observed and flagged separately during unrelated P4 verification, worked around at the time rather than fixed. Verified above (harness Case B) that this change resolves it too.
