### PR TITLE
Fix data table widget: Escape-cancel, dynamic-cell a11y attrs, picker search case-sensitivity

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
@@ -196,6 +196,11 @@
   const deleteColBtn = document.querySelector('.delete-col');
 
   let selectedCell = null;
+  const cellOriginalValues = new WeakMap();
+
+  function handleCellFocus(e) {
+    cellOriginalValues.set(e.target, e.target.textContent);
+  }
 
   // Keyboard navigation
   function handleCellKeydown(e) {
@@ -222,7 +227,11 @@
         break;
       case 'Escape':
         e.preventDefault();
+        if (cellOriginalValues.has(cellDiv)) {
+          cellDiv.textContent = cellOriginalValues.get(cellDiv);
+        }
         cellDiv.blur();
+        saveTableData();
         break;
     }
   }
@@ -249,6 +258,7 @@
   // Add event listeners to all editable cells
   function attachCellListeners() {
     table.querySelectorAll('[contenteditable]').forEach(cell => {
+      cell.addEventListener('focus', handleCellFocus);
       cell.addEventListener('keydown', handleCellKeydown);
       cell.addEventListener('click', () => {
         selectedCell = cell.closest('td') || cell.closest('th');
@@ -265,6 +275,7 @@
 
     for (let i = 0; i < colCount; i++) {
       const td = document.createElement('td');
+      td.setAttribute('role', 'cell');
       td.setAttribute('data-col', i);
       td.innerHTML = '<div class="cell-content" contenteditable="true" role="textbox" tabindex="0"></div>';
       newRow.appendChild(td);
@@ -280,12 +291,15 @@
     const headerRow = table.querySelector('thead tr');
     const colIndex = headerRow.children.length;
     const headerCell = document.createElement('th');
+    headerCell.setAttribute('scope', 'col');
+    headerCell.setAttribute('role', 'columnheader');
     headerCell.setAttribute('data-col', colIndex);
     headerCell.innerHTML = '<div class="header-cell" contenteditable="true" role="textbox" tabindex="0">New</div>';
     headerRow.appendChild(headerCell);
 
     table.querySelectorAll('tbody tr').forEach((row, rowIndex) => {
       const td = document.createElement('td');
+      td.setAttribute('role', 'cell');
       td.setAttribute('data-row', rowIndex);
       td.setAttribute('data-col', colIndex);
       td.innerHTML = '<div class="cell-content" contenteditable="true" role="textbox" tabindex="0"></div>';

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -1475,7 +1475,7 @@
     if (!list) return;
     var q = query.trim().toLowerCase();
     list.querySelectorAll('li').forEach(function (li) {
-      li.style.display = (!q || li.dataset.name.indexOf(q) !== -1) ? '' : 'none';
+      li.style.display = (!q || li.dataset.name.toLowerCase().indexOf(q) !== -1) ? '' : 'none';
     });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to issue #433, addressing the three smaller, separable items called out in the [fact-check comment](https://github.com/SimisRnD/simis-cms/issues/433#issuecomment-5147655569) that were deliberately left out of the crash/persistence fix (`fix/data-table-widget-crash-and-persistence-433`):

1. **Escape does not cancel a cell edit.** In `table-widget-edit.jsp`, `handleCellKeydown`'s Escape branch was byte-identical to the Enter branch (`e.preventDefault(); cellDiv.blur();`), so typed text was never reverted. Now the cell's original text is cached in a `WeakMap` when it receives focus, and Escape restores that cached value (then re-syncs the hidden input via the existing `saveTableData()`) before blurring.
2. **Rows/columns added via the toolbar are missing accessibility attributes.** The server-rendered populated branch gives `<th>` `scope="col" role="columnheader"` and `<td>` `role="cell"`, but the `addRowBtn`/`addColBtn` click handlers that create new `<th>`/`<td>` elements didn't set them. Now they match.
3. **The +Widget picker's search is case-sensitive against a lowercased query.** `filterWidgetList` lowercased the typed query but compared it against the widget's raw `dataset.name`, so typing a widget's real mixed-case name (e.g. `dataTable`) didn't match itself — only an all-lowercase prefix like `data` did. Fixed by lowercasing both sides. This was a generic bug in the comparison, not specific to `dataTable`: most multi-word widget names in `widget-library.xml` are camelCase (`blogPost`, `allowedIP`, `webPageForm`, etc.) and were equally affected by the same one-line fix.

## Test plan

Verified live via a local docker-compose rehearsal (build WAR, `docker compose up --build`), using the existing `⚙ Prefs` raw-JSON panel to set a fresh `dataTable` widget's `editMode` preference so its edit UI renders (this reachability gap is unrelated/pre-existing, not part of this fix):
- [x] Typed text into a cell, pressed Escape, confirmed it reverted to the original text
- [x] Clicked Add Row and Add Column, inspected the new `<th>`/`<td>` elements — confirmed `scope="col"`/`role="columnheader"` on the new header cell and `role="cell"` on every new data cell
- [x] Typed the mixed-case widget name `dataTable` into the +Widget picker search and confirmed it now matches (previously only `data` matched)

This PR is scoped to only these three items, kept separate from the crash/persistence fix per this repo's one-defect-per-PR convention.