### PR TITLE
Fix unauthenticated editMode bypass in ItemsListWidget

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidget.java
@@ -80,9 +80,7 @@ public class ItemsListWidget extends GenericWidget {
     context.getRequest().setAttribute("collection", collection);
 
     // P5.3: Pass edit mode flag to enable collection item management UI
-    boolean isEditMode = "true".equals(context.getRequest().getParameter("editMode")) ||
-                        "true".equals(context.getRequest().getAttribute("pageEditMode") != null ?
-                        context.getRequest().getAttribute("pageEditMode").toString() : "false");
+    boolean isEditMode = "true".equals(context.getRequest().getAttribute("pageEditMode"));
     context.getRequest().setAttribute("isEditMode", String.valueOf(isEditMode));
 
     // Determine the record paging

--- a/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidgetTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.items.LoadCollectionCommand;
+import com.simisinc.platform.domain.model.items.Collection;
+import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS Inc.
+ */
+class ItemsListWidgetTest extends WidgetBase {
+
+  private static Collection collection(long id, String uniqueId) {
+    Collection collection = new Collection();
+    collection.setId(id);
+    collection.setUniqueId(uniqueId);
+    return collection;
+  }
+
+  private WidgetContext executeWithCollection() {
+    try (MockedStatic<LoadCollectionCommand> loadCollection = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class)) {
+      loadCollection.when(() -> LoadCollectionCommand.loadCollectionByUniqueIdForAuthorizedUser(any(), anyLong()))
+          .thenReturn(collection(1L, "widgets"));
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      return new ItemsListWidget().execute(widgetContext);
+    }
+  }
+
+  @Test
+  void executeIgnoresTheRawEditModeRequestParameterWithNoPageEditModeAttribute() {
+    // Before the fix, a bare `?editMode=true` on the query string -- with no session-backed
+    // pageEditMode attribute at all -- was enough on its own to flip isEditMode true for any
+    // logged-in visitor, since the vulnerable code OR'd the raw request parameter in directly.
+    widgetContext.getRequest().setAttribute("editMode", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeIgnoresTheRawEditModeRequestParameterWhenLoggedOut() {
+    // Same exploit as above, but for the anonymous case the bug report called out explicitly.
+    logout(widgetContext);
+    widgetContext.getRequest().setAttribute("editMode", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeSetsEditModeWhenPageServletHasPublishedTheSessionBackedPageEditModeAttribute() {
+    // PageServlet only ever publishes "pageEditMode"="true" after EditorPermissionCommand
+    // .canEditContent has passed for the current request (see PageServlet.java) -- this is the
+    // legitimate authenticated-editor path this widget must still honor.
+    widgetContext.getRequest().setAttribute("pageEditMode", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals("true", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeIgnoresTheRawEditModeParamEvenWhenPageEditModeIsExplicitlyFalse() {
+    // PageServlet publishes pageEditMode unconditionally on every request (including "false"), so
+    // this is the realistic shape of an unauthorized request on a page with an active editor
+    // session belonging to someone else -- the raw param must still not leak through.
+    widgetContext.getRequest().setAttribute("pageEditMode", "false");
+    widgetContext.getRequest().setAttribute("editMode", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeDefaultsEditModeToFalseWhenNeitherAttributeNorParamIsPresent() {
+    WidgetContext result = executeWithCollection();
+
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+}


### PR DESCRIPTION
## Background

`ItemsListWidget.execute()` computed `isEditMode` by OR-ing two things:

- the raw `editMode` **request parameter**, read straight off the query string with no session, login, or permission check, and
- the `pageEditMode` **request attribute**, which `PageServlet` only ever sets after the current user has passed `EditorPermissionCommand.canEditContent(...)` for this request.

Because of the `||`, the first (unguarded) disjunct alone was enough. Any visitor — anonymous included — could append `?editMode=true` to a URL containing this widget (`items-list.jsp`) and get `isEditMode=true`, which renders the collection item reorder/deactivate/save-item edit affordances to them.

## Blast radius

This is UI-exposure, not a direct data mutation: `isEditMode`/`${isEditMode}` is consumed only in `items-list.jsp` (render guards around edit-affordance markup). The actual mutating actions this UI triggers — `reorderCollectionItem`, `deactivateCollectionItem`, `saveCollectionItem` in `PageServlet` — each independently gate on the real session-backed `pageEditMode` boolean plus a CSRF form-token check, and 404/403 on bad input. So an anonymous visitor exploiting this sees the edit buttons and can click them, but the underlying POSTs are still rejected server-side. Still worth closing, since showing privileged UI to unauthorized/anonymous users is itself a real exposure (and a foothold for further probing).

## Fix

Drop the raw-parameter disjunct entirely and key `isEditMode` off the session-backed `pageEditMode` request attribute alone:

```java
boolean isEditMode = "true".equals(context.getRequest().getAttribute("pageEditMode"));
```

`PageServlet` only ever publishes `pageEditMode="true"` once `EditorPermissionCommand.canEditContent` has passed for the current request/session (checked both when the session flag is set and again when it's read) — and `PageServlet`'s own comment already names `ItemsListWidget` as a documented direct consumer of this attribute. This is also exactly the tier `PageServlet`'s three collection-item mutating actions gate on (no additional `canBuildLayout`/`canEditContent` check at those call sites), so matching `pageEditMode` alone is the correct and sufficient tier here — not stricter, not looser than the actions it guards.

(Note: `"true".equals(obj)` is already null-safe, so the old ternary null-guard around the attribute read was unnecessary complexity, not a real requirement.)

## Precedent

#710 fixed the identical bug class in the sibling `TableWidget` (an ungated `editMode` check serving the full edit toolbar to anonymous visitors). One correction while working this: #710's description states "every other content widget... gates this on `canEditContent`" — `TableWidget` itself actually gates on a per-widget `editMode` **preference** + `canEditContent`, a different mechanism from `ItemsListWidget`'s page-level `pageEditMode` attribute, and `ItemsListWidget` was not, in fact, already covered. This PR closes that gap.

## Tests

Added `ItemsListWidgetTest` (none existed previously):
- raw `editMode=true` request parameter alone, no `pageEditMode` attribute, logged in → `isEditMode` false
- same, logged out → `isEditMode` false
- `pageEditMode` attribute `"true"` → `isEditMode` true
- `pageEditMode` attribute explicitly `"false"` (PageServlet publishes it unconditionally) with `editMode=true` still present → `isEditMode` false
- neither present → `isEditMode` false

## Verification

- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green, 1379 tests, 0 failures (`ItemsListWidgetTest` 5/5)
- `ant -lib lib/war clean compile-jsp` — JSP syntax gate passes, `items-list.jsp` still parses fine against the String-typed `isEditMode`