### PR TITLE
Fix NPE on /admin/modify-user when no userId is given

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -65,6 +65,10 @@ public class UserFormWidget extends GenericWidget {
     } else {
       long userId = context.getParameterAsLong("userId");
       user = LoadUserCommand.loadUser(userId);
+      if (user == null) {
+        // No userId, or it didn't match an existing record -- treat this as the New User form
+        user = new User();
+      }
     }
 
     // Set the request items

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -41,8 +41,10 @@ import com.simisinc.platform.presentation.controller.AuditEventCommand;
  * The user-edit form is reachable by both admin and community-manager (admin-layout.xml). Without a
  * check, the role checkboxes let a lower-privileged editor grant themselves or anyone else a higher
  * role -- e.g. a community-manager (level 90) granting admin (level 100), a full privilege escalation.
- * These verify the editor can only set roles at or below their own level, admins are unaffected, and a
- * higher role the target already holds is neither grantable nor strippable by a lower editor.
+ * Most of these verify the editor can only set roles at or below their own level, admins are
+ * unaffected, and a higher role the target already holds is neither grantable nor strippable by a
+ * lower editor. One covers a separate regression: execute() with no userId (the New User form) must
+ * not pass LoadUserCommand's not-found null straight to the JSP.
  *
  * @author Elizabeth Houser
  */
@@ -69,6 +71,25 @@ class UserFormWidgetTest extends WidgetBase {
     user.setId(5L);
     user.setEmail("saved@example.com");
     return user;
+  }
+
+  @Test
+  void executeWithoutUserIdBuildsBlankUserForNewUserForm() {
+    // GET /admin/modify-user with no userId (and no requestObject from a prior post()) is the New
+    // User form. LoadUserCommand.loadUser(-1) intentionally returns null for a not-found id -- the
+    // widget must not pass that null straight to the JSP.
+    setRoles(widgetContext, ADMIN);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+
+      Assertions.assertDoesNotThrow(() -> new UserFormWidget().execute(widgetContext));
+
+      User user = (User) widgetContext.getRequest().getAttribute("user");
+      Assertions.assertNotNull(user, "a blank User must be set so the New User form can render");
+      Assertions.assertEquals(-1L, user.getId().longValue(), "a blank User must keep the 'new record' id sentinel");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

`GET /admin/modify-user` with no `userId` query param throws an unhandled `NullPointerException` and 500s.

`UserFormWidget.execute()` does:

```java
long userId = context.getParameterAsLong("userId");
user = LoadUserCommand.loadUser(userId);
...
context.setPageTitle(user.getFullName());
```

With no `userId` param, `getParameterAsLong` defaults to `-1`, and `LoadUserCommand.loadUser(-1)` intentionally returns `null` (it's the documented not-found/no-id signal). The next line unconditionally calls `user.getFullName()`, which NPEs.

`/admin/modify-user{?userId}` is registered as the "Edit User" page (`admin-layout.xml`) and every in-UI link to it (`user-details.jsp`, the `post()` error-redirect) always includes a `userId`. The app's actual "New User" flow is the modal on `/admin/users` (`UsersListWidget.addUserAction()`), which posts directly and never hits this code path, so that flow is unaffected. This fix is about the edit page failing closed with a 500 (instead of degrading gracefully) whenever it's reached without an id — a stale bookmark, a hand-edited URL, or similar.

## Fix

When no matching user is found, build a blank `User()` instead of leaving it `null`, so the page renders as a blank/new-user form. This mirrors the existing not-found fallback in `WebPageFormWidget.execute()`.

## Testing

- Added `executeWithoutUserIdBuildsBlankUserForNewUserForm` to `UserFormWidgetTest`, covering the exact `execute()` path that NPE'd (no mocked `LoadUserCommand` — the real `loadUser(-1)` short-circuit is exercised).
- `ant -lib lib/war -lib lib/tests clean ci-test`: green, `UserFormWidgetTest` 5/5 passing.