### PR TITLE
Add direct test coverage for the Page-overload role-gate denial path

### DIFF
--- a/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
@@ -460,4 +460,45 @@ class WebComponentCommandTest {
     Assertions.assertTrue(WebComponentCommand.allowsUser(page, userSession),
         "the Page-specific overload must read page.getCapabilities(), not just page.getRoles()");
   }
+
+  // PageServlet's page-level access check (the "PAGE NOT ALLOWED" 404 gate, checked once per
+  // request before any widget's execute()/post()/delete() runs) calls this exact Page overload.
+  // #799/#800 removed several widgets' own redundant in-code hasRole("admin") checks on the theory
+  // that this page-level gate already covers admin-only pages like /admin/allowed-ip-list and
+  // /admin/blocked-ip-list on its own -- these two tests prove that for the Page overload
+  // specifically, not just the underlying List<String> overload userDoesNotHaveRoleTest covers.
+
+  @Test
+  void pageOverloadDeniesAUserWithoutTheRequiredRole() {
+    UserSession userSession = sessionWithRoles("content-manager"); // logged in, but not admin
+
+    Page page = new Page("/admin/allowed-ip-list", null, null);
+    page.setRoles(List.of("admin"));
+
+    Assertions.assertFalse(WebComponentCommand.allowsUser(page, userSession));
+  }
+
+  @Test
+  void pageOverloadAllowsAUserWithTheRequiredRole() {
+    UserSession userSession = sessionWithRoles("admin");
+
+    Page page = new Page("/admin/allowed-ip-list", null, null);
+    page.setRoles(List.of("admin"));
+
+    Assertions.assertTrue(WebComponentCommand.allowsUser(page, userSession));
+  }
+
+  private static UserSession sessionWithRoles(String... roleCodes) {
+    List<Role> roleList = new ArrayList<>();
+    for (String code : roleCodes) {
+      roleList.add(new Role(code, code));
+    }
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(roleList);
+    user.setGroupList(new ArrayList<>());
+    UserSession userSession = new UserSession();
+    userSession.login(user);
+    return userSession;
+  }
 }


### PR DESCRIPTION
## Context

While reviewing #800 (the root-cause fix for #799's Delete-dispatch bug), I checked its removal of `AllowedIPListWidget`/`BlockedIPListWidget`'s in-code `hasRole("admin")` checks against PR #800's own safety claim -- that authorization for admin-only pages is enforced once, at the page level, not inside individual widgets.

Traced it end to end: `PageServlet.java`'s "PAGE NOT ALLOWED" check (`WebComponentCommand.allowsUser(pageRef, userSession)`) runs before any widget's `execute()`/`post()`/`delete()`, for every HTTP method, and hard-404s a non-admin hitting `/admin/allowed-ip-list` or `/admin/blocked-ip-list`. That confirms #800 introduced no regression -- the in-widget checks it removed were genuinely redundant.

But `WebComponentCommandTest` had a gap: `userDoesNotHaveRoleTest` covers the denial logic for the underlying `List<String>` overload, and `pageOverloadReadsCapabilitiesFromThePageItself` covers the `Page`-typed overload's *allow* path (via a capability) -- but nothing exercised the `Page` overload's *denial* path directly, even though that's the exact call shape `PageServlet` actually uses for this gate.

## Change

Two small tests on `WebComponentCommandTest`, modeled on the page.xml role config for `/admin/allowed-ip-list` (`role="admin"`):
- `pageOverloadDeniesAUserWithoutTheRequiredRole` -- a logged-in non-admin user is denied
- `pageOverloadAllowsAUserWithTheRequiredRole` -- an admin user is allowed (paired for symmetry, so a future "always deny" bug wouldn't hide behind an untested allow path either)

## Testing

- Full `ant -lib lib/war -lib lib/tests clean ci-test`: green, 1392 tests, 0 failures.
- Verified the new tests actually catch a regression, not just pass trivially: temporarily stubbed `WebComponentCommand.allowsUser(Page, UserSession)` to always return `true`, confirmed exactly `pageOverloadDeniesAUserWithoutTheRequiredRole` failed (1 failure), then reverted -- `git diff` on the production file is clean.