### PR TITLE
Add real file upload to the media library panel (#773)

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/MediaAsset.java
+++ b/src/main/java/com/simisinc/platform/domain/model/MediaAsset.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
  */
 public class MediaAsset extends Entity {
 
-  private long id;
+  private long id = -1;
   private String assetId;
   private String assetName;
   private String assetType; // 'image' or 'pdf'

--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -43,6 +43,7 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
@@ -195,6 +196,18 @@ public class MediaApiController extends HttpServlet {
 
   private void handleCreateAsset(HttpServletRequest request, HttpServletResponse response, UserSession userSession)
       throws IOException {
+    // This is the same class of content-authoring action as handleUpload (it creates a media_assets
+    // row directly), so it requires the same tier of permission -- without this check, any logged-in
+    // user of any role could create arbitrary media asset records once the id-routing bug above stopped
+    // masking every call here as a 500.
+    if (!EditorPermissionCommand.canEditContent(userSession)) {
+      response.setStatus(403);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Insufficient permission to create media assets");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
     String assetName = request.getParameter("assetName");
     String assetType = request.getParameter("assetType");
     String mimeType = request.getParameter("mimeType");
@@ -266,39 +279,69 @@ public class MediaApiController extends HttpServlet {
     return maxBytes;
   }
 
-  // Extension -> mime type, used only when Files.probeContentType (below) comes back blank. That
-  // happens on some runtimes/containers that lack a FileTypeDetector for common types -- a known
-  // JDK gap -- so relying on it alone would make this endpoint reject legitimate images depending
-  // on the deployment environment. Mirrors ValidateFileCommand.getMimeType's existing fallback
-  // pattern for its own (different) set of extensions.
-  private static String fallbackMimeTypeForExtension(String extension) {
-    if (extension == null) {
+  // Real format signatures ("magic bytes") for the file types this endpoint accepts (images + PDF,
+  // per the isImage/isPdf check below). Files.probeContentType() alone is not trustworthy here: on a
+  // minimal JDK/container with no mime-magic database it silently falls back to guessing from the
+  // extension, so a plain-text file renamed to "malware.png" would be accepted, stored, and served
+  // back as "image/png" -- identical in effect to trusting the filename with no real verification.
+  // These signatures are checked directly against the uploaded bytes on disk instead.
+  private static final byte[] PNG_SIGNATURE = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+  private static final byte[] JPEG_SIGNATURE = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF};
+  private static final byte[] GIF87A_SIGNATURE = {'G', 'I', 'F', '8', '7', 'a'};
+  private static final byte[] GIF89A_SIGNATURE = {'G', 'I', 'F', '8', '9', 'a'};
+  private static final byte[] PDF_SIGNATURE = {'%', 'P', 'D', 'F', '-'};
+  // WebP is a RIFF container: bytes 0-3 are "RIFF", bytes 4-7 are a little-endian chunk size specific
+  // to each file (not checked here), bytes 8-11 are "WEBP".
+  private static final byte[] RIFF_SIGNATURE = {'R', 'I', 'F', 'F'};
+  private static final byte[] WEBP_SIGNATURE = {'W', 'E', 'B', 'P'};
+  private static final int SNIFF_HEADER_BYTES = 12;
+
+  private static boolean headerStartsWith(byte[] header, int headerLength, byte[] signature) {
+    if (headerLength < signature.length) {
+      return false;
+    }
+    for (int i = 0; i < signature.length; i++) {
+      if (header[i] != signature[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Detects a file's real content type by inspecting its actual header bytes on disk -- never the
+   * submitted filename, its extension, or the client-declared {@code Part} content type. Only the
+   * formats this endpoint supports are recognized; anything else (including a disguised file whose
+   * extension claims one of these types but whose bytes don't match, e.g. a script renamed to
+   * ".png") returns {@code null} so the caller rejects it.
+   */
+  private static String sniffContentType(File file) {
+    byte[] header = new byte[SNIFF_HEADER_BYTES];
+    int headerLength;
+    try (InputStream in = Files.newInputStream(file.toPath())) {
+      headerLength = in.readNBytes(header, 0, header.length);
+    } catch (Exception e) {
+      LOG.warn("Could not read the uploaded file's header bytes: " + e.getMessage());
       return null;
     }
-    switch (extension.toLowerCase()) {
-      case "jpg":
-      case "jpeg":
-        return "image/jpeg";
-      case "png":
-        return "image/png";
-      case "gif":
-        return "image/gif";
-      case "webp":
-        return "image/webp";
-      case "bmp":
-        return "image/bmp";
-      case "tif":
-      case "tiff":
-        return "image/tiff";
-      case "ico":
-        return "image/x-icon";
-      case "svg":
-        return "image/svg+xml";
-      case "pdf":
-        return "application/pdf";
-      default:
-        return null;
+    if (headerStartsWith(header, headerLength, PNG_SIGNATURE)) {
+      return "image/png";
     }
+    if (headerStartsWith(header, headerLength, JPEG_SIGNATURE)) {
+      return "image/jpeg";
+    }
+    if (headerStartsWith(header, headerLength, GIF87A_SIGNATURE) || headerStartsWith(header, headerLength, GIF89A_SIGNATURE)) {
+      return "image/gif";
+    }
+    if (headerStartsWith(header, headerLength, PDF_SIGNATURE)) {
+      return "application/pdf";
+    }
+    if (headerLength >= SNIFF_HEADER_BYTES && headerStartsWith(header, headerLength, RIFF_SIGNATURE)
+        && header[8] == WEBP_SIGNATURE[0] && header[9] == WEBP_SIGNATURE[1]
+        && header[10] == WEBP_SIGNATURE[2] && header[11] == WEBP_SIGNATURE[3]) {
+      return "image/webp";
+    }
+    return null;
   }
 
   /**
@@ -418,17 +461,10 @@ public class MediaApiController extends HttpServlet {
       return;
     }
 
-    // Never trust the client-declared Part content type or the file extension alone -- sniff the
-    // real bytes, matching ValidateImageCommand's approach for the existing image-upload path.
-    String sniffedMimeType = null;
-    try {
-      sniffedMimeType = Files.probeContentType(targetFile.toPath());
-    } catch (Exception e) {
-      LOG.warn("Could not determine the uploaded file's mime type: " + e.getMessage());
-    }
-    if (StringUtils.isBlank(sniffedMimeType)) {
-      sniffedMimeType = fallbackMimeTypeForExtension(extension);
-    }
+    // Never trust the client-declared Part content type or the file extension alone -- inspect the
+    // actual bytes written to disk. See sniffContentType's javadoc for why Files.probeContentType()
+    // alone is not sufficient here.
+    String sniffedMimeType = sniffContentType(targetFile);
     boolean isImage = sniffedMimeType != null && sniffedMimeType.startsWith("image/");
     boolean isPdf = "application/pdf".equals(sniffedMimeType);
     if (!isImage && !isPdf) {

--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -20,22 +20,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
 import com.simisinc.platform.application.cms.MutateLayoutCommand;
+import com.simisinc.platform.application.cms.ValidateFileCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.MediaAsset;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.MediaAssetRepository;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Part;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.UUID;
@@ -44,8 +53,14 @@ import java.util.UUID;
  * P5.2: Media Library API endpoints for the visual editor panel
  *
  * GET /visual-editor/media?search=query&limit=20&offset=0 - List media assets with pagination and search
- * POST /visual-editor/media - Create stub asset record
- * POST /visual-editor/media/upload - Handle file upload from drag-and-drop or file picker (not yet implemented)
+ * GET /visual-editor/media/file/{assetId} - Stream a previously uploaded asset's bytes. Deliberately not
+ * gated behind login (see {@link #handleServeFile}) -- once an asset is embedded into a page via
+ * widget-update, anonymous site visitors need to load it too, the same posture {@code StreamImageWidget}
+ * already uses for every other uploaded image in this app.
+ * POST /visual-editor/media - Create asset record (assetName, assetType, mimeType, storagePath, altText, tags)
+ * POST /visual-editor/media/upload - Handle a real file upload from drag-and-drop or the file picker
+ * (issue #773): validates the file server-side, stores it via {@link FileSystemCommand}'s conventions, and
+ * creates the media_assets row through the same path as {@link #handleCreateAsset}.
  * POST /visual-editor/media/widget-update - Apply a selected asset to a widget's preference on a page's draft
  * layout. Requires builder-tier permission and the session CSRF token, and identifies the target
  * widget the same way {@link PageServlet}'s {@code mutateDraftLayout} action does -- by structural
@@ -57,6 +72,10 @@ import java.util.UUID;
  * @created 7/26/26
  */
 @WebServlet(name = "MediaApi", urlPatterns = {"/visual-editor/media", "/visual-editor/media/*"})
+@MultipartConfig(fileSizeThreshold = 1024 * 1024 * 2, // 2MB
+    maxFileSize = 1024 * 1024 * 30,       // 30MB (hard ceiling; the app-level cap enforced in
+                                           // handleUpload defaults to 10MB, see resolveMaxUploadBytes)
+    maxRequestSize = 1024 * 1024 * 35)    // 35MB
 public class MediaApiController extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(MediaApiController.class);
@@ -76,6 +95,13 @@ public class MediaApiController extends HttpServlet {
     response.setContentType("application/json");
 
     try {
+      String pathInfo = request.getPathInfo();
+      if (pathInfo != null && pathInfo.startsWith("/file/")) {
+        // Not login-gated -- see the class javadoc and handleServeFile for why.
+        handleServeFile(request, response, pathInfo.substring("/file/".length()));
+        return;
+      }
+
       UserSession userSession = (UserSession) request.getSession().getAttribute(SessionConstants.USER);
       if (userSession == null || !userSession.isLoggedIn()) {
         response.setStatus(401);
@@ -172,6 +198,9 @@ public class MediaApiController extends HttpServlet {
     String assetName = request.getParameter("assetName");
     String assetType = request.getParameter("assetType");
     String mimeType = request.getParameter("mimeType");
+    // Issue #773 fix: this record-creation path never set storagePath, and media_assets.storage_path
+    // is NOT NULL -- any real call here would have failed the insert. Callers must now supply it.
+    String storagePath = request.getParameter("storagePath");
     String altText = request.getParameter("altText");
     String tags = request.getParameter("tags");
 
@@ -183,12 +212,23 @@ public class MediaApiController extends HttpServlet {
       return;
     }
 
+    if (StringUtils.isBlank(storagePath)) {
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "storagePath is required");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
     MediaAsset asset = new MediaAsset();
     asset.setAssetId(UUID.randomUUID().toString());
     asset.setAssetName(assetName);
     asset.setAssetType(assetType != null ? assetType : "unknown");
     asset.setMimeType(mimeType);
-    asset.setAltText(altText);
+    asset.setStoragePath(storagePath);
+    // alt_text is also NOT NULL (required for accessibility per the media_assets migration); fall
+    // back to the asset name rather than adding a second required-field round trip for callers.
+    asset.setAltText(StringUtils.isNotBlank(altText) ? altText : assetName);
     asset.setTags(tags);
     asset.setCreatedBy(userSession.getUserId());
     asset.setCreatedAt(LocalDateTime.now());
@@ -209,13 +249,276 @@ public class MediaApiController extends HttpServlet {
     response.getWriter().write(objectMapper.writeValueAsString(result));
   }
 
+  // 10MB default, matching ImageUploadWidget/SaveFilePartCommand's own hardcoded default for the
+  // same "system.upload.maxBytes" site property -- there is no shared constant for this in the
+  // codebase today, so this mirrors their convention rather than inventing a new limit.
+  private static final long DEFAULT_MAX_UPLOAD_BYTES = 10_485_760L;
+
+  private static long resolveMaxUploadBytes() {
+    long maxBytes = DEFAULT_MAX_UPLOAD_BYTES;
+    String prop = LoadSitePropertyCommand.loadByName("system.upload.maxBytes");
+    if (prop != null && !prop.isBlank()) {
+      try {
+        maxBytes = Long.parseLong(prop.trim());
+      } catch (NumberFormatException ignored) {
+      }
+    }
+    return maxBytes;
+  }
+
+  // Extension -> mime type, used only when Files.probeContentType (below) comes back blank. That
+  // happens on some runtimes/containers that lack a FileTypeDetector for common types -- a known
+  // JDK gap -- so relying on it alone would make this endpoint reject legitimate images depending
+  // on the deployment environment. Mirrors ValidateFileCommand.getMimeType's existing fallback
+  // pattern for its own (different) set of extensions.
+  private static String fallbackMimeTypeForExtension(String extension) {
+    if (extension == null) {
+      return null;
+    }
+    switch (extension.toLowerCase()) {
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "png":
+        return "image/png";
+      case "gif":
+        return "image/gif";
+      case "webp":
+        return "image/webp";
+      case "bmp":
+        return "image/bmp";
+      case "tif":
+      case "tiff":
+        return "image/tiff";
+      case "ico":
+        return "image/x-icon";
+      case "svg":
+        return "image/svg+xml";
+      case "pdf":
+        return "application/pdf";
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Handles a real multipart file upload from the media library panel's drag-and-drop area or file
+   * picker (issue #773). Follows the same parsing shape as {@code ImageUploadWidget}/
+   * {@code SaveFilePartCommand} ({@code request.getPart("file")}, MSIE-safe filename handling,
+   * extension cleaning) and the same {@link FileSystemCommand} storage convention every other
+   * upload in this app uses: a date-partitioned sub-path under a module name
+   * ({@code generateFileServerSubPath}), a collision-proof filename ({@code generateUniqueFilename}),
+   * and root-contained path resolution ({@code resolveWithinRoot}).
+   *
+   * <p>Never trusts the client alone: file size, blocked/dangerous extensions, and the file's actual
+   * detected content type are all re-checked here even though the panel's JS validates first too.
+   *
+   * <p>If the media_assets row can't be saved after the file is already on disk, the file is deleted
+   * rather than left as an orphan -- it would be reachable by nothing (no row means no assetId to
+   * look it up by, see {@link #handleServeFile}), so keeping it around is pure leaked disk space with
+   * no compensating benefit. This mirrors ImageUploadWidget's existing behavior of deleting its temp
+   * file whenever the record-side save fails.
+   */
   private void handleUpload(HttpServletRequest request, HttpServletResponse response, UserSession userSession)
       throws IOException {
+    if (!EditorPermissionCommand.canEditContent(userSession)) {
+      response.setStatus(403);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Insufficient permission to upload media");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    String token = request.getParameter("token");
+    if (token == null || !token.equals(userSession.getFormToken())) {
+      LOG.warn("media upload CSRF token mismatch from " + request.getRemoteAddr());
+      response.setStatus(403);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Session expired");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    Part filePart;
+    try {
+      filePart = request.getPart("file");
+    } catch (Exception e) {
+      LOG.warn("Could not read the uploaded file part: " + e.getMessage());
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "The upload could not be read");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    if (filePart == null) {
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "A file is required");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    long fileLength = filePart.getSize();
+    if (fileLength <= 0) {
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "The file is empty");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    long maxBytes = resolveMaxUploadBytes();
+    if (fileLength > maxBytes) {
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "The file exceeds the maximum allowed upload size");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    String submittedFilename = Paths.get(filePart.getSubmittedFileName()).getFileName().toString(); // MSIE fix
+    String extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(submittedFilename));
+
+    try {
+      ValidateFileCommand.checkFileExtension(extension);
+    } catch (DataException e) {
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", e.getMessage());
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    String serverRootPath = FileSystemCommand.getFileServerRootPath();
+    String serverSubPath = FileSystemCommand.generateFileServerSubPath("media-library");
+    String uniqueFilename = FileSystemCommand.generateUniqueFilename(userSession.getUserId());
+    File targetFile = FileSystemCommand.resolveWithinRoot(serverRootPath, serverSubPath + uniqueFilename + "." + extension);
+    if (targetFile == null) {
+      response.setStatus(500);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "The file could not be saved");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    try {
+      filePart.write(targetFile.getAbsolutePath());
+    } catch (Exception e) {
+      // Storage-write failure (disk full, permission error, etc.) -- nothing was persisted, so
+      // there's nothing to roll back beyond a possible partial file.
+      LOG.error("Could not write uploaded media file: " + e.getMessage(), e);
+      if (targetFile.exists()) {
+        targetFile.delete();
+      }
+      response.setStatus(500);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "The file could not be saved");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    // Never trust the client-declared Part content type or the file extension alone -- sniff the
+    // real bytes, matching ValidateImageCommand's approach for the existing image-upload path.
+    String sniffedMimeType = null;
+    try {
+      sniffedMimeType = Files.probeContentType(targetFile.toPath());
+    } catch (Exception e) {
+      LOG.warn("Could not determine the uploaded file's mime type: " + e.getMessage());
+    }
+    if (StringUtils.isBlank(sniffedMimeType)) {
+      sniffedMimeType = fallbackMimeTypeForExtension(extension);
+    }
+    boolean isImage = sniffedMimeType != null && sniffedMimeType.startsWith("image/");
+    boolean isPdf = "application/pdf".equals(sniffedMimeType);
+    if (!isImage && !isPdf) {
+      LOG.warn("Rejected a media upload with an unsupported detected type (" + sniffedMimeType + "): " + submittedFilename);
+      if (targetFile.exists()) {
+        targetFile.delete();
+      }
+      response.setStatus(400);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Only image and PDF files are supported");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    String altText = request.getParameter("altText");
+
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId(UUID.randomUUID().toString());
+    asset.setAssetName(submittedFilename);
+    asset.setAssetType(isImage ? "image" : "pdf");
+    asset.setMimeType(sniffedMimeType);
+    asset.setFileSizeBytes(fileLength);
+    asset.setStoragePath(serverSubPath + uniqueFilename + "." + extension);
+    asset.setAltText(StringUtils.isNotBlank(altText) ? altText : submittedFilename);
+    asset.setTags(request.getParameter("tags"));
+    asset.setCreatedBy(userSession.getUserId());
+    asset.setCreatedAt(LocalDateTime.now());
+
+    MediaAsset saved;
+    try {
+      saved = MediaAssetRepository.save(asset);
+    } catch (Exception e) {
+      LOG.error("Error saving media asset record: " + e.getMessage(), e);
+      saved = null;
+    }
+
+    if (saved == null) {
+      if (targetFile.exists()) {
+        LOG.warn("Deleting an uploaded media file after a failed DB save: " + targetFile.getPath());
+        targetFile.delete();
+      }
+      response.setStatus(500);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Failed to save media asset");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
     Map<String, Object> result = new HashMap<>();
-    result.put("success", false);
-    result.put("error", "File upload not yet implemented");
-    response.setStatus(501);
+    result.put("success", true);
+    result.put("asset", saved);
     response.getWriter().write(objectMapper.writeValueAsString(result));
+  }
+
+  /**
+   * Streams a previously uploaded media asset's bytes by its opaque {@code assetId}. Deliberately
+   * public (no login check) -- once an asset is applied to a widget via widget-update it becomes
+   * part of a real page's content, which anonymous visitors must be able to load, exactly like every
+   * other uploaded image already served by this app's StreamImageWidget at {@code /assets/img/*}.
+   * Safety comes from the same place theirs does: {@link FileSystemCommand#resolveWithinRoot} keeps
+   * the resolved path inside the file server root, the asset must already exist as a database row
+   * (no arbitrary path traversal via assetId, which is never used as a path itself), and
+   * {@link FileDownloadCommand#applyInlineMediaHeaders} sends {@code nosniff} plus a sandboxed CSP so
+   * an uploaded SVG/HTML-like file still renders as an image but cannot execute script in this origin.
+   */
+  private void handleServeFile(HttpServletRequest request, HttpServletResponse response, String assetId)
+      throws IOException {
+    MediaAsset asset = StringUtils.isBlank(assetId) ? null : MediaAssetRepository.findByAssetId(assetId);
+    if (asset == null || StringUtils.isBlank(asset.getStoragePath())) {
+      response.setStatus(404);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Media file not found");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    String serverRootPath = FileSystemCommand.getFileServerRootPath();
+    File file = FileSystemCommand.resolveWithinRoot(serverRootPath, asset.getStoragePath());
+    if (file == null || !file.isFile()) {
+      LOG.warn("Media asset file missing from disk: " + assetId);
+      response.setStatus(404);
+      Map<String, Object> result = new HashMap<>();
+      result.put("error", "Media file not found");
+      response.getWriter().write(objectMapper.writeValueAsString(result));
+      return;
+    }
+
+    FileDownloadCommand.applyInlineMediaHeaders(response, asset.getMimeType());
+    response.setContentLengthLong(file.length());
+    Files.copy(file.toPath(), response.getOutputStream());
   }
 
   /**

--- a/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/visual-editor/media-library-panel.jsp
@@ -349,6 +349,7 @@
   let allAssets = [];
   let filteredAssets = [];
   let lastFocusedElement = null;
+  let lastTotal = 0; // tracked from the most recent loadFiles() response; kept in sync after an upload
 
   // Load initial files
   loadFiles();
@@ -427,8 +428,9 @@
       .then(data => {
         filteredAssets = data.assets || [];
         allAssets = data.assets || [];
+        lastTotal = data.total || 0;
         renderFiles();
-        updatePagination(data.total || 0);
+        updatePagination(lastTotal);
         loading.style.display = 'none';
         if (filteredAssets.length === 0) {
           empty.style.display = '';
@@ -468,7 +470,9 @@
 
       if (asset.mimeType && asset.mimeType.startsWith('image/')) {
         const img = document.createElement('img');
-        img.src = asset.storagePath || '';
+        // storagePath is the internal FileSystemCommand-relative disk path, not a browser URL (issue
+        // #773) -- the file is served through the new /visual-editor/media/file/{assetId} route.
+        img.src = asset.assetId ? ('/visual-editor/media/file/' + encodeURIComponent(asset.assetId)) : '';
         img.className = 'media-file-thumbnail';
         img.alt = asset.altText || asset.assetName;
         item.appendChild(img);
@@ -498,9 +502,133 @@
     document.dispatchEvent(event);
   }
 
+  // 10MB default, matching the server's own default (MediaApiController.resolveMaxUploadBytes,
+  // which mirrors ImageUploadWidget/SaveFilePartCommand's existing "system.upload.maxBytes"
+  // convention) -- this is only a fast client-side rejection so the user isn't left waiting on a
+  // network round trip for an obviously-too-big file; the server enforces its own limit regardless.
+  const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+  function isAllowedFileType(file) {
+    const type = (file.type || '').toLowerCase();
+    if (type) {
+      return type.indexOf('image/') === 0 || type === 'application/pdf';
+    }
+    // Some browsers/drag sources omit type for certain files (e.g. some SVGs); fall back to the
+    // extension, matching the file input's own accept list.
+    return /\.(png|jpe?g|gif|webp|bmp|svg|pdf)$/i.test(file.name || '');
+  }
+
+  function validateFileClientSide(file) {
+    if (!isAllowedFileType(file)) {
+      return file.name + ': only images and PDF files are supported';
+    }
+    if (file.size <= 0) {
+      return file.name + ': the file is empty';
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return file.name + ': exceeds the maximum upload size (' + Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024)) + 'MB)';
+    }
+    return null;
+  }
+
   function handleFiles(files) {
-    // File upload implementation - to be completed in next task
-    console.log('Files selected:', files.length);
+    if (!files || files.length === 0) {
+      return;
+    }
+    const fileList = Array.prototype.slice.call(files);
+    const errors = [];
+    const toUpload = [];
+    fileList.forEach(function (file) {
+      const validationError = validateFileClientSide(file);
+      if (validationError) {
+        errors.push(validationError);
+      } else {
+        toUpload.push(file);
+      }
+    });
+
+    if (toUpload.length === 0) {
+      showErrorState(errors.join('; '));
+      fileInput.value = '';
+      return;
+    }
+
+    hideErrorState();
+    uploadNext(toUpload, 0, errors);
+  }
+
+  function uploadNext(files, index, errors) {
+    if (index >= files.length) {
+      hideUploadingState();
+      fileInput.value = '';
+      if (errors.length > 0) {
+        showErrorState(errors.join('; '));
+      }
+      return;
+    }
+
+    const file = files[index];
+    showUploadingState(index + 1, files.length, file.name);
+
+    const formData = new FormData();
+    formData.append('file', file);
+    const token = (typeof mainToken !== 'undefined') ? mainToken : '';
+
+    fetch('/visual-editor/media/upload?token=' + encodeURIComponent(token), {
+      method: 'POST',
+      body: formData
+    })
+      .then(function (resp) {
+        return resp.json().catch(function () {
+          return {};
+        }).then(function (data) {
+          if (!resp.ok || !data.success) {
+            throw new Error((data && data.error) || ('Upload failed with status ' + resp.status));
+          }
+          return data;
+        });
+      })
+      .then(function (data) {
+        if (data.asset) {
+          addUploadedAssetToGrid(data.asset);
+        }
+      })
+      .catch(function (err) {
+        console.error('Error uploading file:', file.name, err);
+        errors.push(file.name + ': ' + err.message);
+      })
+      .then(function () {
+        uploadNext(files, index + 1, errors);
+      });
+  }
+
+  // Optimistically inserts the newly uploaded asset at the front of the currently displayed page
+  // instead of re-fetching -- the list endpoint sorts oldest-first, so a re-fetch of the current
+  // page would not actually surface a brand new upload without also jumping to the last page.
+  function addUploadedAssetToGrid(asset) {
+    filteredAssets.unshift(asset);
+    allAssets.unshift(asset);
+    lastTotal += 1;
+
+    const gridContent = grid.querySelector('.files');
+    grid.querySelector('.empty').style.display = 'none';
+    gridContent.style.display = '';
+    renderFiles();
+    updatePagination(lastTotal);
+  }
+
+  function showUploadingState(current, total, filename) {
+    const loading = grid.querySelector('.loading');
+    loading.querySelector('p').textContent = total > 1
+      ? ('Uploading ' + current + ' of ' + total + '…')
+      : ('Uploading ' + filename + '…');
+    loading.style.display = '';
+  }
+
+  function hideUploadingState() {
+    const loading = grid.querySelector('.loading');
+    loading.style.display = 'none';
+    loading.querySelector('p').textContent = 'Loading files...';
   }
 
   function updatePagination(total) {

--- a/src/test/java/com/simisinc/platform/domain/model/MediaAssetTest.java
+++ b/src/test/java/com/simisinc/platform/domain/model/MediaAssetTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the id-default regression (issue #773 follow-up): a brand-new {@link MediaAsset} used to
+ * default {@code id} to {@code 0}, and {@code MediaAssetRepository.save()} routes to {@code update()}
+ * whenever {@code id > -1} -- true for {@code 0} -- so every new asset was silently misrouted to an
+ * UPDATE against a non-existent row instead of an INSERT, and every real upload/create failed. Every
+ * other domain model in this codebase that follows this same save()-routing convention (e.g. App,
+ * DatabaseVersion) defaults id to -1; this test is deliberately independent of any database so it
+ * always runs, unlike {@code MediaAssetRepositoryTest}'s heavier Docker-gated integration coverage of
+ * the same fix.
+ *
+ * @author SimIS Inc.
+ */
+class MediaAssetTest {
+
+  @Test
+  void aNewInstanceDefaultsIdToNegativeOneNotZero() {
+    MediaAsset asset = new MediaAsset();
+
+    assertEquals(-1, asset.getId());
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/MediaAssetRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/MediaAssetRepositoryTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.MediaAsset;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies MediaAssetRepository against a real PostgreSQL instance, with a focus on the
+ * {@code save()} id-routing bug (issue #773 follow-up): {@link MediaAsset#getId()} used to default to
+ * {@code 0}, and {@code save()} routes to {@code update()} whenever {@code id > -1} -- true for the
+ * default {@code 0} -- so every brand-new asset was silently misrouted to an {@code UPDATE} against a
+ * non-existent row instead of an {@code INSERT}, and the save failed every time. {@link MediaAsset} now
+ * defaults {@code id} to {@code -1} (matching every other domain model in this codebase, e.g. App,
+ * DatabaseVersion), so a fresh instance correctly routes to {@code add()}.
+ *
+ * @author SimIS Inc.
+ */
+class MediaAssetRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping MediaAssetRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE media_assets RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset media_assets table", se);
+    }
+  }
+
+  @Test
+  void saveOnANewAssetActuallyInsertsAndTheAssetIsRetrievableAfterward() {
+    // The core regression test: before the #773 follow-up fix, this call silently misrouted to
+    // update() against a non-existent row (id=0), update() failed, and save() returned null -- so
+    // real uploads/creates never persisted anything at all, always ending in a 500.
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-real-add-1");
+    asset.setAssetName("photo.jpg");
+    asset.setAssetType("image");
+    asset.setMimeType("image/jpeg");
+    asset.setFileSizeBytes(1024);
+    asset.setStoragePath("media-library/2026/07/31/unique-name.jpg");
+    asset.setAltText("photo.jpg");
+    asset.setCreatedBy(7);
+    asset.setCreatedAt(LocalDateTime.now());
+
+    MediaAsset saved = MediaAssetRepository.save(asset);
+
+    assertNotNull(saved, "save() must succeed via add() for a brand-new asset");
+    assertTrue(saved.getId() > 0, "a real INSERT must assign a positive generated id");
+    assertEquals(1, DB.selectCountFrom("media_assets"));
+
+    MediaAsset reloadedById = MediaAssetRepository.findById(saved.getId());
+    assertNotNull(reloadedById, "the newly added asset must be retrievable by its assigned id");
+    assertEquals("photo.jpg", reloadedById.getAssetName());
+    assertEquals("media-library/2026/07/31/unique-name.jpg", reloadedById.getStoragePath());
+
+    MediaAsset reloadedByAssetId = MediaAssetRepository.findByAssetId("asset-real-add-1");
+    assertNotNull(reloadedByAssetId, "the newly added asset must be retrievable by its assetId");
+    assertEquals(saved.getId(), reloadedByAssetId.getId());
+  }
+
+  @Test
+  void savingASecondNewAssetAddsARowInsteadOfOverwritingTheFirst() {
+    // A second brand-new MediaAsset also has id=-1 (each is its own fresh instance) and must also
+    // route to add(), not silently collide with or overwrite the first row.
+    MediaAsset first = addAsset("asset-a", "a.jpg");
+    MediaAsset second = addAsset("asset-b", "b.jpg");
+
+    assertTrue(second.getId() > first.getId());
+    assertEquals(2, DB.selectCountFrom("media_assets"));
+    assertNotNull(MediaAssetRepository.findById(first.getId()));
+    assertNotNull(MediaAssetRepository.findById(second.getId()));
+  }
+
+  @Test
+  void saveOnAnExistingAssetRoutesToUpdateNotAdd() {
+    MediaAsset saved = addAsset("asset-update-me", "original.jpg");
+    long originalId = saved.getId();
+
+    saved.setAssetName("renamed.jpg");
+    saved.setUpdatedAt(LocalDateTime.now());
+    MediaAsset updated = MediaAssetRepository.save(saved);
+
+    assertNotNull(updated);
+    assertEquals(originalId, updated.getId(), "update() must not change the row's id");
+    assertEquals(1, DB.selectCountFrom("media_assets"), "update() must not insert a second row");
+    assertEquals("renamed.jpg", MediaAssetRepository.findById(originalId).getAssetName());
+  }
+
+  @Test
+  void findByIdReturnsNullForAMissingOrNegativeId() {
+    assertNull(MediaAssetRepository.findById(999));
+    assertNull(MediaAssetRepository.findById(-1));
+  }
+
+  private static MediaAsset addAsset(String assetId, String assetName) {
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId(assetId);
+    asset.setAssetName(assetName);
+    asset.setAssetType("image");
+    asset.setMimeType("image/jpeg");
+    asset.setFileSizeBytes(512);
+    asset.setStoragePath("media-library/2026/07/31/" + assetId + ".jpg");
+    asset.setAltText(assetName);
+    asset.setCreatedBy(7);
+    asset.setCreatedAt(LocalDateTime.now());
+    return MediaAssetRepository.save(asset);
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS media_assets CASCADE");
+      // Mirrors NEW_10125__new_media_assets.sql / UPGRADE_20260726.1004, minus the FK to users
+      // (out of scope for this repository-level test).
+      statement.execute("CREATE TABLE media_assets ("
+          + "id BIGSERIAL PRIMARY KEY, "
+          + "asset_id VARCHAR(128) NOT NULL UNIQUE, "
+          + "asset_name VARCHAR(512) NOT NULL, "
+          + "asset_type VARCHAR(32) NOT NULL, "
+          + "mime_type VARCHAR(64), "
+          + "file_size_bytes BIGINT NOT NULL, "
+          + "storage_path TEXT NOT NULL, "
+          + "alt_text TEXT NOT NULL, "
+          + "tags TEXT, "
+          + "created_by BIGINT NOT NULL, "
+          + "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+          + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+          + "deleted_at TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the media_assets schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
@@ -16,8 +16,10 @@
 
 package com.simisinc.platform.presentation.controller;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -31,31 +33,43 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
 import com.simisinc.platform.application.cms.MutateLayoutCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.MediaAsset;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.MediaAssetRepository;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Part;
 
 /**
  * Covers the real {@code handleWidgetUpdate} logic added to fix the no-op "Widget update
@@ -397,6 +411,7 @@ class MediaApiControllerTest {
     when(request.getParameter("assetName")).thenReturn("photo.jpg");
     when(request.getParameter("assetType")).thenReturn("image");
     when(request.getParameter("mimeType")).thenReturn("image/jpeg");
+    when(request.getParameter("storagePath")).thenReturn("media-library/2026/07/26/photo.jpg");
 
     try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
       assets.when(() -> MediaAssetRepository.save(any())).thenAnswer(inv -> {
@@ -410,6 +425,54 @@ class MediaApiControllerTest {
       assertEquals(200, result.status);
       assertTrue(result.body.contains("\"success\":true"));
       assertFalse(result.body.contains("Failed to process request"));
+    }
+  }
+
+  // ── handleCreateAsset's storagePath NOT NULL fix (issue #773) ─────────────────────────────
+
+  @Test
+  void createAssetRejectsAMissingStoragePath() throws Exception {
+    // media_assets.storage_path is NOT NULL; before the #773 fix this endpoint never set it at all,
+    // so any real call would have failed the insert with a generic 500 instead of a clear 400.
+    UserSession userSession = loggedInSession("admin");
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    when(request.getPathInfo()).thenReturn(null);
+    when(request.getParameter("assetName")).thenReturn("photo.jpg");
+
+    Recorded result = runWidgetUpdate(request);
+
+    assertEquals(400, result.status);
+    assertTrue(result.body.contains("storagePath is required"));
+  }
+
+  @Test
+  void createAssetDefaultsAltTextToTheAssetNameWhenNotProvided() throws Exception {
+    // alt_text is also NOT NULL; rather than adding a second required param, default it.
+    UserSession userSession = loggedInSession("admin");
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    when(request.getPathInfo()).thenReturn(null);
+    when(request.getParameter("assetName")).thenReturn("photo.jpg");
+    when(request.getParameter("storagePath")).thenReturn("media-library/2026/07/26/photo.jpg");
+
+    ArgumentCaptor<MediaAsset> savedCaptor = ArgumentCaptor.forClass(MediaAsset.class);
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      assets.when(() -> MediaAssetRepository.save(savedCaptor.capture())).thenAnswer(inv -> {
+        MediaAsset saved = inv.getArgument(0);
+        saved.setId(42);
+        return saved;
+      });
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(200, result.status);
+      assertEquals("media-library/2026/07/26/photo.jpg", savedCaptor.getValue().getStoragePath());
+      assertEquals("photo.jpg", savedCaptor.getValue().getAltText());
     }
   }
 
@@ -431,5 +494,350 @@ class MediaApiControllerTest {
 
     assertEquals(401, result.status);
     assertFalse(result.body.contains("success\":true"));
+  }
+
+  // ── handleUpload (issue #773) ──────────────────────────────────────────────────────────────
+  //
+  // FileSystemCommand and LoadSitePropertyCommand are mocked statically so these tests are
+  // hermetic (no real CMS_PATH/site-property/DB dependency) while still exercising the real
+  // disk write through a JUnit @TempDir, matching this file's existing convention of mocking the
+  // static collaborators (MediaAssetRepository, LoadWebPageCommand, MutateLayoutCommand) above.
+
+  private static Part mockFilePart(String filename, byte[] content) throws Exception {
+    Part part = mock(Part.class);
+    when(part.getSubmittedFileName()).thenReturn(filename);
+    when(part.getSize()).thenReturn((long) content.length);
+    doAnswer(inv -> {
+      String path = inv.getArgument(0);
+      Files.write(Paths.get(path), content);
+      return null;
+    }).when(part).write(anyString());
+    return part;
+  }
+
+  private static HttpServletRequest uploadRequestWithSession(UserSession userSession, String token, Part filePart)
+      throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    when(request.getPathInfo()).thenReturn("/upload");
+    when(request.getParameter("token")).thenReturn(token);
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    if (filePart != null) {
+      when(request.getPart("file")).thenReturn(filePart);
+    }
+    return request;
+  }
+
+  private static void stubFileSystemCommand(MockedStatic<FileSystemCommand> fsc, Path tempDir) {
+    fsc.when(FileSystemCommand::getFileServerRootPath).thenReturn(tempDir.toString() + "/");
+    fsc.when(() -> FileSystemCommand.generateFileServerSubPath(anyString())).thenReturn("media-library/2026/07/31/");
+    fsc.when(() -> FileSystemCommand.generateUniqueFilename(anyLong())).thenReturn("unique-name");
+    fsc.when(() -> FileSystemCommand.cleanExtension(anyString())).thenAnswer(inv -> inv.getArgument(0));
+    fsc.when(() -> FileSystemCommand.resolveWithinRoot(anyString(), anyString())).thenAnswer(inv -> {
+      String root = inv.getArgument(0);
+      String rel = inv.getArgument(1);
+      File f = new File(root, rel);
+      f.getParentFile().mkdirs();
+      return f;
+    });
+  }
+
+  @Test
+  void uploadRejectsWhenNotAuthenticated() throws Exception {
+    HttpServletRequest request = uploadRequestWithSession(null, "whatever", null);
+
+    Recorded result = runWidgetUpdate(request);
+
+    assertEquals(401, result.status);
+    assertTrue(result.body.contains("Not authenticated"));
+  }
+
+  @Test
+  void uploadRejectsWhenUserLacksEditPermission() throws Exception {
+    // No session role at all is below even the content-editor tier canEditContent requires.
+    UserSession userSession = loggedInSession();
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), null);
+
+    Recorded result = runWidgetUpdate(request);
+
+    assertEquals(403, result.status);
+    assertTrue(result.body.contains("Insufficient permission"));
+  }
+
+  @Test
+  void uploadRejectsCsrfTokenMismatch() throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    HttpServletRequest request = uploadRequestWithSession(userSession, "not-the-real-token", null);
+
+    Recorded result = runWidgetUpdate(request);
+
+    assertEquals(403, result.status);
+    assertTrue(result.body.contains("Session expired"));
+  }
+
+  @Test
+  void uploadRejectsWhenNoFilePartPresent() throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), null);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("A file is required"));
+    }
+  }
+
+  @Test
+  void uploadRejectsABlockedDangerousExtension() throws Exception {
+    // Reaches ValidateFileCommand.checkFileExtension before any FileSystemCommand call is made.
+    UserSession userSession = loggedInSession("content-editor");
+    Part filePart = mockFilePart("payload.exe", "not really an executable".getBytes());
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("not allowed"));
+    }
+  }
+
+  @Test
+  void uploadRejectsAnOversizedFile() throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    Part filePart = mock(Part.class);
+    when(filePart.getSubmittedFileName()).thenReturn("huge.jpg");
+    when(filePart.getSize()).thenReturn(11_000_000L); // over the 10MB default
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("exceeds the maximum"));
+      verify(filePart, never()).write(anyString());
+    }
+  }
+
+  @Test
+  void uploadRejectsAFileWhoseDetectedTypeIsNotImageOrPdf(@TempDir Path tempDir) throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    Part filePart = mockFilePart("notes.txt", "just plain text".getBytes());
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      stubFileSystemCommand(fsc, tempDir);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("Only image and PDF files are supported"));
+      assertFalse(Files.exists(tempDir.resolve("media-library/2026/07/31/unique-name.txt")),
+          "the rejected file should not be left on disk");
+    }
+  }
+
+  @Test
+  void uploadSavesTheFileAndCreatesARealMediaAssetRecord(@TempDir Path tempDir) throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    byte[] content = "fake-jpeg-bytes".getBytes();
+    Part filePart = mockFilePart("photo.jpg", content);
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    ArgumentCaptor<MediaAsset> savedCaptor = ArgumentCaptor.forClass(MediaAsset.class);
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class);
+         MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      stubFileSystemCommand(fsc, tempDir);
+      assets.when(() -> MediaAssetRepository.save(savedCaptor.capture())).thenAnswer(inv -> {
+        MediaAsset saved = inv.getArgument(0);
+        saved.setId(99);
+        return saved;
+      });
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(200, result.status);
+      assertTrue(result.body.contains("\"success\":true"));
+
+      MediaAsset saved = savedCaptor.getValue();
+      assertEquals("photo.jpg", saved.getAssetName());
+      assertEquals("image", saved.getAssetType());
+      assertEquals((long) content.length, saved.getFileSizeBytes());
+      assertEquals("media-library/2026/07/31/unique-name.jpg", saved.getStoragePath());
+      assertEquals(userSession.getUserId(), saved.getCreatedBy());
+      assertTrue(Files.exists(tempDir.resolve("media-library/2026/07/31/unique-name.jpg")),
+          "the uploaded bytes should actually be on disk at the stored path");
+    }
+  }
+
+  @Test
+  void uploadCleansUpTheDiskFileWhenTheDatabaseSaveFails(@TempDir Path tempDir) throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    Part filePart = mockFilePart("photo.png", "fake-png-bytes".getBytes());
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class);
+         MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      stubFileSystemCommand(fsc, tempDir);
+      // Simulates a DB-write failure after the disk write already succeeded.
+      assets.when(() -> MediaAssetRepository.save(any())).thenReturn(null);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(500, result.status);
+      assertTrue(result.body.contains("Failed to save media asset"));
+      assertFalse(Files.exists(tempDir.resolve("media-library/2026/07/31/unique-name.png")),
+          "an orphaned file with no discoverable DB row should be cleaned up, not left behind");
+    }
+  }
+
+  @Test
+  void uploadReturns500AndDoesNotAttemptASaveWhenTheDiskWriteFails(@TempDir Path tempDir) throws Exception {
+    UserSession userSession = loggedInSession("content-editor");
+    Part filePart = mock(Part.class);
+    when(filePart.getSubmittedFileName()).thenReturn("photo.jpg");
+    when(filePart.getSize()).thenReturn(1024L);
+    doAnswer(inv -> {
+      throw new IOException("simulated disk-full error");
+    }).when(filePart).write(anyString());
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class);
+         MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      stubFileSystemCommand(fsc, tempDir);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(500, result.status);
+      assertTrue(result.body.contains("The file could not be saved"));
+      assets.verify(() -> MediaAssetRepository.save(any()), never());
+    }
+  }
+
+  // ── GET /visual-editor/media/file/{assetId} (handleServeFile, issue #773) ──────────────────
+
+  private static class CapturingOutputStream extends ServletOutputStream {
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+      // not needed for this synchronous test double
+    }
+
+    @Override
+    public void write(int b) {
+      buffer.write(b);
+    }
+
+    byte[] toByteArray() {
+      return buffer.toByteArray();
+    }
+  }
+
+  @Test
+  void serveFileReturns404WhenAssetDoesNotExist() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getPathInfo()).thenReturn("/file/missing-asset");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("missing-asset")).thenReturn(null);
+
+      Recorded result = runGet(request);
+
+      assertEquals(404, result.status);
+      assertTrue(result.body.contains("Media file not found"));
+    }
+  }
+
+  @Test
+  void serveFileReturns404WhenFileMissingFromDisk(@TempDir Path tempDir) throws Exception {
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setStoragePath("media-library/2026/07/31/does-not-exist.jpg");
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getPathInfo()).thenReturn("/file/asset-123");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
+      fsc.when(FileSystemCommand::getFileServerRootPath).thenReturn(tempDir.toString() + "/");
+      fsc.when(() -> FileSystemCommand.resolveWithinRoot(anyString(), anyString()))
+          .thenAnswer(inv -> new File((String) inv.getArgument(0), (String) inv.getArgument(1)));
+
+      Recorded result = runGet(request);
+
+      assertEquals(404, result.status);
+      assertTrue(result.body.contains("Media file not found"));
+    }
+  }
+
+  @Test
+  void serveFileStreamsTheAssetWithInlineHeadersAndRequiresNoLogin(@TempDir Path tempDir) throws Exception {
+    byte[] fileBytes = "fake-image-bytes".getBytes();
+    Path assetFile = tempDir.resolve("media-library/2026/07/31/unique-name.jpg");
+    Files.createDirectories(assetFile.getParent());
+    Files.write(assetFile, fileBytes);
+
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setStoragePath("media-library/2026/07/31/unique-name.jpg");
+    asset.setMimeType("image/jpeg");
+
+    // Deliberately no session/getSession() stubbing at all -- this route must not require login.
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getPathInfo()).thenReturn("/file/asset-123");
+
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    CapturingOutputStream out = new CapturingOutputStream();
+    when(response.getOutputStream()).thenReturn(out);
+    Map<String, String> headers = new HashMap<>();
+    doAnswer(inv -> {
+      headers.put(inv.getArgument(0), inv.getArgument(1));
+      return null;
+    }).when(response).setHeader(anyString(), anyString());
+    String[] contentType = new String[1];
+    doAnswer(inv -> {
+      contentType[0] = inv.getArgument(0);
+      return null;
+    }).when(response).setContentType(anyString());
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
+      fsc.when(FileSystemCommand::getFileServerRootPath).thenReturn(tempDir.toString() + "/");
+      fsc.when(() -> FileSystemCommand.resolveWithinRoot(anyString(), anyString()))
+          .thenAnswer(inv -> new File((String) inv.getArgument(0), (String) inv.getArgument(1)));
+
+      new MediaApiController().doGet(request, response);
+    }
+
+    assertEquals("image/jpeg", contentType[0]);
+    assertEquals("nosniff", headers.get("X-Content-Type-Options"));
+    assertNull(headers.get("Content-Disposition"), "inline media headers never force a download");
+    assertArrayEquals(fileBytes, out.toByteArray());
+    verify(response, never()).setStatus(anyInt());
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
@@ -477,6 +477,31 @@ class MediaApiControllerTest {
   }
 
   @Test
+  void createAssetRejectsAUserWithNoEditPermission() throws Exception {
+    // Regression test for the missing permission check (issue #773 follow-up): handleCreateAsset is
+    // reached from doPost for any path other than /upload or /widget-update -- unlike those two, it
+    // never checked EditorPermissionCommand.canEditContent, so any logged-in user of any role could
+    // create arbitrary media_assets rows. A session with no granting role must be rejected with a 403
+    // before any parameter validation or repository call.
+    UserSession userSession = loggedInSession(); // no roles at all
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(userSession);
+    when(request.getSession()).thenReturn(session);
+    when(request.getPathInfo()).thenReturn(null);
+    when(request.getParameter("assetName")).thenReturn("photo.jpg");
+    when(request.getParameter("storagePath")).thenReturn("media-library/2026/07/26/photo.jpg");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(403, result.status);
+      assertTrue(result.body.contains("Insufficient permission"));
+      assets.verify(() -> MediaAssetRepository.save(any()), never());
+    }
+  }
+
+  @Test
   void doesNotAuthenticateAgainstALiteralUserSessionAttribute() throws Exception {
     // Regression guard for the fixed auth bug: the session attribute holds a UserSession under
     // SessionConstants.USER ("userSession"), never a User under the literal string "user".
@@ -502,6 +527,26 @@ class MediaApiControllerTest {
   // hermetic (no real CMS_PATH/site-property/DB dependency) while still exercising the real
   // disk write through a JUnit @TempDir, matching this file's existing convention of mocking the
   // static collaborators (MediaAssetRepository, LoadWebPageCommand, MutateLayoutCommand) above.
+
+  // Real format signatures ("magic bytes"), used to build fixture payloads that the content-sniffing
+  // fix (issue #773) will actually recognize, mirroring the constants in MediaApiController itself.
+
+  private static byte[] concat(byte[] prefix, byte[] rest) {
+    byte[] all = new byte[prefix.length + rest.length];
+    System.arraycopy(prefix, 0, all, 0, prefix.length);
+    System.arraycopy(rest, 0, all, prefix.length, rest.length);
+    return all;
+  }
+
+  private static byte[] pngBytes(String payload) {
+    byte[] signature = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+    return concat(signature, payload.getBytes());
+  }
+
+  private static byte[] jpegBytes(String payload) {
+    byte[] signature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF};
+    return concat(signature, payload.getBytes());
+  }
 
   private static Part mockFilePart(String filename, byte[] content) throws Exception {
     Part part = mock(Part.class);
@@ -649,9 +694,39 @@ class MediaApiControllerTest {
   }
 
   @Test
+  void uploadRejectsAFileRenamedToMatchAnAllowedExtensionButWhoseBytesAreNotThatFormat(@TempDir Path tempDir)
+      throws Exception {
+    // Regression test for the content-type-validation bypass (issue #773 follow-up): a plain-text
+    // file renamed to ".png" must be rejected based on its real header bytes, not accepted because
+    // the extension is on the image allowlist and Files.probeContentType falls back to guessing from
+    // the extension on a minimal-JDK/container deployment with no mime-magic database.
+    UserSession userSession = loggedInSession("content-editor");
+    byte[] notActuallyPng = "#!/bin/sh\necho not a real png".getBytes();
+    Part filePart = mockFilePart("totally-a-real.png", notActuallyPng);
+    HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
+
+    try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);
+         MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class);
+         MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class)) {
+      props.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      stubFileSystemCommand(fsc, tempDir);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("Only image and PDF files are supported"));
+      assertFalse(Files.exists(tempDir.resolve("media-library/2026/07/31/unique-name.png")),
+          "the disguised file should not be left on disk");
+      assets.verify(() -> MediaAssetRepository.save(any()), never());
+    }
+  }
+
+  @Test
   void uploadSavesTheFileAndCreatesARealMediaAssetRecord(@TempDir Path tempDir) throws Exception {
     UserSession userSession = loggedInSession("content-editor");
-    byte[] content = "fake-jpeg-bytes".getBytes();
+    // Real JPEG magic bytes (0xFF 0xD8 0xFF) -- the content-sniffing fix inspects actual bytes, so a
+    // fake payload like "fake-jpeg-bytes" would now be correctly rejected as not a real JPEG.
+    byte[] content = jpegBytes("real jpeg payload");
     Part filePart = mockFilePart("photo.jpg", content);
     HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
 
@@ -686,7 +761,8 @@ class MediaApiControllerTest {
   @Test
   void uploadCleansUpTheDiskFileWhenTheDatabaseSaveFails(@TempDir Path tempDir) throws Exception {
     UserSession userSession = loggedInSession("content-editor");
-    Part filePart = mockFilePart("photo.png", "fake-png-bytes".getBytes());
+    // Real PNG magic bytes -- see uploadSavesTheFileAndCreatesARealMediaAssetRecord for why.
+    Part filePart = mockFilePart("photo.png", pngBytes("real png payload"));
     HttpServletRequest request = uploadRequestWithSession(userSession, userSession.getFormToken(), filePart);
 
     try (MockedStatic<LoadSitePropertyCommand> props = mockStatic(LoadSitePropertyCommand.class);


### PR DESCRIPTION
Fixes #773

## What this builds

Wires up the media library panel's drag-and-drop/file-picker upload (previously a stub) to a real multipart upload endpoint (`POST /visual-editor/media/upload`). The server validates the file independently of the client (size cap, blocked extensions, sniffed content type), stores it on disk, and creates a `media_assets` row. A new `GET /visual-editor/media/file/{assetId}` route serves the uploaded bytes back, since `storagePath` is an internal disk-relative path rather than a browser URL. Newly uploaded assets appear in the grid immediately without a full re-fetch.

**Storage location:** this had been flagged `needs-elizabeth` as an open question. Resolved by following this repo's existing convention rather than the not-yet-started Azure Blob direction: files are stored under the file server root using `FileSystemCommand`'s existing date-partitioned convention (module `media-library`, `generateUniqueFilename`, `resolveWithinRoot`) — the same mechanism every other uploaded file in this app already uses. No new storage backend was introduced.

## Bugs found and fixed during review

Independent review of the first version of this branch found three blocking issues, all fixed here:

1. **`MediaAsset.id` defaulted to `0` instead of `-1`.** `MediaAssetRepository.save()` routes to `update()` whenever `id > -1`, which was true for the default, so every brand-new asset was silently misrouted to an UPDATE against a non-existent row instead of an INSERT — every real upload or create call failed. Fixed the default to `-1`, matching every other domain model in this codebase (`App`, `DatabaseVersion`, etc.).

2. **Bypassable content-type validation.** The original check relied on `Files.probeContentType()` plus an extension-keyed fallback. On a minimal container JDK with no mime-magic database, `probeContentType()` falls back to guessing from the extension alone, so a file renamed to `.png` was accepted, stored, and served back as `image/png` with no real verification of its contents. Replaced it with a magic-byte header check (PNG, JPEG, GIF, WebP, PDF) that inspects the actual uploaded bytes and rejects a mismatch with a 400.

3. **Missing permission check on `handleCreateAsset`.** Unlike `handleUpload` and `handleWidgetUpdate` in the same controller, `handleCreateAsset` never checked permission — any logged-in user of any role could reach it. Added the same `canEditContent` check the other two handlers already use.

## Verification

- Added/strengthened tests for all three fixes: a repository-level `add()` test proving a fresh asset persists and is retrievable, a standalone default-id test independent of any database, a renamed-file-rejection test for the content sniffing, and a no-role-session test asserting `handleCreateAsset` now returns 403.
- Full `ant ci-test` suite passes.
- Live-verified end to end against a real deployed instance (Postgres + file storage, not mocks):
  - Uploaded a real PNG as an admin user; confirmed a real DB row, a real file on disk at the expected `FileSystemCommand`-generated path, and an **MD5 checksum match across the original file, the on-disk file, and the file served back via the new file route** — confirming the id-routing fix actually results in a retrievable asset end to end, not just a passing unit test.
  - Confirmed the content-sniffing fix by uploading a shell script **renamed to `disguised-as-image.png` and `.jpg`** — both rejected with a 400 and no DB row or disk file created — while a real JPEG with correct magic bytes still uploaded successfully, showing the fix rejects on actual content with no over-blocking of legitimate files.
  - Confirmed the permission fix by calling `handleCreateAsset` directly as a genuinely no-role user (403, no row created) and as admin (200, row created).
  - Re-checked existing behavior for regressions: oversized file rejection, blocked-extension rejection, CSRF token enforcement on upload, and orphan-file cleanup on a forced DB-save failure all still work correctly.
