### PR TITLE
Fix mailing list Delete action being non-functional

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidget.java
@@ -27,6 +27,7 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.lang3.StringUtils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 /**
@@ -88,6 +89,16 @@ public class MailingListsWidget extends GenericWidget {
     // Show the list
     context.setJsp(jsp);
     return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+    // The row's delete link submits via confirmPostAction(), a real POST -- WebContainerContext
+    // checks isPost() before isDelete(), so this always reaches post(), never delete() directly.
+    // Forward to it explicitly (same fix shape as #658/PR #659).
+    if ("delete".equals(context.getParameter("command"))) {
+      return delete(context);
+    }
+    return null;
   }
 
   public WidgetContext delete(WidgetContext context) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidgetTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * The "Delete" row action on /admin/mailing-lists submits via confirmPostAction(), a real POST --
+ * WebContainerContext checks isPost() before isDelete(), so this always reaches post(), never
+ * delete() directly. This widget had no post() override, so every click fell through to
+ * GenericWidget's default (a no-op that just logs "MUST OVERRIDE THE DEFAULT POST METHOD"), and the
+ * row was never removed. Same dispatch-gap shape as #658/PR #659 (blocked/allowed IP lists) and
+ * #562/#646 (MailingListMembersWidget). These tests call post() directly, the method a real request
+ * actually reaches, so they fail if this dispatch gap reopens.
+ */
+class MailingListsWidgetTest extends WidgetBase {
+
+  private static MailingList mailingList(long memberCount) {
+    MailingList list = new MailingList();
+    list.setId(1L);
+    list.setName("newsletter");
+    list.setTitle("Newsletter");
+    list.setMemberCount(memberCount);
+    return list;
+  }
+
+  @Test
+  void deleteMailingListViaPostRemovesItAndRedirects() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+
+    MailingList list = mailingList(0);
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.findById(1L)).thenReturn(list);
+      repository.when(() -> MailingListRepository.remove(list)).thenReturn(true);
+
+      WidgetContext result = new MailingListsWidget().post(widgetContext);
+
+      repository.verify(() -> MailingListRepository.remove(list), times(1));
+      assertEquals("Mailing list deleted", result.getSuccessMessage());
+      assertEquals("/admin/mailing-lists", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postWithoutDeleteCommandDoesNotTouchTheRepository() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    // No "command" parameter -- not a delete request.
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      WidgetContext result = new MailingListsWidget().post(widgetContext);
+
+      repository.verify(() -> MailingListRepository.remove(any()), never());
+      assertNull(result);
+    }
+  }
+
+  @Test
+  void deleteMailingListViaPostLeavesRecordsWithTooManyMembers() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "delete");
+    addQueryParameter(widgetContext, "mailingListId", "1");
+
+    MailingList list = mailingList(11);
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.findById(1L)).thenReturn(list);
+
+      WidgetContext result = new MailingListsWidget().post(widgetContext);
+
+      repository.verify(() -> MailingListRepository.remove(any()), never());
+      assertEquals("Mailing list cannot be deleted, there are related records", result.getWarningMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The "Delete" row action on `/admin/mailing-lists` does nothing — the confirm dialog shows, the page redirects back to the list, but the row is never removed and no message is shown. Confirmed live in a local docker-compose rehearsal: clicking Delete (a real POST) leaves the row in the `mailing_lists` table untouched; a plain GET to the exact same URL correctly deletes it.

Fixes #796 (full root-cause writeup there).

## Root cause

The delete link submits via `confirmPostAction(...)`, a real HTTP `POST` with `command=delete` as a form field. `WebContainerContext`'s constructor checks `isPost()` before it ever looks at the `command` parameter, so the request always dispatches to the widget's `post(WidgetContext)` method, never `delete(WidgetContext)`. `MailingListsWidget` only defined `execute()` and `delete()` — no `post()` — so the call fell through to `GenericWidget`'s default, which just logs `MUST OVERRIDE THE DEFAULT POST METHOD` and returns `null`.

Same dispatch-gap shape already fixed once in this codebase for the blocked/allowed-IP list pages (#658 / PR #659) and for `MailingListMembersWidget`.

## Fix

Add a `post(WidgetContext)` override to `MailingListsWidget` that checks `command=delete` and forwards to the existing `delete(WidgetContext)` logic — mirroring `BlockedIPListWidget.post()`.

## Testing

- Added `MailingListsWidgetTest` (3 tests): a POST with `command=delete` reaches the repository and returns the success message/redirect; a POST without that command touches nothing; the existing member-count guard in `delete()` still applies when reached via POST.
- `ant -lib lib/war -lib lib/tests ci-test`: full suite green, including the new tests and the unaffected sibling `MailingListMembersWidgetTest`.
- Live-verified in a docker-compose rehearsal, before and after the fix: pre-fix, POSTing the exact request the rendered link sends left the row in place and logged `MUST OVERRIDE THE DEFAULT POST METHOD`; post-fix, the identical request deletes the row with no error logged.

## Scope note

This is unrelated to #753 (adding audit logging to mailing-list CRUD) — neither `create`, `edit`, nor `delete` on a mailing list emits an audit event today, independent of this dispatch bug. Kept as a standalone, single-defect fix.