### PR TITLE
Add a trend chart for Core Web Vitals on the admin dashboard (issue #762)

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/cms/WebVitalsAggregate.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/WebVitalsAggregate.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A single day's p50/p75/p95 Core Web Vitals aggregate for one URL and metric, as computed
+ * nightly by WebVitalsAggregationJob into the web_vitals_aggregates table. Used to plot a
+ * multi-day trend (issue #762), one row per (url, metric_type, day).
+ *
+ * @author claude
+ * @created 7/31/26
+ */
+public class WebVitalsAggregate extends Entity {
+
+  private String url;
+  private String metricType;
+  private double p50Value;
+  private double p75Value;
+  private double p95Value;
+  private long sampleCount;
+  private Timestamp aggregatedAt;
+
+  public WebVitalsAggregate() {
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getMetricType() {
+    return metricType;
+  }
+
+  public void setMetricType(String metricType) {
+    this.metricType = metricType;
+  }
+
+  public double getP50Value() {
+    return p50Value;
+  }
+
+  public void setP50Value(double p50Value) {
+    this.p50Value = p50Value;
+  }
+
+  public double getP75Value() {
+    return p75Value;
+  }
+
+  public void setP75Value(double p75Value) {
+    this.p75Value = p75Value;
+  }
+
+  public double getP95Value() {
+    return p95Value;
+  }
+
+  public void setP95Value(double p95Value) {
+    this.p95Value = p95Value;
+  }
+
+  public long getSampleCount() {
+    return sampleCount;
+  }
+
+  public void setSampleCount(long sampleCount) {
+    this.sampleCount = sampleCount;
+  }
+
+  public Timestamp getAggregatedAt() {
+    return aggregatedAt;
+  }
+
+  public void setAggregatedAt(Timestamp aggregatedAt) {
+    this.aggregatedAt = aggregatedAt;
+  }
+
+  /**
+   * Day-granularity label (yyyy-MM-dd) for chart axes and the screen-reader data table -- matches
+   * the aggregation job's one-row-per-day grain, so this is always stable regardless of the time
+   * component NOW()/date_trunc('day', ...) happens to store.
+   */
+  public String getDateLabel() {
+    if (aggregatedAt == null) {
+      return "";
+    }
+    return new SimpleDateFormat("yyyy-MM-dd").format(aggregatedAt);
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebVitalsAggregateRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebVitalsAggregateRepository.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.WebVitalsAggregate;
+import com.simisinc.platform.infrastructure.database.DB;
+
+/**
+ * Reads the daily p50/p75/p95 rows that WebVitalsAggregationJob writes into
+ * web_vitals_aggregates, for plotting a Core Web Vitals trend over a selectable date range
+ * (issue #762). Purely a query layer -- no new collection or aggregation logic; the nightly job
+ * (WebVitalsAggregationJob) already computes and stores one row per (url, metric_type, day).
+ *
+ * @author claude
+ * @created 7/31/26
+ */
+public class WebVitalsAggregateRepository {
+
+  private static Log LOG = LogFactory.getLog(WebVitalsAggregateRepository.class);
+
+  // The widest range the admin dashboard's trend chart offers (7/30/90 days); also used to bound
+  // findDistinctUrls() so the URL picker covers every range the chart can show.
+  public static final int MAX_TREND_DAYS = 90;
+
+  /**
+   * Distinct URLs with at least one aggregate row in the last {@code daysToLimit} days, for
+   * populating the trend chart's URL picker. Ordered alphabetically for a stable, scannable list.
+   */
+  public static List<String> findDistinctUrls(int daysToLimit) {
+    int days = boundDays(daysToLimit);
+    String SQL_QUERY = "SELECT DISTINCT url " +
+        "FROM web_vitals_aggregates " +
+        "WHERE aggregated_at > NOW() - INTERVAL '" + days + " days' " +
+        "ORDER BY url";
+    List<String> urls = new ArrayList<>();
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+        ResultSet rs = pst.executeQuery()) {
+      while (rs.next()) {
+        urls.add(rs.getString("url"));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return urls;
+  }
+
+  /**
+   * The daily p50/p75/p95 aggregate rows for one URL and metric over the last {@code daysToLimit}
+   * days, oldest first -- the exact series a trend line chart plots. Returns an empty list (not
+   * null) for a blank url/metricType so callers can render "no data" without a null check.
+   */
+  public static List<WebVitalsAggregate> findAggregates(String url, String metricType, int daysToLimit) {
+    List<WebVitalsAggregate> records = new ArrayList<>();
+    if (StringUtils.isBlank(url) || StringUtils.isBlank(metricType)) {
+      return records;
+    }
+    int days = boundDays(daysToLimit);
+    String SQL_QUERY = "SELECT url, metric_type, p50_value, p75_value, p95_value, sample_count, aggregated_at " +
+        "FROM web_vitals_aggregates " +
+        "WHERE url = ? AND metric_type = ? AND aggregated_at > NOW() - INTERVAL '" + days + " days' " +
+        "ORDER BY aggregated_at";
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(SQL_QUERY)) {
+      pst.setString(1, url);
+      pst.setString(2, metricType);
+      try (ResultSet rs = pst.executeQuery()) {
+        while (rs.next()) {
+          records.add(mapRow(rs));
+        }
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return records;
+  }
+
+  private static WebVitalsAggregate mapRow(ResultSet rs) throws SQLException {
+    WebVitalsAggregate record = new WebVitalsAggregate();
+    record.setUrl(rs.getString("url"));
+    record.setMetricType(rs.getString("metric_type"));
+    record.setP50Value(toDouble(rs.getBigDecimal("p50_value")));
+    record.setP75Value(toDouble(rs.getBigDecimal("p75_value")));
+    record.setP95Value(toDouble(rs.getBigDecimal("p95_value")));
+    record.setSampleCount(rs.getLong("sample_count"));
+    record.setAggregatedAt(rs.getTimestamp("aggregated_at"));
+    return record;
+  }
+
+  private static double toDouble(BigDecimal value) {
+    return value != null ? value.doubleValue() : 0.0;
+  }
+
+  /**
+   * Bounds a requested day count to a sane, positive range so a bad/absent value can't build an
+   * unbounded or negative SQL INTERVAL. Mirrors WebPageHitRepository.resolveRetentionDays' shape,
+   * capped at MAX_TREND_DAYS (90) rather than 10 years since this only ever backs the 7/30/90-day
+   * trend chart, not a retention policy.
+   */
+  static int boundDays(int days) {
+    if (days < 1) {
+      return 1;
+    }
+    if (days > MAX_TREND_DAYS) {
+      return MAX_TREND_DAYS;
+    }
+    return days;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/WebVitalsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/WebVitalsWidget.java
@@ -16,19 +16,25 @@
 
 package com.simisinc.platform.presentation.widgets.admin;
 
+import com.simisinc.platform.domain.model.cms.WebVitalsAggregate;
 import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.persistence.cms.WebVitalsAggregateRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 
 /**
  * Displays Core Web Vitals performance metrics aggregated from real user sessions.
- * Shows p75 percentiles by URL and metric (LCP, CLS, INP, FCP, TTFB).
+ * Shows p75 percentiles by URL and metric (LCP, CLS, INP, FCP, TTFB), plus a selectable
+ * URL/metric/date-range trend line of the same daily aggregates (issue #762).
  * Color-coded: green (good) / yellow (needs work) / red (poor).
  *
  * @author claude
@@ -51,6 +57,12 @@ public class WebVitalsWidget extends GenericWidget {
   static final int FCP_NEEDS_WORK = 3000; // 3.0s
   static final int TTFB_GOOD = 600;       // 600ms
   static final int TTFB_NEEDS_WORK = 1800; // 1800ms
+
+  // Trend chart support (issue #762)
+  static final List<String> METRIC_TYPES = List.of("LCP", "CLS", "INP", "FCP", "TTFB");
+  static final String DEFAULT_TREND_METRIC = "LCP";
+  static final int DEFAULT_TREND_DAYS = 30;
+  static final Set<Integer> VALID_TREND_DAYS = Set.of(7, 30, 90);
 
   public WidgetContext execute(WidgetContext context) {
     try {
@@ -77,6 +89,26 @@ public class WebVitalsWidget extends GenericWidget {
       context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
       context.getRequest().setAttribute("title", context.getPreferences().get("title"));
 
+      // Trend chart: URL/metric/range picker plus the initial series to paint on first load
+      List<String> trendUrls = WebVitalsAggregateRepository.findDistinctUrls(WebVitalsAggregateRepository.MAX_TREND_DAYS);
+      String trendUrl = resolveTrendUrl(context.getParameter("trendUrl"), trendUrls, sortedUrls);
+      String trendMetric = resolveTrendMetric(context.getParameter("trendMetric"));
+      int trendDays = resolveTrendDays(context.getParameter("trendDays"));
+      // Always a real ArrayList (never List.of()/Collections.emptyList()) -- the JSP's
+      // <jsp:useBean class="java.util.ArrayList"> casts this attribute directly, and an
+      // immutable-list implementation would throw ClassCastException on that cast (see
+      // WebPageHitRepository/WebVitalsAggregateRepository, which return "new ArrayList<>()" for
+      // the same reason).
+      List<WebVitalsAggregate> trendDataList = StringUtils.isNotBlank(trendUrl)
+          ? WebVitalsAggregateRepository.findAggregates(trendUrl, trendMetric, trendDays)
+          : new ArrayList<>();
+
+      context.getRequest().setAttribute("trendUrls", trendUrls);
+      context.getRequest().setAttribute("trendUrl", trendUrl);
+      context.getRequest().setAttribute("trendMetric", trendMetric);
+      context.getRequest().setAttribute("trendDays", trendDays);
+      context.getRequest().setAttribute("trendDataList", trendDataList);
+
       context.setJsp(JSP);
       return context;
     } catch (Exception e) {
@@ -84,6 +116,127 @@ public class WebVitalsWidget extends GenericWidget {
       context.getRequest().setAttribute("errorMessage", "Error loading performance data");
       context.setJsp(JSP);
       return context;
+    }
+  }
+
+  /**
+   * AJAX endpoint (GET ?widget=...&action=get&trendUrl=...&trendMetric=...&trendDays=...) behind
+   * the trend chart's URL/metric/range picker -- same GET+action=/token= dispatch shape as
+   * SiteStatsWidget.action(), which WebContainerCommand routes to this method (not post()) because
+   * the request is a GET carrying an "action" parameter, not a POST.
+   */
+  public WidgetContext action(WidgetContext context) {
+    String trendUrl = context.getParameter("trendUrl");
+    String trendMetric = resolveTrendMetric(context.getParameter("trendMetric"));
+    int trendDays = resolveTrendDays(context.getParameter("trendDays"));
+
+    String json = "[]";
+    if (StringUtils.isNotBlank(trendUrl)) {
+      List<WebVitalsAggregate> trendDataList = WebVitalsAggregateRepository.findAggregates(trendUrl, trendMetric, trendDays);
+      try (Jsonb jsonb = JsonbBuilder.create()) {
+        json = jsonb.toJson(toChartPoints(trendDataList));
+      } catch (Exception e) {
+        LOG.error("Error serializing web vitals trend data", e);
+      }
+    }
+    context.setJson(json);
+    return context;
+  }
+
+  private static List<TrendPoint> toChartPoints(List<WebVitalsAggregate> trendDataList) {
+    List<TrendPoint> points = new ArrayList<>();
+    for (WebVitalsAggregate aggregate : trendDataList) {
+      points.add(new TrendPoint(aggregate.getDateLabel(), aggregate.getP50Value(), aggregate.getP75Value(), aggregate.getP95Value()));
+    }
+    return points;
+  }
+
+  /** Only an already-known URL is honored, so a bogus/stale value falls back cleanly. */
+  static String resolveTrendUrl(String requestedUrl, List<String> trendUrls, List<String> sortedUrls) {
+    if (StringUtils.isNotBlank(requestedUrl) && trendUrls.contains(requestedUrl)) {
+      return requestedUrl;
+    }
+    // Default to the same URL the summary table leads with (slowest by LCP p75), if it also has
+    // aggregate history; otherwise the first URL with any trend data at all.
+    if (!sortedUrls.isEmpty() && trendUrls.contains(sortedUrls.get(0))) {
+      return sortedUrls.get(0);
+    }
+    return trendUrls.isEmpty() ? null : trendUrls.get(0);
+  }
+
+  /** Whitelist, not a free-text passthrough -- the value is interpolated into a JS array below. */
+  static String resolveTrendMetric(String requestedMetric) {
+    if (requestedMetric != null) {
+      String upper = requestedMetric.trim().toUpperCase();
+      if (METRIC_TYPES.contains(upper)) {
+        return upper;
+      }
+    }
+    return DEFAULT_TREND_METRIC;
+  }
+
+  /** Only 7/30/90 are offered by the UI; anything else falls back to the 30-day default. */
+  static int resolveTrendDays(String requestedDays) {
+    if (StringUtils.isNotBlank(requestedDays)) {
+      try {
+        int days = Integer.parseInt(requestedDays.trim());
+        if (VALID_TREND_DAYS.contains(days)) {
+          return days;
+        }
+      } catch (NumberFormatException e) {
+        // fall through to the default
+      }
+    }
+    return DEFAULT_TREND_DAYS;
+  }
+
+  /** A single day's chart point, serialized to JSON for the trend chart's AJAX refresh. */
+  public static class TrendPoint {
+    private String date;
+    private double p50;
+    private double p75;
+    private double p95;
+
+    public TrendPoint() {
+    }
+
+    public TrendPoint(String date, double p50, double p75, double p95) {
+      this.date = date;
+      this.p50 = p50;
+      this.p75 = p75;
+      this.p95 = p95;
+    }
+
+    public String getDate() {
+      return date;
+    }
+
+    public void setDate(String date) {
+      this.date = date;
+    }
+
+    public double getP50() {
+      return p50;
+    }
+
+    public void setP50(double p50) {
+      this.p50 = p50;
+    }
+
+    public double getP75() {
+      return p75;
+    }
+
+    public void setP75(double p75) {
+      this.p75 = p75;
+    }
+
+    public double getP95() {
+      return p95;
+    }
+
+    public void setP95(double p95) {
+      this.p95 = p95;
     }
   }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/web-vitals.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-vitals.jsp
@@ -16,6 +16,11 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="trendUrls" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="trendDataList" class="java.util.ArrayList" scope="request"/>
 
 <div class="section">
   <h1><i class="fa fa-tachometer-alt"></i> Core Web Vitals Performance</h1>
@@ -156,5 +161,254 @@
         border-radius: 3px;
       }
     </style>
+  </c:if>
+</div>
+
+<div class="section">
+  <h3><i class="fa fa-chart-line"></i> Trend</h3>
+
+  <c:if test="${empty trendUrls}">
+    <div class="alert alert-info">No trend data yet. The nightly aggregation job populates this once a URL has more than one day of history.</div>
+  </c:if>
+
+  <c:if test="${not empty trendUrls}">
+    <div class="trend-controls" style="display:flex; flex-wrap:wrap; gap:1rem; align-items:flex-end; margin-bottom:1rem;">
+      <label>URL
+        <select id="trendUrlSelect${widgetContext.uniqueId}">
+          <c:forEach items="${trendUrls}" var="urlOption">
+            <option value="<c:out value="${urlOption}"/>"<c:if test="${urlOption == trendUrl}"> selected="selected"</c:if>><c:out value="${urlOption}"/></option>
+          </c:forEach>
+        </select>
+      </label>
+      <label>Metric
+        <select id="trendMetricSelect${widgetContext.uniqueId}">
+          <option value="LCP"<c:if test="${trendMetric == 'LCP'}"> selected="selected"</c:if>>LCP</option>
+          <option value="CLS"<c:if test="${trendMetric == 'CLS'}"> selected="selected"</c:if>>CLS</option>
+          <option value="INP"<c:if test="${trendMetric == 'INP'}"> selected="selected"</c:if>>INP</option>
+          <option value="FCP"<c:if test="${trendMetric == 'FCP'}"> selected="selected"</c:if>>FCP</option>
+          <option value="TTFB"<c:if test="${trendMetric == 'TTFB'}"> selected="selected"</c:if>>TTFB</option>
+        </select>
+      </label>
+      <div id="trendRangeTabs${widgetContext.uniqueId}" role="group" aria-label="Date range">
+        <button type="button" class="button<c:if test="${trendDays == 7}"> is-active</c:if>" data-days="7">7 days</button>
+        <button type="button" class="button<c:if test="${trendDays == 30}"> is-active</c:if>" data-days="30">30 days</button>
+        <button type="button" class="button<c:if test="${trendDays == 90}"> is-active</c:if>" data-days="90">90 days</button>
+      </div>
+    </div>
+
+    <%-- The canvas chart is not readable by assistive technology, so it is labeled and paired with an
+         equivalent screen-reader-only data table (WCAG 2.1 SC 1.1.1 / 1.3.1; Section 508), matching the
+         convention in site-stats-line-chart.jsp. --%>
+    <canvas id="trendChart${widgetContext.uniqueId}" width="600" height="250" role="img"
+            aria-label="Core Web Vitals trend chart. The data follows in a table."></canvas>
+    <table class="show-for-sr" id="trendTable${widgetContext.uniqueId}">
+      <caption>Core Web Vitals trend &ndash; data table</caption>
+      <thead>
+        <tr>
+          <th scope="col">Date</th>
+          <th scope="col">p50</th>
+          <th scope="col">p75</th>
+          <th scope="col">p95</th>
+        </tr>
+      </thead>
+      <tbody>
+        <c:forEach items="${trendDataList}" var="point">
+          <tr>
+            <th scope="row"><c:out value="${point.dateLabel}"/></th>
+            <td><c:out value="${point.p50Value}"/></td>
+            <td><c:out value="${point.p75Value}"/></td>
+            <td><c:out value="${point.p95Value}"/></td>
+          </tr>
+        </c:forEach>
+      </tbody>
+    </table>
+
+    <script src="${ctx}/javascript/chartjs-4.4.1/chart.umd.min.js"></script>
+    <script nonce="${cspNonce}">
+      (function() {
+        // Good/needs-improvement thresholds per metric (p75 targets) -- must stay in sync with
+        // WebVitalsWidget.java's LCP_GOOD/LCP_NEEDS_WORK etc. constants and the thresholds table
+        // above; both are small, rarely-changed literal tables, so this mirrors rather than shares
+        // them across the Java/JS boundary, same as the thresholds table's own hardcoded values.
+        var METRIC_THRESHOLDS = {
+          LCP: { good: 2500, poor: 4000 },
+          CLS: { good: 0.1, poor: 0.25 },
+          INP: { good: 200, poor: 500 },
+          FCP: { good: 1800, poor: 3000 },
+          TTFB: { good: 600, poor: 1800 }
+        };
+
+        // Shades the chart's plot area green/yellow/red at the current metric's Good/Needs
+        // Improvement/Poor boundaries -- the same badge colors used by the summary table above.
+        var thresholdBandsPlugin = {
+          id: 'thresholdBands',
+          beforeDraw: function(chart) {
+            var bands = chart.config._thresholdBands;
+            var yScale = chart.scales.y;
+            if (!bands || !yScale) {
+              return;
+            }
+            var area = chart.chartArea;
+            var ctx = chart.ctx;
+            var goodY = Math.max(area.top, Math.min(yScale.getPixelForValue(bands.good), area.bottom));
+            var poorY = Math.max(area.top, Math.min(yScale.getPixelForValue(bands.poor), area.bottom));
+            ctx.save();
+            ctx.fillStyle = 'rgba(40, 167, 69, 0.12)';
+            ctx.fillRect(area.left, goodY, area.width, area.bottom - goodY);
+            ctx.fillStyle = 'rgba(255, 193, 7, 0.12)';
+            ctx.fillRect(area.left, poorY, area.width, goodY - poorY);
+            ctx.fillStyle = 'rgba(220, 53, 69, 0.12)';
+            ctx.fillRect(area.left, area.top, area.width, poorY - area.top);
+            ctx.restore();
+          }
+        };
+
+        var trendCtx = document.getElementById("trendChart${widgetContext.uniqueId}").getContext('2d');
+        var trendChart = new Chart(trendCtx, {
+          type: 'line',
+          data: {
+            labels: [
+              <c:forEach items="${trendDataList}" var="point" varStatus="status">
+              "${js:escape(point.dateLabel)}"<c:if test="${!status.last}">, </c:if>
+              </c:forEach>
+            ],
+            datasets: [
+              {
+                label: 'p75',
+                data: [
+                  <c:forEach items="${trendDataList}" var="point" varStatus="status">
+                  ${point.p75Value}<c:if test="${!status.last}">, </c:if>
+                  </c:forEach>
+                ],
+                borderColor: 'rgb(54, 162, 235)',
+                backgroundColor: 'rgba(54, 162, 235, 0.15)',
+                tension: 0.1,
+                fill: false
+              },
+              {
+                label: 'p50',
+                data: [
+                  <c:forEach items="${trendDataList}" var="point" varStatus="status">
+                  ${point.p50Value}<c:if test="${!status.last}">, </c:if>
+                  </c:forEach>
+                ],
+                borderColor: 'rgb(160, 160, 160)',
+                borderDash: [4, 4],
+                pointRadius: 2,
+                tension: 0.1,
+                fill: false
+              },
+              {
+                label: 'p95',
+                data: [
+                  <c:forEach items="${trendDataList}" var="point" varStatus="status">
+                  ${point.p95Value}<c:if test="${!status.last}">, </c:if>
+                  </c:forEach>
+                ],
+                borderColor: 'rgb(220, 53, 69)',
+                borderDash: [2, 2],
+                pointRadius: 2,
+                tension: 0.1,
+                fill: false
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            plugins: {
+              legend: {
+                display: true
+              }
+            },
+            scales: {
+              y: {
+                beginAtZero: true
+              },
+              x: {}
+            }
+          },
+          plugins: [thresholdBandsPlugin]
+        });
+
+        var urlSelect = document.getElementById("trendUrlSelect${widgetContext.uniqueId}");
+        var metricSelect = document.getElementById("trendMetricSelect${widgetContext.uniqueId}");
+        var rangeTabs = document.getElementById("trendRangeTabs${widgetContext.uniqueId}");
+        var activeRangeButton = rangeTabs.querySelector('.is-active');
+        var currentDays = activeRangeButton ? activeRangeButton.getAttribute('data-days') : '30';
+
+        // Escape a label for safe insertion into the screen-reader table (dates are server-formatted,
+        // but this mirrors site-stats-table.jsp's defensive escaping for AJAX-refreshed text nodes).
+        function escapeHtml${widgetContext.uniqueId}(text) {
+          var div = document.createElement('div');
+          div.textContent = text == null ? '' : text;
+          return div.innerHTML;
+        }
+
+        function applyThresholdBands() {
+          trendChart.config._thresholdBands = METRIC_THRESHOLDS[metricSelect.value] || null;
+        }
+
+        function rebuildTrendTable(points) {
+          var rows = [];
+          $.each(points, function(i, point) {
+            rows.push("<tr><th scope=\"row\">" + escapeHtml${widgetContext.uniqueId}(point.date) + "</th><td>" +
+                parseFloat(point.p50).toLocaleString() + "</td><td>" +
+                parseFloat(point.p75).toLocaleString() + "</td><td>" +
+                parseFloat(point.p95).toLocaleString() + "</td></tr>");
+          });
+          $("#trendTable${widgetContext.uniqueId} tbody").remove();
+          $('<tbody/>', { html: rows.join('') }).appendTo("#trendTable${widgetContext.uniqueId}");
+        }
+
+        function refreshTrendChart() {
+          $.ajax({
+            url: '${widgetContext.uri}?widget=${widgetContext.uniqueId}&action=get' +
+                '&trendUrl=' + encodeURIComponent(urlSelect.value) +
+                '&trendMetric=' + encodeURIComponent(metricSelect.value) +
+                '&trendDays=' + encodeURIComponent(currentDays) +
+                '&token=${userSession.formToken}',
+            type: 'GET',
+            dataType: 'json',
+            cache: false,
+            timeout: 5000
+          }).done(function(points) {
+            var labels = [];
+            var p50 = [];
+            var p75 = [];
+            var p95 = [];
+            $.each(points, function(i, point) {
+              labels.push(point.date);
+              p50.push(point.p50);
+              p75.push(point.p75);
+              p95.push(point.p95);
+            });
+            trendChart.data.labels = labels;
+            trendChart.data.datasets[0].data = p75;
+            trendChart.data.datasets[1].data = p50;
+            trendChart.data.datasets[2].data = p95;
+            applyThresholdBands();
+            trendChart.update();
+            rebuildTrendTable(points);
+          });
+        }
+
+        urlSelect.addEventListener('change', refreshTrendChart);
+        metricSelect.addEventListener('change', refreshTrendChart);
+        Array.prototype.forEach.call(rangeTabs.querySelectorAll('button'), function(btn) {
+          btn.addEventListener('click', function() {
+            currentDays = btn.getAttribute('data-days');
+            Array.prototype.forEach.call(rangeTabs.querySelectorAll('button'), function(other) {
+              other.classList.remove('is-active');
+            });
+            btn.classList.add('is-active');
+            refreshTrendChart();
+          });
+        });
+
+        // Paint the threshold bands for the initial (server-rendered) metric selection.
+        applyThresholdBands();
+        trendChart.update();
+      })();
+    </script>
   </c:if>
 </div>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebVitalsAggregateRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebVitalsAggregateRepositoryTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.WebVitalsAggregate;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link WebVitalsAggregateRepository#findAggregates} and
+ * {@link WebVitalsAggregateRepository#findDistinctUrls} -- the trend chart's data source (issue
+ * #762) -- against a real PostgreSQL instance.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack, mirroring
+ * {@code ContentRepositoryTest}. It is skipped automatically when Docker is not available.
+ * </p>
+ *
+ * @author claude
+ * @created 7/31/26
+ */
+class WebVitalsAggregateRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping WebVitalsAggregateRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_vitals_aggregates RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_vitals_aggregates table", se);
+    }
+  }
+
+  @Test
+  void findAggregatesReturnsOnlyTheRequestedUrlAndMetricOldestFirst() throws SQLException {
+    insertAggregate("/pricing", "LCP", 1200, 2400, 3600, "3 days");
+    insertAggregate("/pricing", "LCP", 1300, 2500, 3700, "1 days");
+    insertAggregate("/pricing", "LCP", 1100, 2300, 3500, "2 days");
+    // Different metric, same URL -- must not leak into the LCP series
+    insertAggregate("/pricing", "CLS", 5, 8, 12, "1 days");
+    // Different URL, same metric -- must not leak either
+    insertAggregate("/checkout", "LCP", 2000, 3000, 4000, "1 days");
+
+    List<WebVitalsAggregate> series = WebVitalsAggregateRepository.findAggregates("/pricing", "LCP", 30);
+
+    assertEquals(3, series.size());
+    // Oldest (3 days ago) first, newest (1 day ago) last
+    assertEquals(2400, series.get(0).getP75Value());
+    assertEquals(2300, series.get(1).getP75Value());
+    assertEquals(2500, series.get(2).getP75Value());
+    for (WebVitalsAggregate row : series) {
+      assertEquals("/pricing", row.getUrl());
+      assertEquals("LCP", row.getMetricType());
+    }
+  }
+
+  @Test
+  void findAggregatesExcludesRowsOutsideTheRequestedWindow() throws SQLException {
+    insertAggregate("/pricing", "LCP", 1200, 2400, 3600, "5 days");
+    insertAggregate("/pricing", "LCP", 1300, 2500, 3700, "45 days");
+
+    List<WebVitalsAggregate> last7Days = WebVitalsAggregateRepository.findAggregates("/pricing", "LCP", 7);
+    List<WebVitalsAggregate> last90Days = WebVitalsAggregateRepository.findAggregates("/pricing", "LCP", 90);
+
+    assertEquals(1, last7Days.size(), "the 45-day-old row must not appear in a 7-day window");
+    assertEquals(2400, last7Days.get(0).getP75Value());
+    assertEquals(2, last90Days.size(), "both rows fall inside a 90-day window");
+  }
+
+  @Test
+  void findAggregatesReturnsAnEmptyListForABlankUrlOrMetric() {
+    assertTrue(WebVitalsAggregateRepository.findAggregates("", "LCP", 30).isEmpty());
+    assertTrue(WebVitalsAggregateRepository.findAggregates("/pricing", "", 30).isEmpty());
+    assertTrue(WebVitalsAggregateRepository.findAggregates(null, "LCP", 30).isEmpty());
+  }
+
+  @Test
+  void findDistinctUrlsReturnsSortedUniqueUrlsWithinTheWindow() throws SQLException {
+    insertAggregate("/pricing", "LCP", 1200, 2400, 3600, "1 days");
+    insertAggregate("/pricing", "CLS", 5, 8, 12, "2 days"); // same URL, different metric -- one entry
+    insertAggregate("/checkout", "LCP", 2000, 3000, 4000, "1 days");
+    insertAggregate("/archived", "LCP", 900, 1200, 1800, "120 days"); // outside a 90-day window
+
+    List<String> urls = WebVitalsAggregateRepository.findDistinctUrls(90);
+
+    assertEquals(List.of("/checkout", "/pricing"), urls);
+  }
+
+  @Test
+  void boundDaysClampsToTheSupportedRange() {
+    assertEquals(1, WebVitalsAggregateRepository.boundDays(0));
+    assertEquals(1, WebVitalsAggregateRepository.boundDays(-5));
+    assertEquals(7, WebVitalsAggregateRepository.boundDays(7));
+    assertEquals(90, WebVitalsAggregateRepository.boundDays(90));
+    assertEquals(90, WebVitalsAggregateRepository.boundDays(365));
+  }
+
+  private static void insertAggregate(String url, String metricType, double p50, double p75, double p95,
+      String ageInterval) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("INSERT INTO web_vitals_aggregates "
+          + "(url, metric_type, p50_value, p75_value, p95_value, sample_count, aggregated_at) VALUES ("
+          + "'" + url + "', '" + metricType + "', " + p50 + ", " + p75 + ", " + p95 + ", 10, "
+          + "NOW() - INTERVAL '" + ageInterval + "')");
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real web_vitals_aggregates table (matches
+    // UPGRADE_20260727.1001__web_vitals_context_and_aggregates.sql) -- enough for the
+    // findAggregates/findDistinctUrls read paths under test.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_vitals_aggregates CASCADE");
+      statement.execute("CREATE TABLE web_vitals_aggregates ("
+          + "id BIGSERIAL PRIMARY KEY, "
+          + "url VARCHAR(2048) NOT NULL, "
+          + "metric_type VARCHAR(50) NOT NULL, "
+          + "p50_value NUMERIC(10, 2), "
+          + "p75_value NUMERIC(10, 2), "
+          + "p95_value NUMERIC(10, 2), "
+          + "sample_count INTEGER NOT NULL DEFAULT 0, "
+          + "aggregated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, "
+          + "UNIQUE (url, metric_type, aggregated_at))");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_vitals_aggregates schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/WebVitalsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/WebVitalsWidgetTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.WebVitalsAggregate;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.persistence.cms.WebVitalsAggregateRepository;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Covers the trend chart wiring WebVitalsWidget feeds to web-vitals.jsp (issue #762): the
+ * URL/metric/date-range picker's defaulting and whitelist-validation logic in execute(), and the
+ * AJAX JSON endpoint in action() that the picker calls on every change.
+ *
+ * @author claude
+ * @created 7/31/26
+ */
+class WebVitalsWidgetTest extends WidgetBase {
+
+  private static WebVitalsAggregate aggregate(String url, String metricType, String date, double p50, double p75, double p95) {
+    WebVitalsAggregate aggregate = new WebVitalsAggregate();
+    aggregate.setUrl(url);
+    aggregate.setMetricType(metricType);
+    aggregate.setP50Value(p50);
+    aggregate.setP75Value(p75);
+    aggregate.setP95Value(p95);
+    aggregate.setSampleCount(42);
+    aggregate.setAggregatedAt(Timestamp.valueOf(date + " 00:00:00"));
+    return aggregate;
+  }
+
+  /**
+   * loadWebVitalsAggregates() (the pre-existing 7-day summary query) hits DB.getConnection()
+   * directly rather than through a mockable repository; stubbing it to throw SQLException exercises
+   * that method's own catch block (an empty summary) without needing a real database, so these tests
+   * can focus on the new trend attributes.
+   */
+  private static MockedStatic<DB> noDatabase() throws SQLException {
+    MockedStatic<DB> db = mockStatic(DB.class);
+    db.when(DB::getConnection).thenThrow(new SQLException("no database in this unit test"));
+    return db;
+  }
+
+  @Test
+  void executeDefaultsTrendToTheSlowestSummaryUrlLcpAnd30Days() throws SQLException {
+    List<String> trendUrls = List.of("/checkout", "/pricing");
+    List<WebVitalsAggregate> trendRows = List.of(aggregate("/checkout", "LCP", "2026-07-01", 1200, 2400, 3600));
+
+    try (MockedStatic<DB> db = noDatabase();
+        MockedStatic<WebVitalsAggregateRepository> repo = mockStatic(WebVitalsAggregateRepository.class)) {
+      repo.when(() -> WebVitalsAggregateRepository.findDistinctUrls(anyInt())).thenReturn(trendUrls);
+      repo.when(() -> WebVitalsAggregateRepository.findAggregates(eq("/checkout"), eq("LCP"), eq(30))).thenReturn(trendRows);
+
+      setRoles(widgetContext, ADMIN);
+      new WebVitalsWidget().execute(widgetContext);
+
+      Assertions.assertEquals(WebVitalsWidget.JSP, widgetContext.getJsp());
+      Assertions.assertEquals(trendUrls, request.getAttribute("trendUrls"));
+      // No summary data (loadWebVitalsAggregates failed), so sortedUrls is empty and the trend
+      // picker falls back to the first URL that actually has trend history.
+      Assertions.assertEquals("/checkout", request.getAttribute("trendUrl"));
+      Assertions.assertEquals("LCP", request.getAttribute("trendMetric"));
+      Assertions.assertEquals(30, request.getAttribute("trendDays"));
+      Assertions.assertEquals(trendRows, request.getAttribute("trendDataList"));
+    }
+  }
+
+  @Test
+  void executeHonorsExplicitTrendUrlMetricAndDaysParameters() throws SQLException {
+    List<String> trendUrls = List.of("/checkout", "/pricing");
+    List<WebVitalsAggregate> trendRows = List.of(aggregate("/pricing", "CLS", "2026-06-01", 0.05, 0.08, 0.12));
+
+    try (MockedStatic<DB> db = noDatabase();
+        MockedStatic<WebVitalsAggregateRepository> repo = mockStatic(WebVitalsAggregateRepository.class)) {
+      repo.when(() -> WebVitalsAggregateRepository.findDistinctUrls(anyInt())).thenReturn(trendUrls);
+      repo.when(() -> WebVitalsAggregateRepository.findAggregates(eq("/pricing"), eq("CLS"), eq(90))).thenReturn(trendRows);
+
+      addQueryParameter(widgetContext, "trendUrl", "/pricing");
+      addQueryParameter(widgetContext, "trendMetric", "cls");
+      addQueryParameter(widgetContext, "trendDays", "90");
+      setRoles(widgetContext, ADMIN);
+      new WebVitalsWidget().execute(widgetContext);
+
+      Assertions.assertEquals("/pricing", request.getAttribute("trendUrl"));
+      Assertions.assertEquals("CLS", request.getAttribute("trendMetric"));
+      Assertions.assertEquals(90, request.getAttribute("trendDays"));
+      Assertions.assertEquals(trendRows, request.getAttribute("trendDataList"));
+    }
+  }
+
+  @Test
+  void executeFallsBackCleanlyWhenThereIsNoTrendDataAtAll() throws SQLException {
+    try (MockedStatic<DB> db = noDatabase();
+        MockedStatic<WebVitalsAggregateRepository> repo = mockStatic(WebVitalsAggregateRepository.class)) {
+      repo.when(() -> WebVitalsAggregateRepository.findDistinctUrls(anyInt())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new WebVitalsWidget().execute(widgetContext);
+
+      Assertions.assertEquals(WebVitalsWidget.JSP, widgetContext.getJsp());
+      Assertions.assertNull(request.getAttribute("trendUrl"));
+      Assertions.assertEquals(List.of(), request.getAttribute("trendUrls"));
+      // Must be an empty list the JSP's <jsp:useBean class="java.util.ArrayList"> can still cast --
+      // not null, and not an immutable List.of() (see the comment in WebVitalsWidget.execute()).
+      Object trendDataList = request.getAttribute("trendDataList");
+      Assertions.assertNotNull(trendDataList);
+      Assertions.assertTrue(trendDataList instanceof ArrayList, "trendDataList must be a real ArrayList");
+      Assertions.assertTrue(((ArrayList<?>) trendDataList).isEmpty());
+      // findAggregates must never be called with a null/blank URL
+      repo.verify(() -> WebVitalsAggregateRepository.findAggregates(anyString(), anyString(), anyInt()), org.mockito.Mockito.never());
+    }
+  }
+
+  @Test
+  void resolveTrendUrlPrefersAnExplicitlyRequestedKnownUrl() {
+    List<String> trendUrls = List.of("/a", "/b");
+    Assertions.assertEquals("/b", WebVitalsWidget.resolveTrendUrl("/b", trendUrls, List.of("/a")));
+  }
+
+  @Test
+  void resolveTrendUrlIgnoresAnUnknownRequestedUrl() {
+    List<String> trendUrls = List.of("/a", "/b");
+    // "/z" has no trend history, so it falls back rather than querying an empty series
+    Assertions.assertEquals("/a", WebVitalsWidget.resolveTrendUrl("/z", trendUrls, List.of()));
+  }
+
+  @Test
+  void resolveTrendUrlPrefersTheSummarysSlowestUrlWhenNoneWasRequested() {
+    List<String> trendUrls = List.of("/a", "/b", "/c");
+    Assertions.assertEquals("/b", WebVitalsWidget.resolveTrendUrl(null, trendUrls, List.of("/b", "/a")));
+  }
+
+  @Test
+  void resolveTrendUrlReturnsNullWhenThereIsNoTrendDataAtAll() {
+    Assertions.assertNull(WebVitalsWidget.resolveTrendUrl(null, List.of(), List.of("/a")));
+  }
+
+  @Test
+  void resolveTrendMetricUppercasesAndWhitelists() {
+    Assertions.assertEquals("CLS", WebVitalsWidget.resolveTrendMetric("cls"));
+    Assertions.assertEquals("LCP", WebVitalsWidget.resolveTrendMetric(null));
+    Assertions.assertEquals("LCP", WebVitalsWidget.resolveTrendMetric("not-a-real-metric"));
+    Assertions.assertEquals("LCP", WebVitalsWidget.resolveTrendMetric("<script>"));
+  }
+
+  @Test
+  void resolveTrendDaysOnlyAllowsSevenThirtyOrNinety() {
+    Assertions.assertEquals(7, WebVitalsWidget.resolveTrendDays("7"));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays("30"));
+    Assertions.assertEquals(90, WebVitalsWidget.resolveTrendDays("90"));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays(null));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays(""));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays("15"));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays("not-a-number"));
+    Assertions.assertEquals(30, WebVitalsWidget.resolveTrendDays("-7"));
+  }
+
+  @Test
+  void actionReturnsTheSeriesAsJsonForTheRequestedUrlMetricAndDays() {
+    List<WebVitalsAggregate> trendRows = List.of(
+        aggregate("/pricing", "LCP", "2026-07-01", 1200, 2400, 3600),
+        aggregate("/pricing", "LCP", "2026-07-02", 1300, 2500, 3700));
+
+    try (MockedStatic<WebVitalsAggregateRepository> repo = mockStatic(WebVitalsAggregateRepository.class)) {
+      repo.when(() -> WebVitalsAggregateRepository.findAggregates(eq("/pricing"), eq("LCP"), eq(7))).thenReturn(trendRows);
+
+      addQueryParameter(widgetContext, "trendUrl", "/pricing");
+      addQueryParameter(widgetContext, "trendMetric", "LCP");
+      addQueryParameter(widgetContext, "trendDays", "7");
+      new WebVitalsWidget().action(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertNotNull(json);
+      Assertions.assertTrue(json.contains("\"2026-07-01\""), json);
+      Assertions.assertTrue(json.contains("2400"), json);
+      Assertions.assertTrue(json.contains("2500"), json);
+    }
+  }
+
+  @Test
+  void actionReturnsAnEmptyArrayWhenNoUrlWasRequested() {
+    new WebVitalsWidget().action(widgetContext);
+    Assertions.assertEquals("[]", widgetContext.getJson());
+  }
+}

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -192,6 +192,17 @@ ALLOWLIST: dict[str, str] = {
         "No application-level escaping or filtering on this path.",
     "${pageValue}":
         "pageValue is the loop variable over recordPaging.pageList, and DataConstraints.getPageList() (DataConstraints.java:176-202) only ever adds String.valueOf-style decimal renderings o",
+    "${point.p50Value}":
+        "WebVitalsAggregate.p50Value (domain/model/cms/WebVitalsAggregate.java) is a Java primitive "
+        "double, populated from a NUMERIC column via ResultSet.getBigDecimal(...).doubleValue() in "
+        "WebVitalsAggregateRepository -- same reasoning as ${data.value}/${summary.lcpP75 ...} "
+        "above, a primitive cannot carry markup.",
+    "${point.p75Value}":
+        "Same as ${point.p50Value} -- WebVitalsAggregate.p75Value is the identical primitive double, "
+        "populated the same way.",
+    "${point.p95Value}":
+        "Same as ${point.p50Value} -- WebVitalsAggregate.p95Value is the identical primitive double, "
+        "populated the same way.",
     "${pricingRule.buyXItems}":
         "PricingRule.buyXItems is a Java primitive `int` (domain/model/ecommerce/PricingRule.java:57, getter `public int getBuyXItems()` at PricingRule.java:257) loaded via `DB.getInt(rs, .",
     "${pricingRule.getYItemsFree}":


### PR DESCRIPTION
## Summary

Closes #762. `web_vitals_aggregates` already computes and stores p50/p75/p95 per URL, per metric, per day (nightly job), but `WebVitalsWidget`/`web-vitals.jsp` only ever showed the latest single value, hardcoded to a 7-day lookback -- no way to see whether a page's Core Web Vitals are trending better or worse.

## What changed

- Added a repository method to fetch the daily aggregate rows for a given URL/metric/date-range.
- Added a trend line chart (per URL, selectable metric) plotting p75 over a selectable 7/30/90-day range, alongside the existing single-value summary (not replacing it).
- Chart.js config uses the real vendored v4 API (`scales.x`/`scales.y`, `options.plugins.legend`) from the start -- this codebase has hit the v2-vs-v4 config mismatch twice before in the site-stats charts (#593, #595), so this was written against the real library rather than assumed v2-style docs.
- Good/Needs-Improvement/Poor thresholds are shown as shaded bands on the chart, consistent with the existing badge coloring on the single-value view.

## Testing

- `WebVitalsAggregateRepositoryTest` (new, Testcontainers/Postgres): 5 tests.
- `WebVitalsWidgetTest` (new): 11 tests covering wiring, parameter whitelisting, and the AJAX JSON response.
- Full `ant ci-test`: all green.
- `check-unescaped-el.py --strict`: 0 unallowlisted (3 new allowlist entries for the trend table's primitive-double EL expressions, same reasoning as the existing `StatisticsData`/`VitalsSummary` entries).
- Live Docker rehearsal: seeded 90 days of `/pricing` LCP+CLS and 30 days of `/checkout` LCP aggregate data, confirmed the summary view is unchanged, the trend chart renders with visible threshold bands, and switching URL/metric/range redraws the chart with different data through the real AJAX endpoint -- zero console errors.

## Access control note (checked during review)

The new AJAX endpoint (`action=get`) is covered by the same `role="admin"` page gate as the rest of the widget (`WebContainerCommand` applies the role check before method dispatch, so it isn't a separate exposed surface), and carries the same CSRF form-token pattern already used by `SiteStatsWidget`.