### PR TITLE
Re-enable the compact calendar view on /admin/calendars

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1328,7 +1328,7 @@
     <section>
       <column class="small-12 cell">
         <widget name="calendar">
-          <!--<view>small</view>-->
+          <view>small</view>
         </widget>
       </column>
     </section>


### PR DESCRIPTION
## Problem

Closes #687. `CalendarWidget`'s `view=small` preference (dispatches to `small-calendar.jsp` with a default 550px height) has been fully implemented since this repo's initial commit, but the `<view>small</view>` setting on `/admin/calendars` was commented out with no explanatory comment. `git log -S` shows no toggle anywhere in this repo's history — the original reason predates it and isn't recoverable.

The issue itself flagged this as needing more care than a typical "just uncomment it" fix, since it suspected a real reason ("likely the fixed height cap didn't fit") rather than an accidental gap.

## What I checked before touching it

Live-verified in a docker-compose rehearsal, comparing the compact view against what's currently shown: the compact view renders as a normal, fully functional month calendar — correct grid, events display correctly (tested with the seeded Independence Day/Independence Day-observed holidays), Month/List/Today navigation all present, and the calendar-list table below it unaffected. No visible height-cap, overflow, or layout issue at the default 550px height. The suspected reason for disabling it doesn't reproduce.

## Fix

Remove the `<!-- -->` wrapper around `<view>small</view>` — no other changes.

## Testing

- `xmllint --noout`: well-formed.
- `ant -lib lib/war compile-jsp`: passes.
- Live-verified in docker (see above) — screenshots available if useful, not attached here.
- No Java changes, so no new/updated unit tests.