### PR TITLE
Fix SaveDraftLayoutCommand silently failing to persist layout reorders

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommand.java
@@ -56,8 +56,9 @@ public class SaveDraftLayoutCommand {
   /**
    * @param webPage    the page whose layout is being changed
    * @param layoutJson JSON string: {"sections":[{"s":origIdx,"columns":[{"c":origIdx,"widgets":[origIdx,...]},...]},...]}
+   * @param modifiedBy user id of the person making this change
    */
-  public static void saveDraftLayout(WebPage webPage, String layoutJson) throws DataException {
+  public static void saveDraftLayout(WebPage webPage, String layoutJson, long modifiedBy) throws DataException {
     if (webPage == null || webPage.getId() == -1) {
       throw new DataException("Page not found");
     }
@@ -174,7 +175,10 @@ public class SaveDraftLayoutCommand {
       // Persist
       webPage.setDraftPageXml(newXml);
       webPage.setDraft(true);
-      WebPageRepository.save(webPage);
+      webPage.setModifiedBy(modifiedBy);
+      if (WebPageRepository.save(webPage) == null) {
+        throw new DataException("Could not save draft layout for " + webPage.getLink());
+      }
       WebPageXmlLayoutCommand.removeCustomPage(webPage.getLink());
       LOG.debug("Draft layout saved for: " + webPage.getLink());
 

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -324,7 +324,7 @@ public class PageServlet extends HttpServlet {
         String layoutJson = request.getParameter("layout");
         response.setContentType("application/json");
         try {
-          SaveDraftLayoutCommand.saveDraftLayout(webPage, layoutJson);
+          SaveDraftLayoutCommand.saveDraftLayout(webPage, layoutJson, userSession.getUserId());
           response.getWriter().print("{\"success\":true}");
         } catch (Exception e) {
           LOG.error("saveDraftLayout failed for " + pagePath, e);

--- a/src/test/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommandIntegrationTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommandIntegrationTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+
+/**
+ * Verifies {@link SaveDraftLayoutCommand}'s reorder persistence against a real PostgreSQL
+ * instance.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises {@code SaveDraftLayoutCommand} through the real {@code WebPageRepository}/JDBC stack,
+ * including the {@code web_pages_modified_by_fkey} foreign key that a mock-based test (see
+ * {@link SaveDraftLayoutCommandTest}) cannot exercise -- a mock never rejects an invalid id. It is
+ * skipped automatically when Docker is not available, so it does not break the build on hosts
+ * without a Docker daemon.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class SaveDraftLayoutCommandIntegrationTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+  private static final String PAGE_XML =
+      "<page><section class=\"first\"><column class=\"small-12 cell\" /></section></page>";
+  private static final String REORDER_JSON = "{\"sections\":[{\"s\":0,\"columns\":[{\"c\":0,\"widgets\":[]}]}]}";
+
+  private static GenericContainer<?> postgres;
+  private static long validUserId;
+
+  @BeforeAll
+  static void startDatabase() {
+    // Only run when a Docker daemon is reachable; otherwise mark the whole class as skipped
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping SaveDraftLayoutCommand integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    // Point the application's shared DataSource at the container
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+    validUserId = insertUser("editor1");
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetPages() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_pages table", se);
+    }
+  }
+
+  @Test
+  void saveDraftLayoutPersistsToTheDatabase() throws Exception {
+    WebPage page = insertPage("/integration-test-page");
+
+    SaveDraftLayoutCommand.saveDraftLayout(page, REORDER_JSON, validUserId);
+
+    WebPage reloaded = WebPageRepository.findById(page.getId());
+    assertNotNull(reloaded.getDraftPageXml(),
+        "draftPageXml should be persisted to the row, not just returned to the in-memory caller");
+    assertTrue(reloaded.getDraft(), "draft flag should be persisted");
+    assertEquals(validUserId, reloaded.getModifiedBy());
+  }
+
+  @Test
+  void saveDraftLayoutWithInvalidModifiedByThrowsAndDoesNotPersist() throws Exception {
+    WebPage page = insertPage("/integration-test-page-2");
+    long noSuchUserId = validUserId + 999;
+
+    assertThrows(DataException.class,
+        () -> SaveDraftLayoutCommand.saveDraftLayout(page, REORDER_JSON, noSuchUserId),
+        "modified_by referencing a nonexistent user must violate web_pages_modified_by_fkey and "
+            + "surface as a real error, not a silent no-op");
+
+    WebPage reloaded = WebPageRepository.findById(page.getId());
+    assertNull(reloaded.getDraftPageXml(),
+        "the reorder must not silently succeed: draftPageXml must remain unset when the save was rejected");
+    assertFalse(reloaded.getDraft(), "draft flag must not be set either, since nothing was actually saved");
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // `users` is a focused subset -- just enough to satisfy web_pages' created_by/modified_by
+    // foreign keys (the real table's `geom` column needs PostGIS, which this test has no need
+    // for). `web_pages` is the full real column set: WebPageRepository.update() writes every one
+    // of these columns in a single UPDATE, so a narrower subset would fail with an unrelated
+    // "column does not exist" instead of exercising the modified_by fkey this test targets.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
+      statement.execute("DROP TABLE IF EXISTS users CASCADE");
+      statement.execute("CREATE TABLE users ("
+          + "user_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "username VARCHAR(255) UNIQUE NOT NULL, "
+          + "password VARCHAR(255) NOT NULL)");
+      statement.execute("CREATE TABLE web_pages ("
+          + "web_page_id BIGSERIAL PRIMARY KEY, "
+          + "link VARCHAR(255) UNIQUE NOT NULL, "
+          + "redirect_url VARCHAR(255), "
+          + "page_title VARCHAR(255), "
+          + "page_keywords VARCHAR(255), "
+          + "page_description VARCHAR(255), "
+          + "draft BOOLEAN DEFAULT false, "
+          + "enabled BOOLEAN DEFAULT true, "
+          + "created_by BIGINT REFERENCES users(user_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT REFERENCES users(user_id), "
+          + "role_id_list VARCHAR(100) DEFAULT NULL, "
+          + "template VARCHAR(255), "
+          + "page_xml TEXT, "
+          + "comments TEXT, "
+          + "draft_page_xml TEXT, "
+          + "page_image_url VARCHAR(255), "
+          + "searchable BOOLEAN DEFAULT true, "
+          + "show_in_sitemap BOOLEAN DEFAULT true, "
+          + "has_redirect BOOLEAN DEFAULT false, "
+          + "sitemap_priority NUMERIC(2,1) DEFAULT 0.5, "
+          + "sitemap_changefreq VARCHAR(20), "
+          + "publish_at TIMESTAMP, "
+          + "expires_at TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_pages/users schema", se);
+    }
+  }
+
+  private static long insertUser(String uniqueId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO users (unique_id, username, password) VALUES (?, ?, ?) RETURNING user_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      pst.setString(3, "not-a-real-hash");
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert test user", se);
+    }
+  }
+
+  private static WebPage insertPage(String link) {
+    WebPage page = new WebPage();
+    page.setLink(link);
+    page.setPageXml(PAGE_XML);
+    page.setCreatedBy(validUserId);
+    WebPage saved = WebPageRepository.save(page);
+    if (saved == null) {
+      throw new IllegalStateException("Test setup failed: could not insert page " + link);
+    }
+    return saved;
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveDraftLayoutCommandTest.java
@@ -19,6 +19,8 @@ package com.simisinc.platform.application.cms;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 
@@ -89,7 +91,7 @@ class SaveDraftLayoutCommandTest {
 
     try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
       DataException ex = assertThrows(DataException.class,
-          () -> SaveDraftLayoutCommand.saveDraftLayout(page, buggyLayoutJson),
+          () -> SaveDraftLayoutCommand.saveDraftLayout(page, buggyLayoutJson, 42L),
           "a section reporting zero columns when it actually has some must be rejected");
       assertTrue(ex.getMessage().contains("data loss"), "the rejection reason should be clear: " + ex.getMessage());
 
@@ -109,7 +111,7 @@ class SaveDraftLayoutCommandTest {
          MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
       repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
 
-      SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson);
+      SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson, 42L);
 
       repo.verify(() -> WebPageRepository.save(any(WebPage.class)));
     }
@@ -130,7 +132,7 @@ class SaveDraftLayoutCommandTest {
          MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
       repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
 
-      SaveDraftLayoutCommand.saveDraftLayout(page, reorderJson);
+      SaveDraftLayoutCommand.saveDraftLayout(page, reorderJson, 42L);
     }
 
     String result = page.getDraftPageXml();
@@ -150,11 +152,54 @@ class SaveDraftLayoutCommandTest {
          MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
       repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
 
-      SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson);
+      SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson, 42L);
     }
 
     String result = page.getDraftPageXml();
     assertTrue(result.contains("<uniqueId>left</uniqueId>") && result.contains("<uniqueId>right</uniqueId>"),
         "both columns/widgets should be preserved when the columns key is absent");
+  }
+
+  // ── modifiedBy / persistence-failure propagation ─────────────────────────
+  // A draft-layout reorder must record who made it and must not report success when the
+  // underlying save silently fails (e.g. a stale modified_by value tripping the
+  // web_pages_modified_by_fkey foreign key). See SaveDraftLayoutCommandIntegrationTest for the
+  // same two properties proven against a real database instead of a mock.
+
+  @Test
+  void saveDraftLayoutSetsModifiedByBeforeSaving() throws DataException {
+    WebPage page = pageWithXml(EMPTY_SECTION_XML);
+    String layoutJson = "{\"sections\":[{\"s\":0,\"columns\":[]}]}";
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+         MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
+      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> i.getArgument(0));
+      cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
+
+      SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson, 42L);
+
+      repo.verify(() -> WebPageRepository.save(argThat(p -> p.getModifiedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void saveDraftLayoutThrowsWhenSaveFails() {
+    WebPage page = pageWithXml(EMPTY_SECTION_XML);
+    String layoutJson = "{\"sections\":[{\"s\":0,\"columns\":[]}]}";
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+         MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
+      // A null return simulates WebPageRepository.update() failing (e.g. the FK violation logged
+      // by DB.update() when modified_by isn't a real user id) -- saveDraftLayout() must not treat
+      // that as success.
+      repo.when(() -> WebPageRepository.save(any(WebPage.class))).thenAnswer(i -> null);
+      cmd.when(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString())).thenAnswer(i -> null);
+
+      assertThrows(DataException.class,
+          () -> SaveDraftLayoutCommand.saveDraftLayout(page, layoutJson, 42L),
+          "a null return from WebPageRepository.save() means persistence failed and must not be swallowed");
+
+      cmd.verify(() -> WebPageXmlLayoutCommand.removeCustomPage(anyString()), never());
+    }
   }
 }


### PR DESCRIPTION
## Problem

`SaveDraftLayoutCommand.saveDraftLayout()` has the same bug class PR #737 fixed in `MutateLayoutCommand`:

1. It never called `webPage.setModifiedBy(...)` before saving -- the method didn't even take a `modifiedBy` parameter, unlike every public method on `MutateLayoutCommand` since #737.
2. It called `WebPageRepository.save(webPage);` as a bare statement and never checked the return value. `save()` returns `null` on a DB failure (e.g. a `web_pages_modified_by_fkey` violation), which this command silently swallowed while still returning normally as if the reorder succeeded.

Net effect: `PageServlet`'s `saveDraftLayout` action (composition-canvas drag-to-reorder) could no-op on a save failure while still returning `{"success":true}` to the client.

## Fix

Mirrors #737's fix shape exactly:
- Added a `long modifiedBy` parameter to `saveDraftLayout(...)`, and call `webPage.setModifiedBy(modifiedBy)` before saving.
- Check `WebPageRepository.save(webPage)`'s return value; throw `DataException` when it's `null`.
- Updated the one call site (`PageServlet`'s `saveDraftLayout` action handler) to pass `userSession.getUserId()`, matching how it already calls `MutateLayoutCommand`.

## Testing

- Updated `SaveDraftLayoutCommandTest`'s 4 existing calls for the new parameter, and added a mock-based pair (`saveDraftLayoutSetsModifiedByBeforeSaving` / `saveDraftLayoutThrowsWhenSaveFails`) mirroring `MutateLayoutCommandTest`'s equivalent pair.
- Added `SaveDraftLayoutCommandIntegrationTest`, a real-Postgres Testcontainers test mirroring `MutateLayoutCommandIntegrationTest` (skipped when Docker isn't available): a valid reorder persists `modified_by`/`draft_page_xml`, and a `modifiedBy` referencing a nonexistent user trips the real `web_pages_modified_by_fkey` constraint and surfaces as a thrown `DataException` rather than a silent no-op.
- `ant -lib lib/war -lib lib/tests clean compile-test` and `ant -lib lib/war -lib lib/tests ci-test` (full suite, 1383 tests) both green; `ant -lib lib/war compile-jsp` also green.