### PR TITLE
Add status, search/filter, and import audit to mailing list member view

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
@@ -47,6 +47,14 @@ public class MailingListMember extends Entity {
 
   /** Only populated by queries that join to emails -- not a mailing_list_members column. */
   private String emailAddress = null;
+  private String firstName = null;
+  private String lastName = null;
+  private String organization = null;
+  private String ipAddress = null;
+  /** The vendor's deliverability classification for this email address (e.g. ZeroBounce); see
+   *  emails.validation_status. A property of the address itself, not of this one membership --
+   *  quarantineReason above is the list-membership-specific consequence of a bad classification. */
+  private String validationStatus = null;
 
   public MailingListMember() {
   }
@@ -177,5 +185,45 @@ public class MailingListMember extends Entity {
 
   public void setEmailAddress(String emailAddress) {
     this.emailAddress = emailAddress;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getOrganization() {
+    return organization;
+  }
+
+  public void setOrganization(String organization) {
+    this.organization = organization;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public void setIpAddress(String ipAddress) {
+    this.ipAddress = ipAddress;
+  }
+
+  public String getValidationStatus() {
+    return validationStatus;
+  }
+
+  public void setValidationStatus(String validationStatus) {
+    this.validationStatus = validationStatus;
   }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -218,6 +218,8 @@ public class MailingListMemberRepository {
       record.setUnsubscribedBy(rs.getLong("unsubscribed_by"));
       record.setUnsubscribeReason(rs.getString("unsubscribe_reason"));
       record.setIsValid(rs.getBoolean("is_valid"));
+      record.setQuarantined(rs.getTimestamp("quarantined"));
+      record.setQuarantineReason(rs.getString("quarantine_reason"));
       record.setUnsubscribeToken(rs.getString("unsubscribe_token"));
       record.setEmailAddress(rs.getString("email_address"));
       return record;
@@ -225,6 +227,73 @@ public class MailingListMemberRepository {
       LOG.error("buildRecordWithEmail", se);
       return null;
     }
+  }
+
+  /** Like {@link #buildRecordWithEmail}, plus the emails-table display/classification columns
+   *  needed to render a per-list member table (name, organization, IP, deliverability status). */
+  private static MailingListMember buildRecordWithEmailDetails(ResultSet rs) {
+    try {
+      MailingListMember record = buildRecordWithEmail(rs);
+      if (record == null) {
+        return null;
+      }
+      record.setFirstName(rs.getString("first_name"));
+      record.setLastName(rs.getString("last_name"));
+      record.setOrganization(rs.getString("organization"));
+      record.setIpAddress(rs.getString("ip_address"));
+      record.setValidationStatus(rs.getString("validation_status"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecordWithEmailDetails", se);
+      return null;
+    }
+  }
+
+  /**
+   * Members of a list for the admin member-management table (issue #763): supports the same
+   * name/email search {@link com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository}
+   * offers on the cross-list search flow, plus a status filter over this table's own
+   * quarantined/unsubscribed columns (a property of this one list membership, not of the email
+   * address globally -- see the quarantine migration's own comment on why that distinction matters).
+   */
+  public static List<MailingListMember> findAll(MailingListMemberSpecification specification, DataConstraints constraints) {
+    SqlUtils select = new SqlUtils().addNames(
+        "emails.email AS email_address", "first_name", "last_name", "organization", "ip_address", "validation_status");
+    SqlJoins joins = new SqlJoins().add(JOIN);
+    SqlUtils where = new SqlUtils();
+    if (specification != null) {
+      if (specification.getMailingListId() > -1) {
+        where.add("mailing_list_members.list_id = ?", specification.getMailingListId());
+      }
+      if (StringUtils.isNotBlank(specification.getMatchesEmail())) {
+        where.add("LOWER(emails.email) = LOWER(?)", specification.getMatchesEmail().trim());
+      }
+      if (StringUtils.isNotBlank(specification.getMatchesName())) {
+        // Same escaped LIKE pattern as EmailRepository's cross-list name search
+        String likeValue = specification.getMatchesName().trim()
+            .replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_")
+            .replace("[", "![");
+        where.add("LOWER(concat_ws(' ', first_name, last_name)) LIKE LOWER(?) ESCAPE '!'", "%" + likeValue + "%");
+      }
+      if ("quarantined".equals(specification.getStatus())) {
+        where.add("mailing_list_members.quarantined IS NOT NULL");
+      } else if ("unsubscribed".equals(specification.getStatus())) {
+        where.add("mailing_list_members.unsubscribed IS NOT NULL");
+      } else if ("active".equals(specification.getStatus())) {
+        where.add("mailing_list_members.quarantined IS NULL");
+        where.add("mailing_list_members.unsubscribed IS NULL");
+      }
+    }
+    if (constraints == null) {
+      constraints = new DataConstraints();
+    }
+    constraints.setDefaultColumnToSortBy("mailing_list_members.created desc");
+    DataResult result = DB.selectAllFrom(TABLE_NAME, select, joins, where, null, constraints,
+        MailingListMemberRepository::buildRecordWithEmailDetails);
+    List<MailingListMember> members = (List<MailingListMember>) result.getRecords();
+    return members != null ? members : new ArrayList<>();
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberSpecification.java
@@ -25,6 +25,10 @@ package com.simisinc.platform.infrastructure.persistence.mailinglists;
 public class MailingListMemberSpecification {
 
   private long mailingListId = -1;
+  private String matchesEmail = null;
+  private String matchesName = null;
+  /** One of "quarantined" / "unsubscribed" / "active", or null/blank for no status filter. */
+  private String status = null;
 
   public MailingListMemberSpecification() {
   }
@@ -35,5 +39,29 @@ public class MailingListMemberSpecification {
 
   public void setMailingListId(long mailingListId) {
     this.mailingListId = mailingListId;
+  }
+
+  public String getMatchesEmail() {
+    return matchesEmail;
+  }
+
+  public void setMatchesEmail(String matchesEmail) {
+    this.matchesEmail = matchesEmail;
+  }
+
+  public String getMatchesName() {
+    return matchesName;
+  }
+
+  public void setMatchesName(String matchesName) {
+    this.matchesName = matchesName;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
@@ -26,6 +26,7 @@ import com.simisinc.platform.application.mailinglists.SaveEmailCommand;
 import com.simisinc.platform.domain.model.BlockedIP;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.*;
@@ -74,13 +75,31 @@ public class MailingListMembersWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("mailingList", mailingList);
 
-    // Determine criteria
-    EmailSpecification specification = new EmailSpecification();
-    specification.setMailingListId(mailingList.getId());
+    // Determine the search/filter criteria (GET, so it's bookmarkable and survives paging --
+    // see recordPagingParams below, which must carry these or they'd silently reset on page 2+)
+    String searchName = context.getParameter("searchName");
+    String searchEmail = context.getParameter("searchEmail");
+    String status = context.getParameter("status");
+    context.getRequest().setAttribute("searchName", searchName);
+    context.getRequest().setAttribute("searchEmail", searchEmail);
+    context.getRequest().setAttribute("status", status);
 
-    // Load the email addresses
-    List<Email> emailList = EmailRepository.findAll(specification, constraints);
-    context.getRequest().setAttribute("emailList", emailList);
+    // Determine criteria
+    MailingListMemberSpecification specification = new MailingListMemberSpecification();
+    specification.setMailingListId(mailingList.getId());
+    if (StringUtils.isNotBlank(searchName)) {
+      specification.setMatchesName(searchName);
+    }
+    if (StringUtils.isNotBlank(searchEmail)) {
+      specification.setMatchesEmail(searchEmail);
+    }
+    if (StringUtils.isNotBlank(status)) {
+      specification.setStatus(status);
+    }
+
+    // Load the list's members
+    List<MailingListMember> memberList = MailingListMemberRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("memberList", memberList);
 
     // Standard request items
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
@@ -163,8 +182,14 @@ public class MailingListMembersWidget extends GenericWidget {
     try {
       int memberCount = ProcessEmailCSVFileCommand.processCSV(context, mailingList);
       context.setSuccessMessage(memberCount + " email" + (memberCount != 1 ? "s" : "") + " added");
+      // Record the import of mailing-list member PII (email, name), mirroring downloadCSVFile's
+      // data.export below -- data.import didn't exist anywhere in the codebase before this
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.import", AuditEventCommand.SUCCESS,
+          "mailing_list_members", String.valueOf(mailingList.getId()), mailingList.getName(), "memberCount=" + memberCount);
     } catch (Exception e) {
       context.setErrorMessage(e.getMessage());
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "data.import", AuditEventCommand.FAILURE,
+          "mailing_list_members", String.valueOf(mailingList.getId()), mailingList.getName(), e.getMessage());
     }
     // Determine the page to return to
     context.setRedirect("/admin/mailing-list-members?mailingListId=" + mailingList.getId());

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -18,10 +18,11 @@
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
 <%@ taglib prefix="geoip" uri="/WEB-INF/tlds/geoip-functions.tld" %>
+<%@ taglib prefix="url" uri="/WEB-INF/tlds/url-functions.tld" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="mailingList" class="com.simisinc.platform.domain.model.mailinglists.MailingList" scope="request"/>
-<jsp:useBean id="emailList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="memberList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
@@ -53,11 +54,38 @@
     document.getElementById("fileForm").submit();
   }
 </script>
+<%-- Search/filter (GET so the query lives in the URL and paging preserves it) --%>
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <input type="hidden" name="mailingListId" value="${mailingList.id}"/>
+  <div class="grid-x grid-margin-x">
+    <div class="cell medium-4">
+      <label for="memberSearchName" class="show-for-sr">Search by name</label>
+      <input id="memberSearchName" type="search" name="searchName" placeholder="Search by name..."<c:if test="${!empty searchName}"> value="<c:out value="${searchName}"/>"</c:if>>
+    </div>
+    <div class="cell medium-4">
+      <label for="memberSearchEmail" class="show-for-sr">Search by email</label>
+      <input id="memberSearchEmail" type="search" name="searchEmail" placeholder="Search by email..."<c:if test="${!empty searchEmail}"> value="<c:out value="${searchEmail}"/>"</c:if>>
+    </div>
+    <div class="cell medium-3">
+      <label for="memberStatus" class="show-for-sr">Filter by status</label>
+      <select id="memberStatus" name="status">
+        <option value="">All statuses</option>
+        <option value="active"<c:if test="${status eq 'active'}"> selected</c:if>>Active</option>
+        <option value="unsubscribed"<c:if test="${status eq 'unsubscribed'}"> selected</c:if>>Unsubscribed</option>
+        <option value="quarantined"<c:if test="${status eq 'quarantined'}"> selected</c:if>>Quarantined</option>
+      </select>
+    </div>
+    <div class="cell medium-1">
+      <button type="submit" class="button expanded">Search</button>
+    </div>
+  </div>
+</form>
 <table>
   <thead>
     <tr>
       <th>Name</th>
       <th>Email</th>
+      <th>Status</th>
       <th>Location</th>
       <th width="120">IP Address</th>
       <th width="200">Added</th>
@@ -65,38 +93,53 @@
     </tr>
   </thead>
   <tbody>
-    <c:forEach items="${emailList}" var="email">
+    <c:forEach items="${memberList}" var="member">
     <tr>
       <td>
-        <c:out value="${email.firstName}" />
+        <c:out value="${member.firstName}" />
       </td>
       <td>
-        <%--<a href="${ctx}/admin/mailing-list-email-details?userId=${email.id}"><c:out value="${email.email}" /></a>--%>
-        <c:out value="${email.email}" />
-        <c:if test="${!empty email.organization}">
-          <br /><small class="subheader"><c:out value="${email.organization}" /></small>
+        <c:out value="${member.emailAddress}" />
+        <c:if test="${!empty member.organization}">
+          <br /><small class="subheader"><c:out value="${member.organization}" /></small>
         </c:if>
       </td>
-      <td><small><c:out value="${geoip:location(email.ipAddress, '--')}"/></small></td>
-      <td><small><c:out value="${empty email.ipAddress ? '--' : email.ipAddress}" /></small></td>
-      <td><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${email.created}" /></td>
       <td>
-        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape(email.email)}" />?');" title="Remove member"><i class="fa fa-remove"></i></a>
-        <c:if test="${!empty email.ipAddress}">
-          <a href="#" onclick="return confirmPostAction('Block IP <c:out value="${js:escape(email.ipAddress)}" />? This will prevent that IP from accessing the site. The member itself is not removed.', '${widgetContext.uri}?command=blockIP&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${email.id}');" title="Block this IP"><i class="fa fa-ban"></i></a>
+        <c:choose>
+          <c:when test="${!empty member.quarantined}">
+            <span class="label alert" title="Quarantined: <c:out value="${member.quarantineReason}"/>">Quarantined</span>
+          </c:when>
+          <c:when test="${!empty member.unsubscribed}">
+            <span class="label warning">Unsubscribed</span>
+          </c:when>
+          <c:when test="${!empty member.validationStatus && member.validationStatus ne 'valid'}">
+            <span class="label warning" title="Deliverability: <c:out value="${member.validationStatus}"/>">Flagged</span>
+          </c:when>
+          <c:otherwise>
+            <span class="label success">Active</span>
+          </c:otherwise>
+        </c:choose>
+      </td>
+      <td><small><c:out value="${geoip:location(member.ipAddress, '--')}"/></small></td>
+      <td><small><c:out value="${empty member.ipAddress ? '--' : member.ipAddress}" /></small></td>
+      <td><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${member.created}" /></td>
+      <td>
+        <a href="${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${member.emailId}" onclick="return confirm('Are you sure you want to remove <c:out value="${js:escape(member.emailAddress)}" />?');" title="Remove member"><i class="fa fa-remove"></i></a>
+        <c:if test="${!empty member.ipAddress}">
+          <a href="#" onclick="return confirmPostAction('Block IP <c:out value="${js:escape(member.ipAddress)}" />? This will prevent that IP from accessing the site. The member itself is not removed.', '${widgetContext.uri}?command=blockIP&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&mailingListId=${mailingList.id}&emailId=${member.emailId}');" title="Block this IP"><i class="fa fa-ban"></i></a>
         </c:if>
       </td>
     </tr>
     </c:forEach>
-    <c:if test="${empty emailList}">
+    <c:if test="${empty memberList}">
       <tr>
-        <td colspan="6">No members were found</td>
+        <td colspan="7"><c:choose><c:when test="${!empty searchName || !empty searchEmail || !empty status}">No members matched your search</c:when><c:otherwise>No members were found</c:otherwise></c:choose></td>
       </tr>
     </c:if>
   </tbody>
 </table>
-<%-- Paging Control --%>
-<c:set var="recordPagingParams" scope="request" value="mailingListId=${mailingList.id}"/>
+<%-- Paging Control -- must carry every active search/filter param, or they silently reset on page 2+ --%>
+<c:set var="recordPagingParams" scope="request">mailingListId=${mailingList.id}<c:if test="${!empty searchName}">&searchName=${url:encodeUri(searchName)}</c:if><c:if test="${!empty searchEmail}">&searchEmail=${url:encodeUri(searchEmail)}</c:if><c:if test="${!empty status}">&status=${url:encodeUri(status)}</c:if></c:set>
 <%@include file="../paging_control.jspf" %>
 <div class="reveal small" id="formReveal" data-reveal data-close-on-click="false" data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-labelledby="mailingFormRevealTitle">
   <button class="close-button" data-close aria-label="Close modal" type="button">

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
@@ -454,6 +454,8 @@ class NewsletterSendQueueRepositoryTest {
           + "unsubscribed_by BIGINT, "
           + "unsubscribe_reason VARCHAR(100), "
           + "is_valid BOOLEAN DEFAULT true, "
+          + "quarantined TIMESTAMP(3), "
+          + "quarantine_reason VARCHAR(50), "
           + "unsubscribe_token VARCHAR(255))");
       statement.execute("CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id)");
       statement.execute("CREATE UNIQUE INDEX mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token)");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
@@ -37,6 +38,7 @@ import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberSpecification;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -203,7 +205,8 @@ class MailingListMembersWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "mailingListId", "1");
 
     try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
-        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class)) {
+        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
       processCsv.when(() -> ProcessEmailCSVFileCommand.processCSV(any(), any())).thenReturn(3);
 
@@ -211,6 +214,10 @@ class MailingListMembersWidgetTest extends WidgetBase {
 
       assertEquals("/admin/mailing-list-members?mailingListId=1", result.getRedirect());
       assertEquals("3 emails added", result.getSuccessMessage());
+      // #763: data.import didn't exist anywhere in the codebase before this -- CSV imports of
+      // member PII must be as traceable as the existing data.export download already is.
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("data.import"), eq(AuditEventCommand.SUCCESS),
+          eq("mailing_list_members"), eq("1"), eq("Newsletter"), eq("memberCount=3")));
     }
   }
 
@@ -221,7 +228,8 @@ class MailingListMembersWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "mailingListId", "1");
 
     try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
-        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class)) {
+        MockedStatic<ProcessEmailCSVFileCommand> processCsv = mockStatic(ProcessEmailCSVFileCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
       processCsv.when(() -> ProcessEmailCSVFileCommand.processCSV(any(), any()))
           .thenThrow(new DataException("Valid file not found"));
@@ -230,6 +238,56 @@ class MailingListMembersWidgetTest extends WidgetBase {
 
       assertEquals("/admin/mailing-list-members?mailingListId=1", result.getRedirect());
       assertEquals("Valid file not found", result.getErrorMessage());
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("data.import"), eq(AuditEventCommand.FAILURE),
+          eq("mailing_list_members"), eq("1"), eq("Newsletter"), eq("Valid file not found")));
+    }
+  }
+
+  // #763: search/filter on the per-list member table, reusing the same matchesEmail/matchesName
+  // shape EmailSpecification already offered on the cross-list search flow (MailingListsWidget),
+  // plus a status filter over this table's own quarantined/unsubscribed columns.
+
+  @Test
+  void executePassesSearchAndStatusParamsToTheSpecification() {
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "searchName", "Jane Doe");
+    addQueryParameter(widgetContext, "searchEmail", "jane@example.com");
+    addQueryParameter(widgetContext, "status", "quarantined");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      memberRepo.when(() -> MailingListMemberRepository.findAll(any(), any())).thenReturn(new java.util.ArrayList<>());
+
+      new MailingListMembersWidget().execute(widgetContext);
+
+      ArgumentCaptor<MailingListMemberSpecification> captor = ArgumentCaptor.forClass(MailingListMemberSpecification.class);
+      memberRepo.verify(() -> MailingListMemberRepository.findAll(captor.capture(), any()));
+      MailingListMemberSpecification specification = captor.getValue();
+      assertEquals(1L, specification.getMailingListId());
+      assertEquals("Jane Doe", specification.getMatchesName());
+      assertEquals("jane@example.com", specification.getMatchesEmail());
+      assertEquals("quarantined", specification.getStatus());
+    }
+  }
+
+  @Test
+  void executeLeavesFiltersUnsetWhenNoSearchParamsAreGiven() {
+    addQueryParameter(widgetContext, "mailingListId", "1");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      memberRepo.when(() -> MailingListMemberRepository.findAll(any(), any())).thenReturn(new java.util.ArrayList<>());
+
+      new MailingListMembersWidget().execute(widgetContext);
+
+      ArgumentCaptor<MailingListMemberSpecification> captor = ArgumentCaptor.forClass(MailingListMemberSpecification.class);
+      memberRepo.verify(() -> MailingListMemberRepository.findAll(captor.capture(), any()));
+      MailingListMemberSpecification specification = captor.getValue();
+      assertNull(specification.getMatchesName());
+      assertNull(specification.getMatchesEmail());
+      assertNull(specification.getStatus());
     }
   }
 


### PR DESCRIPTION
Closes #763 (narrow follow-up to #462, which is being closed as superseded).

## The three confirmed gaps

1. **Surface status in the member table.** The backing data already existed (`mailing_list_members.quarantined`/`quarantine_reason`, `emails.validation_status`) but nothing displayed it. Found and fixed a pre-existing gap while wiring this up: `MailingListMemberRepository.buildRecordWithEmail` never actually populated `quarantined`/`quarantine_reason` onto the `MailingListMember` it builds, despite the model having those fields since the quarantine migration -- so this data was silently unavailable to every caller, not just this new column.

2. **Search/filter scoped to one list's members.** Reuses the exact `matchesEmail`/`matchesName` shape `EmailSpecification` already offers on the cross-list search flow (`MailingListsWidget`), plus a new status filter over `mailing_list_members`' own `quarantined`/`unsubscribed` columns (a property of this one list membership, not of the email address globally). Switches the widget's query from `EmailRepository` (global, no per-list status) to a new `MailingListMemberRepository.findAll`.

3. **Audit-log the CSV import path.** Adds a `data.import` event, mirroring the `data.export` event this same widget already records for CSV download -- `data.import` didn't exist anywhere in the codebase before this.

## A landmine avoided

`paging_control.jspf` silently drops any param not listed in `recordPagingParams`, resetting filters on page 2+ (a known gotcha in this codebase). Fixed `recordPagingParams` to carry the new search/status params across pages, and verified live that it actually works, not just that the link looks right.

## Testing

- New/updated unit tests: `MailingListMembersWidgetTest` covers the search-param-to-specification wiring and the new `data.import` audit calls (success and failure).
- `NewsletterSendQueueRepositoryTest`'s hand-rolled `mailing_list_members` Testcontainers schema predated the quarantine migration and was missing `quarantined`/`quarantine_reason` -- the `buildRecordWithEmail` fix above now reads those columns, which surfaced the gap as a real test failure. Updated the schema to match the real current table.
- Full `ant -lib lib/war -lib lib/tests clean ci-test`: green, 1392 tests, 0 failures. `ant -lib lib/war package` (JSP compile gate): green.
- Live-verified in a docker-compose rehearsal against a real Postgres instance: seeded members in all 4 status states (active, unsubscribed, quarantined, flagged-but-not-yet-quarantined) and confirmed each renders the correct badge; confirmed search-by-name, exact search-by-email, and the status filter all correctly narrow the real query; confirmed the empty-search-results message; confirmed pagination genuinely preserves an active filter across pages (not just that the generated link looks right -- followed it and got the correct second page of results); confirmed a real CSV import failure lands a `data.import` failure event in `audit_log` with the real error message (the success path is covered by the unit test).

## Not included (per the issue's own explicit scope)

- A `notes` field, JSON import/export, and a single unified status enum column are all explicitly called out in #763 as optional/not required, since the status is already fully queryable via the existing distributed columns. Left out accordingly.