### PR TITLE
Re-enable 3 commented-out siteStats dashboard tiles

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -882,7 +882,6 @@
           <report>daily-user-registrations</report>
         </widget>
       </column>
-<!--
       <column class="small-12 medium-6 cell">
         <widget name="siteStats" class="stats card">
           <title>Daily Mailing List Subscriptions</title>
@@ -890,8 +889,6 @@
           <report>daily-mailing-list-subscriptions</report>
         </widget>
       </column>
--->
-<!--
       <column class="small-12 medium-6 cell">
         <widget name="siteStats" class="stats card">
           <title>Daily Active Users</title>
@@ -899,7 +896,6 @@
           <report>dau</report>
         </widget>
       </column>
--->
       <column class="small-12 medium-6 cell">
         <widget name="siteStats" class="stats card">
           <title>Monthly Active Users</title>
@@ -1068,7 +1064,6 @@
           <limit>10</limit>
         </widget>
       </column>
-      <!--
       <column class="small-12 medium-12 large-6 cell">
         <widget name="siteStats" class="stats card">
           <icon>fa-sticky-note-o</icon>
@@ -1079,7 +1074,6 @@
           <limit>10</limit>
         </widget>
       </column>
-      -->
     </section>
   </page>
 


### PR DESCRIPTION
## Problem

Closes #680. `SiteStatsWidget.runReport()` fully implements the `dau`, `daily-mailing-list-subscriptions`, and `web-pages` report keys, but their `admin-layout.xml` tiles are wrapped in `<!-- -->` with no explanatory comment — unlike the `conversion-rate` tile nearby, whose comment explains exactly why it's disabled (needs a page+form pairing configured, not ready).

`git log -S` on each `<report>...</report>` string shows no toggle anywhere in this repo's history — they were already commented out as of the very first commit ("Initial public code drop"), so the original reason predates this repository and isn't recoverable from git.

The 4th key covered by #680, `locations-list`, was already wired up separately by #713 (merged shortly after #680 was filed; that PR just didn't reference the issue, so it stayed open). Left a comment on #680 documenting that.

## Fix

Remove the `<!-- -->` wrapper around the three `<column>` blocks — no other changes. Each mirrors an already-live sibling report exactly:

- `dau` ↔ `mau` (`UserLoginRepository.findUniqueDailyLogins`/`findUniqueMonthlyLogins`)
- `daily-mailing-list-subscriptions` ↔ `monthly-mailing-list-subscriptions` (`MailingListMemberRepository.findDailySubscriptions`/`findMonthlySubscriptions`)
- `web-pages` ↔ `referrals` (both simple `TABLE_JSP` report tiles, `WebPageHitRepository.findTopWebPages`/`SessionRepository.findTopReferrals`)

`conversion-rate` is intentionally left alone.

## Testing

- `xmllint --noout` on the edited file: well-formed.
- `ant -lib lib/war compile-jsp`: passes (JSP syntax gate).
- `ant -lib lib/war -lib lib/tests ci-test`: full suite green, 0 failures. (No Java code changed, so no new/updated tests — this is a pure layout-XML change re-enabling already-implemented, already-tested report logic.)
- **Could not live-verify the rendered tiles in a docker-compose rehearsal** — Docker Hub pulls of the pinned `tomcat:11.0-jdk21` base image consistently failed with `DeadlineExceeded` in this environment (a registry/network issue, reproduced 3 times across two different base images, unrelated to this change). Saying so explicitly rather than claiming a check that didn't happen. The change itself is minimal (six comment-marker lines removed, no logic touched) and each report mirrors an already-working sibling exactly, but a visual check of the actual rendered dashboard is still worth doing before merge if a working rehearsal environment is available.