### PR TITLE
Media library click-to-replace: real Image widget + server-side enforcement

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.presentation.widgets.cms.ImageWidget;
 import com.simisinc.platform.presentation.widgets.cms.TableWidget;
 
 /**
@@ -489,6 +490,10 @@ public class MutateLayoutCommand {
             + "at most " + TableWidget.MAX_ROWS + " rows, " + TableWidget.MAX_COLUMNS + " columns, and "
             + TableWidget.MAX_CELL_LENGTH + " characters per header/cell");
       }
+    }
+    if (ImageWidget.WIDGET_NAME.equals(widgetName) && prefs.containsKey("imageUrl")
+        && !ImageWidget.isValidImageUrl(prefs.get("imageUrl"))) {
+      throw new DataException("Invalid image url: expected a site-relative path or an http(s)/mailto/tel address");
     }
   }
 }

--- a/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/MutateLayoutCommand.java
@@ -491,9 +491,62 @@ public class MutateLayoutCommand {
             + TableWidget.MAX_CELL_LENGTH + " characters per header/cell");
       }
     }
-    if (ImageWidget.WIDGET_NAME.equals(widgetName) && prefs.containsKey("imageUrl")
-        && !ImageWidget.isValidImageUrl(prefs.get("imageUrl"))) {
+    if (ImageWidget.WIDGET_NAME.equals(widgetName) && prefs.containsKey(ImageWidget.IMAGE_URL_PREF_KEY)
+        && !ImageWidget.isValidImageUrl(prefs.get(ImageWidget.IMAGE_URL_PREF_KEY))) {
       throw new DataException("Invalid image url: expected a site-relative path or an http(s)/mailto/tel address");
+    }
+  }
+
+  // ── Read-only queries ─────────────────────────────────────────────────────
+
+  /**
+   * Returns the widget-library {@code name} of the widget at {@code sectionIdx}:{@code columnIdx}:
+   * {@code widgetIdx} in the page's current draft layout (or its published layout when there is no
+   * draft) -- resolved from the same source XML, and by the same structural traversal, that
+   * {@link #setWidgetPreferences} uses internally. That means the answer can never drift from what
+   * a subsequent mutation at the same position would actually touch, unlike a second, independently
+   * written traversal that might parse or resolve pages slightly differently.
+   *
+   * <p>This exists so a caller that must authorize *which* widget a mutation is about to touch --
+   * before honoring a client-supplied preference key -- can check it against the real, structurally
+   * resolved widget rather than trusting anything the client claims about it. (For example,
+   * {@code MediaApiController}'s widget-update endpoint: its client-side "this is an image widget"
+   * gate is UI-only, so the server must independently confirm the target widget really is one before
+   * applying a client-chosen asset to it.) Read-only: never touches {@code draftPageXml}.
+   *
+   * @return the widget's {@code name} attribute (may be blank if the widget element has none)
+   * @throws DataException if the page has no XML layout, or the position is out of range
+   */
+  public static String getWidgetName(WebPage webPage, int sectionIdx, int columnIdx, int widgetIdx)
+      throws DataException {
+    if (webPage == null || webPage.getId() == -1) {
+      throw new DataException("Page not found");
+    }
+    String sourceXml = StringUtils.isNotBlank(webPage.getDraftPageXml())
+        ? webPage.getDraftPageXml()
+        : webPage.getPageXml();
+    if (StringUtils.isBlank(sourceXml)) {
+      throw new DataException("Page has no XML layout");
+    }
+    try {
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      dbf.setExpandEntityReferences(false);
+      DocumentBuilder builder = dbf.newDocumentBuilder();
+      Document doc = builder.parse(new InputSource(new StringReader(sourceXml)));
+
+      List<Element> sections = childElements(doc.getDocumentElement(), "section");
+      checkSectionIdx(sections, sectionIdx);
+      List<Element> columns = childElements(sections.get(sectionIdx), "column");
+      checkColumnIdx(columns, columnIdx, sectionIdx);
+      List<Element> widgets = childElements(columns.get(columnIdx), "widget");
+      checkWidgetIdx(widgets, widgetIdx, sectionIdx, columnIdx);
+      return widgets.get(widgetIdx).getAttribute("name");
+    } catch (DataException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.error("MutateLayoutCommand.getWidgetName failed for " + webPage.getLink(), e);
+      throw new DataException("Could not resolve widget: " + e.getMessage());
     }
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.application.cms.MutateLayoutCommand;
 import com.simisinc.platform.domain.model.MediaAsset;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.MediaAssetRepository;
+import com.simisinc.platform.presentation.widgets.cms.ImageWidget;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -50,8 +51,13 @@ import java.util.UUID;
  * layout. Requires builder-tier permission and the session CSRF token, and identifies the target
  * widget the same way {@link PageServlet}'s {@code mutateDraftLayout} action does -- by structural
  * position, not by a render-time {@code widgetContext.uniqueId} -- so it can safely delegate to
- * {@link MutateLayoutCommand#setWidgetPreferences}. Params: assetId, pagePath, sectionIdx,
- * columnIdx, widgetIdx, prefKey, token.
+ * {@link MutateLayoutCommand#setWidgetPreferences}. Before delegating, it independently re-resolves
+ * the widget actually at that position via {@link MutateLayoutCommand#getWidgetName} and confirms it
+ * is really an {@link ImageWidget#WIDGET_NAME} and that {@code prefKey} is really
+ * {@link ImageWidget#IMAGE_URL_PREF_KEY} -- the visual editor's client-side "this is an image
+ * widget" gate is UI-only, so this is the check that actually stops a crafted request from
+ * overwriting some other widget's unrelated preference (issue #772 follow-up). Params: assetId,
+ * pagePath, sectionIdx, columnIdx, widgetIdx, prefKey, token.
  *
  * @author claude
  * @created 7/26/26
@@ -231,6 +237,19 @@ public class MediaApiController extends HttpServlet {
    * traversal logic to drift out of sync with the real renderer) and it is what
    * {@link MutateLayoutCommand#setWidgetPreferences} already requires. Requires the builder-tier
    * permission and the session's CSRF form token, matching every other draft-layout mutation.
+   *
+   * <p>Unlike every other {@code setWidgetPreferences} caller, this endpoint's entire contract is
+   * narrow: it only ever sets an image widget's {@code imageUrl}. platform-editor.js's "Choose image
+   * from Media Library" trigger only renders for a widget whose {@code data-editor-widget-name} is
+   * {@code "image"}, but that is a client-side heuristic an attacker simply need not honor -- nothing
+   * stops a request naming any {@code widgetIdx} with any {@code prefKey}. So before delegating, this
+   * method independently resolves the real widget at {@code sectionIdx}/{@code columnIdx}/
+   * {@code widgetIdx} from the page's own XML (via {@link MutateLayoutCommand#getWidgetName}, the
+   * same structural resolution {@code setWidgetPreferences} itself uses) and refuses to proceed
+   * unless that widget really is {@link ImageWidget#WIDGET_NAME} and {@code prefKey} really is
+   * {@link ImageWidget#IMAGE_URL_PREF_KEY} -- otherwise a crafted request could silently overwrite an
+   * unrelated widget's real preference (e.g. a remoteContent widget's own {@code url} preference)
+   * with an image path.
    */
   private void handleWidgetUpdate(HttpServletRequest request, HttpServletResponse response, UserSession userSession)
       throws IOException {
@@ -303,13 +322,30 @@ public class MediaApiController extends HttpServlet {
     }
 
     try {
+      // The "Choose image from Media Library" trigger is only rendered client-side for a widget
+      // whose data-editor-widget-name is "image" (platform-editor.js) -- that is a UI convenience,
+      // not an authorization check, and a request naming any sectionIdx/columnIdx/widgetIdx with any
+      // prefKey reaches this far regardless. Re-resolve the widget that is *actually* at this
+      // position from the page's own XML -- not from anything the client sent -- and refuse to
+      // proceed unless it really is an image widget and prefKey really is its imageUrl preference.
+      // Without this, a crafted request could silently overwrite an unrelated widget's real
+      // preference (e.g. a remoteContent widget's own "url") with an image path.
+      String targetWidgetName = MutateLayoutCommand.getWidgetName(webPage, sectionIdx, columnIdx, widgetIdx);
+      if (!ImageWidget.WIDGET_NAME.equals(targetWidgetName)) {
+        throw new DataException("Target widget is not an image widget (found '" + targetWidgetName + "')");
+      }
+      if (!ImageWidget.IMAGE_URL_PREF_KEY.equals(prefKey)) {
+        throw new DataException(
+            "prefKey must be '" + ImageWidget.IMAGE_URL_PREF_KEY + "' when targeting an image widget");
+      }
+
       Map<String, String> prefs = new HashMap<>();
       prefs.put(prefKey, asset.getStoragePath());
       String prefsJson = objectMapper.writeValueAsString(prefs);
       MutateLayoutCommand.setWidgetPreferences(webPage, sectionIdx, columnIdx, widgetIdx, prefsJson,
           userSession.getUserId());
     } catch (DataException e) {
-      LOG.warn("widget-update failed for " + pagePath + " " + sectionIdx + ":" + columnIdx + ":" + widgetIdx
+      LOG.warn("widget-update rejected for " + pagePath + " " + sectionIdx + ":" + columnIdx + ":" + widgetIdx
           + ": " + e.getMessage());
       response.setStatus(400);
       Map<String, Object> result = new HashMap<>();

--- a/src/main/java/com/simisinc/platform/presentation/controller/WidgetRenderInfo.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WidgetRenderInfo.java
@@ -37,6 +37,7 @@ public class WidgetRenderInfo implements Serializable {
   private boolean hr = false;
   private String content = null;
   private String prefsJson = "{}";
+  private String widgetName = null;
 
   public WidgetRenderInfo() {
   }
@@ -48,6 +49,7 @@ public class WidgetRenderInfo implements Serializable {
     this.sticky = widget.isSticky();
     this.hr = widget.hasHr();
     this.content = content;
+    this.widgetName = widget.getWidgetName();
     Map<String, String> prefs = widget.getPreferences();
     if (prefs != null && !prefs.isEmpty()) {
       this.prefsJson = prefsToJson(prefs);
@@ -96,5 +98,9 @@ public class WidgetRenderInfo implements Serializable {
 
   public String getPrefsJson() {
     return prefsJson;
+  }
+
+  public String getWidgetName() {
+    return widgetName;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageWidget.java
@@ -46,9 +46,19 @@ public class ImageWidget extends GenericWidget {
 
   /**
    * This widget's registered name in widget-library.xml. Used by MutateLayoutCommand to know when
-   * an "imageUrl" preference value belongs to this widget and needs {@link #isValidImageUrl}.
+   * an "imageUrl" preference value belongs to this widget and needs {@link #isValidImageUrl}, and by
+   * MediaApiController to confirm a widget-update request's target is really an image widget before
+   * honoring the client-supplied prefKey (issue #772 follow-up).
    */
   public static final String WIDGET_NAME = "image";
+
+  /**
+   * The name of this widget's sole render-source preference. MediaApiController's widget-update
+   * endpoint (the Media Library's click-to-replace) exists only to set this preference on a widget
+   * confirmed to be {@link #WIDGET_NAME} -- it rejects any other prefKey, since nothing else this
+   * widget owns should ever be reachable through that path.
+   */
+  public static final String IMAGE_URL_PREF_KEY = "imageUrl";
 
   /**
    * {@code imageUrl} is rendered straight into an &lt;img src&gt; attribute (see {@link #execute}),
@@ -71,7 +81,7 @@ public class ImageWidget extends GenericWidget {
     // scheme other than http(s)/mailto/tel, while still allowing an ordinary site-relative path
     // (e.g. a Media Library asset's storage path). An unset or unsafe value simply falls through
     // to the placeholder rendering in the JSP -- never a broken <img> tag.
-    String imageUrl = UrlCommand.sanitizeUrl(context.getPreferences().get("imageUrl"));
+    String imageUrl = UrlCommand.sanitizeUrl(context.getPreferences().get(IMAGE_URL_PREF_KEY));
     context.getRequest().setAttribute("imageUrl", imageUrl);
 
     // Always provide a String (never null) so the placeholder branch can tell an intentionally

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ImageWidget.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A general-purpose drop-on-a-page widget whose {@code imageUrl} preference is the sole source
+ * of what it renders -- unlike the ecommerce/collection/blog widgets, which always resolve an
+ * &lt;img&gt; through a domain-entity reference (product, item, post) rather than a directly
+ * editable preference (issue #772).
+ *
+ * <p>{@code imageUrl} is attacker-reachable content: it is written by
+ * {@link com.simisinc.platform.application.cms.MutateLayoutCommand#setWidgetPreferences} /
+ * {@code #addWidget} (the visual editor's free-form preference-save path, and the Media Library's
+ * click-to-replace, both reached from PageServlet/MediaApiController) and persisted into the
+ * page's draft XML. {@link #isValidImageUrl(String)} is the save-path gate -- it must reject an
+ * unsafe value there, before it is ever written. The {@link UrlCommand#sanitizeUrl} call in
+ * {@link #execute} below is defense in depth only, in case bad data reaches render some other way.
+ *
+ * @author elizabeth houser
+ * @created 7/31/2026
+ */
+public class ImageWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/cms/image.jsp";
+
+  /**
+   * This widget's registered name in widget-library.xml. Used by MutateLayoutCommand to know when
+   * an "imageUrl" preference value belongs to this widget and needs {@link #isValidImageUrl}.
+   */
+  public static final String WIDGET_NAME = "image";
+
+  /**
+   * {@code imageUrl} is rendered straight into an &lt;img src&gt; attribute (see {@link #execute}),
+   * so a value that would break out of that attribute or introduce an active scheme (javascript:/
+   * data:) must never be persisted -- not merely dropped at render time. An unset/blank value is
+   * valid: it simply means no image has been chosen yet, and the widget renders its placeholder.
+   *
+   * @return true if {@code url} is blank, or is a safe site-relative path / http(s)/mailto/tel
+   *     absolute url per {@link UrlCommand#sanitizeUrl(String)}
+   */
+  public static boolean isValidImageUrl(String url) {
+    return StringUtils.isBlank(url) || UrlCommand.sanitizeUrl(url) != null;
+  }
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // The value is rendered straight into a src attribute, so sanitize it the same way the other
+    // widgets that render an editor-supplied url into src/href do (ButtonWidget's link,
+    // RemoteContentWidget's image url) -- this rejects attribute-breakout characters and any
+    // scheme other than http(s)/mailto/tel, while still allowing an ordinary site-relative path
+    // (e.g. a Media Library asset's storage path). An unset or unsafe value simply falls through
+    // to the placeholder rendering in the JSP -- never a broken <img> tag.
+    String imageUrl = UrlCommand.sanitizeUrl(context.getPreferences().get("imageUrl"));
+    context.getRequest().setAttribute("imageUrl", imageUrl);
+
+    // Always provide a String (never null) so the placeholder branch can tell an intentionally
+    // decorative image (alt="") apart from one an author simply hasn't described yet, per this
+    // codebase's existing accessibility convention (see ContentAccessibilityCommand) of only
+    // flagging a genuinely *missing* alt attribute, not an empty one.
+    String altText = StringUtils.defaultString(context.getPreferences().get("altText"));
+    context.getRequest().setAttribute("altText", altText);
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/cms/image.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/image.jsp
@@ -1,0 +1,29 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="imageUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="altText" class="java.lang.String" scope="request"/>
+<c:choose>
+  <c:when test="${!empty imageUrl}">
+    <img class="platform-image-widget" src="<c:out value="${imageUrl}"/>" alt="<c:out value="${altText}"/>"/>
+  </c:when>
+  <c:otherwise>
+    <%-- No image configured yet -- a placeholder, never a broken <img> tag --%>
+    <div class="platform-image-widget-placeholder" role="img" aria-label="<c:out value="${empty altText ? 'No image set' : altText}"/>">
+      <i class="fa fa-image" aria-hidden="true"></i>
+    </div>
+  </c:otherwise>
+</c:choose>

--- a/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-body-renderer.jspf
@@ -81,12 +81,12 @@
               ${widget.content}
             </c:when>
             <c:when test="${!empty widget.cssClass}">
-              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>"</c:if>>
+              <div <c:if test="${!empty widget.htmlId}">id="<c:out value="${widget.htmlId}"/>" </c:if>class="<c:out value="${widget.cssClass}"/>"<c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>" data-editor-widget-name="<c:out value="${widget.widgetName}"/>"</c:if>>
                 ${widget.content}
               </div>
             </c:when>
             <c:otherwise>
-              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>"</c:if>>
+              <div<c:if test="${!empty widget.htmlId}"> id="<c:out value="${widget.htmlId}"/>"</c:if><c:if test="${!empty widget.cssStyle}"> style="<c:out value="${widget.cssStyle}" />"</c:if><c:if test="${widget.sticky}"> data-sticky data-margin-top="<c:out value="${stickyMarginTop}"/>" data-top-anchor="<c:out value="${columnId}"/>" data-btm-anchor="platform-footer"</c:if><c:if test="${pageEditMode eq 'true'}"> data-editor-widget="${sectionStatus.index}-${columnStatus.index}-${widgetStatus.index}" data-editor-widget-prefs="<c:out value="${widget.prefsJson}"/>" data-editor-widget-name="<c:out value="${widget.widgetName}"/>"</c:if>>
                 ${widget.content}
               </div>
             </c:otherwise>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -42,6 +42,7 @@
   <widget name="button" class="com.simisinc.platform.presentation.widgets.cms.ButtonWidget" />
   <widget name="menu" class="com.simisinc.platform.presentation.widgets.cms.MenuWidget" />
   <widget name="card" class="com.simisinc.platform.presentation.widgets.cms.CardWidget" />
+  <widget name="image" class="com.simisinc.platform.presentation.widgets.cms.ImageWidget" />
   <widget name="content" class="com.simisinc.platform.presentation.widgets.cms.ContentWidget" />
   <widget name="contentTabs" class="com.simisinc.platform.presentation.widgets.cms.ContentTabsWidget" />
   <widget name="contentCards" class="com.simisinc.platform.presentation.widgets.cms.ContentCardsWidget" />

--- a/src/main/webapp/css/platform-editor.css
+++ b/src/main/webapp/css/platform-editor.css
@@ -574,6 +574,20 @@ body.page-edit-mode [data-editor-widget]:hover > .sc-mutate-btns {
   background: #6c757d;
 }
 
+.sc-mutate-btn-image {
+  background: rgba(111, 66, 193, 0.75);
+}
+
+.sc-mutate-btn-image:hover {
+  background: #6f42c1;
+}
+
+/* Widget armed as the target for the next Media Library file click (issue #772) */
+body.page-edit-mode [data-editor-widget].sc-image-armed {
+  outline: 2px dashed #6f42c1;
+  outline-offset: -2px;
+}
+
 /* ── Widget preferences panel ── */
 
 #sc-prefs-panel {

--- a/src/main/webapp/css/platform.css
+++ b/src/main/webapp/css/platform.css
@@ -951,6 +951,25 @@ ul.pagination li.pagination-next a:hover {
   width: 100%;
 }
 
+/* Image Widget (issue #772) */
+
+.platform-image-widget {
+  max-width: 100%;
+  height: auto;
+}
+.platform-image-widget-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  padding: 1.5rem;
+  background: var(--sc-surface-sunken, #f4f6f8);
+  border: 1px dashed var(--sc-border, #d7dce2);
+  border-radius: var(--sc-radius-md, 6px);
+  color: var(--sc-text-muted, #5b6470);
+  font-size: 2rem;
+}
+
 /* User Card Profile */
 
 .card-profile-stats {

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -1065,28 +1065,25 @@
       });
       btns.appendChild(prefsTriggerBtn);
       // Image trigger — arms this widget as the target for the next Media Library file click.
-      // Click again to disarm; only lights up when this widget actually has an image preference
-      // to target (see detectImagePrefKey), matching the "no image preference" failure mode.
-      var imageTriggerBtn = document.createElement('button');
-      imageTriggerBtn.type = 'button';
-      imageTriggerBtn.className = 'sc-mutate-btn-image sc-image-trigger';
-      imageTriggerBtn.title = 'Choose image from Media Library';
-      imageTriggerBtn.textContent = '🖼 Image';
-      imageTriggerBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        if (activeImageWidget && activeImageWidget.el === el) {
-          disarmImageWidget();
-          setToolbarStatus('');
-          return;
-        }
-        var prefKey = detectImagePrefKey(el);
-        if (!prefKey) {
-          setToolbarStatus('This widget has no image preference to target.');
-          return;
-        }
-        armImageWidget(el, s, c, w, prefKey);
-      });
-      btns.appendChild(imageTriggerBtn);
+      // Only rendered for an actual "image" widget (see IMAGE_WIDGET_TYPE below): that widget's
+      // one editable image preference is its render source, so there is nothing to guess here.
+      if (el.dataset.editorWidgetName === IMAGE_WIDGET_TYPE) {
+        var imageTriggerBtn = document.createElement('button');
+        imageTriggerBtn.type = 'button';
+        imageTriggerBtn.className = 'sc-mutate-btn-image sc-image-trigger';
+        imageTriggerBtn.title = 'Choose image from Media Library';
+        imageTriggerBtn.textContent = '🖼 Image';
+        imageTriggerBtn.addEventListener('click', function (e) {
+          e.stopPropagation();
+          if (activeImageWidget && activeImageWidget.el === el) {
+            disarmImageWidget();
+            setToolbarStatus('');
+            return;
+          }
+          armImageWidget(el, s, c, w, IMAGE_WIDGET_PREF_KEY);
+        });
+        btns.appendChild(imageTriggerBtn);
+      }
       // Add-widget-after trigger for this widget position
       var addWidgetAfterBtn = document.createElement('button');
       addWidgetAfterBtn.type = 'button';
@@ -1331,49 +1328,14 @@
 
   // ── Active image widget (media library click-to-replace, issue #772) ────────
   //
-  // A widget doesn't declare "this preference holds an image" anywhere machine-readable at
-  // runtime today -- widget-schema.json has that shape but is deliberately not wired up (see its
-  // own header comment / P5.2 audit), and no widget type in this codebase currently exposes a
-  // single canonical "image src" preference the way e.g. `link` is the canonical URL preference
-  // on the button/link widgets. So instead of a hardcoded widget-type→prefKey table (which would
-  // either be fiction for types that have no such field, or wrong the moment a real one is added),
-  // this infers the target preference key from the widget's OWN current preferences JSON already
-  // sitting in data-editor-widget-prefs (the same attribute openPrefsPanel already reads): a
-  // stored value that already looks like an image file wins outright, otherwise a conventional
-  // image-ish key name if the widget has one set (even blank -- e.g. a freshly added widget).
-  // Returns null when neither signal is present, which is the expected, handled case for the many
-  // widget types that simply have no image preference (point 5 of the issue's failure modes).
-  var IMAGE_PREF_KEY_CANDIDATES = [
-    'image', 'imageUrl', 'imageSrc', 'imagePath', 'img',
-    'photo', 'photoUrl', 'picture', 'pictureUrl',
-    'poster', 'posterUrl', 'thumbnail', 'thumbnailUrl',
-    'backgroundImage', 'backgroundImageUrl', 'bgImage', 'url'
-  ];
-  var IMAGE_EXT_RE = /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/i;
-
-  function detectImagePrefKey(widgetEl) {
-    var prefs;
-    try {
-      prefs = JSON.parse(widgetEl.dataset.editorWidgetPrefs || '{}');
-    } catch (e) {
-      return null;
-    }
-    if (!prefs || typeof prefs !== 'object') return null;
-
-    var keys = Object.keys(prefs);
-    // Strongest signal: an existing value that already looks like an image file.
-    for (var i = 0; i < keys.length; i++) {
-      var v = prefs[keys[i]];
-      if (typeof v === 'string' && IMAGE_EXT_RE.test(v)) return keys[i];
-    }
-    // Fall back to a conventional image-ish key name, in priority order.
-    for (var j = 0; j < IMAGE_PREF_KEY_CANDIDATES.length; j++) {
-      if (Object.prototype.hasOwnProperty.call(prefs, IMAGE_PREF_KEY_CANDIDATES[j])) {
-        return IMAGE_PREF_KEY_CANDIDATES[j];
-      }
-    }
-    return null;
-  }
+  // The "image" widget (ImageWidget/widget-library.xml) is the one widget type in this codebase
+  // whose rendered <img> is driven directly by an editable preference rather than a
+  // domain-entity reference (product/item/blog post, etc.) -- so the target widget type and its
+  // preference key are both known constants, not something to infer from arbitrary widgets'
+  // preference JSON (the prior heuristic here false-positived on e.g. the remoteContent widget's
+  // unrelated "url" preference and silently corrupted it).
+  var IMAGE_WIDGET_TYPE = 'image';
+  var IMAGE_WIDGET_PREF_KEY = 'imageUrl';
 
   function armImageWidget(el, s, c, w, prefKey) {
     if (activeImageWidget && activeImageWidget.el) {
@@ -1443,8 +1405,8 @@
             img.src = newUrl;
             updatedInPlace = true;
           }
-          // Keep the cached prefs JSON in sync so a subsequent detectImagePrefKey/openPrefsPanel
-          // call on this same widget sees the value that was just applied.
+          // Keep the cached prefs JSON in sync so a subsequent openPrefsPanel call on this same
+          // widget sees the value that was just applied.
           try {
             var prefs = JSON.parse(target.el.dataset.editorWidgetPrefs || '{}');
             prefs[target.prefKey] = newUrl;

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -26,6 +26,7 @@
   var savedSelection = null;    // Selection saved before link prompt opens
   var originalHtml = null;      // snapshot before editing begins (for Discard)
   var actionsBar = null;        // Save/Discard bar for the active widget
+  var activeImageWidget = null; // {s, c, w, el, prefKey} widget armed for the next Media Library file click (#772)
 
   // Quill inline editor state
   var activeQuill = null;         // active Quill instance
@@ -1063,6 +1064,29 @@
         openPrefsPanel(prefsTriggerBtn, s, c, w, el.dataset.editorWidgetPrefs || '{}');
       });
       btns.appendChild(prefsTriggerBtn);
+      // Image trigger — arms this widget as the target for the next Media Library file click.
+      // Click again to disarm; only lights up when this widget actually has an image preference
+      // to target (see detectImagePrefKey), matching the "no image preference" failure mode.
+      var imageTriggerBtn = document.createElement('button');
+      imageTriggerBtn.type = 'button';
+      imageTriggerBtn.className = 'sc-mutate-btn-image sc-image-trigger';
+      imageTriggerBtn.title = 'Choose image from Media Library';
+      imageTriggerBtn.textContent = '🖼 Image';
+      imageTriggerBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (activeImageWidget && activeImageWidget.el === el) {
+          disarmImageWidget();
+          setToolbarStatus('');
+          return;
+        }
+        var prefKey = detectImagePrefKey(el);
+        if (!prefKey) {
+          setToolbarStatus('This widget has no image preference to target.');
+          return;
+        }
+        armImageWidget(el, s, c, w, prefKey);
+      });
+      btns.appendChild(imageTriggerBtn);
       // Add-widget-after trigger for this widget position
       var addWidgetAfterBtn = document.createElement('button');
       addWidgetAfterBtn.type = 'button';
@@ -1305,6 +1329,156 @@
     }).catch(function (err) { setToolbarStatus('Error: ' + err.message); });
   }
 
+  // ── Active image widget (media library click-to-replace, issue #772) ────────
+  //
+  // A widget doesn't declare "this preference holds an image" anywhere machine-readable at
+  // runtime today -- widget-schema.json has that shape but is deliberately not wired up (see its
+  // own header comment / P5.2 audit), and no widget type in this codebase currently exposes a
+  // single canonical "image src" preference the way e.g. `link` is the canonical URL preference
+  // on the button/link widgets. So instead of a hardcoded widget-type→prefKey table (which would
+  // either be fiction for types that have no such field, or wrong the moment a real one is added),
+  // this infers the target preference key from the widget's OWN current preferences JSON already
+  // sitting in data-editor-widget-prefs (the same attribute openPrefsPanel already reads): a
+  // stored value that already looks like an image file wins outright, otherwise a conventional
+  // image-ish key name if the widget has one set (even blank -- e.g. a freshly added widget).
+  // Returns null when neither signal is present, which is the expected, handled case for the many
+  // widget types that simply have no image preference (point 5 of the issue's failure modes).
+  var IMAGE_PREF_KEY_CANDIDATES = [
+    'image', 'imageUrl', 'imageSrc', 'imagePath', 'img',
+    'photo', 'photoUrl', 'picture', 'pictureUrl',
+    'poster', 'posterUrl', 'thumbnail', 'thumbnailUrl',
+    'backgroundImage', 'backgroundImageUrl', 'bgImage', 'url'
+  ];
+  var IMAGE_EXT_RE = /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/i;
+
+  function detectImagePrefKey(widgetEl) {
+    var prefs;
+    try {
+      prefs = JSON.parse(widgetEl.dataset.editorWidgetPrefs || '{}');
+    } catch (e) {
+      return null;
+    }
+    if (!prefs || typeof prefs !== 'object') return null;
+
+    var keys = Object.keys(prefs);
+    // Strongest signal: an existing value that already looks like an image file.
+    for (var i = 0; i < keys.length; i++) {
+      var v = prefs[keys[i]];
+      if (typeof v === 'string' && IMAGE_EXT_RE.test(v)) return keys[i];
+    }
+    // Fall back to a conventional image-ish key name, in priority order.
+    for (var j = 0; j < IMAGE_PREF_KEY_CANDIDATES.length; j++) {
+      if (Object.prototype.hasOwnProperty.call(prefs, IMAGE_PREF_KEY_CANDIDATES[j])) {
+        return IMAGE_PREF_KEY_CANDIDATES[j];
+      }
+    }
+    return null;
+  }
+
+  function armImageWidget(el, s, c, w, prefKey) {
+    if (activeImageWidget && activeImageWidget.el) {
+      activeImageWidget.el.classList.remove('sc-image-armed');
+    }
+    activeImageWidget = {s: s, c: c, w: w, el: el, prefKey: prefKey};
+    el.classList.add('sc-image-armed');
+    setToolbarStatus('Choose a file in the Media Library to set this widget\'s "' + prefKey + '" image.');
+    if (typeof window.showMediaLibrary === 'function') {
+      window.showMediaLibrary();
+    }
+  }
+
+  function disarmImageWidget() {
+    if (activeImageWidget && activeImageWidget.el) {
+      activeImageWidget.el.classList.remove('sc-image-armed');
+    }
+    activeImageWidget = null;
+  }
+
+  // Applies the selected media asset to the armed widget's preference via the already-tested
+  // POST /visual-editor/media/widget-update (MediaApiController#handleWidgetUpdate), then updates
+  // the widget's rendered <img> in place when one is found, falling back to this file's usual
+  // reload-on-mutation pattern otherwise.
+  function applyImageToWidget(target, asset) {
+    if (!target.el || !document.body.contains(target.el)) {
+      setToolbarStatus('That widget is no longer on the page.');
+      disarmImageWidget();
+      return;
+    }
+    var token = getToken();
+    if (!token) {
+      setToolbarStatus('No session token');
+      return;
+    }
+
+    setToolbarStatus('Applying image…');
+
+    var body = new URLSearchParams();
+    body.append('assetId', asset.assetId);
+    body.append('pagePath', pagePath);
+    body.append('prefKey', target.prefKey);
+    body.append('sectionIdx', String(target.s));
+    body.append('columnIdx', String(target.c));
+    body.append('widgetIdx', String(target.w));
+    body.append('token', token);
+
+    fetch('/visual-editor/media/widget-update', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: body.toString()
+    })
+      .then(function (resp) {
+        return resp.json().catch(function () { return {}; }).then(function (data) {
+          if (!resp.ok || !data.success) {
+            throw new Error((data && data.error) || ('HTTP ' + resp.status));
+          }
+          return data;
+        });
+      })
+      .then(function (data) {
+        var newUrl = data.asset && data.asset.storagePath;
+        var updatedInPlace = false;
+        if (newUrl && target.el && document.body.contains(target.el)) {
+          var img = target.el.querySelector('img');
+          if (img) {
+            img.src = newUrl;
+            updatedInPlace = true;
+          }
+          // Keep the cached prefs JSON in sync so a subsequent detectImagePrefKey/openPrefsPanel
+          // call on this same widget sees the value that was just applied.
+          try {
+            var prefs = JSON.parse(target.el.dataset.editorWidgetPrefs || '{}');
+            prefs[target.prefKey] = newUrl;
+            target.el.dataset.editorWidgetPrefs = JSON.stringify(prefs);
+          } catch (ex) { /* ignore -- cosmetic cache only */ }
+        }
+        markHasDraft();
+        disarmImageWidget();
+        if (updatedInPlace) {
+          setToolbarStatus('Image updated');
+        } else {
+          setToolbarStatus('Image updated — reloading…');
+          window.location.reload();
+        }
+      })
+      .catch(function (err) {
+        setToolbarStatus('Error: ' + err.message);
+      });
+  }
+
+  // The media library panel dispatches this on every file click, whether or not a widget is
+  // currently armed. When nothing is armed there is intentionally nothing to do here: issue #431's
+  // "copy URL to clipboard + toast" behavior for that case doesn't exist in this codebase yet (no
+  // listener anywhere), and building it is that issue's job, not this one's.
+  document.addEventListener('media-selected', function (e) {
+    if (!activeImageWidget) return;
+    var asset = e.detail && e.detail.asset;
+    if (!asset || !asset.assetId) {
+      setToolbarStatus('Selected file is missing an asset id.');
+      return;
+    }
+    applyImageToWidget(activeImageWidget, asset);
+  });
+
   // ── Widget picker ─────────────────────────────────────────────────────────
 
   function buildWidgetPicker() {
@@ -1526,7 +1700,8 @@
         deactivateQuill(false);
         return;
       }
-      if (activeContent) deactivateEdit(true);
+      if (activeContent) { deactivateEdit(true); return; }
+      if (activeImageWidget) { disarmImageWidget(); setToolbarStatus(''); }
     }
     // Ctrl+S (or Cmd+S) saves the active Quill editor
     if ((e.ctrlKey || e.metaKey) && e.key === 's' && activeQuill && quillActionsBar) {

--- a/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
@@ -92,6 +92,18 @@ class MutateLayoutCommandTest {
       "  </section>\n" +
       "</page>";
 
+  // A page with an image (ImageWidget) instance, for the imageUrl validation tests.
+  private static final String IMAGE_WIDGET_XML =
+      "<page>\n" +
+      "  <section class=\"first\">\n" +
+      "    <column class=\"small-12 cell\">\n" +
+      "      <widget name=\"image\">\n" +
+      "        <imageUrl>/media/original.png</imageUrl>\n" +
+      "      </widget>\n" +
+      "    </column>\n" +
+      "  </section>\n" +
+      "</page>";
+
   private static WebPage pageWithXml(String xml) {
     WebPage p = new WebPage();
     p.setId(99);
@@ -110,7 +122,8 @@ class MutateLayoutCommandTest {
       repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
       cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
       cmd.when(WebPageXmlLayoutCommand::getWidgetLibrary)
-          .thenReturn(Map.of("content", "ContentWidget", "menu", "MenuWidget", "dataTable", "TableWidget"));
+          .thenReturn(Map.of("content", "ContentWidget", "menu", "MenuWidget", "dataTable", "TableWidget",
+              "image", "ImageWidget"));
       mutation.run();
     }
     return page.getDraftPageXml();
@@ -465,6 +478,55 @@ class MutateLayoutCommandTest {
         () -> mutate(page, () -> MutateLayoutCommand.addWidget(page, 0, 0, -1, "dataTable",
             "{\"tableData\":\"{\\\"rows\\\":[]}\"}", 42L)),
         "tableData missing 'headers' must be rejected before the widget is ever added");
+  }
+
+  // ── setWidgetPreferences / addWidget: ImageWidget's imageUrl is validated at this boundary ──────
+  // (issue #772: this preference is rendered straight into an <img src>, so an unsafe value must
+  // be rejected here rather than merely dropped at render time.)
+
+  @Test
+  void setWidgetPreferencesAcceptsSiteRelativeImageUrl() throws DataException {
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    String result = mutate(page, () ->
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"imageUrl\":\"/media/new.png\"}", 42L));
+    assertTrue(result.contains("<imageUrl>/media/new.png</imageUrl>"), "the new image url should be written");
+  }
+
+  @Test
+  void setWidgetPreferencesAcceptsBlankImageUrlToClearIt() throws DataException {
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    String result = mutate(page, () ->
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"imageUrl\":\"\"}", 42L));
+    assertTrue(result.contains("<imageUrl/>") || result.contains("<imageUrl></imageUrl>"),
+        "a blank value is valid -- it clears the image back to the placeholder");
+  }
+
+  @Test
+  void setWidgetPreferencesRejectsJavascriptSchemeImageUrl() {
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    assertThrows(DataException.class,
+        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
+            "{\"imageUrl\":\"javascript:alert(1)\"}", 42L)),
+        "an active scheme must be rejected before it is persisted");
+  }
+
+  @Test
+  void setWidgetPreferencesRejectsAttributeBreakoutImageUrl() {
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    assertThrows(DataException.class,
+        () -> mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
+            "{\"imageUrl\":\"/media/x.png\\\" onerror=\\\"alert(1)\"}", 42L)),
+        "a value that could break out of the src attribute must be rejected before it is persisted");
+  }
+
+  @Test
+  void setWidgetPreferencesIgnoresImageUrlValidationForOtherWidgets() throws DataException {
+    // An "imageUrl"-named preference on some other widget type is just an opaque string to this
+    // class -- only the image widget's value gets validated as a safe url.
+    WebPage page = pageWithXml(ONE_SECTION_XML);
+    String result = mutate(page, () ->
+        MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, "{\"imageUrl\":\"javascript:alert(1)\"}", 42L));
+    assertTrue(result.contains("<imageUrl>javascript:alert(1)</imageUrl>"));
   }
 
   // ── modifiedBy / persistence-failure propagation ─────────────────────────

--- a/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
@@ -529,6 +529,71 @@ class MutateLayoutCommandTest {
     assertTrue(result.contains("<imageUrl>javascript:alert(1)</imageUrl>"));
   }
 
+  // ── getWidgetName ─────────────────────────────────────────────────────────
+  // Read-only resolver added for issue #772's follow-up: MediaApiController's widget-update
+  // endpoint must confirm the *real* widget at a position -- resolved the same way
+  // setWidgetPreferences resolves it internally -- before honoring a client-supplied prefKey.
+
+  @Test
+  void getWidgetNameReturnsTheRegisteredNameOfTheWidgetAtThePosition() throws DataException {
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    assertEquals("image", MutateLayoutCommand.getWidgetName(page, 0, 0, 0));
+  }
+
+  @Test
+  void getWidgetNameResolvesEachWidgetInAMultiWidgetColumnIndependently() throws DataException {
+    WebPage page = pageWithXml(
+        "<page>\n" +
+        "  <section>\n" +
+        "    <column class=\"small-12 cell\">\n" +
+        "      <widget name=\"content\"><uniqueId>a</uniqueId></widget>\n" +
+        "      <widget name=\"image\"><imageUrl>/media/x.png</imageUrl></widget>\n" +
+        "    </column>\n" +
+        "  </section>\n" +
+        "</page>");
+    assertEquals("content", MutateLayoutCommand.getWidgetName(page, 0, 0, 0));
+    assertEquals("image", MutateLayoutCommand.getWidgetName(page, 0, 0, 1));
+  }
+
+  @Test
+  void getWidgetNamePrefersTheDraftLayoutOverThePublishedOne() throws DataException {
+    // Mirrors mutate()'s own source resolution: a pending, unpublished edit must be what gets
+    // checked, not the stale published version -- otherwise this check could pass or fail against a
+    // widget arrangement that's no longer accurate.
+    WebPage page = pageWithXml(IMAGE_WIDGET_XML);
+    page.setDraftPageXml(
+        "<page>\n" +
+        "  <section>\n" +
+        "    <column class=\"small-12 cell\">\n" +
+        "      <widget name=\"remoteContent\"><url>https://example.com</url></widget>\n" +
+        "    </column>\n" +
+        "  </section>\n" +
+        "</page>");
+    assertEquals("remoteContent", MutateLayoutCommand.getWidgetName(page, 0, 0, 0));
+  }
+
+  @Test
+  void getWidgetNameRejectsOutOfRangeIndices() {
+    WebPage page = pageWithXml(ONE_SECTION_XML);
+    assertThrows(DataException.class, () -> MutateLayoutCommand.getWidgetName(page, 5, 0, 0));
+    assertThrows(DataException.class, () -> MutateLayoutCommand.getWidgetName(page, 0, 5, 0));
+    assertThrows(DataException.class, () -> MutateLayoutCommand.getWidgetName(page, 0, 0, 5));
+  }
+
+  @Test
+  void getWidgetNameRejectsAPageWithNoXmlLayout() {
+    WebPage page = new WebPage();
+    page.setId(99);
+    page.setLink("/no-xml");
+    assertThrows(DataException.class, () -> MutateLayoutCommand.getWidgetName(page, 0, 0, 0));
+  }
+
+  @Test
+  void getWidgetNameRejectsAMissingPage() {
+    WebPage missing = new WebPage(); // id defaults to -1: not a real, persisted page
+    assertThrows(DataException.class, () -> MutateLayoutCommand.getWidgetName(missing, 0, 0, 0));
+  }
+
   // ── modifiedBy / persistence-failure propagation ─────────────────────────
   // A structural mutation must record who made it and must not report success when the
   // underlying save silently fails (e.g. a stale modified_by value tripping the

--- a/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/MediaApiControllerTest.java
@@ -52,6 +52,8 @@ import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.MediaAssetRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.presentation.widgets.cms.ImageWidget;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -98,7 +100,10 @@ class MediaApiControllerTest {
     Map<String, String> params = new HashMap<>();
     params.put("assetId", "asset-123");
     params.put("pagePath", "/about");
-    params.put("prefKey", "url");
+    // The endpoint's real contract (post-#772 follow-up): the only prefKey it will ever honor is
+    // the image widget's own imageUrl preference. Individual tests below that need to exercise the
+    // rejection path (wrong prefKey / wrong widget type) override this explicitly.
+    params.put("prefKey", ImageWidget.IMAGE_URL_PREF_KEY);
     params.put("sectionIdx", "0");
     params.put("columnIdx", "1");
     params.put("widgetIdx", "2");
@@ -263,6 +268,8 @@ class MediaApiControllerTest {
          MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
       assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
       pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+      mutate.when(() -> MutateLayoutCommand.getWidgetName(webPage, 0, 1, 2))
+          .thenReturn(ImageWidget.WIDGET_NAME);
 
       Recorded result = runWidgetUpdate(request);
 
@@ -273,7 +280,124 @@ class MediaApiControllerTest {
       mutate.verify(() -> MutateLayoutCommand.setWidgetPreferences(
           eq(webPage), eq(0), eq(1), eq(2), prefsJsonCaptor.capture(), eq(userSession.getUserId())));
       JsonNode prefs = MAPPER.readTree(prefsJsonCaptor.getValue());
-      assertEquals("/assets/photo.jpg", prefs.get("url").asText());
+      assertEquals("/assets/photo.jpg", prefs.get(ImageWidget.IMAGE_URL_PREF_KEY).asText());
+    }
+  }
+
+  // ── issue #772 follow-up: the server must independently verify the target is an image widget ──
+  //
+  // The visual editor's "Choose image from Media Library" trigger only renders client-side for a
+  // widget whose data-editor-widget-name is "image" (platform-editor.js) -- that gate is UI-only.
+  // A prior live-verify pass crafted the identical request shape the JS sends (valid session, valid
+  // CSRF token, a real assetId/pagePath) but aimed at a *different* widget's structural position with
+  // that widget's own real preference key, and the server accepted it (200) and silently overwrote
+  // that widget's real preference with an image path. These two tests recreate that attack and its
+  // sibling (right widget, wrong prefKey), and deliberately do NOT mock MutateLayoutCommand or
+  // WebPageRepository as no-ops -- they must prove the *real* getWidgetName resolution against real
+  // page XML rejects the request, not merely that some mock was configured to reject it.
+
+  @Test
+  void rejectsWidgetUpdateTargetingANonImageWidgetAndLeavesItsRealPreferenceUntouched() throws Exception {
+    UserSession userSession = loggedInSession("admin");
+    Map<String, String> params = baseParams(userSession.getFormToken());
+    // The attacker reuses a real, non-image widget's own real preference key ("url" on a
+    // remoteContent widget) at the structural position that widget actually occupies.
+    params.put("prefKey", "url");
+    params.put("sectionIdx", "0");
+    params.put("columnIdx", "0");
+    params.put("widgetIdx", "0");
+    HttpServletRequest request = requestWithSession(userSession, params);
+
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setStoragePath("/assets/photo.jpg");
+
+    WebPage webPage = new WebPage();
+    webPage.setId(55);
+    webPage.setLink("/about");
+    webPage.setPageXml(
+        "<page>\n" +
+        "  <section>\n" +
+        "    <column class=\"small-12 cell\">\n" +
+        "      <widget name=\"remoteContent\">\n" +
+        "        <url>https://legit.example.com/feed.json</url>\n" +
+        "      </widget>\n" +
+        "    </column>\n" +
+        "  </section>\n" +
+        "</page>");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class);
+         MockedStatic<LoadWebPageCommand> pages = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
+      pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains("not an image widget"),
+          "must be rejected for targeting the wrong widget type, not silently applied");
+
+      // The real setWidgetPreferences -- and the WebPageRepository.save it would call to persist --
+      // must never be reached: rejection has to happen before any write is attempted.
+      repo.verify(() -> WebPageRepository.save(any()), never());
+
+      // The widget actually on the page, as it would really render, is completely unchanged: no
+      // draft was created, and the published XML still holds the original url.
+      assertTrue(webPage.getDraftPageXml() == null || webPage.getDraftPageXml().isEmpty(),
+          "no draft mutation should have been written");
+      assertTrue(webPage.getPageXml().contains("<url>https://legit.example.com/feed.json</url>"),
+          "the remoteContent widget's real url preference must be completely unchanged");
+    }
+  }
+
+  @Test
+  void rejectsWidgetUpdateWithAPrefKeyOtherThanImageUrlEvenAgainstARealImageWidget() throws Exception {
+    // Sibling of the above: even when the target genuinely is an image widget, this endpoint must
+    // only ever be able to touch its imageUrl -- never some other preference of that same widget
+    // (e.g. altText) via the same request shape.
+    UserSession userSession = loggedInSession("admin");
+    Map<String, String> params = baseParams(userSession.getFormToken());
+    params.put("prefKey", "altText");
+    params.put("sectionIdx", "0");
+    params.put("columnIdx", "0");
+    params.put("widgetIdx", "0");
+    HttpServletRequest request = requestWithSession(userSession, params);
+
+    MediaAsset asset = new MediaAsset();
+    asset.setAssetId("asset-123");
+    asset.setStoragePath("/assets/photo.jpg");
+
+    WebPage webPage = new WebPage();
+    webPage.setId(55);
+    webPage.setLink("/about");
+    webPage.setPageXml(
+        "<page>\n" +
+        "  <section>\n" +
+        "    <column class=\"small-12 cell\">\n" +
+        "      <widget name=\"image\">\n" +
+        "        <imageUrl>/media/original.png</imageUrl>\n" +
+        "        <altText>A real, curated description</altText>\n" +
+        "      </widget>\n" +
+        "    </column>\n" +
+        "  </section>\n" +
+        "</page>");
+
+    try (MockedStatic<MediaAssetRepository> assets = mockStatic(MediaAssetRepository.class);
+         MockedStatic<LoadWebPageCommand> pages = mockStatic(LoadWebPageCommand.class);
+         MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
+      assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
+      pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+
+      Recorded result = runWidgetUpdate(request);
+
+      assertEquals(400, result.status);
+      assertTrue(result.body.contains(ImageWidget.IMAGE_URL_PREF_KEY),
+          "must be rejected for using the wrong prefKey, not silently applied to altText");
+
+      repo.verify(() -> WebPageRepository.save(any()), never());
+      assertTrue(webPage.getPageXml().contains("<altText>A real, curated description</altText>"),
+          "the widget's real altText must be completely unchanged");
     }
   }
 
@@ -293,6 +417,8 @@ class MediaApiControllerTest {
          MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
       assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
       pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+      mutate.when(() -> MutateLayoutCommand.getWidgetName(webPage, 0, 1, 2))
+          .thenReturn(ImageWidget.WIDGET_NAME);
       mutate.when(() -> MutateLayoutCommand.setWidgetPreferences(
           any(), anyInt(), anyInt(), anyInt(), anyString(), anyLong()))
           .thenThrow(new DataException("Widget index 2 at 0:1 out of range (1 widget(s))"));
@@ -321,6 +447,8 @@ class MediaApiControllerTest {
          MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
       assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
       pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+      mutate.when(() -> MutateLayoutCommand.getWidgetName(webPage, 0, 1, 2))
+          .thenReturn(ImageWidget.WIDGET_NAME);
 
       new MediaApiController().doPost(request, response);
 
@@ -374,6 +502,8 @@ class MediaApiControllerTest {
          MockedStatic<MutateLayoutCommand> mutate = mockStatic(MutateLayoutCommand.class)) {
       assets.when(() -> MediaAssetRepository.findByAssetId("asset-123")).thenReturn(asset);
       pages.when(() -> LoadWebPageCommand.loadByLink("/about")).thenReturn(webPage);
+      mutate.when(() -> MutateLayoutCommand.getWidgetName(webPage, 0, 1, 2))
+          .thenReturn(ImageWidget.WIDGET_NAME);
 
       Recorded result = runWidgetUpdate(request);
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ImageWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ImageWidgetTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import com.simisinc.platform.WidgetBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author elizabeth houser
+ * @created 7/31/2026
+ */
+class ImageWidgetTest extends WidgetBase {
+
+  @Test
+  void execute() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"image\">\n" +
+            "  <imageUrl>/assets/media/photo.png</imageUrl>\n" +
+            "  <altText>A description of the photo</altText>\n" +
+            "</widget>");
+
+    ImageWidget widget = new ImageWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("/assets/media/photo.png", request.getAttribute("imageUrl"));
+    Assertions.assertEquals("A description of the photo", request.getAttribute("altText"));
+    Assertions.assertEquals(ImageWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeWithNoImageSetRendersPlaceholderAttributes() {
+    // No preferences at all -- the freshly-added-via-"+Widget" case. The widget must still resolve
+    // to its JSP (which renders a placeholder), never leave imageUrl pointing at a broken <img>.
+    ImageWidget widget = new ImageWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertNull(request.getAttribute("imageUrl"));
+    Assertions.assertEquals("", request.getAttribute("altText"));
+    Assertions.assertEquals(ImageWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeDropsUnsafeImageUrlRatherThanRenderingIt() {
+    // Defense in depth: MutateLayoutCommand's save-path validation (isValidImageUrl) should
+    // already have rejected this, but a value that reaches render some other way must still never
+    // be written into the src attribute.
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"image\">\n" +
+            "  <imageUrl>javascript:alert(1)</imageUrl>\n" +
+            "</widget>");
+
+    ImageWidget widget = new ImageWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertNull(request.getAttribute("imageUrl"));
+    Assertions.assertEquals(ImageWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void isValidImageUrlAcceptsBlankAndSiteRelativePaths() {
+    Assertions.assertTrue(ImageWidget.isValidImageUrl(null));
+    Assertions.assertTrue(ImageWidget.isValidImageUrl(""));
+    Assertions.assertTrue(ImageWidget.isValidImageUrl("/assets/media/photo.png"));
+    Assertions.assertTrue(ImageWidget.isValidImageUrl("https://example.com/photo.png"));
+  }
+
+  @Test
+  void isValidImageUrlRejectsActiveSchemesAndAttributeBreakout() {
+    Assertions.assertFalse(ImageWidget.isValidImageUrl("javascript:alert(1)"));
+    Assertions.assertFalse(ImageWidget.isValidImageUrl("data:text/html,<script>alert(1)</script>"));
+    Assertions.assertFalse(ImageWidget.isValidImageUrl("/assets/x.png\" onerror=\"alert(1)"));
+  }
+}


### PR DESCRIPTION
Fixes #772

## Background: why this took two builds

A first attempt (see the comment on #772) wired click-to-replace to the existing, already-tested `/visual-editor/media/widget-update` endpoint using a heuristic to guess which preference on a widget held its image. That approach was rejected before a PR was opened, for two reasons:

- The heuristic included the bare key `url` as a candidate, which collides with `remoteContent`'s real "Source URL" preference — any configured `remoteContent` widget would get silently armed, and clicking a file would overwrite its content-fetch URL instead of replacing an image.
- More fundamentally, no widget type shipped in this codebase at the time had both a rendered `<img>` and a single editable string preference actually driving that `src`. Every real image-bearing widget (ProductImageWidget, BlogPostWidget, PhotoGalleryWidget, ItemsListWidget, etc.) resolves its image through a domain-entity reference (a foreign key to a product/post/item record), not a layout preference. There was nothing real to target.

## What this PR does

**A real Image widget.** Adds `ImageWidget` / `cms/image.jsp`, registered in `widget-library.xml` so it's addable from the composition canvas's existing "+Widget" picker. It exposes exactly two preferences: `imageUrl` (the render source) and `altText`, following the codebase's existing alt-text conventions. `imageUrl` is validated both at save (`MutateLayoutCommand`, the same defense-in-depth pattern already used for `TableWidget`'s `tableData`) and at render (`UrlCommand.sanitizeUrl`, matching `ButtonWidget`/`RemoteContentWidget`); a missing image renders a placeholder rather than a broken `<img>`.

**Click-to-replace retargeted by real widget type.** The heuristic guesswork (`detectImagePrefKey()`) is gone. The widget wrapper now carries a `data-editor-widget-name` attribute (plumbed through `WidgetRenderInfo` from the existing `Widget.widgetName`), and the "Choose image from Media Library" trigger only renders for a widget whose `data-editor-widget-name` is `image`, targeting its known `imageUrl` preference directly. Verified live via a docker-compose rehearsal: added an image widget through the "+Widget" picker, confirmed the placeholder with no image set, armed it and applied an asset through the real Media Library panel, and confirmed via a fresh page reload (not a client-side patch) that the persisted `imageUrl` is what actually renders — including replacing an already-set image with a different one, reconfirmed after another reload, and surviving Publish.

**A server-side authorization gap found and closed.** Live testing of the above surfaced that the client-side "Choose image" trigger was a UI-only gate: `MediaApiController.handleWidgetUpdate` would honor any client-supplied `prefKey` against any widget position without ever confirming the target was actually an image widget. A crafted request naming the `widgetIdx` of an unrelated widget (e.g. `remoteContent`) together with that widget's own real preference key (`url`) was accepted (200) and silently overwrote it — reproducing, one layer lower, the exact corruption this branch's Image widget work was meant to fix.

This is closed with `MutateLayoutCommand.getWidgetName()`, a read-only resolver that looks up the real widget at `sectionIdx:columnIdx:widgetIdx` using the same source XML and the same private traversal helpers (`childElements`, `checkSectionIdx`, `checkColumnIdx`, `checkWidgetIdx`) that `setWidgetPreferences` already uses internally — so the answer can never drift from what a mutation at that position would actually touch. `handleWidgetUpdate` now calls this before delegating to `setWidgetPreferences` and rejects with a 400 unless the resolved widget is really `ImageWidget.WIDGET_NAME` and `prefKey` is really `ImageWidget.IMAGE_URL_PREF_KEY`.

### Live verification that the corruption path is actually closed

Built a test page (`content` widget, then a real `image` widget added via the actual `+Widget` picker, then a real `remoteContent` widget with a genuine external `url` preference) and recreated the exact attack against the running app:

- POST at the `remoteContent` widget's real position with its own real preference key (`sectionIdx=0&columnIdx=0&widgetIdx=2&prefKey=url`) → **HTTP 400**, `{"error":"Target widget is not an image widget (found 'remoteContent')"}`.
- Sibling case — the real `image` widget targeted with the wrong preference key (`widgetIdx=1&prefKey=altText`) → **HTTP 400**, `{"error":"prefKey must be 'imageUrl' when targeting an image widget"}`.
- `draft_page_xml` and `page_xml` queried directly from the database before and after both attempts are byte-for-byte identical — the `remoteContent` widget's real `url` and the `image` widget's real `imageUrl` were untouched.
- The legitimate flow was re-run after the attack attempts to confirm no regression: arm the image widget, pick an asset from the Media Library, live update in canvas, survives a fresh reload, and survives Publish — an anonymous `curl` to the published page shows the new image rendering and the `remoteContent` widget's own image unaffected alongside it.

Added tests recreating both attack cases (asserting the widget's real preference is left completely unchanged, not just the HTTP status) plus direct coverage of `getWidgetName`, and updated the existing widget-update tests for the new `prefKey` contract. Full suite: `MutateLayoutCommandTest` 52/52, `MediaApiControllerTest` 16/16, `ImageWidgetTest` 5/5.
