### PR TITLE
Fix workflow-triggering jobs permanently failing to deserialize

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.infrastructure.scheduler;
 
+import com.simisinc.platform.domain.events.Event;
 import com.simisinc.platform.infrastructure.database.DataSource;
 import com.simisinc.platform.infrastructure.instance.InstanceManager;
 import com.simisinc.platform.infrastructure.scheduler.admin.CapabilityGrantExpirationJob;
@@ -51,6 +52,8 @@ import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageProvider;
 import org.jobrunr.storage.StorageProviderUtils;
 import org.jobrunr.storage.sql.common.SqlStorageProviderFactory;
+import org.jobrunr.utils.mapper.jackson3.Jackson3JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
 import jakarta.servlet.ServletContext;
 import java.io.InputStream;
@@ -137,7 +140,15 @@ public class SchedulerManager {
       storageProvider = jobStorageProvider;
 
       // Initialize the scheduler
+      // WorkflowEngineJob carries a polymorphic Event field (UserRegisteredEvent, FormSubmittedEvent,
+      // etc.), so JobRunr's default JsonMapper -- whose PolymorphicTypeValidator trusts nothing by
+      // default -- can serialize it but then refuses to deserialize it back (JobParameterNotDeserializableException
+      // wrapping InvalidTypeIdException), permanently failing every workflow-triggering job. Explicitly
+      // trusting the Event hierarchy here covers all current and future subclasses.
       JobRunr.configure()
+          .useJsonMapper(new Jackson3JsonMapper(
+              BasicPolymorphicTypeValidator.builder()
+                  .allowIfSubType(Event.class)))
           .useStorageProvider(jobStorageProvider)
 //          .useJobActivator(new JobActivator() {
 //            public <T> T activateJob(Class<T> aClass) {

--- a/src/test/java/com/simisinc/platform/infrastructure/scheduler/WorkflowEngineJobTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/scheduler/WorkflowEngineJobTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.jobrunr.utils.mapper.jackson3.Jackson3JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.events.cms.UserRegisteredEvent;
+import com.simisinc.platform.domain.model.User;
+
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+
+/**
+ * Covers the JobRunr {@code JsonMapper} configuration that {@link SchedulerManager#startup} wires
+ * up for {@link WorkflowEngineJob}. Its {@code event} field is typed as the abstract {@link Event},
+ * so JobRunr's Jackson 3 mapper writes a type id on serialize; deserialize only succeeds if the
+ * mapper's {@code PolymorphicTypeValidator} was told to trust {@link Event} subtypes. Without that,
+ * every job carrying a real event (e.g. {@link UserRegisteredEvent}) serializes fine at enqueue time
+ * but then permanently fails at run time with {@code JobParameterNotDeserializableException}, wrapping
+ * a denied {@code InvalidTypeIdException} -- silently, since JobRunr swallows the failure into its own
+ * job-storage error state rather than surfacing it to the end user or admin.
+ *
+ * @author SimIS
+ * @created 7/31/2026
+ */
+class WorkflowEngineJobTest {
+
+  private static UserRegisteredEvent sampleEvent() {
+    User user = new User();
+    user.setId(42L);
+    user.setEmail("test@example.com");
+    user.setUsername("testuser");
+
+    UserRegisteredEvent event = new UserRegisteredEvent();
+    event.setUser(user);
+    event.setIpAddress("203.0.113.7");
+    event.setLocation("Testville, TS, Testland");
+    return event;
+  }
+
+  @Test
+  void mapperConfiguredWithEventAllowlistRoundTripsAWorkflowEngineJob() {
+    Jackson3JsonMapper mapper = new Jackson3JsonMapper(
+        BasicPolymorphicTypeValidator.builder().allowIfSubType(Event.class));
+
+    WorkflowEngineJob job = new WorkflowEngineJob(sampleEvent());
+    String json = mapper.serialize(job);
+    WorkflowEngineJob deserialized = mapper.deserialize(json, WorkflowEngineJob.class);
+
+    UserRegisteredEvent event = assertInstanceOf(UserRegisteredEvent.class, deserialized.getEvent());
+    assertEquals(42L, event.getUser().getId());
+    assertEquals("test@example.com", event.getUser().getEmail());
+    assertEquals("203.0.113.7", event.getIpAddress());
+    assertEquals("Testville, TS, Testland", event.getLocation());
+  }
+
+  @Test
+  void mapperWithoutTheEventAllowlistReproducesTheOriginalDeserializationFailure() {
+    // JobRunr's own default -- what SchedulerManager relied on implicitly before this fix, since it
+    // never called useJsonMapper(...) at all -- trusts no application types by default.
+    Jackson3JsonMapper defaultMapper = new Jackson3JsonMapper();
+
+    WorkflowEngineJob job = new WorkflowEngineJob(sampleEvent());
+    String json = defaultMapper.serialize(job);
+
+    assertThrows(RuntimeException.class, () -> defaultMapper.deserialize(json, WorkflowEngineJob.class));
+  }
+}


### PR DESCRIPTION
## Summary
- `WorkflowEngineJob` carries a polymorphic `Event` field (`UserRegisteredEvent`, `FormSubmittedEvent`, `CalendarEventScheduledEvent`, etc.), but `SchedulerManager` never configured JobRunr's `JsonMapper`. JobRunr 8.4+ defaults to a `Jackson3JsonMapper` whose `PolymorphicTypeValidator` trusts no application types, so the job serializes fine at enqueue time but always fails at run time with `JobParameterNotDeserializableException` wrapping a denied `InvalidTypeIdException` — silently, since JobRunr swallows this into its own job-storage failure state rather than surfacing it anywhere.
- Every workflow triggered off any domain event (account validation, form submissions, calendar changes, page publishes, orders, password resets) has been failing this way since the jobrunr 6.3.0→8.7.1 bump (#203) — reproduced live in a docker-compose rehearsal stack: completing `/validate-account` to set a password immediately logged this exact failure.
- Configures JobRunr with a `Jackson3JsonMapper` whose `PolymorphicTypeValidator` explicitly trusts the `Event` hierarchy (`.allowIfSubType(Event.class)`), covering all current and future subclasses in one place rather than one-off allowlisting each event type.

## Test plan
- [x] Added `WorkflowEngineJobTest`: round-trips a `WorkflowEngineJob` through the fixed mapper config (passes), and separately confirms the unconfigured default `Jackson3JsonMapper()` reproduces the original failure (also passes, i.e. correctly demonstrates the bug without the fix)
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — `BUILD SUCCESSFUL`, zero failures across the full suite