### PR TITLE
Audit mailing-list entity create/edit/delete

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListFormWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.application.mailinglists.SaveMailingListCommand;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.beanutils.BeanUtils;
 
@@ -66,6 +67,9 @@ public class MailingListFormWidget extends GenericWidget {
     BeanUtils.populate(mailingListBean, context.getParameterMap());
     mailingListBean.setCreatedBy(context.getUserId());
 
+    // An existing id means an edit; a new record is a create
+    String eventType = mailingListBean.getId() > -1 ? "mailing_list.update" : "mailing_list.create";
+
     // Save the record
     MailingList mailingList = null;
     try {
@@ -74,10 +78,15 @@ public class MailingListFormWidget extends GenericWidget {
         throw new AppException("Your information could not be saved due to a system error. Please try again.");
       }
     } catch (DataException | AppException e) {
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, eventType, AuditEventCommand.FAILURE,
+          "mailing_list", String.valueOf(mailingListBean.getId()), mailingListBean.getName(), e.getMessage());
       context.setErrorMessage(e.getMessage());
       context.setRequestObject(mailingListBean);
       return context;
     }
+
+    AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, eventType, AuditEventCommand.SUCCESS,
+        "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(), null);
 
     // Determine the page to return to
     context.setSuccessMessage("Mailing list was saved");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidget.java
@@ -24,6 +24,7 @@ import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailReposi
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailSpecification;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -111,10 +112,17 @@ public class MailingListsWidget extends GenericWidget {
       } else {
         if (mailingList.getMemberCount() > 10) {
           context.setWarningMessage("Mailing list cannot be deleted, there are related records");
+          AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "mailing_list.delete", AuditEventCommand.FAILURE,
+              "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(),
+              "refused: memberCount=" + mailingList.getMemberCount());
         } else if (DeleteMailingListCommand.delete(mailingList)) {
           context.setSuccessMessage("Mailing list deleted");
+          AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "mailing_list.delete", AuditEventCommand.SUCCESS,
+              "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(), null);
         } else {
           context.setWarningMessage("Mailing list could not be deleted, there are dependencies");
+          AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "mailing_list.delete", AuditEventCommand.FAILURE,
+              "mailing_list", String.valueOf(mailingList.getId()), mailingList.getName(), "refused: dependencies");
         }
       }
     }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListFormWidgetTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.mailinglists.SaveMailingListCommand;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * #753: creating, editing, or deleting a mailing list was completely unaudited. These tests cover
+ * create and update -- {@link MailingListsWidgetTest} covers delete.
+ *
+ * @author elizabeth houser
+ */
+class MailingListFormWidgetTest extends WidgetBase {
+
+  @Test
+  void postRecordsMailingListCreateOnSuccess() throws Exception {
+    addQueryParameter(widgetContext, "name", "Newsletter");
+    // No "id" parameter -- a new record
+
+    MailingList saved = new MailingList();
+    saved.setId(5L);
+    saved.setName("Newsletter");
+
+    try (MockedStatic<SaveMailingListCommand> saveCommand = mockStatic(SaveMailingListCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      saveCommand.when(() -> SaveMailingListCommand.saveMailingList(any())).thenReturn(saved);
+
+      WidgetContext result = new MailingListFormWidget().post(widgetContext);
+
+      assertEquals("Mailing list was saved", result.getSuccessMessage());
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.create"), eq(AuditEventCommand.SUCCESS),
+          eq("mailing_list"), eq("5"), eq("Newsletter"), any()));
+    }
+  }
+
+  @Test
+  void postRecordsMailingListUpdateOnSuccess() throws Exception {
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "name", "Newsletter Renamed");
+
+    MailingList saved = new MailingList();
+    saved.setId(5L);
+    saved.setName("Newsletter Renamed");
+
+    try (MockedStatic<SaveMailingListCommand> saveCommand = mockStatic(SaveMailingListCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      saveCommand.when(() -> SaveMailingListCommand.saveMailingList(any())).thenReturn(saved);
+
+      WidgetContext result = new MailingListFormWidget().post(widgetContext);
+
+      assertEquals("Mailing list was saved", result.getSuccessMessage());
+      // An existing id means this is an edit, not a create -- must be audited as such
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.update"), eq(AuditEventCommand.SUCCESS),
+          eq("mailing_list"), eq("5"), eq("Newsletter Renamed"), any()));
+    }
+  }
+
+  @Test
+  void postRecordsMailingListCreateFailureWhenValidationFails() throws Exception {
+    // No "name" -- SaveMailingListCommand's own validation rejects this before touching the repository
+    try (MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      WidgetContext result = new MailingListFormWidget().post(widgetContext);
+
+      assertEquals("Please check the form and try again:\nA name is required", result.getErrorMessage());
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.create"), eq(AuditEventCommand.FAILURE),
+          eq("mailing_list"), any(), any(), eq("Please check the form and try again:\nA name is required")));
+    }
+  }
+
+  @Test
+  void postRecordsMailingListUpdateFailureWhenTheSaveThrows() throws Exception {
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "name", "Newsletter");
+
+    try (MockedStatic<SaveMailingListCommand> saveCommand = mockStatic(SaveMailingListCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      saveCommand.when(() -> SaveMailingListCommand.saveMailingList(any()))
+          .thenThrow(new DataException("The existing record could not be found"));
+
+      WidgetContext result = new MailingListFormWidget().post(widgetContext);
+
+      assertEquals("The existing record could not be found", result.getErrorMessage());
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.update"), eq(AuditEventCommand.FAILURE),
+          eq("mailing_list"), eq("5"), eq("Newsletter"), eq("The existing record could not be found")));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListsWidgetTest.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.mailinglists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import org.mockito.MockedStatic;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 /**
@@ -59,7 +61,8 @@ class MailingListsWidgetTest extends WidgetBase {
 
     MailingList list = mailingList(0);
 
-    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       repository.when(() -> MailingListRepository.findById(1L)).thenReturn(list);
       repository.when(() -> MailingListRepository.remove(list)).thenReturn(true);
 
@@ -68,6 +71,9 @@ class MailingListsWidgetTest extends WidgetBase {
       repository.verify(() -> MailingListRepository.remove(list), times(1));
       assertEquals("Mailing list deleted", result.getSuccessMessage());
       assertEquals("/admin/mailing-lists", result.getRedirect());
+      // #753: mailing-list entity CRUD was completely unaudited before this
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.delete"), eq(AuditEventCommand.SUCCESS),
+          eq("mailing_list"), eq("1"), eq("newsletter"), any()));
     }
   }
 
@@ -93,13 +99,16 @@ class MailingListsWidgetTest extends WidgetBase {
 
     MailingList list = mailingList(11);
 
-    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       repository.when(() -> MailingListRepository.findById(1L)).thenReturn(list);
 
       WidgetContext result = new MailingListsWidget().post(widgetContext);
 
       repository.verify(() -> MailingListRepository.remove(any()), never());
       assertEquals("Mailing list cannot be deleted, there are related records", result.getWarningMessage());
+      audit.verify(() -> AuditEventCommand.record(any(), any(), eq("mailing_list.delete"), eq(AuditEventCommand.FAILURE),
+          eq("mailing_list"), eq("1"), eq("newsletter"), any()));
     }
   }
 }


### PR DESCRIPTION
Closes #753 (split out of #461, same thread as #752).

## Problem

`SaveMailingListCommand.java`, `DeleteMailingListCommand.java`, and `MailingListFormWidget.java` had zero audit calls -- confirmed directly, not just taken from the issue. Only member-level actions (CSV export, the quarantine job, "Block IP") were logged; the list entity itself had no trail.

## Fix

Mirrors `GroupFormWidget`'s already-correct pattern for the identical shape (a form widget whose `post()` does create-or-update based on whether an id was submitted):

- `MailingListFormWidget.post()`: `mailing_list.create` or `mailing_list.update` (decided by `id > -1` *before* calling `SaveMailingListCommand`, same as `GroupFormWidget`), both SUCCESS and FAILURE outcomes.
- `MailingListsWidget.delete()`: `mailing_list.delete`, SUCCESS on an actual removal, FAILURE otherwise -- with the failure `details` distinguishing the two different reasons a delete can be refused (the memberCount>10 pre-check vs. a repository-level dependency failure), rather than collapsing both into one message.

All events use category `CONFIGURATION`, matching how other non-authorization admin-entity settings (theme, site properties) are categorized in this codebase.

## Testing

- New `MailingListFormWidgetTest` (create/update × success/failure, 4 tests).
- Updated `MailingListsWidgetTest`'s existing delete tests to verify the new audit calls.
- Full `ant -lib lib/war -lib lib/tests clean ci-test`: green, 1394 tests, 0 failures. `ant -lib lib/war package`: green.
- Live-verified in a docker-compose rehearsal against a real Postgres instance: created a list, renamed it, deleted it, and confirmed all three `mailing_list.create`/`update`/`delete` rows landed in `audit_log` in order with the correct target id and label (the label correctly reflects the rename by the time of the delete event).