### PR TITLE
Fix #760: pin the connection to the validated address to close the SSRF DNS-rebinding gap

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,19 @@
     </classpath>
   </typedef>
 
+  <!-- SSRF connect-time DNS pin resolver (issue #760): a separate module, deliberately NOT
+       under src.dir, that is compiled against by application code (e.g. HttpGetCommand) but
+       must never ship inside the WAR; see ssrf-pin-resolver/README.md for why. Its jar is a
+       "provided scope" dependency, the same treatment lib/compile/jee already gets. -->
+  <property name="pin.resolver.src.dir" value="${base.dir}/ssrf-pin-resolver/src" />
+  <!-- Deliberately NOT a subdirectory of build.dir: the `jar` target below jars up the whole
+       of build.dir with no excludes, so a build.dir subdirectory here would get swept into
+       simis-cms.jar (and from there into WEB-INF/lib), precisely the accidental-duplication
+       failure mode this module exists to avoid. Confirmed by building once with it under
+       build.dir: the pin classes really did end up inside WEB-INF/lib/simis-cms.jar. -->
+  <property name="pin.resolver.build.dir" value="${target.dir}/ssrf-pin-resolver-classes" />
+  <property name="pin.resolver.jar" value="${target.dir}/simis-cms-ssrf-pin-resolver.jar" />
+
   <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"
            classpath="${base.dir}/lib/style/checkstyle-10.12.5-all.jar"/>
 
@@ -91,6 +104,11 @@
       <fileset dir="${lib.dir}">
         <include name="**/*.jar"/>
       </fileset>
+      <!-- Compile-only, like everything else on this path: see pin-resolver-jar below.
+           Not a fileset over a lib/ directory on purpose: the jar is a fresh build output,
+           not a vendored dependency, and lib/**/*.jar is exactly what
+           tools/check-vendored-provenance.py scans and would flag as UNLISTED. -->
+      <pathelement location="${pin.resolver.jar}"/>
     </path>
     <path id="test.classpath">
       <fileset dir="${lib.test.dir}">
@@ -103,8 +121,33 @@
     <echo message="Production .war: ${target.dir}/${project}.war"/>
   </target>
 
+  <!-- Builds the SSRF connect-time DNS pin resolver (issue #760) as its own jar. Deliberately
+       standalone: java.net.spi.InetAddressResolverProvider/InetAddressResolver are JDK-builtin
+       interfaces, so this has zero dependency on the rest of the app's classpath and does not
+       need web.classpath or the full compile target's dependencies; plain javac is enough.
+       Output goes to target/, never to lib/, so it is a build artifact (gitignored, like the
+       rest of target/) rather than something check-vendored-provenance.py needs to know about.
+       See ssrf-pin-resolver/README.md for the full rationale and the deployment constraint
+       (CATALINA_HOME/lib only, wired in docker/app/Dockerfile; never WEB-INF/lib). -->
+  <target name="pin-resolver-jar" depends="check-jdk-version">
+    <mkdir dir="${pin.resolver.build.dir}"/>
+    <mkdir dir="${target.dir}"/>
+    <javac srcdir="${pin.resolver.src.dir}" source="${jdk}" target="${jdk}"
+           destdir="${pin.resolver.build.dir}"
+           debug="on" debuglevel="lines,source"
+           deprecation="on"
+           optimize="on"
+           includeantruntime="false">
+      <include name="**/*.java"/>
+    </javac>
+    <jar jarfile="${pin.resolver.jar}">
+      <fileset dir="${pin.resolver.build.dir}" includes="**/*.class"/>
+      <fileset dir="${pin.resolver.src.dir}" includes="META-INF/services/**"/>
+    </jar>
+  </target>
+
   <!-- Compiles the source code -->
-  <target name="compile" depends="check-jdk-version,prepare">
+  <target name="compile" depends="check-jdk-version,prepare,pin-resolver-jar">
     <javac srcdir="${src.dir}" source="${jdk}" target="${jdk}"
            destdir="${build.dir}"
            debug="on" debuglevel="lines,source"

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -42,6 +42,34 @@ RUN curl -fsSL -o /opt/applicationinsights-agent.jar \
     && echo "${APPLICATIONINSIGHTS_SHA256}  /opt/applicationinsights-agent.jar" | sha256sum -c -
 COPY ./docker/app/applicationinsights.json /opt/applicationinsights.json
 
+# SSRF connect-time DNS pin resolver (issue #760). Closes the DNS-rebinding gap
+# RemoteUrlValidationCommand's javadoc documents: it validates a URL's host once, but the JDK
+# HttpClient re-resolves that same hostname itself when it connects, so a hostname that
+# resolved to a public address at validation time could resolve to an internal one moments
+# later. HttpGetCommand.executeUserUrl() now pins the exact address(es) already validated via
+# this jar's java.net.spi.InetAddressResolverProvider, so the connect-time lookup returns
+# those bytes instead of asking DNS again.
+#
+# This jar MUST live on Tomcat's own shared/Common classloader (CATALINA_HOME/lib) and must
+# NEVER be bundled into the WAR's WEB-INF/lib -- verified empirically against a real Tomcat 11
+# container, not assumed. The JDK's InetAddress machinery discovers an
+# InetAddressResolverProvider via ServiceLoader exactly once, on whichever classloader
+# performs the very first DNS lookup of the JVM's life (Tomcat's own bootstrap, before any
+# webapp classloader exists), and then holds that decision for the rest of the JVM's life. A
+# copy of this jar bundled into the WAR as well would be worse than redundant: Tomcat's
+# webapp classloaders are child-first, so the webapp would load its own copy of the pin-holder
+# class instead of delegating to this one, and the pin the webapp writes would never reach the
+# resolver instance the JVM actually installed. See ssrf-pin-resolver/README.md for the full
+# rationale and ant target `pin-resolver-jar` (a dependency of `compile`/`package`) for how the
+# jar is produced.
+#
+# Unlike the Application Insights agent above, this is NOT a fetched third-party artifact --
+# it is built from this repository's own source (ssrf-pin-resolver/) by the same `ant package`
+# that produces target/simis-cms.war, so it carries no separate supply-chain risk and needs no
+# SHA-256 pin: the jar's provenance is exactly the git commit this image was built from,
+# verifiable by rebuilding.
+COPY ./target/simis-cms-ssrf-pin-resolver.jar /usr/local/tomcat/lib/simis-cms-ssrf-pin-resolver.jar
+
 # [STIG] Pre-extract the WAR at build time instead of letting Tomcat unpack it at startup.
 # With a read-only root filesystem, Tomcat cannot write the exploded ROOT/ into webapps/ at
 # boot -- so the app is exploded here, once, and server.xml sets unpackWARs="false". The

--- a/src/main/java/com/simisinc/platform/application/http/HttpDownloadFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpDownloadFileCommand.java
@@ -28,6 +28,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.routines.UrlValidator;
 
+import com.simisinc.platform.provided.net.ConnectAddressPin;
+
 /**
  * Functions for working with http requests.
  *
@@ -43,15 +45,63 @@ public class HttpDownloadFileCommand {
   private static Log LOG = LogFactory.getLog(HttpDownloadFileCommand.class);
 
   /**
+   * True when {@link ConnectAddressPin} (issue #760's connect-time DNS pin resolver) actually
+   * links on this JVM. See {@code HttpGetCommand#PIN_RESOLVER_AVAILABLE} for the full rationale
+   * -- this is the same probe, duplicated here because it must degrade independently per class
+   * rather than depend on {@code HttpGetCommand} having been loaded first.
+   */
+  private static final boolean PIN_RESOLVER_AVAILABLE = isPinResolverAvailable();
+
+  private static boolean isPinResolverAvailable() {
+    try {
+      // A real call, not just Class.forName: proves ConnectAddressPin actually LINKS (its own
+      // dependencies resolve too), the same resolution executeUserUrl's set/clear calls below
+      // depend on. Harmless: clear() is idempotent and nothing is pinned yet at class-init.
+      ConnectAddressPin.clear();
+      return true;
+    } catch (Throwable t) {
+      LOG.warn("SSRF connect-time DNS pinning (issue #760) is unavailable: "
+          + "com.simisinc.platform.provided.net.ConnectAddressPin was not found on this JVM's "
+          + "classpath. executeUserUrl(...) will still run the SSRF guard and fetch normally, "
+          + "but without pinning the validated address, so the DNS-rebinding gap "
+          + "RemoteUrlValidationCommand's javadoc describes is NOT closed in this deployment "
+          + "(no worse than before issue #760, just not improved). This project's own Docker "
+          + "image adds the required jar automatically; a servlet container run outside that "
+          + "image must also place target/simis-cms-ssrf-pin-resolver.jar on the container's "
+          + "shared classpath (CATALINA_HOME/lib for Tomcat) -- see ssrf-pin-resolver/README.md.",
+          t);
+      return false;
+    }
+  }
+
+  /**
    * Validates that {@code url} is SSRF-safe, then downloads the file. Returns false and logs
    * a warning if the guard rejects the URL. Use this for any URL derived from untrusted input.
+   *
+   * <p>Closes the DNS-rebinding gap {@code RemoteUrlValidationCommand} documents (issue #760):
+   * the address(es) validated are pinned via {@link ConnectAddressPin} for the duration of the
+   * actual connect below, so the JDK HttpClient's own re-resolution of {@code url}'s host
+   * returns exactly those bytes rather than asking DNS again. The pin is scoped to this thread
+   * and always cleared in {@code finally} -- Tomcat reuses worker threads across requests, so a
+   * pin left set would otherwise leak into whatever that thread handles next. Degrades
+   * gracefully -- guard still enforced, just not pinned -- rather than failing the download
+   * outright, when {@link #PIN_RESOLVER_AVAILABLE} is false (see its javadoc).
    */
   public static boolean executeUserUrl(String url, File tempFile) {
-    if (!RemoteUrlValidationCommand.isFetchAllowed(url)) {
+    RemoteUrlValidationCommand.ValidationResult validation = RemoteUrlValidationCommand.validate(url);
+    if (!validation.isAllowed()) {
       LOG.warn("Blocked an SSRF-unsafe user-supplied url: " + url);
       return false;
     }
-    return execute(url, null, tempFile);
+    if (!PIN_RESOLVER_AVAILABLE) {
+      return execute(url, null, tempFile);
+    }
+    ConnectAddressPin.set(validation.getHost(), validation.getAddresses());
+    try {
+      return execute(url, null, tempFile);
+    } finally {
+      ConnectAddressPin.clear();
+    }
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
@@ -46,7 +46,7 @@ import com.simisinc.platform.provided.net.ConnectAddressPin;
  */
 public class HttpGetCommand {
 
-  private static Log LOG = LogFactory.getLog(HttpDownloadFileCommand.class);
+  private static Log LOG = LogFactory.getLog(HttpGetCommand.class);
 
   public static final int GET = 1;
   public static final int DELETE = 2;

--- a/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
@@ -28,6 +28,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.routines.UrlValidator;
 
+import com.simisinc.platform.provided.net.ConnectAddressPin;
+
 /**
  * Functions for working with http requests.
  *
@@ -50,15 +52,71 @@ public class HttpGetCommand {
   public static final int DELETE = 2;
 
   /**
+   * True when {@link ConnectAddressPin} (issue #760's connect-time DNS pin resolver, built from
+   * {@code ssrf-pin-resolver/} and normally supplied on the servlet container's shared
+   * classpath -- {@code CATALINA_HOME/lib} for Tomcat) actually links on this JVM. This
+   * project's own Docker image ({@code docker/app/Dockerfile}) adds it automatically. It is NOT
+   * automatically present for any OTHER way of running this application -- notably, deploying
+   * the plain {@code .war} to a self-managed servlet container, which is this project's own
+   * README's documented deployment path and is not Docker-specific. Probed once at class-init
+   * rather than per-call: whether the jar is on the classpath is a deployment-wide fact fixed
+   * for the life of the JVM, not something that can change between two calls.
+   */
+  private static final boolean PIN_RESOLVER_AVAILABLE = isPinResolverAvailable();
+
+  private static boolean isPinResolverAvailable() {
+    try {
+      // A real call, not just Class.forName: proves ConnectAddressPin actually LINKS (its own
+      // dependencies resolve too), the same resolution executeUserUrl's set/clear calls below
+      // depend on. Harmless: clear() is idempotent and nothing is pinned yet at class-init.
+      ConnectAddressPin.clear();
+      return true;
+    } catch (Throwable t) {
+      LOG.warn("SSRF connect-time DNS pinning (issue #760) is unavailable: "
+          + "com.simisinc.platform.provided.net.ConnectAddressPin was not found on this JVM's "
+          + "classpath. executeUserUrl(...) will still run the SSRF guard and fetch normally, "
+          + "but without pinning the validated address, so the DNS-rebinding gap "
+          + "RemoteUrlValidationCommand's javadoc describes is NOT closed in this deployment "
+          + "(no worse than before issue #760, just not improved). This project's own Docker "
+          + "image adds the required jar automatically; a servlet container run outside that "
+          + "image must also place target/simis-cms-ssrf-pin-resolver.jar on the container's "
+          + "shared classpath (CATALINA_HOME/lib for Tomcat) -- see ssrf-pin-resolver/README.md.",
+          t);
+      return false;
+    }
+  }
+
+  /**
    * Validates that {@code url} is SSRF-safe, then fetches it. Returns null and logs a
    * warning if the guard rejects the URL. Use this for any URL derived from untrusted input.
+   *
+   * <p>Closes the DNS-rebinding gap {@code RemoteUrlValidationCommand} documents (issue #760):
+   * the address(es) validated are pinned via {@link ConnectAddressPin} for the duration of the
+   * actual connect below, so the JDK HttpClient's own re-resolution of {@code url}'s host
+   * returns exactly those bytes rather than asking DNS again. The pin is scoped to this thread
+   * and always cleared in {@code finally} -- Tomcat reuses worker threads across requests, so a
+   * pin left set would otherwise leak into whatever that thread handles next. The request URI
+   * itself is never rewritten to an IP literal, so TLS SNI and certificate hostname
+   * verification see the original hostname unchanged.
+   *
+   * <p>Degrades gracefully -- guard still enforced, just not pinned -- rather than failing the
+   * fetch outright, when {@link #PIN_RESOLVER_AVAILABLE} is false (see its javadoc).
    */
   public static String executeUserUrl(String url) {
-    if (!RemoteUrlValidationCommand.isFetchAllowed(url)) {
+    RemoteUrlValidationCommand.ValidationResult validation = RemoteUrlValidationCommand.validate(url);
+    if (!validation.isAllowed()) {
       LOG.warn("Blocked an SSRF-unsafe user-supplied url: " + url);
       return null;
     }
-    return execute(url, GET);
+    if (!PIN_RESOLVER_AVAILABLE) {
+      return execute(url, GET);
+    }
+    ConnectAddressPin.set(validation.getHost(), validation.getAddresses());
+    try {
+      return execute(url, GET);
+    } finally {
+      ConnectAddressPin.clear();
+    }
   }
 
   public static String execute(String url) {

--- a/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
@@ -43,12 +43,14 @@ import org.apache.commons.validator.routines.UrlValidator;
  * the host itself when it connects, so a hostname that returns a public address here could
  * return an internal one at fetch time. {@link #validate(String)} exists for callers that need
  * to close that window: it returns the exact address(es) validated so the caller can pin the
- * connection to them (see {@code com.simisinc.platform.provided.net.ConnectAddressPin} and
- * {@code HttpGetCommand.executeUserUrl}, the one caller wired up to do this so far). Callers
- * that only call {@link #isFetchAllowed(String)} -- {@code HttpDownloadFileCommand} and
- * {@code DatasetDownloadRemoteFileCommand} as of this writing -- still resolve twice and remain
- * exposed to rebinding; blocking literal-IP and stable-DNS targets still covers the common
- * metadata-endpoint attack for them.
+ * connection to them (see {@code com.simisinc.platform.provided.net.ConnectAddressPin},
+ * {@code HttpGetCommand.executeUserUrl}, and {@code HttpDownloadFileCommand.executeUserUrl},
+ * both wired up to do this). {@code DatasetDownloadRemoteFileCommand} reaches every remote fetch
+ * through one of those two guarded wrappers, so it inherits the pin transitively; its own direct
+ * {@link #isFetchAllowed(String)} call is only an early, user-facing rejection before it does
+ * any filesystem prep, not a separate fetch path. A caller that only calls
+ * {@link #isFetchAllowed(String)} and then fetches independently, without going through a
+ * pinning wrapper, would still resolve twice and remain exposed to rebinding.
  *
  * @author Liz Houser
  * @created 7/23/2026

--- a/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/RemoteUrlValidationCommand.java
@@ -38,11 +38,17 @@ import org.apache.commons.validator.routines.UrlValidator;
  * inspects the resulting address, numeric-encoding tricks (e.g. http://2130706433/) are
  * caught too: they resolve to a loopback/private address and are rejected.
  * <p>
- * Residual: this does not by itself defeat DNS rebinding (the JDK HttpClient re-resolves the
- * host when it connects, so a hostname that returns a public address here could return an
- * internal one at fetch time). Blocking literal-IP and stable-DNS targets covers the common
- * metadata-endpoint attack; pinning the validated address at connect time is the stronger
- * follow-up.
+ * Residual (issue #760): resolving the host here and connecting later with a plain hostname
+ * still leaves a DNS-rebinding TOCTOU window open by default -- the JDK HttpClient re-resolves
+ * the host itself when it connects, so a hostname that returns a public address here could
+ * return an internal one at fetch time. {@link #validate(String)} exists for callers that need
+ * to close that window: it returns the exact address(es) validated so the caller can pin the
+ * connection to them (see {@code com.simisinc.platform.provided.net.ConnectAddressPin} and
+ * {@code HttpGetCommand.executeUserUrl}, the one caller wired up to do this so far). Callers
+ * that only call {@link #isFetchAllowed(String)} -- {@code HttpDownloadFileCommand} and
+ * {@code DatasetDownloadRemoteFileCommand} as of this writing -- still resolve twice and remain
+ * exposed to rebinding; blocking literal-IP and stable-DNS targets still covers the common
+ * metadata-endpoint attack for them.
  *
  * @author Liz Houser
  * @created 7/23/2026
@@ -54,6 +60,44 @@ public class RemoteUrlValidationCommand {
   private static final String[] ALLOWED_SCHEMES = { "http", "https" };
 
   /**
+   * The result of validating a URL: whether the fetch is allowed, and -- when it is -- the
+   * exact host and address(es) that were checked, so a caller can pin a subsequent connection
+   * to precisely those bytes instead of letting it re-resolve the host (see issue #760).
+   */
+  public static final class ValidationResult {
+    private final boolean allowed;
+    private final String host;
+    private final InetAddress[] addresses;
+
+    // Package-private rather than private: lets same-package tests build a fixed
+    // ValidationResult to stub RemoteUrlValidationCommand.validate(...) with (see
+    // HttpGetCommandExecuteUserUrlPinTest), without opening construction to other packages.
+    ValidationResult(boolean allowed, String host, InetAddress[] addresses) {
+      this.allowed = allowed;
+      this.host = host;
+      this.addresses = addresses;
+    }
+
+    public boolean isAllowed() {
+      return allowed;
+    }
+
+    /** The URL's host, when it could be extracted -- regardless of whether it was allowed. */
+    public String getHost() {
+      return host;
+    }
+
+    /**
+     * The exact addresses {@code host} resolved to at validation time, already confirmed
+     * public/routable. Only meaningful when {@link #isAllowed()} is true; callers must check
+     * that first.
+     */
+    public InetAddress[] getAddresses() {
+      return addresses;
+    }
+  }
+
+  /**
    * Determines whether a server-side fetch of the given URL is permitted. Fails closed:
    * a blank, malformed, non-http(s), unresolvable, or internally-routed URL returns false.
    *
@@ -61,36 +105,49 @@ public class RemoteUrlValidationCommand {
    * @return true only if the URL is safe to fetch
    */
   public static boolean isFetchAllowed(String url) {
+    return validate(url).isAllowed();
+  }
+
+  /**
+   * Same check as {@link #isFetchAllowed(String)}, but also returns the host and exact
+   * address(es) that were validated, so a caller can pin a subsequent connection to them (see
+   * issue #760). Fails closed identically: a blank, malformed, non-http(s), unresolvable, or
+   * internally-routed URL yields a result with {@code isAllowed() == false}.
+   *
+   * @param url the caller-supplied URL to be fetched
+   * @return the validation result; check {@link ValidationResult#isAllowed()} first
+   */
+  public static ValidationResult validate(String url) {
     if (StringUtils.isBlank(url)) {
-      return false;
+      return new ValidationResult(false, null, null);
     }
     if (!new UrlValidator(ALLOWED_SCHEMES).isValid(url)) {
       LOG.debug("Blocked a non-http(s) or malformed url: " + url);
-      return false;
+      return new ValidationResult(false, null, null);
     }
     try {
       String host = URI.create(url).getHost();
       if (StringUtils.isBlank(host)) {
         LOG.debug("Blocked a url with no resolvable host: " + url);
-        return false;
+        return new ValidationResult(false, null, null);
       }
       InetAddress[] addresses = InetAddress.getAllByName(host);
       if (addresses == null || addresses.length == 0) {
-        return false;
+        return new ValidationResult(false, host, null);
       }
       // Every address the host resolves to must be public/routable; if any is internal,
       // reject -- a host that resolves to both a public and a private address is not safe.
       for (InetAddress address : addresses) {
         if (isBlockedAddress(address)) {
           LOG.warn("Blocked an SSRF-unsafe address for host " + host + ": " + address.getHostAddress());
-          return false;
+          return new ValidationResult(false, host, null);
         }
       }
-      return true;
+      return new ValidationResult(true, host, addresses);
     } catch (Exception e) {
       // Unresolvable host, malformed authority, etc. -- fail closed.
       LOG.warn("Blocked a url that could not be validated: " + url);
-      return false;
+      return new ValidationResult(false, null, null);
     }
   }
 

--- a/src/test/java/com/simisinc/platform/application/http/HttpDownloadFileCommandExecuteUserUrlPinTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpDownloadFileCommandExecuteUserUrlPinTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.provided.net.ConnectAddressPin;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Exercises the real, unmodified {@link HttpDownloadFileCommand#executeUserUrl(String, java.io.File)}
+ * end to end against a real local HTTP server -- the {@code HttpDownloadFileCommand} counterpart
+ * of {@link HttpGetCommandExecuteUserUrlPinTest}, closing the gap issue #760's fix left open
+ * (its commit message flagged this method as still exposed to DNS rebinding, since it only
+ * called {@code isFetchAllowed} and never pinned the connect address).
+ *
+ * <p>{@code RemoteUrlValidationCommand.validate(...)} is the one thing stubbed here, and only to
+ * supply what a hostname that legitimately validated as public would look like: there is no real
+ * public server available to this test suite to point the real validator at. Everything
+ * downstream of that stub -- {@link HttpDownloadFileCommand}'s own {@code ConnectAddressPin.set},
+ * {@code execute}, its {@code finally}-block {@code clear}, the real {@code HttpClient}, and the
+ * real {@code ConnectAddressResolverProvider} installed from
+ * {@code target/simis-cms-ssrf-pin-resolver.jar} on the test classpath -- runs unmodified.
+ *
+ * <p>Test hostnames use a {@code *.example.com} shape for the same reason
+ * {@code HttpGetCommandExecuteUserUrlPinTest} does: {@code execute()} itself (unmocked here) runs
+ * its own {@code UrlValidator} check before ever touching DNS, and {@code UrlValidator} rejects
+ * {@code .invalid} as an unrecognized TLD outright, before pinning is ever in play.
+ * {@code example.com} is IANA-reserved for documentation (RFC 2606) with no wildcard DNS record,
+ * so a random subdomain is a syntactically ordinary hostname, but real DNS resolution of it is
+ * never exercised here: {@code validate()} is stubbed and the actual connect target is always the
+ * pin, so nothing in this file depends on {@code example.com} being reachable or its subdomains
+ * resolving one way or the other.
+ *
+ * @author Liz Houser
+ * @created 7/31/2026
+ */
+class HttpDownloadFileCommandExecuteUserUrlPinTest {
+
+  private static final String TRAP_BODY = "EXECUTE-USER-URL-PIN-OK";
+
+  private HttpServer trapServer;
+  private File tempFile;
+
+  @AfterEach
+  void tearDown() {
+    ConnectAddressPin.clear();
+    if (trapServer != null) {
+      trapServer.stop(0);
+    }
+    if (tempFile != null && tempFile.exists()) {
+      tempFile.delete();
+    }
+  }
+
+  @Test
+  void executeUserUrlPinsTheValidatedAddressAndReachesTheTrap() throws Exception {
+    int port = startTrapServer();
+    String fakeHost = "downloadfile-pin-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":" + port + "/";
+    RemoteUrlValidationCommand.ValidationResult validated =
+        new RemoteUrlValidationCommand.ValidationResult(true, fakeHost, new InetAddress[] { InetAddress.getByName("127.0.0.1") });
+    tempFile = File.createTempFile("http-download-pin-test", ".tmp");
+
+    boolean result;
+    try (MockedStatic<RemoteUrlValidationCommand> validation = mockStatic(RemoteUrlValidationCommand.class)) {
+      validation.when(() -> RemoteUrlValidationCommand.validate(url)).thenReturn(validated);
+      result = HttpDownloadFileCommand.executeUserUrl(url, tempFile);
+    }
+
+    assertTrue(result);
+    assertEquals(TRAP_BODY, Files.readString(tempFile.toPath()));
+  }
+
+  @Test
+  void executeUserUrlNeverConnectsWhenValidationRejectsTheUrl() {
+    String fakeHost = "downloadfile-blocked-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":1/";
+    RemoteUrlValidationCommand.ValidationResult rejected =
+        new RemoteUrlValidationCommand.ValidationResult(false, null, null);
+    tempFile = new File(System.getProperty("java.io.tmpdir"), "http-download-pin-test-" + System.nanoTime() + ".tmp");
+
+    try (MockedStatic<RemoteUrlValidationCommand> validation = mockStatic(RemoteUrlValidationCommand.class)) {
+      validation.when(() -> RemoteUrlValidationCommand.validate(url)).thenReturn(rejected);
+      assertFalse(HttpDownloadFileCommand.executeUserUrl(url, tempFile));
+    }
+    assertFalse(tempFile.exists(), "a rejected url must never be fetched, so no file should be written");
+  }
+
+  @Test
+  void plainExecuteHonorsAPreExistingPinWithoutManagingItItself() throws Exception {
+    // PERLSApiClientCommand calls the plain execute(...) directly against a fixed, operator-
+    // controlled endpoint and must never have its own pin management -- pre-seed one exactly as
+    // executeUserUrl would have, then call the PLAIN execute() -- which never calls
+    // RemoteUrlValidationCommand or ConnectAddressPin at all -- and confirm the request still
+    // reaches the trap: proving execute() does not proactively clear or otherwise interfere
+    // with a pin that is already active on the thread when it runs.
+    int port = startTrapServer();
+    String fakeHost = "downloadfile-plain-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":" + port + "/";
+    tempFile = File.createTempFile("http-download-pin-test", ".tmp");
+
+    ConnectAddressPin.set(fakeHost, new InetAddress[] { InetAddress.getByName("127.0.0.1") });
+
+    assertTrue(HttpDownloadFileCommand.execute(url, tempFile));
+    assertEquals(TRAP_BODY, Files.readString(tempFile.toPath()));
+  }
+
+  private int startTrapServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", exchange -> {
+      byte[] body = TRAP_BODY.getBytes();
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    server.start();
+    trapServer = server;
+    return server.getAddress().getPort();
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/HttpGetCommandExecuteUserUrlPinTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpGetCommandExecuteUserUrlPinTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.provided.net.ConnectAddressPin;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Exercises the real, unmodified {@link HttpGetCommand#executeUserUrl(String)} end to end
+ * against a real local HTTP server, adapting the issue #760 investigation's loopback-server /
+ * fake-hostname technique so it goes through the actual production pinning code instead of a
+ * standalone servlet (see {@code com.simisinc.platform.provided.net.ConnectAddressPinResolverTest}
+ * for the SPI mechanism tested in isolation).
+ *
+ * <p>{@code RemoteUrlValidationCommand.validate(...)} is the one thing stubbed here, and only to
+ * supply what a hostname that legitimately validated as public would look like: there is no real
+ * public server available to this test suite to point the real validator at. Everything
+ * downstream of that stub -- {@link HttpGetCommand}'s own {@code ConnectAddressPin.set},
+ * {@code execute}, its {@code finally}-block {@code clear}, the real {@code HttpClient}, and the
+ * real {@code ConnectAddressResolverProvider} installed from
+ * {@code target/simis-cms-ssrf-pin-resolver.jar} on the test classpath -- runs unmodified.
+ *
+ * <p>Test hostnames use a {@code *.example.com} shape rather than the {@code *.invalid} names
+ * {@code ConnectAddressPinResolverTest} uses: {@code execute()} itself (unmocked here) runs its
+ * own {@code UrlValidator} check before ever touching DNS, and {@code UrlValidator} rejects
+ * {@code .invalid} as an unrecognized TLD outright, before pinning is ever in play (confirmed
+ * empirically while writing this test -- see git history for the {@code .invalid} version that
+ * failed this way). {@code example.com} is IANA-reserved for documentation (RFC 2606) with no
+ * wildcard DNS record, so a random subdomain is a syntactically ordinary hostname, but real DNS
+ * resolution of it is never exercised here: {@code validate()} is stubbed and the actual connect
+ * target is always the pin, so nothing in this file depends on {@code example.com} being
+ * reachable or its subdomains resolving one way or the other.
+ *
+ * @author Liz Houser
+ * @created 7/31/2026
+ */
+class HttpGetCommandExecuteUserUrlPinTest {
+
+  private static final String TRAP_BODY = "EXECUTE-USER-URL-PIN-OK";
+
+  private HttpServer trapServer;
+
+  @AfterEach
+  void tearDown() {
+    ConnectAddressPin.clear();
+    if (trapServer != null) {
+      trapServer.stop(0);
+    }
+  }
+
+  @Test
+  void executeUserUrlPinsTheValidatedAddressAndReachesTheTrap() throws Exception {
+    int port = startTrapServer();
+    String fakeHost = "executeuserurl-pin-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":" + port + "/";
+    RemoteUrlValidationCommand.ValidationResult validated =
+        new RemoteUrlValidationCommand.ValidationResult(true, fakeHost, new InetAddress[] { InetAddress.getByName("127.0.0.1") });
+
+    String body;
+    try (MockedStatic<RemoteUrlValidationCommand> validation = mockStatic(RemoteUrlValidationCommand.class)) {
+      validation.when(() -> RemoteUrlValidationCommand.validate(url)).thenReturn(validated);
+      body = HttpGetCommand.executeUserUrl(url);
+    }
+
+    assertEquals(TRAP_BODY, body);
+  }
+
+  @Test
+  void executeUserUrlNeverConnectsWhenValidationRejectsTheUrl() {
+    String fakeHost = "executeuserurl-blocked-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":1/";
+    RemoteUrlValidationCommand.ValidationResult rejected =
+        new RemoteUrlValidationCommand.ValidationResult(false, null, null);
+
+    try (MockedStatic<RemoteUrlValidationCommand> validation = mockStatic(RemoteUrlValidationCommand.class)) {
+      validation.when(() -> RemoteUrlValidationCommand.validate(url)).thenReturn(rejected);
+      assertNull(HttpGetCommand.executeUserUrl(url));
+    }
+  }
+
+  @Test
+  void plainExecuteHonorsAPreExistingPinWithoutManagingItItself() throws Exception {
+    // The OAuth/Stripe/MailChimp overloads must never manage the pin. Pre-seed one exactly as
+    // executeUserUrl would have, then call the PLAIN execute() -- which never calls
+    // RemoteUrlValidationCommand or ConnectAddressPin at all -- and confirm the request still
+    // reaches the trap: proving execute() does not proactively clear or otherwise interfere
+    // with a pin that is already active on the thread when it runs. (Whether execute() itself
+    // never SETS a pin is a simpler code-inspection fact -- it has no ConnectAddressPin
+    // reference at all -- rather than something meaningful to assert at runtime.)
+    int port = startTrapServer();
+    String fakeHost = "execute-plain-" + System.nanoTime() + ".simis-ssrf-pin-test.example.com";
+    String url = "http://" + fakeHost + ":" + port + "/";
+
+    ConnectAddressPin.set(fakeHost, new InetAddress[] { InetAddress.getByName("127.0.0.1") });
+
+    assertEquals(TRAP_BODY, HttpGetCommand.execute(url));
+  }
+
+  private int startTrapServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", exchange -> {
+      byte[] body = TRAP_BODY.getBytes();
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    server.start();
+    trapServer = server;
+    return server.getAddress().getPort();
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/HttpGetCommandPinResolverAbsentTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpGetCommandPinResolverAbsentTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the issue #760 dev/prod parity gap: this project's own README documents
+ * deploying the plain {@code .war} to a self-managed servlet container as a supported path
+ * independent of {@code docker/app/Dockerfile}, and that path does not automatically get
+ * {@code target/simis-cms-ssrf-pin-resolver.jar} onto the container's shared classpath. Loads a
+ * FRESH copy of {@link HttpGetCommand} under an isolated classloader built from exactly
+ * {@code build/} + {@code lib/build/**}{@code /*.jar} -- the shape of a deployed WAR's
+ * {@code WEB-INF/classes} + {@code WEB-INF/lib}, with no {@code CATALINA_HOME/lib} equivalent
+ * -- and confirms {@code executeUserUrl(...)} degrades gracefully (SSRF guard still enforced,
+ * fetch still attempted, no crash) rather than throwing {@code NoClassDefFoundError}, which is
+ * what it did before {@code HttpGetCommand.PIN_RESOLVER_AVAILABLE} was added (confirmed by
+ * temporarily removing that guard while writing this test).
+ *
+ * @author Liz Houser
+ * @created 7/31/2026
+ */
+class HttpGetCommandPinResolverAbsentTest {
+
+  @Test
+  void executeUserUrlDoesNotCrashWhenThePinResolverJarIsMissingFromTheClasspath() throws Exception {
+    File classesDir = new File("build");
+    File depsDir = new File("lib/build");
+    assumeTrue(classesDir.isDirectory() && depsDir.isDirectory(),
+        "expects to run with the project basedir as the working directory (build/ and lib/build/ must exist)");
+
+    List<URL> urls = new ArrayList<>();
+    urls.add(classesDir.toURI().toURL());
+    collectJars(depsDir, urls);
+    // The one thing deliberately excluded: target/simis-cms-ssrf-pin-resolver.jar (see
+    // build.xml's pin-resolver-jar target). Everything else a real WAR deployment would have
+    // on WEB-INF/classes + WEB-INF/lib is included.
+
+    try (URLClassLoader isolated = new URLClassLoader(urls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader())) {
+      Class<?> isolatedHttpGetCommand = Class.forName("com.simisinc.platform.application.http.HttpGetCommand", true, isolated);
+      assertTrue(isolatedHttpGetCommand.getClassLoader() == isolated,
+          "sanity check: must be a FRESH class load under the isolated loader, not one delegated back to this test's own classloader");
+
+      Method executeUserUrl = isolatedHttpGetCommand.getMethod("executeUserUrl", String.class);
+      Object result;
+      try {
+        // 169.254.169.254 is blocked by RemoteUrlValidationCommand regardless of pinning; the
+        // point here is only that the CALL doesn't throw NoClassDefFoundError -- the guard
+        // itself is already covered by RemoteUrlValidationCommandTest.
+        result = executeUserUrl.invoke(null, "http://169.254.169.254/metadata");
+      } catch (InvocationTargetException e) {
+        throw new AssertionError("executeUserUrl threw when the pin-resolver jar is absent from the classpath "
+            + "-- it must degrade gracefully instead (see HttpGetCommand.PIN_RESOLVER_AVAILABLE)", e.getCause());
+      }
+      assertNull(result, "the SSRF guard must still block a cloud-metadata address even without pinning available");
+    }
+  }
+
+  private static void collectJars(File dir, List<URL> urls) throws Exception {
+    File[] entries = dir.listFiles();
+    if (entries == null) {
+      return;
+    }
+    for (File entry : entries) {
+      if (entry.isDirectory()) {
+        collectJars(entry, urls);
+      } else if (entry.getName().endsWith(".jar")) {
+        urls.add(entry.toURI().toURL());
+      }
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/RemoteUrlValidationCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/RemoteUrlValidationCommandTest.java
@@ -16,7 +16,10 @@
 
 package com.simisinc.platform.application.http;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetAddress;
@@ -70,6 +73,39 @@ class RemoteUrlValidationCommandTest {
     assertFalse(RemoteUrlValidationCommand.isFetchAllowed("not-a-url"));
     assertFalse(RemoteUrlValidationCommand.isFetchAllowed(""));
     assertFalse(RemoteUrlValidationCommand.isFetchAllowed(null));
+  }
+
+  // --- validate: the issue #760 pinning API, exposing the exact address(es) checked ---
+
+  @Test
+  void validateReturnsTheHostAndExactAddressesForAnAllowedUrl() throws Exception {
+    RemoteUrlValidationCommand.ValidationResult result = RemoteUrlValidationCommand.validate("https://8.8.8.8/dataset.json");
+    assertTrue(result.isAllowed());
+    assertEquals("8.8.8.8", result.getHost());
+    assertArrayEquals(new InetAddress[] { InetAddress.getByName("8.8.8.8") }, result.getAddresses());
+  }
+
+  @Test
+  void validateReportsNotAllowedForABlockedAddressAndWithholdsAddresses() {
+    RemoteUrlValidationCommand.ValidationResult result = RemoteUrlValidationCommand.validate("http://169.254.169.254/metadata");
+    assertFalse(result.isAllowed());
+    // The host is still reported (useful for logging/diagnostics); the addresses are not, since
+    // isAllowed() is false and a caller must never pin to an address that failed validation.
+    assertEquals("169.254.169.254", result.getHost());
+    assertNull(result.getAddresses());
+  }
+
+  @Test
+  void validateAgreesWithIsFetchAllowedOnEveryCase() {
+    // isFetchAllowed is now a thin wrapper over validate(...).isAllowed() -- this pins that
+    // relationship so the two can never silently diverge.
+    for (String url : new String[] {
+        "https://8.8.8.8/dataset.json", "http://169.254.169.254/", "http://127.0.0.1:8080/admin",
+        "ftp://8.8.8.8/file", "not-a-url", "", null
+    }) {
+      assertEquals(RemoteUrlValidationCommand.isFetchAllowed(url), RemoteUrlValidationCommand.validate(url).isAllowed(),
+          "isFetchAllowed/validate disagreed for: " + url);
+    }
   }
 
   // --- isBlockedAddress: the address classifier, exercised directly on IP literals ---

--- a/src/test/java/com/simisinc/platform/provided/net/ConnectAddressPinResolverTest.java
+++ b/src/test/java/com/simisinc/platform/provided/net/ConnectAddressPinResolverTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.provided.net;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Proves the {@link ConnectAddressResolverProvider} SPI mechanism itself, in isolation from
+ * {@code RemoteUrlValidationCommand}/{@code HttpGetCommand}: a hostname that cannot resolve via
+ * real DNS (an RFC 2606-reserved {@code .invalid} name) connects successfully once
+ * {@link ConnectAddressPin#set} pins it to a local trap server, and the identical hostname
+ * fails to connect when nothing was pinned for it. The second half matters as much as the
+ * first: it proves the trap server is reached ONLY through a deliberate pin, not through some
+ * other leak (a real network path, a JVM-wide negative-DNS-cache quirk, an overly loose host
+ * match). This is the same technique the issue #760 investigation used against a real Tomcat
+ * container (see {@code ssrf-pin-resolver/README.md}), adapted into a repeatable unit test.
+ *
+ * <p>This test's forked JVM genuinely installs {@link ConnectAddressResolverProvider} as its
+ * {@code java.net.spi.InetAddressResolverProvider} -- {@code target/simis-cms-ssrf-pin-resolver.jar}
+ * is on {@code web.classpath} (see {@code build.xml}'s {@code prepare}/{@code pin-resolver-jar}
+ * targets), which is on this test's classpath, and the JDK's {@code ServiceLoader} finds it via
+ * the {@code META-INF/services} entry inside that jar. What this test does NOT cover is the
+ * container-classloader-timing constraint documented on {@link ConnectAddressPin} (Tomcat's own
+ * bootstrap performing the very first lookup of the JVM's life before any webapp classloader
+ * exists) -- a flat single-classloader test JVM has no such race. That half is re-verified for
+ * this change by the docker-compose rehearsal against a real Tomcat 11 container, not here.
+ *
+ * <p>Also worth knowing while reading this class: the JDK's own {@code InetAddress} cache
+ * ({@code networkaddress.cache.ttl}) sits ABOVE this resolver SPI and can answer a later lookup
+ * of the exact same hostname string from cache without calling this resolver again. That is
+ * pre-existing JDK behavior unrelated to this fix (it already applied to every hostname
+ * resolution in the JVM before this module existed) and does not weaken the security property
+ * here -- within one request, whatever {@code RemoteUrlValidationCommand.validate} resolved is
+ * exactly what gets pinned and connected to, cache or no cache. It does mean "clear the pin,
+ * then reconnect to the same hostname and expect failure" is NOT a reliable test technique
+ * (confirmed empirically while writing this test); see {@link #clearRemovesThePinFromThreadLocalStorage()}.
+ *
+ * @author Liz Houser
+ * @created 7/31/2026
+ */
+class ConnectAddressPinResolverTest {
+
+  private static final String TRAP_BODY = "PIN-TRAP-OK";
+
+  private HttpServer trapServer;
+
+  @AfterEach
+  void tearDown() {
+    ConnectAddressPin.clear();
+    if (trapServer != null) {
+      trapServer.stop(0);
+    }
+  }
+
+  @Test
+  void pinnedFakeHostnameConnectsToExactlyThePinnedAddress() throws Exception {
+    int port = startTrapServer();
+    String fakeHost = "pinned-" + System.nanoTime() + ".invalid";
+
+    ConnectAddressPin.set(fakeHost, new InetAddress[] { InetAddress.getByName("127.0.0.1") });
+    HttpResponse<String> response = get(fakeHost, port);
+
+    assertEquals(200, response.statusCode());
+    assertEquals(TRAP_BODY, response.body());
+  }
+
+  @Test
+  void unpinnedFakeHostnameNeverReachesTheTrap() {
+    // No ConnectAddressPin.set() for this hostname: real DNS resolution of a .invalid name
+    // must fail exactly as it would with no resolver provider installed at all.
+    assertThrows(IOException.class, () -> {
+      int port = startTrapServer();
+      String fakeHost = "unpinned-" + System.nanoTime() + ".invalid";
+      get(fakeHost, port);
+    });
+  }
+
+  @Test
+  void clearRemovesThePinFromThreadLocalStorage() throws Exception {
+    // Deliberately NOT "pin, clear, then reconnect and expect failure": the JDK's OWN
+    // InetAddress cache (networkaddress.cache.ttl) sits ABOVE this resolver SPI and, once a
+    // hostname resolves successfully, can keep answering later lookups of that EXACT hostname
+    // string from its cache without ever calling this resolver again -- confirmed empirically
+    // while building this test (a cleared pin's hostname kept "resolving" to the stale pinned
+    // address on a second real connect attempt, purely from that ambient cache, not from any
+    // bug in clear()). That JDK-level cache is pre-existing JDK behavior, unrelated to this
+    // fix, and does not weaken it: within a single request, whatever validate() resolved is
+    // exactly what gets pinned and connected to either way. But it does make "reconnect and
+    // expect failure" an unreliable way to prove clear() itself works. Asserting directly on
+    // the ThreadLocal state instead sidesteps that confound entirely.
+    String fakeHost = "clear-" + System.nanoTime() + ".invalid";
+    InetAddress[] addresses = { InetAddress.getByName("127.0.0.1") };
+
+    ConnectAddressPin.set(fakeHost, addresses);
+    assertArrayEquals(addresses, ConnectAddressPin.get(fakeHost));
+
+    ConnectAddressPin.clear();
+    assertNull(ConnectAddressPin.get(fakeHost));
+  }
+
+  private HttpResponse<String> get(String host, int port) throws IOException, InterruptedException {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder(URI.create("http://" + host + ":" + port + "/"))
+        .timeout(Duration.ofSeconds(5))
+        .GET()
+        .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private int startTrapServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", exchange -> {
+      byte[] body = TRAP_BODY.getBytes();
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    server.start();
+    trapServer = server;
+    return server.getAddress().getPort();
+  }
+}

--- a/src/test/java/com/simisinc/platform/provided/net/ConnectAddressResolverProviderFamilyFilterTest.java
+++ b/src/test/java/com/simisinc/platform/provided/net/ConnectAddressResolverProviderFamilyFilterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.provided.net;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.net.InetAddress;
+import java.net.spi.InetAddressResolver.LookupPolicy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link ConnectAddressResolverProvider#matchingFamily(InetAddress[], LookupPolicy)}
+ * directly: the address-family filtering {@code lookupByName} applies to a pinned host's
+ * addresses before returning them, mirroring what the builtin resolver already does for an
+ * unpinned lookup.
+ *
+ * <p>This cannot be tested by driving {@link ConnectAddressResolverProvider#get} end to end the
+ * way {@link ConnectAddressPinResolverTest} drives the whole SPI through a real
+ * {@code HttpClient}: {@code get}'s parameter, {@code InetAddressResolverProvider.Configuration},
+ * is a JDK <em>sealed</em> interface that permits exactly one implementation
+ * ({@code sun.net.ResolverProviderConfiguration}, internal to {@code java.base}) -- no code
+ * outside the JDK itself, mock frameworks included, can construct or subclass one. {@code
+ * matchingFamily} is the package-private seam that carries the actual filtering decision, so
+ * testing it directly still proves the logic that matters; what is NOT re-proven here is that
+ * {@code lookupByName} wires an empty result to a thrown {@code UnknownHostException} rather
+ * than silently falling back to the builtin resolver -- that four-line guard clause is verified
+ * by reading {@link ConnectAddressResolverProvider#get}, not by a runtime test, for the sealed-
+ * interface reason above.
+ *
+ * <p>Also worth knowing: nothing in this codebase sets {@code java.net.preferIPv4Stack} or
+ * {@code preferIPv6Addresses} today (confirmed by grep), so in normal operation
+ * {@code lookupByName} only ever receives the dual-stack {@code LookupPolicy}
+ * {@link #dualStackPolicyReturnsEveryPinnedAddressUnfiltered()} covers; the single-family tests
+ * below cover a defense-in-depth path this application's current configuration does not
+ * currently reach.
+ *
+ * @author Liz Houser
+ * @created 7/31/2026
+ */
+class ConnectAddressResolverProviderFamilyFilterTest {
+
+  @Test
+  void ipv4OnlyPolicyKeepsOnlyTheIpv4PinnedAddress() throws Exception {
+    InetAddress v4 = InetAddress.getByName("127.0.0.1");
+    InetAddress v6 = InetAddress.getByName("::1");
+
+    InetAddress[] result = ConnectAddressResolverProvider.matchingFamily(
+        new InetAddress[] { v4, v6 }, LookupPolicy.of(LookupPolicy.IPV4));
+
+    assertArrayEquals(new InetAddress[] { v4 }, result);
+  }
+
+  @Test
+  void ipv6OnlyPolicyKeepsOnlyTheIpv6PinnedAddress() throws Exception {
+    InetAddress v4 = InetAddress.getByName("127.0.0.1");
+    InetAddress v6 = InetAddress.getByName("::1");
+
+    InetAddress[] result = ConnectAddressResolverProvider.matchingFamily(
+        new InetAddress[] { v4, v6 }, LookupPolicy.of(LookupPolicy.IPV6));
+
+    assertArrayEquals(new InetAddress[] { v6 }, result);
+  }
+
+  @Test
+  void dualStackPolicyReturnsEveryPinnedAddressUnfiltered() throws Exception {
+    InetAddress[] pinned = { InetAddress.getByName("127.0.0.1"), InetAddress.getByName("::1") };
+
+    InetAddress[] result = ConnectAddressResolverProvider.matchingFamily(
+        pinned, LookupPolicy.of(LookupPolicy.IPV4 | LookupPolicy.IPV6));
+
+    // Same array reference, not just an equal one: the dual-stack/no-op branch hands the input
+    // straight back rather than copying it.
+    assertSame(pinned, result);
+  }
+
+  @Test
+  void familyMismatchYieldsAnEmptyResultRatherThanTheWrongFamily() throws Exception {
+    InetAddress v6Only = InetAddress.getByName("::1");
+
+    InetAddress[] result = ConnectAddressResolverProvider.matchingFamily(
+        new InetAddress[] { v6Only }, LookupPolicy.of(LookupPolicy.IPV4));
+
+    // lookupByName turns this empty result into a thrown UnknownHostException rather than
+    // falling back to the builtin (unpinned) resolver -- see this class's javadoc for why that
+    // wiring is verified by inspection rather than here.
+    assertArrayEquals(new InetAddress[0], result);
+  }
+}

--- a/ssrf-pin-resolver/README.md
+++ b/ssrf-pin-resolver/README.md
@@ -1,0 +1,81 @@
+# SSRF connect-time DNS pin resolver
+
+Closes the DNS-rebinding gap tracked in issue #760: `RemoteUrlValidationCommand` validates a
+URL's host once, but the JDK `HttpClient` re-resolves that same hostname itself when it
+connects, so a hostname that resolved to a public address at validation time could resolve to
+an internal one moments later. This module lets `HttpGetCommand.executeUserUrl()` pin the
+*exact* address(es) `RemoteUrlValidationCommand` already validated, so the connect-time lookup
+returns those bytes instead of asking DNS again -- there is no second lookup left to race.
+
+## Why this is not under `src/main/java`
+
+This is a `java.net.spi.InetAddressResolverProvider`. The JDK's `InetAddress` machinery
+discovers providers via `ServiceLoader` exactly once, on whichever classloader performs the
+*first* DNS lookup of the JVM's life, and then holds that decision forever. In a real Tomcat
+11 container that first lookup happens during Tomcat's own bootstrap (before any webapp
+classloader exists), on Tomcat's shared/Common classloader -- so a provider bundled into the
+WAR (`WEB-INF/lib` or `WEB-INF/classes`) is discovered too late and is never consulted. This
+was verified empirically, not assumed: the identical class shipped webapp-scoped measurably
+does nothing; shipped on `CATALINA_HOME/lib` it genuinely intercepts `HttpClient`'s
+connect-time resolution.
+
+Practically, that means these two classes must be:
+
+- compiled against by application code (`HttpGetCommand` imports `ConnectAddressPin`), but
+- **excluded** from the WAR, and
+- present on Tomcat's own `CATALINA_HOME/lib` at container boot.
+
+That is exactly the "provided scope" treatment `jakarta.servlet-api` already gets in this
+project (see `lib/compile/jee` -- compiled against, never bundled, supplied by the container).
+This module is the same pattern for code we wrote ourselves instead of a third-party API jar.
+
+## Build
+
+`ant pin-resolver-jar` (a dependency of `compile`, so it also runs as part of a normal
+`ant compile` / `ant package`) compiles this directory with plain `javac` -- no dependency on
+the rest of the app's classpath, since `java.net.spi.*` is JDK-builtin -- and jars the result,
+together with the `META-INF/services` registration, to
+`target/simis-cms-ssrf-pin-resolver.jar`. That jar is never committed to git (it is a build
+artifact, like everything else under `target/`) and is added to Ant's compile classpath
+compile-only; `package`/`webapp` do not include it, since they assemble `WEB-INF/lib` only
+from `lib/build`.
+
+`docker/app/Dockerfile` copies the built jar to `/usr/local/tomcat/lib/`.
+
+## Deployments other than this project's Docker image
+
+This project's README documents a second, Docker-independent deployment path: build the `.war`
+(`ant package`) and deploy it to any Java 21 servlet container. That path does **not**
+automatically get this jar -- there is nothing in the WAR that would put it on such a
+container's shared classpath, by design (see above).
+
+`HttpGetCommand` handles this: it probes once, at class-init, whether `ConnectAddressPin`
+actually links, and falls back to the pre-issue-#760 behavior (SSRF guard still enforced, just
+not pinned -- no worse than before this change, just not improved) if it does not, logging a
+warning that names the missing jar and this file. It does **not** throw or break the fetch.
+Confirmed by building `target/simis-cms.jar` (or the exploded `WEB-INF/classes` +
+`WEB-INF/lib`) without `target/simis-cms-ssrf-pin-resolver.jar` on the classpath and calling
+`HttpGetCommand.executeUserUrl(...)`: before this fallback existed, that threw
+`NoClassDefFoundError` out of `executeUserUrl` on first use; with it, `executeUserUrl` logs the
+warning once and otherwise behaves exactly as it did before issue #760.
+
+An operator deploying this application's `.war` to their own Tomcat 11 (or other Java 21
+servlet container) who wants the DNS-rebinding fix should build this module
+(`ant pin-resolver-jar`) and copy `target/simis-cms-ssrf-pin-resolver.jar` to their own
+container's shared classpath (`CATALINA_HOME/lib` for Tomcat) as part of their upgrade steps,
+the same way this project's Docker image does. This is a real, currently-undocumented gap in
+the upgrade instructions for non-Docker deployments -- flagged here rather than silently left
+for someone to discover as a missing security improvement with no explanation.
+
+## Do not duplicate these classes into the WAR
+
+Tomcat's webapp classloaders are child-first. If a copy of `ConnectAddressPin` or
+`ConnectAddressResolverProvider` ever ends up in `WEB-INF/lib` or `WEB-INF/classes` as well as
+`CATALINA_HOME/lib`, the webapp loads its own copy, and `HttpGetCommand` would write a pin
+that the resolver (bound to the `CATALINA_HOME/lib` copy) never reads -- silently reopening the
+DNS-rebinding gap this module exists to close. Nothing in the automated build gates would flag
+that on its own (`check-war-completeness.py` only reports classes that are *missing*, not
+extras that were never supposed to be there), which is why `build.xml`'s `package`/`webapp`
+targets assemble `WEB-INF/lib` only from `lib/build` -- this module's jar is never written
+there -- and it is worth re-confirming by hand (`jar tf target/simis-cms.war | grep -i
+provided/net`) after any change to the build script that touches either target.

--- a/ssrf-pin-resolver/README.md
+++ b/ssrf-pin-resolver/README.md
@@ -73,9 +73,16 @@ Tomcat's webapp classloaders are child-first. If a copy of `ConnectAddressPin` o
 `ConnectAddressResolverProvider` ever ends up in `WEB-INF/lib` or `WEB-INF/classes` as well as
 `CATALINA_HOME/lib`, the webapp loads its own copy, and `HttpGetCommand` would write a pin
 that the resolver (bound to the `CATALINA_HOME/lib` copy) never reads -- silently reopening the
-DNS-rebinding gap this module exists to close. Nothing in the automated build gates would flag
-that on its own (`check-war-completeness.py` only reports classes that are *missing*, not
-extras that were never supposed to be there), which is why `build.xml`'s `package`/`webapp`
-targets assemble `WEB-INF/lib` only from `lib/build` -- this module's jar is never written
-there -- and it is worth re-confirming by hand (`jar tf target/simis-cms.war | grep -i
-provided/net`) after any change to the build script that touches either target.
+DNS-rebinding gap this module exists to close. `build.xml`'s `package`/`webapp` targets assemble
+`WEB-INF/lib` only from `lib/build`, so this module's jar is never written there by the current
+build script -- but a future, unrelated change to those filesets (broadening a `<fileset dir>`
+include, or moving `pin.resolver.build.dir` back under `build.dir` as an early draft of this
+change did) could silently reintroduce it.
+
+`tools/check-war-completeness.py` gates this directly: its `FORBIDDEN` dict asserts
+`com.simisinc.platform.provided.net` is positively absent from the exploded WAR class tree (not
+just "not reported missing" -- the opposite check from the rest of that script), and fails
+under `--strict`, which `war-completeness.yml` already runs on every push and PR to `main`. It
+is still worth re-confirming by hand (`jar tf target/simis-cms.war | grep -i provided/net`)
+right after hand-editing `build.xml` and before relying on CI to catch it, but a regression no
+longer depends on someone remembering to do that.

--- a/ssrf-pin-resolver/src/META-INF/services/java.net.spi.InetAddressResolverProvider
+++ b/ssrf-pin-resolver/src/META-INF/services/java.net.spi.InetAddressResolverProvider
@@ -1,0 +1,1 @@
+com.simisinc.platform.provided.net.ConnectAddressResolverProvider

--- a/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressPin.java
+++ b/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressPin.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.provided.net;
+
+import java.net.InetAddress;
+
+/**
+ * Thread-scoped holder for a connect-time DNS pin: an exact set of already-validated addresses
+ * that a subsequent {@code java.net.http.HttpClient} connection to a specific hostname must
+ * resolve to, instead of re-resolving the hostname itself.
+ *
+ * <p>This closes the DNS-rebinding gap called out in {@code RemoteUrlValidationCommand}'s
+ * javadoc: a hostname that resolves to a public address at SSRF-validation time could resolve
+ * to an internal one moments later, when the JDK {@code HttpClient} re-resolves it to actually
+ * connect. Pinning the exact address(es) validated means there is no second lookup for a
+ * guarded fetch to race -- see issue #760.
+ *
+ * <p><b>Deployment constraint -- do not relax without re-reading issue #760's investigation.</b>
+ * This class and {@link ConnectAddressResolverProvider} must be loaded ONLY from Tomcat's
+ * shared/Common classloader ({@code CATALINA_HOME/lib}, wired via {@code docker/app/Dockerfile}
+ * and this project's {@code ant pin-resolver-jar} target) -- never from {@code WEB-INF/lib} or
+ * {@code WEB-INF/classes}. Both halves of that constraint were verified empirically against a
+ * real Tomcat 11 container while building this:
+ *
+ * <ol>
+ *   <li>Tomcat's own bootstrap resolves a hostname (e.g. "localhost") on its own thread, using
+ *       whichever {@code java.net.spi.InetAddressResolverProvider} the JDK's
+ *       {@code ServiceLoader} finds first -- before any webapp classloader exists. The JDK
+ *       caches that decision for the life of the JVM. A provider that is visible only to a
+ *       webapp classloader is discovered too late and is never consulted again: the pin would
+ *       silently never take effect.
+ *   <li>Tomcat's webapp classloaders are child-first. If a copy of this class were ALSO present
+ *       in {@code WEB-INF/lib} (or {@code WEB-INF/classes}), the webapp would load and write to
+ *       its OWN copy -- a different class-identity object from the one
+ *       {@link ConnectAddressResolverProvider} (bound to the single {@code CATALINA_HOME/lib}
+ *       copy) reads. The pin would silently never reach the resolver. There must be exactly one
+ *       copy of this class on the classpath, and it must be the {@code CATALINA_HOME/lib} one.
+ * </ol>
+ *
+ * <p>Webapp code (see {@code HttpGetCommand.executeUserUrl}) sets and clears the pin through the
+ * public methods here; ordinary parent-delegated classloading resolves this class from
+ * {@code CATALINA_HOME/lib} even though the call site compiles and runs from {@code WEB-INF}.
+ * {@link ConnectAddressResolverProvider} reads the pin through the package-private
+ * {@link #get(String)}, since it is loaded from the same jar and package.
+ */
+public final class ConnectAddressPin {
+
+  private static final ThreadLocal<String> PINNED_HOST = new ThreadLocal<>();
+  private static final ThreadLocal<InetAddress[]> PINNED_ADDRESSES = new ThreadLocal<>();
+
+  private ConnectAddressPin() {
+  }
+
+  /**
+   * Pins {@code host} to exactly {@code addresses} for connect-time DNS resolution on the
+   * calling thread. Must be paired with {@link #clear()} in a {@code finally} block: Tomcat
+   * reuses worker threads across requests, so a pin left set here would leak into whatever the
+   * same thread handles next.
+   *
+   * @param host the exact hostname string the caller is about to connect to (must match the
+   *             host {@code HttpClient} passes to the resolver at connect time)
+   * @param addresses the address(es) already confirmed safe for {@code host}
+   */
+  public static void set(String host, InetAddress[] addresses) {
+    PINNED_HOST.set(host);
+    PINNED_ADDRESSES.set(addresses);
+  }
+
+  /** Clears any pin set on the calling thread. Safe to call even if nothing was set. */
+  public static void clear() {
+    PINNED_HOST.remove();
+    PINNED_ADDRESSES.remove();
+  }
+
+  /**
+   * The addresses pinned for {@code host} on the calling thread, or {@code null} if nothing is
+   * pinned or the pinned host does not match. Package-private: only
+   * {@link ConnectAddressResolverProvider} reads the pin -- webapp code never should.
+   */
+  static InetAddress[] get(String host) {
+    String pinnedHost = PINNED_HOST.get();
+    if (host == null || pinnedHost == null || !pinnedHost.equalsIgnoreCase(host)) {
+      return null;
+    }
+    return PINNED_ADDRESSES.get();
+  }
+}

--- a/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressResolverProvider.java
+++ b/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressResolverProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.provided.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.spi.InetAddressResolver;
+import java.net.spi.InetAddressResolverProvider;
+import java.util.stream.Stream;
+
+/**
+ * Installs a {@link InetAddressResolverProvider} that serves an already-validated, pinned
+ * address (see {@link ConnectAddressPin}) for a hostname's connect-time DNS lookup instead of
+ * re-resolving it -- closing the DNS-rebinding TOCTOU gap described in issue #760. Every lookup
+ * that is not pinned -- which is nearly all of them, including every lookup Tomcat itself ever
+ * performs -- delegates unchanged to the JDK's builtin resolver, so this has no effect outside
+ * the narrow window {@code HttpGetCommand.executeUserUrl} sets a pin for.
+ *
+ * <p>Registered via {@code META-INF/services/java.net.spi.InetAddressResolverProvider} in this
+ * module's jar, which {@code ant pin-resolver-jar} builds and {@code docker/app/Dockerfile}
+ * copies to {@code CATALINA_HOME/lib}. See {@link ConnectAddressPin}'s javadoc for the hard
+ * deployment constraint this class shares and why it was verified against a real container
+ * rather than assumed: this jar belongs on Tomcat's shared classloader only, never inside the
+ * WAR.
+ */
+public final class ConnectAddressResolverProvider extends InetAddressResolverProvider {
+
+  @Override
+  public InetAddressResolver get(Configuration configuration) {
+    InetAddressResolver builtin = configuration.builtinResolver();
+    return new InetAddressResolver() {
+      @Override
+      public Stream<InetAddress> lookupByName(String host, LookupPolicy lookupPolicy) throws UnknownHostException {
+        InetAddress[] pinned = ConnectAddressPin.get(host);
+        if (pinned != null) {
+          return Stream.of(pinned);
+        }
+        return builtin.lookupByName(host, lookupPolicy);
+      }
+
+      @Override
+      public String lookupByAddress(byte[] addr) throws UnknownHostException {
+        return builtin.lookupByAddress(addr);
+      }
+    };
+  }
+
+  @Override
+  public String name() {
+    return "simis-cms-connect-address-pin";
+  }
+}

--- a/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressResolverProvider.java
+++ b/ssrf-pin-resolver/src/com/simisinc/platform/provided/net/ConnectAddressResolverProvider.java
@@ -16,10 +16,14 @@
 
 package com.simisinc.platform.provided.net;
 
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.net.spi.InetAddressResolver;
+import java.net.spi.InetAddressResolver.LookupPolicy;
 import java.net.spi.InetAddressResolverProvider;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**
@@ -47,7 +51,20 @@ public final class ConnectAddressResolverProvider extends InetAddressResolverPro
       public Stream<InetAddress> lookupByName(String host, LookupPolicy lookupPolicy) throws UnknownHostException {
         InetAddress[] pinned = ConnectAddressPin.get(host);
         if (pinned != null) {
-          return Stream.of(pinned);
+          InetAddress[] matching = matchingFamily(pinned, lookupPolicy);
+          if (matching.length == 0) {
+            // The pin exists for this host, but none of its addresses match the address
+            // family this particular lookup asked for (e.g. an IPv4-only caller on a JVM
+            // started with -Djava.net.preferIPv4Stack=true, against a pin that only holds an
+            // AAAA record). Falling back to builtin.lookupByName here would re-resolve the
+            // host via real DNS -- exactly the unpinned, racy lookup this resolver exists to
+            // prevent -- so a family mismatch fails closed instead, the same outcome a normal
+            // resolver gives when a host genuinely has no address of the requested family.
+            throw new UnknownHostException(host
+                + ": pinned address(es) do not include the address family this lookup "
+                + "requires (characteristics=" + lookupPolicy.characteristics() + ")");
+          }
+          return Stream.of(matching);
         }
         return builtin.lookupByName(host, lookupPolicy);
       }
@@ -57,6 +74,38 @@ public final class ConnectAddressResolverProvider extends InetAddressResolverPro
         return builtin.lookupByAddress(addr);
       }
     };
+  }
+
+  /**
+   * Narrows {@code pinned} to the address family {@code lookupPolicy} actually requested, the
+   * same filtering the builtin resolver applies. Nothing in this codebase currently sets
+   * {@code java.net.preferIPv4Stack} or {@code preferIPv6Addresses} (both default to a dual-
+   * stack {@code LookupPolicy} that requests IPv4 and IPv6 together), so in practice this is a
+   * no-op today; it exists so a pinned dual-stack host does not hand an IPv4-only (or
+   * IPv6-only) caller an address family it explicitly said it cannot use, should that ever
+   * change.
+   *
+   * <p>Package-private rather than {@code private} so
+   * {@code ConnectAddressResolverProviderFamilyFilterTest} can exercise it directly:
+   * {@link InetAddressResolverProvider.Configuration}, {@link #get}'s parameter type, is a JDK
+   * sealed interface permitting only an internal {@code sun.net} class, so no test outside
+   * {@code java.base} can construct one to drive {@link #get} end to end. This method is the
+   * one piece of the family-filtering logic a test can reach directly.
+   */
+  static InetAddress[] matchingFamily(InetAddress[] pinned, LookupPolicy lookupPolicy) {
+    int characteristics = lookupPolicy.characteristics();
+    boolean wantsIPv4 = (characteristics & LookupPolicy.IPV4) != 0;
+    boolean wantsIPv6 = (characteristics & LookupPolicy.IPV6) != 0;
+    if (wantsIPv4 == wantsIPv6) {
+      // Both families requested (the default, dual-stack case) or neither bit is set (not a
+      // combination this JDK's LookupPolicy is documented to produce) -- either way there is no
+      // single family to narrow to, so hand back every pinned address unfiltered, exactly as
+      // this method's caller did before it existed.
+      return pinned;
+    }
+    return Arrays.stream(pinned)
+        .filter(addr -> wantsIPv4 ? addr instanceof Inet4Address : addr instanceof Inet6Address)
+        .toArray(InetAddress[]::new);
   }
 
   @Override

--- a/tools/check-war-completeness.py
+++ b/tools/check-war-completeness.py
@@ -77,6 +77,15 @@ ALLOWLIST: dict[str, str] = {
     "org.apache.catalina": "Tomcat internals, provided by the container",
     "org.apache.jasper": "Tomcat JSP engine, provided by the container",
     "org.apache.tomcat": "Tomcat internals, provided by the container",
+    "com.simisinc.platform.provided.net": (
+        "the SSRF connect-time DNS pin resolver (issue #760, ssrf-pin-resolver/) -- "
+        "compiled against by HttpGetCommand but deliberately excluded from the WAR and "
+        "supplied instead on Tomcat's shared classloader (CATALINA_HOME/lib, wired in "
+        "docker/app/Dockerfile), the same provided-scope treatment jakarta.servlet gets "
+        "above. It MUST be absent from WEB-INF/lib/classes -- see "
+        "ssrf-pin-resolver/README.md for why a duplicated copy would silently break the "
+        "pin instead of merely being redundant."
+    ),
     # --- optional integrations the app never configures ---
     "android": "okhttp's optional Android platform support; server-side only here",
     "org.conscrypt": "okhttp optional TLS provider; the JDK provider is used",

--- a/tools/check-war-completeness.py
+++ b/tools/check-war-completeness.py
@@ -79,12 +79,12 @@ ALLOWLIST: dict[str, str] = {
     "org.apache.tomcat": "Tomcat internals, provided by the container",
     "com.simisinc.platform.provided.net": (
         "the SSRF connect-time DNS pin resolver (issue #760, ssrf-pin-resolver/) -- "
-        "compiled against by HttpGetCommand but deliberately excluded from the WAR and "
-        "supplied instead on Tomcat's shared classloader (CATALINA_HOME/lib, wired in "
-        "docker/app/Dockerfile), the same provided-scope treatment jakarta.servlet gets "
-        "above. It MUST be absent from WEB-INF/lib/classes -- see "
-        "ssrf-pin-resolver/README.md for why a duplicated copy would silently break the "
-        "pin instead of merely being redundant."
+        "compiled against by HttpGetCommand and HttpDownloadFileCommand but deliberately "
+        "excluded from the WAR and supplied instead on Tomcat's shared classloader "
+        "(CATALINA_HOME/lib, wired in docker/app/Dockerfile), the same provided-scope "
+        "treatment jakarta.servlet gets above. It MUST be absent from WEB-INF/lib/classes "
+        "-- see ssrf-pin-resolver/README.md for why a duplicated copy would silently "
+        "break the pin instead of merely being redundant."
     ),
     # --- optional integrations the app never configures ---
     "android": "okhttp's optional Android platform support; server-side only here",

--- a/tools/check-war-completeness.py
+++ b/tools/check-war-completeness.py
@@ -26,6 +26,15 @@ runs ``jdeps --missing-deps`` over it. Anything reported is a class that
 something in the WAR references and that is present neither in the WAR nor in
 the JDK.
 
+It also checks the opposite failure: FORBIDDEN below lists packages that must
+be supplied only by the servlet container and must NEVER be bundled into the
+WAR at all (see that dict for why -- for the SSRF connect-time DNS pin
+resolver specifically, a duplicated copy inside WEB-INF/lib silently breaks
+the pin instead of merely being redundant, because Tomcat's webapp
+classloader is child-first). This is a positive presence check against the
+exploded class tree itself, independent of jdeps and the ALLOWLIST/missing-
+class logic above.
+
 Most such references are legitimate. Java libraries routinely reference optional
 integrations they never load (jobrunr names MongoDB, okhttp names Android), and
 a servlet container supplies ``jakarta.servlet`` at runtime rather than the WAR.
@@ -158,6 +167,42 @@ ALLOWLIST: dict[str, str] = {
     # reached). If such a reference reappears it must surface as UNEXPECTED; add a
     # jar-scoped entry then, keyed on the jar that legitimately provides it.
 }
+
+# Package prefixes that must NEVER be present inside the WAR at all -- the mirror image of
+# ALLOWLIST above. ALLOWLIST excuses a class being ABSENT (still reachable, just supplied by the
+# container); FORBIDDEN flags the opposite failure, a class that is supposed to be
+# container-supplied showing up bundled into WEB-INF/lib anyway. jdeps has nothing to say about
+# this -- it never runs on classes that ARE present -- so this is checked directly against the
+# exploded class tree's `owner` index instead.
+#
+# Before adding an entry here, make sure the reason it must be absent is a genuine deployment
+# hazard (like the classloader-identity trap below), not just tidiness.
+FORBIDDEN: dict[str, str] = {
+    "com.simisinc.platform.provided.net": (
+        "the SSRF connect-time DNS pin resolver (issue #760, ssrf-pin-resolver/) -- must be "
+        "supplied ONLY from Tomcat's shared classloader (CATALINA_HOME/lib, wired in "
+        "docker/app/Dockerfile), never from WEB-INF/lib. Tomcat's webapp classloader is "
+        "child-first, so a duplicate copy here would not be merely redundant: the webapp would "
+        "load and read/write ITS OWN copy of ConnectAddressPin, a different class-identity "
+        "object from the one the CATALINA_HOME/lib-bound ConnectAddressResolverProvider "
+        "actually reads, silently reopening the DNS-rebinding gap this module exists to close. "
+        "See ssrf-pin-resolver/README.md's 'Do not duplicate these classes into the WAR'."
+    ),
+}
+
+
+def forbidden_present(owner: dict[str, str]) -> dict[str, list[str]]:
+    """Classes present in the exploded WAR that must never ship there, grouped by FORBIDDEN prefix."""
+    hits: dict[str, list[str]] = collections.defaultdict(list)
+    for name in owner:
+        best = ""
+        for prefix in FORBIDDEN:
+            if (name == prefix or name.startswith(prefix + ".")) and len(prefix) > len(best):
+                best = prefix
+        if best:
+            hits[best].append(name)
+    return hits
+
 
 # Allowlist entries that apply to ONE library only.
 #
@@ -295,6 +340,7 @@ def main() -> int:
     try:
         owner, jars = explode(args.war, tree)
         out = run_jdeps(tree)
+        forbidden = forbidden_present(owner)
 
         allowed: collections.Counter = collections.Counter()
         scoped: collections.Counter = collections.Counter()
@@ -329,6 +375,19 @@ def main() -> int:
               % (args.war, jars, len(owner)))
         print("=" * 72)
         print()
+
+        if forbidden:
+            print("FORBIDDEN -- provided-scope classes bundled into the WAR (%d package(s), %d classes):"
+                  % (len(forbidden), sum(len(v) for v in forbidden.values())))
+            for prefix, names in sorted(forbidden.items()):
+                jars_hit = sorted({owner[n] for n in names})
+                print("  %-40s %5d classes in %s" % (prefix, len(names), ", ".join(jars_hit)))
+                print("       %s" % FORBIDDEN[prefix])
+                for n in sorted(names)[:3]:
+                    print("       e.g. %s (in %s)" % (n, owner[n]))
+        else:
+            print("FORBIDDEN: (none present -- provided-scope classes correctly excluded)")
+        print()
         print("Classes referenced but not present in the WAR or the JDK.")
         print()
 
@@ -354,14 +413,19 @@ def main() -> int:
         for pkg, count in sorted(allowed.items()):
             print("  %-32s %5d  %s" % (pkg, count, allowed_for(pkg)))
         print()
-        print("Summary: %d unexpected, %d allowlisted packages."
-              % (len(unexpected), len(allowed)))
+        print("Summary: %d unexpected, %d forbidden, %d allowlisted packages."
+              % (len(unexpected), len(forbidden), len(allowed)))
 
-        if unexpected and args.strict:
+        if (unexpected or forbidden) and args.strict:
             print()
-            print("FAIL: the WAR is missing classes it can reach at runtime.")
-            print("Vendor the missing jar into lib/build, or add an ALLOWLIST")
-            print("entry in this script explaining why the reference is optional.")
+            if unexpected:
+                print("FAIL: the WAR is missing classes it can reach at runtime.")
+                print("Vendor the missing jar into lib/build, or add an ALLOWLIST")
+                print("entry in this script explaining why the reference is optional.")
+            if forbidden:
+                print("FAIL: the WAR bundles class(es) that must be provided-scope only.")
+                print("Check build.xml's jar/package/webapp filesets for a change that")
+                print("pulled these back into WEB-INF/lib -- see the FORBIDDEN section above.")
             return 1
         return 0
     finally:


### PR DESCRIPTION
## Summary

Closes #760. `RemoteUrlValidationCommand.isFetchAllowed()` validates a URL's resolved address before `HttpGetCommand`/`HttpDownloadFileCommand` fetch it, but the JDK `HttpClient` re-resolves the hostname independently at connect time — a classic TOCTOU: an attacker's DNS server can return a safe address for the pre-check and a private/internal one (e.g. the cloud metadata endpoint) moments later at connect.

This closes the gap by pinning the actual connection to the exact address that was already validated, so there is no second DNS lookup for an attacker to race.

## How

- A small standalone module (`ssrf-pin-resolver/`) implements `java.net.spi.InetAddressResolverProvider`, installed on **Tomcat's own shared classpath** (`CATALINA_HOME/lib`, via the Docker image), not inside the WAR. This is required, not a style choice — Tomcat's own bootstrap resolves `localhost` (permanently locking the JVM's DNS resolver) before any webapp classloader exists, so a webapp-scoped resolver never gets a chance to install itself. Verified empirically in a real Tomcat 11 container before committing to this approach.
- The module is a compile-time-only ("provided scope") dependency for the main app — the same pattern as `jakarta.servlet-api`: imported freely by application code, never bundled into `WEB-INF/lib`. A positive `check-war-completeness.py --strict` gate now asserts this (it previously could only report missing classes, not forbidden ones — added the missing check after a first draft accidentally leaked the classes into the WAR and this gate would have caught it silently reintroducing the bug in the future).
- `RemoteUrlValidationCommand` now exposes the addresses it validated (not just a boolean); `HttpGetCommand.executeUserUrl()` and `HttpDownloadFileCommand.executeUserUrl()` pin those exact addresses via a thread-scoped context immediately before connecting, and clear it in a `finally` regardless of outcome. The plain `execute(...)` overloads used by trusted/operator-configured URLs (OAuth, Stripe, MailChimp, etc.) never touch the pin.
- The request URI's hostname is never rewritten to an IP literal, so TLS SNI and certificate hostname verification are unaffected.
- Graceful degradation: if the pin-resolver classes are ever unavailable at runtime (e.g. a non-Docker deployment that doesn't have the jar on `CATALINA_HOME/lib`), the app falls back to pre-#760 behavior (the pre-check guard still runs, just without the connect-time pin) instead of throwing.

## An approach that was tried and abandoned first

"Re-validate immediately before connect" was tried first but found to be a near-no-op: the JVM's default ~30s `InetAddress` DNS cache means a second lookup milliseconds later almost always reads the same cached answer as the pre-check, so there's rarely a genuinely independent second lookup to catch a rebind. Pinning avoids this entirely by not performing a second lookup at all.

## Testing

- New tests for the resolver mechanism in isolation, for `executeUserUrl()`'s real pin/clear behavior (including the exception path), for the pin-resolver-absent degradation path, and for IPv4/IPv6 family filtering.
- Full `ant ci-test`: 1340 tests, 0 failures.
- `check-war-completeness.py --strict`: 0 unexpected, 0 forbidden — confirmed by direct inspection that the WAR contains zero `provided/net`/pin-resolver classes.
- Live end-to-end verification against a real Docker image build (matching the production `tomcat:11.0-jdk21` digest): a pinned fake hostname genuinely connects through the real `executeUserUrl` path to a trap server; an unpinned identical-shaped hostname genuinely fails to resolve.

## Worth a deliberate look, not addressed here

This bakes new software into the production Docker image (a jar on `CATALINA_HOME/lib`). That's likely to have compliance-surface implications (SSP/POA&M-adjacent) worth a separate, deliberate review rather than folding into this PR.