### PR TITLE
Fix data table widget crash, unwired save, unreachable edit UI, and a session-cookie leak (issue #433)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
@@ -95,12 +95,14 @@ public class TableWidget extends GenericWidget {
   public WidgetContext execute(WidgetContext context) {
 
     // Check if in edit mode. The gate is two parts, deliberately: "pageEditMode" is the real,
-    // established page-level flag every other in-place-editable widget gates on (see
-    // ItemsListWidget, and PageServlet.java where it is computed from the session's
-    // pageEditMode flag AND EditorPermissionCommand.canEditContent, then published as a request
-    // attribute for every widget on the page to read) -- unlike a per-widget preference, nothing
-    // ever needs to "set" it for this widget specifically, so the editable toolbar is actually
-    // reachable through the normal "Edit" toggle every other widget uses.
+    // established page-level flag PageServlet.java computes from the session's pageEditMode flag
+    // AND EditorPermissionCommand.canEditContent, then publishes as a request attribute for every
+    // widget on the page to read -- unlike a per-widget preference, nothing ever needs to "set" it
+    // for this widget specifically, so the editable toolbar is actually reachable through the
+    // normal "Edit" toggle every other widget uses. (ItemsListWidget also reads this same
+    // "pageEditMode" attribute, but is not a permission-parity precedent to follow: its isEditMode
+    // ORs in a raw, unchecked "editMode" request parameter with no permission check at all, a
+    // separate pre-existing gap in that widget, not replicated here.)
     //
     // The permission check is repeated here on top of that rather than trusted to have already
     // been applied: relying solely on the page-level flag would mean a stored/cached response, or
@@ -108,8 +110,22 @@ public class TableWidget extends GenericWidget {
     // editable toolbar -- including its structural add/remove controls -- to a visitor without
     // edit rights. Checking again here costs nothing and closes that gap the same way every other
     // content widget's render path does.
+    //
+    // This must check canBuildLayout(), not canEditContent(): the editable UI below includes a
+    // Save button that POSTs PageServlet's "setWidgetPreferences" action, and that action (see
+    // PageServlet's mutateDraftLayout dispatch) is itself gated on
+    // pageEditMode && EditorPermissionCommand.canBuildLayout(userSession) -- content-editor holds
+    // canEditContent but is deliberately excluded from canBuildLayout (see that method's javadoc:
+    // "authors get content guardrails, designers get the canvas"). Gating on canEditContent here
+    // would show a content-editor the full editable Save UI, but every Save click would then be
+    // silently dropped server-side (PageServlet falls through to a normal page render instead of
+    // the JSON response the client expects), discarding the user's edits with a confusing
+    // "Error: HTTP 200" instead of ever persisting them. canBuildLayout keeps this widget's
+    // reachable-editor tier the same as the tier that can actually save it, matching the
+    // "⚙ Prefs" panel this Save button follows the pattern of -- platform-editor.js only ever
+    // inserts that panel's controls when layoutMode (its own canBuildLayout-derived flag) is true.
     boolean pageEditMode = "true".equals(context.getRequest().getAttribute("pageEditMode"));
-    boolean isEditMode = pageEditMode && EditorPermissionCommand.canEditContent(context.getUserSession());
+    boolean isEditMode = pageEditMode && EditorPermissionCommand.canBuildLayout(context.getUserSession());
 
     try {
       // Parse table data from content or create default

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/TableWidget.java
@@ -24,6 +24,11 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * P5.4: Data Table Widget — Inline-editable table for structured data
  *
@@ -89,11 +94,22 @@ public class TableWidget extends GenericWidget {
 
   public WidgetContext execute(WidgetContext context) {
 
-    // Check if in edit mode -- the layout preference alone is not sufficient, since a stored page
-    // could carry editMode=true and would otherwise serve the editable toolbar to any visitor,
-    // including anonymous ones. Match every other content widget's gate (see ContentWidget).
-    boolean isEditMode = "true".equals(context.getPreferences().get("editMode")) &&
-        EditorPermissionCommand.canEditContent(context.getUserSession());
+    // Check if in edit mode. The gate is two parts, deliberately: "pageEditMode" is the real,
+    // established page-level flag every other in-place-editable widget gates on (see
+    // ItemsListWidget, and PageServlet.java where it is computed from the session's
+    // pageEditMode flag AND EditorPermissionCommand.canEditContent, then published as a request
+    // attribute for every widget on the page to read) -- unlike a per-widget preference, nothing
+    // ever needs to "set" it for this widget specifically, so the editable toolbar is actually
+    // reachable through the normal "Edit" toggle every other widget uses.
+    //
+    // The permission check is repeated here on top of that rather than trusted to have already
+    // been applied: relying solely on the page-level flag would mean a stored/cached response, or
+    // any future caller of this widget that forgets to route through PageServlet, could serve the
+    // editable toolbar -- including its structural add/remove controls -- to a visitor without
+    // edit rights. Checking again here costs nothing and closes that gap the same way every other
+    // content widget's render path does.
+    boolean pageEditMode = "true".equals(context.getRequest().getAttribute("pageEditMode"));
+    boolean isEditMode = pageEditMode && EditorPermissionCommand.canEditContent(context.getUserSession());
 
     try {
       // Parse table data from content or create default
@@ -115,8 +131,15 @@ public class TableWidget extends GenericWidget {
         tableData = objectMapper.readTree("{\"headers\": [], \"rows\": []}");
       }
 
-      // Store parsed data for JSP rendering
-      context.getRequest().setAttribute("tableData", tableData);
+      // Store parsed data for JSP rendering as plain Java collections, never as the raw Jackson
+      // JsonNode/ArrayNode -- JSTL's <c:forEach> only knows how to iterate a Collection, array,
+      // java.util.Iterator, Map, or String (see jakarta's ForEachSupport). JsonNode/ArrayNode is
+      // none of those -- it implements Iterable<JsonNode>, which looks iterable in plain Java but
+      // is not one of the types JSTL's tag actually dispatches on -- so handing it to <c:forEach>
+      // throws JspTagException("Don't know how to iterate over supplied \"items\"") for any
+      // non-empty table, a crash PageServlet's outer catch silently turns into an empty HTTP 200.
+      Map<String, Object> tableViewModel = toViewModel(tableData);
+      context.getRequest().setAttribute("tableData", tableViewModel);
       context.getRequest().setAttribute("isEditMode", String.valueOf(isEditMode));
 
       // Select appropriate JSP
@@ -132,6 +155,31 @@ public class TableWidget extends GenericWidget {
     }
 
     return context;
+  }
+
+  /**
+   * Converts the parsed table JSON into plain Java collections that JSTL's {@code <c:forEach>} can
+   * actually iterate: {@code headers} becomes a {@code List<String>}, {@code rows} becomes a
+   * {@code List<List<String>>}. See the comment at the {@link #execute} call site for why the raw
+   * {@link JsonNode} must never reach the JSP directly.
+   */
+  private static Map<String, Object> toViewModel(JsonNode tableData) {
+    List<String> headers = new ArrayList<>();
+    for (JsonNode header : tableData.path("headers")) {
+      headers.add(header.asText());
+    }
+    List<List<String>> rows = new ArrayList<>();
+    for (JsonNode row : tableData.path("rows")) {
+      List<String> rowValues = new ArrayList<>();
+      for (JsonNode cell : row) {
+        rowValues.add(cell.asText());
+      }
+      rows.add(rowValues);
+    }
+    Map<String, Object> viewModel = new LinkedHashMap<>();
+    viewModel.put("headers", headers);
+    viewModel.put("rows", rows);
+    return viewModel;
   }
 
   /**

--- a/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
@@ -14,7 +14,9 @@
   ~ limitations under the License.
   --%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%-- tableData is a JsonNode set by TableWidget in request scope --%>
+<%-- tableData is a Map<String,Object> set by TableWidget in request scope: "headers" is a
+     List<String>, "rows" is a List<List<String>> -- plain Java collections, not the raw Jackson
+     JsonNode, because JSTL's <c:forEach> cannot iterate a JsonNode/ArrayNode. --%>
 
 <div class="table-widget-edit-container">
   <!-- Toolbar -->
@@ -32,6 +34,11 @@
     <button class="toolbar-btn delete-col" title="Delete column" aria-label="Delete selected column">
       <i class="fa fa-trash"></i> Column
     </button>
+    <div class="toolbar-separator"></div>
+    <button class="toolbar-btn save-table" title="Save table" aria-label="Save table changes">
+      <i class="fa fa-save"></i> Save
+    </button>
+    <span class="table-save-status" aria-live="polite"></span>
   </div>
 
   <!-- Table -->
@@ -40,11 +47,11 @@
       <thead>
         <tr role="row" class="header-row">
           <c:choose>
-            <c:when test="${tableData.has('headers') && tableData.get('headers').size() > 0}">
-              <c:forEach items="${tableData.get('headers')}" var="header" varStatus="headerStatus">
+            <c:when test="${not empty tableData.headers}">
+              <c:forEach items="${tableData.headers}" var="header" varStatus="headerStatus">
                 <th role="columnheader" scope="col" data-col="${headerStatus.index}">
                   <div class="header-cell" contenteditable="true" role="textbox" tabindex="0">
-                    <c:out value="${header.asText()}"/>
+                    <c:out value="${header}"/>
                   </div>
                 </th>
               </c:forEach>
@@ -58,13 +65,13 @@
       </thead>
       <tbody>
         <c:choose>
-          <c:when test="${tableData.has('rows') && tableData.get('rows').size() > 0}">
-            <c:forEach items="${tableData.get('rows')}" var="row" varStatus="rowStatus">
+          <c:when test="${not empty tableData.rows}">
+            <c:forEach items="${tableData.rows}" var="row" varStatus="rowStatus">
               <tr role="row" data-row="${rowStatus.index}">
                 <c:forEach items="${row}" var="cell" varStatus="cellStatus">
                   <td role="cell" data-row="${rowStatus.index}" data-col="${cellStatus.index}">
                     <div class="cell-content" contenteditable="true" role="textbox" tabindex="0">
-                      <c:out value="${cell.asText()}"/>
+                      <c:out value="${cell}"/>
                     </div>
                   </td>
                 </c:forEach>
@@ -128,6 +135,28 @@
   .toolbar-separator {
     width: 1px;
     background: #ddd;
+  }
+
+  .toolbar-btn.save-table {
+    background: #0066cc;
+    border-color: #0066cc;
+    color: white;
+  }
+
+  .toolbar-btn.save-table:hover {
+    background: #0052a3;
+    color: white;
+  }
+
+  .toolbar-btn.save-table:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .table-save-status {
+    align-self: center;
+    font-size: 13px;
+    color: #666;
   }
 
   .table-edit-wrapper {
@@ -194,6 +223,8 @@
   const addColBtn = document.querySelector('.add-col');
   const deleteRowBtn = document.querySelector('.delete-row');
   const deleteColBtn = document.querySelector('.delete-col');
+  const saveBtn = document.querySelector('.save-table');
+  const saveStatus = document.querySelector('.table-save-status');
 
   let selectedCell = null;
   const cellOriginalValues = new WeakMap();
@@ -363,11 +394,83 @@
     const tableData = JSON.stringify({ headers, rows });
     tableDataInput.value = tableData;
 
-    // Trigger data update event
+    // Trigger data update event -- carries the latest serialized table data on every edit so any
+    // listener has it available. The actual server save (below) is deliberately explicit, fired
+    // from the Save button rather than on every keystroke/table-changed event, to avoid a network
+    // request per character typed.
     const event = new CustomEvent('table-changed', {
       detail: { tableData: tableData }
     });
     document.dispatchEvent(event);
+  }
+
+  // ── Persist to the server ─────────────────────────────────────────────────
+  //
+  // Table data is stored as an ordinary widget preference in the page's draft layout XML, saved
+  // through the same generic, already-tested mechanism every other widget's preferences go
+  // through: PageServlet's "setWidgetPreferences" action, which calls
+  // MutateLayoutCommand.setWidgetPreferences (itself gated by TableWidget.isValidTableData for
+  // this widget's "tableData" preference specifically). platform-editor.js's own applyPrefs()/
+  // mutatePage() use the identical action/params for the "⚙ Prefs" panel available on every
+  // widget -- this widget's toolbar runs in its own script, outside that file's closure, so the
+  // same request is built directly here rather than calling into it.
+  function getWidgetPosition() {
+    const container = table.closest('[data-editor-widget]');
+    if (!container) return null;
+    const parts = (container.dataset.editorWidget || '').split('-');
+    if (parts.length !== 3) return null;
+    return { s: parts[0], c: parts[1], w: parts[2] };
+  }
+
+  function saveToServer() {
+    const position = getWidgetPosition();
+    if (!position) {
+      if (saveStatus) saveStatus.textContent = 'Unable to save: widget position not found';
+      return;
+    }
+    // "mainToken" is the CSRF form token, declared as a page-global by main.jsp -- the same
+    // source platform-editor.js's own getToken() reads.
+    const token = (typeof mainToken !== 'undefined') ? mainToken : '';
+
+    saveBtn.disabled = true;
+    if (saveStatus) saveStatus.textContent = 'Saving…';
+
+    const body = new URLSearchParams();
+    body.append('action', 'setWidgetPreferences');
+    body.append('token', token);
+    body.append('s', position.s);
+    body.append('c', position.c);
+    body.append('w', position.w);
+    body.append('prefs', JSON.stringify({ tableData: tableDataInput.value }));
+
+    fetch(window.location.pathname, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString()
+    })
+      .then(resp => resp.json().catch(() => ({})).then(data => {
+        if (!resp.ok || !data.success) {
+          throw new Error((data && data.error) || ('HTTP ' + resp.status));
+        }
+        return data;
+      }))
+      .then(() => {
+        if (saveStatus) saveStatus.textContent = 'Saved';
+        // Reload to confirm the change persisted and to pick up the freshly saved draft, matching
+        // every other in-canvas mutation's success behavior (see platform-editor.js).
+        window.location.reload();
+      })
+      .catch(err => {
+        saveBtn.disabled = false;
+        if (saveStatus) saveStatus.textContent = 'Error: ' + err.message;
+      });
+  }
+
+  if (saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      saveTableData();
+      saveToServer();
+    });
   }
 
   // Initial setup

--- a/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/table-widget-edit.jsp
@@ -48,10 +48,17 @@
         <tr role="row" class="header-row">
           <c:choose>
             <c:when test="${not empty tableData.headers}">
-              <c:forEach items="${tableData.headers}" var="header" varStatus="headerStatus">
+              <%-- The loop variable is deliberately NOT named "header": JSP EL reserves that
+                   identifier for the implicit request-header Map (JSP.2.9), so a same-named
+                   <c:forEach> variable is silently ignored -- ${header} always resolves to the
+                   implicit object, never the loop value, regardless of scope. That previously
+                   rendered the viewer's own request headers (including the JSESSIONID/userToken
+                   session cookies) into every <th>, changing per request, instead of the actual
+                   column header text. --%>
+              <c:forEach items="${tableData.headers}" var="headerCell" varStatus="headerStatus">
                 <th role="columnheader" scope="col" data-col="${headerStatus.index}">
                   <div class="header-cell" contenteditable="true" role="textbox" tabindex="0">
-                    <c:out value="${header}"/>
+                    <c:out value="${headerCell}"/>
                   </div>
                 </th>
               </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/cms/table-widget.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/table-widget.jsp
@@ -14,34 +14,36 @@
   ~ limitations under the License.
   --%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%-- tableData is a JsonNode set by TableWidget in request scope --%>
+<%-- tableData is a Map<String,Object> set by TableWidget in request scope: "headers" is a
+     List<String>, "rows" is a List<List<String>> -- plain Java collections, not the raw Jackson
+     JsonNode, because JSTL's <c:forEach> cannot iterate a JsonNode/ArrayNode. --%>
 
 <div class="table-widget-container">
   <table class="data-table" role="table">
-    <c:if test="${tableData.has('headers') && tableData.get('headers').size() > 0}">
+    <c:if test="${not empty tableData.headers}">
       <thead>
         <tr role="row">
-          <c:forEach items="${tableData.get('headers')}" var="header" varStatus="headerStatus">
+          <c:forEach items="${tableData.headers}" var="header" varStatus="headerStatus">
             <th role="columnheader" scope="col">
-              <c:out value="${header.asText()}"/>
+              <c:out value="${header}"/>
             </th>
           </c:forEach>
         </tr>
       </thead>
     </c:if>
     <tbody>
-      <c:if test="${tableData.has('rows') && tableData.get('rows').size() > 0}">
-        <c:forEach items="${tableData.get('rows')}" var="row" varStatus="rowStatus">
+      <c:if test="${not empty tableData.rows}">
+        <c:forEach items="${tableData.rows}" var="row" varStatus="rowStatus">
           <tr role="row">
             <c:forEach items="${row}" var="cell">
               <td role="cell">
-                <c:out value="${cell.asText()}"/>
+                <c:out value="${cell}"/>
               </td>
             </c:forEach>
           </tr>
         </c:forEach>
       </c:if>
-      <c:if test="${tableData.get('rows').size() == 0}">
+      <c:if test="${empty tableData.rows}">
         <tr>
           <td colspan="100" style="text-align: center; padding: 20px; color: #999;">
             No data

--- a/src/main/webapp/WEB-INF/jsp/cms/table-widget.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/table-widget.jsp
@@ -23,9 +23,15 @@
     <c:if test="${not empty tableData.headers}">
       <thead>
         <tr role="row">
-          <c:forEach items="${tableData.headers}" var="header" varStatus="headerStatus">
+          <%-- The loop variable is deliberately NOT named "header": JSP EL reserves that identifier
+               for the implicit request-header Map (JSP.2.9), so a same-named <c:forEach> variable is
+               silently ignored -- ${header} always resolves to the implicit object, never the loop
+               value, regardless of scope. That previously rendered the viewer's own request headers
+               (including the JSESSIONID/userToken session cookies) into every <th>, changing per
+               request, instead of the actual column header text. --%>
+          <c:forEach items="${tableData.headers}" var="headerCell" varStatus="headerStatus">
             <th role="columnheader" scope="col">
-              <c:out value="${header}"/>
+              <c:out value="${headerCell}"/>
             </th>
           </c:forEach>
         </tr>

--- a/src/test/java/com/simisinc/platform/WidgetBase.java
+++ b/src/test/java/com/simisinc/platform/WidgetBase.java
@@ -59,6 +59,7 @@ public class WidgetBase {
 
   public static final String ADMIN = "admin";
   public static final String CONTENT_MANAGER = "content-manager";
+  public static final String CONTENT_EDITOR = "content-editor";
   public static final String COMMUNITY_MANAGER = "community-manager";
 
   public ServletContext servletContext = mock(ServletContext.class);
@@ -174,6 +175,9 @@ public class WidgetBase {
           roleList.add(role);
         } else if (CONTENT_MANAGER.equals(roleValue)) {
           Role role = new Role("Content Manager", CONTENT_MANAGER);
+          roleList.add(role);
+        } else if (CONTENT_EDITOR.equals(roleValue)) {
+          Role role = new Role("Content Editor", CONTENT_EDITOR);
           roleList.add(role);
         } else if (COMMUNITY_MANAGER.equals(roleValue)) {
           Role role = new Role("Content Manager", COMMUNITY_MANAGER);

--- a/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/MutateLayoutCommandTest.java
@@ -25,11 +25,15 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
@@ -418,6 +422,53 @@ class MutateLayoutCommandTest {
     String result = mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0,
         "{\"tableData\":\"{\\\"headers\\\":[\\\"Name\\\",\\\"Age\\\"],\\\"rows\\\":[[\\\"Alice\\\",\\\"30\\\"]]}\"}", 42L));
     assertTrue(result.contains("Alice"), "the new table data should be written");
+  }
+
+  @Test
+  void setWidgetPreferencesPersistsARealisticEditedTableRoundTrip() throws Exception {
+    // Reproduces exactly what table-widget-edit.jsp's Save button now sends (issue #433): the
+    // client serializes the edited table once to get the "tableData" string, then wraps that
+    // string as the value of a "tableData" key in the outer prefs object -- i.e.
+    // JSON.stringify({tableData: JSON.stringify({headers, rows})}). Building the request the same
+    // way here (via Jackson, not hand-escaped literals) is the most direct proof that this
+    // widget's save wiring reaches this method with real edited data and that the data survives
+    // the round trip intact, not just that some JSON containing "Alice" shows up somewhere.
+    ObjectMapper mapper = new ObjectMapper();
+    Map<String, Object> editedTable = new LinkedHashMap<>();
+    editedTable.put("headers", List.of("Name", "Age", "City"));
+    editedTable.put("rows", List.of(
+        List.of("Alice", "30", "Portland"),
+        List.of("Bob", "25", "Austin")));
+    String tableDataJson = mapper.writeValueAsString(editedTable);
+    String prefsJson = mapper.writeValueAsString(Map.of("tableData", tableDataJson));
+
+    WebPage page = pageWithXml(TABLE_WIDGET_XML);
+    String result = mutate(page, () -> MutateLayoutCommand.setWidgetPreferences(page, 0, 0, 0, prefsJson, 42L));
+
+    // The old single-cell fixture data must be gone, replaced by the edit.
+    assertTrue(!result.contains("\\u0022rows\\u0022:[[\\u00221\\u0022]]") && !result.contains(">1<"),
+        "the original placeholder row should not survive the edit");
+
+    // Extract the persisted <tableData> element's text content and parse it back to prove the
+    // edited data round-trips intact, not just that a substring happens to match.
+    int start = result.indexOf("<tableData>") + "<tableData>".length();
+    int end = result.indexOf("</tableData>", start);
+    String persistedRaw = result.substring(start, end)
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">");
+    JsonNode persisted = mapper.readTree(persistedRaw);
+
+    assertEquals(3, persisted.get("headers").size());
+    assertEquals("Name", persisted.get("headers").get(0).asText());
+    assertEquals("Age", persisted.get("headers").get(1).asText());
+    assertEquals("City", persisted.get("headers").get(2).asText());
+    assertEquals(2, persisted.get("rows").size());
+    assertEquals("Alice", persisted.get("rows").get(0).get(0).asText());
+    assertEquals("Portland", persisted.get("rows").get(0).get(2).asText());
+    assertEquals("Bob", persisted.get("rows").get(1).get(0).asText());
+    assertEquals("Austin", persisted.get("rows").get(1).get(2).asText());
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
@@ -18,12 +18,14 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,25 +36,52 @@ class TableWidgetTest extends WidgetBase {
 
   // ── execute() / rendering ─────────────────────────────────────────────────
 
-  @Test
-  void executeWithValidTableDataRendersTheParsedTable() {
-    preferences.put("tableData", "{\"headers\": [\"Name\", \"Age\"], \"rows\": [[\"Alice\", \"30\"], [\"Bob\", \"25\"]]}");
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> tableDataOf(WidgetContext result) {
+    Object attr = result.getRequest().getAttribute("tableData");
+    // The fix under test: JSTL's <c:forEach> cannot iterate a Jackson JsonNode/ArrayNode, so the
+    // request attribute must be a plain Map of Lists, never the raw parsed JsonNode -- asserting
+    // the concrete type here is the regression check for that crash.
+    assertInstanceOf(Map.class, attr, "tableData request attribute must be a java.util.Map, not a JsonNode");
+    return (Map<String, Object>) attr;
+  }
 
-    WidgetContext result = new TableWidget().execute(widgetContext);
+  @Test
+  void executeWithRealisticMultiRowMultiColumnDataDoesNotThrowAndProducesJstlIterableAttributes() {
+    // Genuinely non-empty, realistic data -- not the empty placeholder -- exercising the exact
+    // shape that used to crash JSTL's <c:forEach> in both table-widget.jsp and
+    // table-widget-edit.jsp (tableData.get('headers') being a Jackson ArrayNode).
+    preferences.put("tableData", "{\"headers\": [\"Name\", \"Age\", \"City\"], "
+        + "\"rows\": [[\"Alice\", \"30\", \"Portland\"], [\"Bob\", \"25\", \"Austin\"], [\"Cara\", \"41\", \"Reno\"]]}");
+
+    WidgetContext result = assertDoesNotThrow(() -> new TableWidget().execute(widgetContext));
 
     assertEquals(TableWidget.JSP, result.getJsp(), "non-edit mode should render the plain table JSP");
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertEquals(2, tableData.get("headers").size());
-    assertEquals("Name", tableData.get("headers").get(0).asText());
-    assertEquals(2, tableData.get("rows").size());
-    assertEquals("Bob", tableData.get("rows").get(1).get(0).asText());
+    Map<String, Object> tableData = tableDataOf(result);
+
+    Object headersAttr = tableData.get("headers");
+    assertInstanceOf(List.class, headersAttr, "headers must be a List<String> that <c:forEach> can iterate");
+    List<String> headers = (List<String>) headersAttr;
+    assertEquals(List.of("Name", "Age", "City"), headers);
+
+    Object rowsAttr = tableData.get("rows");
+    assertInstanceOf(List.class, rowsAttr, "rows must be a List<List<String>> that <c:forEach> can iterate");
+    List<List<String>> rows = (List<List<String>>) rowsAttr;
+    assertEquals(3, rows.size());
+    assertEquals(List.of("Alice", "30", "Portland"), rows.get(0));
+    assertEquals(List.of("Bob", "25", "Austin"), rows.get(1));
+    assertEquals(List.of("Cara", "41", "Reno"), rows.get(2));
+    // Every row must itself be a real List too, not left as a nested ArrayNode.
+    rows.forEach(row -> assertInstanceOf(List.class, row));
+
     assertEquals("false", result.getRequest().getAttribute("isEditMode"));
   }
 
   @Test
-  void executeInEditModeSelectsTheEditJspForAUserWithEditPermission() {
+  void executeInEditModeSelectsTheEditJspWhenPageEditModeAndPermissionBothHold() {
+    // "on" case: the real page-level flag PageServlet publishes, plus edit permission.
     setRoles(widgetContext, CONTENT_MANAGER);
-    preferences.put("editMode", "true");
+    request.setAttribute("pageEditMode", "true");
     preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
 
     WidgetContext result = new TableWidget().execute(widgetContext);
@@ -62,28 +91,57 @@ class TableWidgetTest extends WidgetBase {
   }
 
   @Test
-  void executeIgnoresTheEditModePreferenceForAUserWithoutEditPermission() {
-    // The default logged-in test user (see WidgetBase.login) has no roles at all -- the layout
-    // preference alone must not be sufficient to serve the editable toolbar, or any visitor to a
-    // page with editMode=true stored in its layout would get it, including anonymous ones.
-    preferences.put("editMode", "true");
+  void executeIgnoresPageEditModeForAUserWithoutEditPermission() {
+    // "off" case #1: the default logged-in test user (see WidgetBase.login) has no roles at all --
+    // the page-level flag alone must not be sufficient to serve the editable toolbar, matching
+    // every other in-place-editable widget's permission check.
+    request.setAttribute("pageEditMode", "true");
     preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
 
     WidgetContext result = new TableWidget().execute(widgetContext);
 
-    assertEquals(TableWidget.JSP, result.getJsp(), "without edit permission, editMode=true must still render the read-only JSP");
+    assertEquals(TableWidget.JSP, result.getJsp(), "without edit permission, pageEditMode=true must still render the read-only JSP");
     assertEquals("false", result.getRequest().getAttribute("isEditMode"));
   }
 
   @Test
-  void executeIgnoresTheEditModePreferenceWhenNotLoggedIn() {
+  void executeIgnoresPageEditModeWhenNotLoggedIn() {
+    // "off" case #2: an anonymous visitor, even if pageEditMode were somehow still set.
     logout(widgetContext);
-    preferences.put("editMode", "true");
+    request.setAttribute("pageEditMode", "true");
     preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
 
     WidgetContext result = new TableWidget().execute(widgetContext);
 
     assertEquals(TableWidget.JSP, result.getJsp());
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeStaysInReadOnlyModeWhenPageEditModeRequestAttributeIsNotSet() {
+    // "off" case #3: the ordinary render path -- no visual editor session at all.
+    setRoles(widgetContext, CONTENT_MANAGER);
+    preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
+
+    WidgetContext result = new TableWidget().execute(widgetContext);
+
+    assertEquals(TableWidget.JSP, result.getJsp());
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
+  void executeNoLongerHonorsTheOldPerWidgetEditModePreference() {
+    // Regression check for the actual bug: this widget used to gate on its own per-widget
+    // "editMode" preference, which nothing in the codebase ever set, making the edit UI
+    // unreachable. Even with permission, that preference alone (without the real pageEditMode
+    // request attribute) must NOT select the edit JSP.
+    setRoles(widgetContext, CONTENT_MANAGER);
+    preferences.put("editMode", "true");
+    preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
+
+    WidgetContext result = new TableWidget().execute(widgetContext);
+
+    assertEquals(TableWidget.JSP, result.getJsp(), "the stale per-widget editMode preference must have no effect");
     assertEquals("false", result.getRequest().getAttribute("isEditMode"));
   }
 
@@ -95,8 +153,9 @@ class TableWidgetTest extends WidgetBase {
 
     WidgetContext result = new TableWidget().execute(widgetContext);
 
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertEquals("FromRequest", tableData.get("headers").get(0).asText());
+    Map<String, Object> tableData = tableDataOf(result);
+    List<String> headers = (List<String>) tableData.get("headers");
+    assertEquals("FromRequest", headers.get(0));
   }
 
   @Test
@@ -105,9 +164,9 @@ class TableWidgetTest extends WidgetBase {
     WidgetContext result = assertDoesNotThrow(() -> new TableWidget().execute(widgetContext));
 
     assertEquals(TableWidget.JSP, result.getJsp());
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertTrue(tableData.get("headers").isEmpty());
-    assertTrue(tableData.get("rows").isEmpty());
+    Map<String, Object> tableData = tableDataOf(result);
+    assertTrue(((List<?>) tableData.get("headers")).isEmpty());
+    assertTrue(((List<?>) tableData.get("rows")).isEmpty());
   }
 
   @Test
@@ -117,9 +176,9 @@ class TableWidgetTest extends WidgetBase {
     WidgetContext result = assertDoesNotThrow(() -> new TableWidget().execute(widgetContext));
 
     assertEquals(TableWidget.JSP, result.getJsp());
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertTrue(tableData.get("headers").isEmpty());
-    assertTrue(tableData.get("rows").isEmpty());
+    Map<String, Object> tableData = tableDataOf(result);
+    assertTrue(((List<?>) tableData.get("headers")).isEmpty());
+    assertTrue(((List<?>) tableData.get("rows")).isEmpty());
   }
 
   @Test
@@ -131,9 +190,9 @@ class TableWidgetTest extends WidgetBase {
     WidgetContext result = assertDoesNotThrow(() -> new TableWidget().execute(widgetContext));
 
     assertEquals(TableWidget.JSP, result.getJsp());
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertTrue(tableData.get("headers").isEmpty());
-    assertTrue(tableData.get("rows").isEmpty());
+    Map<String, Object> tableData = tableDataOf(result);
+    assertTrue(((List<?>) tableData.get("headers")).isEmpty());
+    assertTrue(((List<?>) tableData.get("rows")).isEmpty());
   }
 
   @Test
@@ -149,8 +208,8 @@ class TableWidgetTest extends WidgetBase {
 
     WidgetContext result = assertDoesNotThrow(() -> new TableWidget().execute(widgetContext));
 
-    JsonNode tableData = (JsonNode) result.getRequest().getAttribute("tableData");
-    assertTrue(tableData.get("rows").isEmpty(), "oversized stored data should render as an empty table, not the raw rows");
+    Map<String, Object> tableData = tableDataOf(result);
+    assertTrue(((List<?>) tableData.get("rows")).isEmpty(), "oversized stored data should render as an empty table, not the raw rows");
   }
 
   // ── isValidTableData(): shape ─────────────────────────────────────────────

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/TableWidgetTest.java
@@ -91,6 +91,24 @@ class TableWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeIgnoresPageEditModeForAContentEditorBecauseTheyCannotReachTheSaveEndpoint() {
+    // content-editor holds EditorPermissionCommand.canEditContent() but is deliberately excluded
+    // from canBuildLayout() -- and the Save button in table-widget-edit.jsp POSTs PageServlet's
+    // "setWidgetPreferences" action, which is itself gated on canBuildLayout (see PageServlet's
+    // mutateDraftLayout dispatch). Serving the editable Save UI to a content-editor here would let
+    // them edit and click Save, only to have the server silently drop the request every time --
+    // regression check for that permission-tier mismatch.
+    setRoles(widgetContext, CONTENT_EDITOR);
+    request.setAttribute("pageEditMode", "true");
+    preferences.put("tableData", "{\"headers\": [\"A\"], \"rows\": [[\"1\"]]}");
+
+    WidgetContext result = new TableWidget().execute(widgetContext);
+
+    assertEquals(TableWidget.JSP, result.getJsp(), "content-editor cannot save this widget, so must not receive the editable Save UI");
+    assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  @Test
   void executeIgnoresPageEditModeForAUserWithoutEditPermission() {
     // "off" case #1: the default logged-in test user (see WidgetBase.login) has no roles at all --
     // the page-level flag alone must not be sufficient to serve the editable toolbar, matching


### PR DESCRIPTION
## Summary

Closes #433's remaining crash/persistence/reachability gap (PR #791 already shipped the smaller Escape-cancel/a11y/search-case items from the same fact-check). Per the issue's own investigation, only 1 of 5 acceptance criteria actually passed before this PR:

1. **Server crash on real data (the blocker).** `TableWidget.execute()` handed JSTL a raw Jackson `JsonNode`/`ArrayNode`, which `<c:forEach>` cannot iterate -- `PageServlet`'s outer catch silently swallowed the resulting exception into an empty HTTP 200. Fixed by converting to real `List<String>`/`List<List<String>>` before exposing it to the JSPs.
2. **Edit UI never wired to save.** No `saveTableContent` action existed; every cell edit dispatched an event nothing listened for. Added a Save button that POSTs through the same, already-tested `MutateLayoutCommand.setWidgetPreferences` path every other widget's preference edits use.
3. **Edit UI unreachable.** `isEditMode` read a per-widget `editMode` preference nothing ever set. Switched to the real `pageEditMode` flag `PageServlet` publishes for every widget.

## A genuine security bug found during review, also fixed here

Adversarial review flagged the original build's live-testing claim of a session-cookie leak as unsubstantiated (a static grep found no Java code path from request headers into the rendered table). Re-testing live proved the leak was real anyway, with a root cause the static search couldn't see: **`header` is a reserved JSP EL implicit-object identifier** (the request's HTTP header map, per the JSP spec). Both table JSPs used `<c:forEach var="header">` -- a same-named loop variable is silently ignored by EL, so `${header}` inside the loop always resolved to the implicit request-header map instead of the loop's actual column value. Every rendered `<th>` was showing the *viewer's own current request headers*, including their `JSESSIONID`/`userToken` session cookies, changing per request. This was previously masked entirely by the crash fixed above (a table with real data never successfully rendered), so it went from unreachable to live as a side effect of fix #1 -- caught and fixed in the same PR before merge, not shipped separately. Fixed by renaming the loop variable to `headerCell`; grepped the rest of `src/main/webapp/WEB-INF/jsp` for the same reserved-identifier collision pattern (`header`, `param`, `cookie`, `initParam`, etc.) and found no other instances.

## Also found and fixed: a permission-gate mismatch

The edit-mode gate originally used `EditorPermissionCommand.canEditContent()` (includes the `content-editor` role), but the only save endpoint it POSTs to requires `canBuildLayout()` (`content-editor` is deliberately excluded -- "authors get content guardrails, designers get the canvas"). A content-editor-only user would see the full editable UI, edit cells, click Save, have the request silently rejected server-side, and see a confusing "Error: HTTP 200" with their edits discarded. Fixed by gating on `canBuildLayout()` to match the save path exactly.

## What this issue is NOT asking for

The issue's original scope asked for table data stored as JSON in the Content table with a distinct format stamp. That was never built and isn't addressed here -- table data is stored as an ordinary widget preference in the page's layout XML, going through the same generic, tested `setWidgetPreferences` mechanism every widget preference uses. A prior fact-check comment on the issue flagged this as a separate architecture decision worth ratifying or rejecting on its own.

## Testing

- New tests: realistic non-empty multi-row/column data proving `TableWidget.execute()` doesn't throw and exposes `List`-typed attributes; `pageEditMode` on/off/anonymous cases including a regression test that the old per-widget `editMode` preference is now inert; a `content-editor` vs `content-manager` permission-gate regression test; a `MutateLayoutCommandTest` round-trip proving the Save button's exact wire shape persists and reads back intact.
- Full `ant ci-test`: 1383 tests, 0 failures.
- `check-unescaped-el.py --strict`: 0 unallowlisted.
- Live Docker rehearsal, each scenario driven end to end: real multi-row/column data rendering correctly in edit mode, view mode, published-page admin view, and anonymous curl; a real Save POST persisting to `draft_page_xml` and confirmed via direct DB query; the widget immediately editable through the normal `+Widget` picker with no raw JSON escape hatch needed; a `content-editor` account correctly getting the read-only view with edits rejected server-side, a `content-manager` account correctly able to save; and the header-cookie leak confirmed present before the JSP fix (via an injected custom header showing up in rendered `<th>` output) and confirmed gone after.

## Worth a follow-up, not fixed here

`ItemsListWidget.java` (cited in this PR's own comments as the precedent for the `pageEditMode` pattern) has its own separate, pre-existing, weaker gate: its `isEditMode` ORs in a raw, unchecked `?editMode=true` request parameter with zero permission check, letting any visitor force its admin UI to render (the actual mutating actions are separately, correctly gated, so this looks like UI-only exposure). Different file, out of scope here, worth its own ticket.