### PR TITLE
Add audit logging for page-layout/composition-canvas mutations

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/AuditEventCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/AuditEventCommand.java
@@ -21,15 +21,23 @@ import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 /**
- * Bridges a widget request to the security audit log (see {@link SaveAuditEventCommand}). It pulls the
- * acting administrator's identity -- user id, username, source IP and session id -- from the
- * {@link WidgetContext} and records an administrative or data-change event.
+ * Bridges a widget or servlet request to the security audit log (see {@link SaveAuditEventCommand}). It
+ * pulls the acting administrator's identity -- user id, username, source IP and session id -- from either
+ * a {@link WidgetContext} or a raw {@link HttpServletRequest}/{@link UserSession} pair, and records an
+ * administrative or data-change event.
  *
  * <p>Presentation code (widgets, and the small number of application commands that already receive a
- * WidgetContext) should call this rather than building an {@code AuditLog} by hand, so the actor is
- * resolved consistently. Auditing is a side effect: extracting the actor and writing the record are both
- * guarded so a failure here can never break the admin action being observed.
+ * WidgetContext) should call the {@code WidgetContext} overload rather than building an {@code AuditLog}
+ * by hand, so the actor is resolved consistently. A servlet that is not part of the widget-rendering
+ * pipeline (e.g. {@code PageServlet}, {@code MediaApiController}) has no {@code WidgetContext} to build
+ * one from -- constructing one just for this would need to reach into {@code WidgetContext}'s
+ * page-render-only {@code coreData} map, which is a rendering concern, not an auditing one -- so it should
+ * call the {@code HttpServletRequest}/{@code UserSession} overload instead. Auditing is a side effect:
+ * extracting the actor and writing the record are both guarded so a failure here can never break the
+ * action being observed.
  *
  * @author SimIS Inc.
  */
@@ -79,6 +87,42 @@ public class AuditEventCommand {
       // Prefer the live request address, matching the Phase 1 authentication events
       if (context.getRequest() != null && context.getRequest().getRemoteAddr() != null) {
         sourceIp = context.getRequest().getRemoteAddr();
+      }
+    } catch (Exception e) {
+      // Never let actor extraction break the caller; record with whatever was resolved
+    }
+    SaveAuditEventCommand.recordAdminEvent(eventCategory, eventType, outcome, actorUserId, actorUsername,
+        sourceIp, sessionId, targetType, targetId, targetLabel, details);
+  }
+
+  /**
+   * Records an admin/data-change audit event for a caller that has a raw servlet request and user session
+   * but no {@link WidgetContext} -- see the class javadoc for why that's a distinct case rather than one
+   * that should just build a WidgetContext. Never throws.
+   */
+  public static void record(HttpServletRequest request, UserSession userSession, String eventCategory,
+      String eventType, String outcome, String targetType, String targetId, String targetLabel,
+      String details) {
+    long actorUserId = -1L;
+    String actorUsername = null;
+    String sourceIp = null;
+    String sessionId = null;
+    try {
+      if (userSession != null) {
+        actorUserId = userSession.getUserId();
+        sessionId = userSession.getSessionId();
+        sourceIp = userSession.getIpAddress();
+        // getUser() lazily loads the acting user; skip it for an unauthenticated/unknown actor
+        if (actorUserId > -1L) {
+          User actor = userSession.getUser();
+          if (actor != null) {
+            actorUsername = actor.getEmail();
+          }
+        }
+      }
+      // Prefer the live request address, matching the WidgetContext overload
+      if (request != null && request.getRemoteAddr() != null) {
+        sourceIp = request.getRemoteAddr();
       }
     } catch (Exception e) {
       // Never let actor extraction break the caller; record with whatever was resolved

--- a/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/MediaApiController.java
@@ -688,9 +688,17 @@ public class MediaApiController extends HttpServlet {
       String prefsJson = objectMapper.writeValueAsString(prefs);
       MutateLayoutCommand.setWidgetPreferences(webPage, sectionIdx, columnIdx, widgetIdx, prefsJson,
           userSession.getUserId());
+      AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.setWidgetPreferences",
+          AuditEventCommand.SUCCESS, "web_page", String.valueOf(webPage.getId()), webPage.getLink(),
+          "via media library: assetId=" + assetId + " widget=" + targetWidgetName
+              + " s=" + sectionIdx + " c=" + columnIdx + " w=" + widgetIdx);
     } catch (DataException e) {
       LOG.warn("widget-update rejected for " + pagePath + " " + sectionIdx + ":" + columnIdx + ":" + widgetIdx
           + ": " + e.getMessage());
+      AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.setWidgetPreferences",
+          AuditEventCommand.FAILURE, "web_page", String.valueOf(webPage.getId()), webPage.getLink(),
+          "via media library: assetId=" + assetId + " s=" + sectionIdx + " c=" + columnIdx + " w=" + widgetIdx
+              + " error=" + e.getMessage());
       response.setStatus(400);
       Map<String, Object> result = new HashMap<>();
       result.put("error", e.getMessage());

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -325,11 +325,15 @@ public class PageServlet extends HttpServlet {
         response.setContentType("application/json");
         try {
           SaveDraftLayoutCommand.saveDraftLayout(webPage, layoutJson);
+          AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.reorder",
+              AuditEventCommand.SUCCESS, "web_page", String.valueOf(webPage.getId()), webPage.getLink(), null);
           response.getWriter().print("{\"success\":true}");
         } catch (Exception e) {
           LOG.error("saveDraftLayout failed for " + pagePath, e);
           response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
           String msg = e.getMessage() != null ? e.getMessage().replace("\"", "'") : "Save failed";
+          AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.reorder",
+              AuditEventCommand.FAILURE, "web_page", String.valueOf(webPage.getId()), webPage.getLink(), msg);
           response.getWriter().print("{\"success\":false,\"error\":\"" + msg + "\"}");
         }
         return;
@@ -574,6 +578,10 @@ public class PageServlet extends HttpServlet {
       // mutateDraftLayout: structural add/remove/set operations on sections, columns, and widgets.
       // All mutations write only to draftPageXml and require the layout-builder capability.
       String mutateAction = request.getParameter("action");
+      // Built from the raw parameters (not the parsed s/c/w/after locals below, which are scoped to the
+      // try block) so the exact same summary is available to both the success and failure audit calls.
+      String mutateDetails = "s=" + request.getParameter("s") + " c=" + request.getParameter("c")
+          + " w=" + request.getParameter("w") + " after=" + request.getParameter("after");
       if (request.getParameter("widget") == null
           && pageEditMode
           && EditorPermissionCommand.canBuildLayout(userSession)
@@ -638,11 +646,17 @@ public class PageServlet extends HttpServlet {
               response.getWriter().print("{\"success\":false,\"error\":\"Unknown action\"}");
               return;
           }
+          AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout." + mutateAction,
+              AuditEventCommand.SUCCESS, "web_page", String.valueOf(webPage.getId()), webPage.getLink(),
+              mutateDetails);
           response.getWriter().print("{\"success\":true}");
         } catch (Exception e) {
           LOG.warn("mutateDraftLayout '" + mutateAction + "' failed for " + pagePath + ": " + e.getMessage());
           response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
           String msg = e.getMessage() != null ? e.getMessage().replace("\"", "'") : "Mutation failed";
+          AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout." + mutateAction,
+              AuditEventCommand.FAILURE, "web_page", String.valueOf(webPage.getId()), webPage.getLink(),
+              mutateDetails + " error=" + msg);
           response.getWriter().print("{\"success\":false,\"error\":\"" + msg + "\"}");
         }
         return;

--- a/src/test/java/com/simisinc/platform/presentation/controller/AuditEventCommandServletOverloadTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/AuditEventCommandServletOverloadTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.User;
+
+/**
+ * Tests the {@link AuditEventCommand#record(HttpServletRequest, UserSession, String, String, String,
+ * String, String, String, String)} overload -- the bridge used by servlets that have a raw request and
+ * user session but no {@link WidgetContext} (e.g. {@code PageServlet}, {@code MediaApiController}).
+ *
+ * @author elizabeth houser
+ */
+class AuditEventCommandServletOverloadTest {
+
+  @Test
+  void resolvesActorSessionAndUsernameFromUserSession() {
+    UserSession userSession = mock(UserSession.class);
+    when(userSession.getUserId()).thenReturn(42L);
+    when(userSession.getSessionId()).thenReturn("sess-123");
+    when(userSession.getIpAddress()).thenReturn("198.51.100.7");
+    User actor = new User();
+    actor.setEmail("editor@example.com");
+    when(userSession.getUser()).thenReturn(actor);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("198.51.100.7");
+
+    try (MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.SUCCESS, "web_page", "7", "/some-page", "s=0 c=0");
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.SUCCESS, 42L, "editor@example.com", "198.51.100.7", "sess-123",
+          "web_page", "7", "/some-page", "s=0 c=0"));
+    }
+  }
+
+  @Test
+  void prefersRequestRemoteAddrOverUserSessionIp() {
+    // The two can differ behind a proxy/load balancer -- the live request address must win, matching
+    // the WidgetContext overload's own behavior.
+    UserSession userSession = mock(UserSession.class);
+    when(userSession.getUserId()).thenReturn(-1L);
+    when(userSession.getIpAddress()).thenReturn("203.0.113.9");
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("198.51.100.7");
+
+    try (MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.addSection",
+          AuditEventCommand.SUCCESS, "web_page", "7", "/some-page", null);
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.CONTENT,
+          "page_layout.addSection", AuditEventCommand.SUCCESS, -1L, null, "198.51.100.7",
+          null, "web_page", "7", "/some-page", null));
+    }
+  }
+
+  @Test
+  void handlesNullUserSessionWithoutThrowing() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("198.51.100.7");
+
+    try (MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      AuditEventCommand.record(request, null, AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.FAILURE, "web_page", "7", "/some-page", "no session");
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.FAILURE, -1L, null, "198.51.100.7", null, "web_page", "7", "/some-page", "no session"));
+    }
+  }
+
+  @Test
+  void skipsUserLookupForAnUnauthenticatedActor() {
+    // getUser() lazily loads from the database -- must not be called for a not-logged-in actor
+    // (userId == -1), matching the WidgetContext overload's own guard.
+    UserSession userSession = mock(UserSession.class);
+    when(userSession.getUserId()).thenReturn(-1L);
+
+    try (MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      AuditEventCommand.record(null, userSession, AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.FAILURE, "web_page", "7", "/some-page", null);
+    }
+    verify(userSession, never()).getUser();
+  }
+
+  @Test
+  void neverThrowsWhenActorResolutionFails() {
+    UserSession userSession = mock(UserSession.class);
+    when(userSession.getUserId()).thenThrow(new RuntimeException("boom"));
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    try (MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      AuditEventCommand.record(request, userSession, AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.FAILURE, "web_page", "7", "/some-page", "details");
+
+      // Auditing is a side effect that must never break the caller -- the record is still written,
+      // just with an unknown actor (-1), rather than propagating the exception.
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.CONTENT, "page_layout.reorder",
+          AuditEventCommand.FAILURE, -1L, null, null, null, "web_page", "7", "/some-page", "details"));
+    }
+  }
+}


### PR DESCRIPTION
Closes #752.

## Problem

`MutateLayoutCommand`, `SaveDraftLayoutCommand`, and their callers (`PageServlet`, `MediaApiController`) emitted zero audit events, so a page's widget layout could be rearranged with no traceability -- unlike the page metadata form, which is already audited via `WebPageFormWidget`.

## Fix

Neither command class has a `WidgetContext` to bridge into the existing `AuditEventCommand.record(context, ...)` helper -- `PageServlet` and `MediaApiController` are plain servlets, not part of the widget-render pipeline. Rather than constructing a fake `WidgetContext` (which would need to reach into its page-render-only `coreData` map, a rendering concern, not an auditing one), this adds a second `AuditEventCommand.record()` overload that resolves the actor from a raw `HttpServletRequest`/`UserSession` pair instead, mirroring the existing overload's actor-resolution logic.

Calls it from all three real mutation entry points:
- `PageServlet`'s `saveDraftLayout` action handler -- `page_layout.reorder`
- `PageServlet`'s `mutateDraftLayout` switch -- `page_layout.<action>` for all 9 structural operations (addSection, removeSection, setSectionClass, addColumn, removeColumn, setColumnClass, addWidget, removeWidget, setWidgetPreferences)
- `MediaApiController`'s `widget-update` handler (the media-library image picker) -- `page_layout.setWidgetPreferences`

Both success and failure outcomes are recorded (category `content`, target `web_page`), so a rejected mutation (e.g. an invalid section index, or a media-library update targeting a non-image widget) is traceable too, not just successful ones.

## Testing

- New `AuditEventCommandServletOverloadTest`: 5 unit tests covering actor/session/IP resolution, the request-address-overrides-session-IP precedence, a null `UserSession`, skipping the user lookup for an unauthenticated actor, and that actor-resolution failures never propagate.
- `ant -lib lib/war -lib lib/tests clean ci-test` (1388 tests) and `ant -lib lib/war compile-jsp` both green; zero regressions in the existing `PageServletTest`/`MediaApiControllerTest` suites.
- Live-verified end-to-end in a docker-compose rehearsal: logged in, drove real HTTP calls through all three entry points (addSection, addWidget, removeWidget, a rejected removeSection, a draft-layout reorder, and a real media-library upload + widget-update including a rejected out-of-range widget index), then confirmed every event landed correctly in both audit sinks -- the `audit_log` table (correct category/event_type/outcome/actor/target/details) and the structured JSON stream (with the tamper-evidence hash chain intact across the new events).
- Confirmed no collision with existing page-metadata auditing: `WebPageFormWidget` and its `content.*` event types are untouched; the new events use a distinct `page_layout.*` prefix in the same `content` category.