### PR TITLE
Add a real widget-type picker to the legacy page designer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -253,6 +253,7 @@
         <include name="**/*.tld"/>
         <include name="**/*.mmdb"/>
         <include name="**/*.properties"/>
+        <include name="**/*.json"/>
       </fileset>
     </copy>
     <copy todir="${target.dir}/${project}/WEB-INF/classes">

--- a/src/main/java/com/simisinc/platform/application/cms/WebPageDesignerToXmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/WebPageDesignerToXmlCommand.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.application.cms;
 
+import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.presentation.controller.Column;
 import com.simisinc.platform.presentation.controller.Page;
@@ -40,7 +41,7 @@ public class WebPageDesignerToXmlCommand {
 
   private static Log LOG = LogFactory.getLog(WebPageDesignerToXmlCommand.class);
 
-  public static String convertFromBootstrapHtml(WebPage webPage, String content) {
+  public static String convertFromBootstrapHtml(WebPage webPage, String content) throws DataException {
 
     Page page = new Page();
     String uniqueIdPrefix = webPage.getLink().substring(1);
@@ -125,7 +126,7 @@ public class WebPageDesignerToXmlCommand {
     return WebPageDesignerToXmlCommand.toXml(page);
   }
 
-  private static Widget createWidget(String uniqueIdPrefix, int widgetCount, String thisWidget) {
+  private static Widget createWidget(String uniqueIdPrefix, int widgetCount, String thisWidget) throws DataException {
     Widget widget = new Widget();
     widget.setWidgetName("content");
     int widgetDataIdx = thisWidget.indexOf("data-widget=\"");
@@ -134,6 +135,13 @@ public class WebPageDesignerToXmlCommand {
       if (StringUtils.isNotBlank(widgetName)) {
         widget.setWidgetName(widgetName);
       }
+    }
+    // The client only offers registered widget types, but never trust it -- an unrecognized name
+    // would otherwise save successfully here and then vanish silently at render time with no error
+    // anywhere (XMLContainerCommands.appendWidgets() drops unknown widgets), which is exactly the
+    // kind of failure this legacy designer's save path (no draft/publish safety net) can't afford.
+    if (!WebPageXmlLayoutCommand.getWidgetLibrary().containsKey(widget.getWidgetName())) {
+      throw new DataException("Unknown widget type: " + widget.getWidgetName());
     }
     // Determine the widget preferences // ideally have a library of widgets and their preferences...
     String htmlContent = thisWidget.substring(25, thisWidget.indexOf("<!--/gm-editable-region-->"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidget.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
+import jakarta.servlet.ServletContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.InputStream;
@@ -58,6 +59,10 @@ public class WebPageDesignerWidget extends GenericWidget {
   static String RAW_XML_JSP = "/cms/web-page-editor.jsp";
   static String ACE_XML_EDITOR_JSP = "/cms/web-page-xml-editor.jsp";
   static String CODE_MIRROR_XML_EDITOR_JSP = "/cms/web-page-code-mirror-xml-editor.jsp";
+  static String WIDGET_SCHEMA_RESOURCE = "/WEB-INF/widgets/widget-schema.json";
+
+  // Loaded once and cached; the file is static content shipped with the app, not per-request data.
+  private static String widgetSchemaJson = null;
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -152,7 +157,22 @@ public class WebPageDesignerWidget extends GenericWidget {
       }
     }
     context.getRequest().setAttribute("webPage", webPage);
+    if (DESIGNER_JSP.equals(context.getJsp())) {
+      context.getRequest().setAttribute("widgetSchemaJson", loadWidgetSchemaJson(context.getRequest().getServletContext()));
+    }
     return context;
+  }
+
+  private static synchronized String loadWidgetSchemaJson(ServletContext servletContext) {
+    if (widgetSchemaJson == null) {
+      try (InputStream is = servletContext.getResourceAsStream(WIDGET_SCHEMA_RESOURCE)) {
+        widgetSchemaJson = IOUtils.toString(is, "UTF-8");
+      } catch (Exception e) {
+        LOG.error("Could not load " + WIDGET_SCHEMA_RESOURCE, e);
+        widgetSchemaJson = "{}";
+      }
+    }
+    return widgetSchemaJson;
   }
 
   public WidgetContext post(WidgetContext context) {
@@ -218,10 +238,10 @@ public class WebPageDesignerWidget extends GenericWidget {
         LOG.debug("Found designer content...");
         LOG.debug("Content found: " + pageDesignHtml);
       }
-      String pageXml = WebPageDesignerToXmlCommand.convertFromBootstrapHtml(webPage, pageDesignHtml);
-      LOG.debug("Converted to: " + pageXml);
-      webPage.setPageXml(pageXml);
       try {
+        String pageXml = WebPageDesignerToXmlCommand.convertFromBootstrapHtml(webPage, pageDesignHtml);
+        LOG.debug("Converted to: " + pageXml);
+        webPage.setPageXml(pageXml);
         SaveWebPageCommand.saveWebPage(webPage);
         context.setJson("[{\"status\":\"0\"}]");
       } catch (Exception e) {

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-designer.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-designer.jsp
@@ -21,17 +21,91 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="webPage" class="com.simisinc.platform.domain.model.cms.WebPage" scope="request"/>
+<jsp:useBean id="widgetSchemaJson" class="java.lang.String" scope="request"/>
 <link href="${ctx}/css/jquery-gridmanager-0.3.1/bootstrap.css" rel="stylesheet">
 <link href="${ctx}/css/jquery-gridmanager-0.3.1/jquery.gridmanager.css" rel="stylesheet">
 <script src="${ctx}/javascript/jquery-gridmanager-0.3.1/jquery-ui.js"></script>
 <script src="${ctx}/javascript/jquery-gridmanager-0.3.1/bootstrap.js"></script>
 <script src="${ctx}/javascript/jquery-gridmanager-0.3.1/jquery.gridmanager.js"></script>
+<%-- Static, developer-authored file (not user input) -- safe to embed unescaped as a JSON script body.
+     HTML-escaping it here would corrupt the JSON, since script content isn't entity-decoded. --%>
+<script type="application/json" id="widget-schema-json"><c:out value="${widgetSchemaJson}" escapeXml="false"/></script>
 <style>
   #designer-container {
     margin: auto;
     max-width: 1170px;
   }
   .margin-bottom-30 { margin-bottom: 30px !important; }
+
+  .widget-picker-overlay {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2000;
+  }
+  .widget-picker-panel {
+    background: #fff;
+    max-width: 420px;
+    max-height: 70vh;
+    margin: 8vh auto;
+    border-radius: 4px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .widget-picker-header {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem;
+    border-bottom: 1px solid #ddd;
+  }
+  .widget-picker-header input {
+    flex: 1;
+    margin: 0;
+  }
+  .widget-picker-close {
+    margin-left: 0.5rem;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #666;
+    text-decoration: none;
+  }
+  .widget-picker-list {
+    overflow-y: auto;
+    padding: 0.5rem 0.75rem 0.75rem;
+  }
+  .widget-picker-category {
+    margin: 0.75rem 0 0.25rem;
+    color: #666;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+  }
+  .widget-picker-items {
+    list-style: none;
+    margin: 0;
+  }
+  .widget-picker-items li a {
+    display: block;
+    padding: 0.4rem 0.5rem;
+    border-radius: 3px;
+    color: inherit;
+    text-decoration: none;
+  }
+  .widget-picker-items li a:hover,
+  .widget-picker-items li a:focus {
+    background: #f0f0f0;
+  }
+  .widget-picker-items li a i {
+    width: 1.25rem;
+    display: inline-block;
+    text-align: center;
+  }
+  .widget-picker-empty {
+    color: #666;
+    padding: 0.5rem;
+  }
 </style>
 <div id="designer-container">
   <c:if test="${!empty title}">
@@ -62,18 +136,128 @@
 </div>
 <script nonce="${cspNonce}">
 
-  function widget_callback(container, btnElem) {
-    // alert("The widget chooser is unavailable");
-    // alert('custom control: ' + btnElem.toString());
+  // The widget-type picker (issue #532). Widget metadata (label/category/icon) comes from
+  // widget-schema.json -- a curated, human-labeled catalog built for exactly this purpose but never
+  // wired to anything until now (the modern composition-canvas "+Widget" picker lists raw internal
+  // widget-library.xml names instead, with no icons/labels/categories -- this picker is deliberately
+  // NOT mirroring that rougher UX, since the schema gives a strictly better one for the same intent).
+  var widgetSchema = {};
+  try {
+    var schemaText = document.getElementById('widget-schema-json').textContent;
+    widgetSchema = (JSON.parse(schemaText || '{}').widgets) || {};
+  } catch (e) {
+    widgetSchema = {};
+  }
+
+  var widgetPickerContainer = null;
+
+  function buildWidgetPickerDom() {
+    var overlay = $('<div>', {id: 'widget-picker-overlay', 'class': 'widget-picker-overlay'});
+    var panel = $('<div>', {'class': 'widget-picker-panel'});
+    var searchInput = $('<input>', {type: 'text', id: 'widget-picker-search', placeholder: 'Search widget types…'});
+    var closeLink = $('<a>', {href: '#', 'class': 'widget-picker-close', 'aria-label': 'Close'}).html('&times;');
+    closeLink.on('click', function (e) {
+      e.preventDefault();
+      closeWidgetPicker();
+    });
+    var header = $('<div>', {'class': 'widget-picker-header'}).append(searchInput).append(closeLink);
+    var list = $('<div>', {id: 'widget-picker-list', 'class': 'widget-picker-list'});
+    panel.append(header).append(list);
+    overlay.append(panel);
+    overlay.on('click', function (e) {
+      if (e.target === overlay[0]) {
+        closeWidgetPicker();
+      }
+    });
+    $('body').append(overlay);
+    searchInput.on('input', function () {
+      renderWidgetPickerList($(this).val());
+    });
+    return overlay;
+  }
+
+  function renderWidgetPickerList(filterText) {
+    var list = $('#widget-picker-list');
+    list.empty();
+    var filter = (filterText || '').toLowerCase();
+    var byCategory = {};
+    Object.keys(widgetSchema).sort().forEach(function (name) {
+      var w = widgetSchema[name] || {};
+      var label = w.label || name;
+      if (filter && label.toLowerCase().indexOf(filter) === -1 && name.toLowerCase().indexOf(filter) === -1) {
+        return;
+      }
+      var category = w.category || 'Other';
+      if (!byCategory[category]) {
+        byCategory[category] = [];
+      }
+      byCategory[category].push({name: name, label: label, icon: w.icon});
+    });
+    var categories = Object.keys(byCategory).sort();
+    categories.forEach(function (category) {
+      list.append($('<h6>', {'class': 'widget-picker-category'}).text(category));
+      var ul = $('<ul>', {'class': 'widget-picker-items'});
+      byCategory[category].forEach(function (item) {
+        var link = $('<a>', {href: '#'})
+          .append($('<i>', {'class': '${font:far()} ' + (item.icon || 'fa-cube')}))
+          .append(' ' + item.label);
+        link.on('click', function (e) {
+          e.preventDefault();
+          insertWidget(item.name, item.label);
+          closeWidgetPicker();
+        });
+        ul.append($('<li>').append(link));
+      });
+      list.append(ul);
+    });
+    if (categories.length === 0) {
+      list.append($('<p>', {'class': 'widget-picker-empty'}).text('No matching widget types.'));
+    }
+  }
+
+  function openWidgetPicker(container) {
+    widgetPickerContainer = container;
+    if ($('#widget-picker-overlay').length === 0) {
+      buildWidgetPickerDom();
+    }
+    renderWidgetPickerList('');
+    $('#widget-picker-overlay').show();
+    $('#widget-picker-search').val('').trigger('focus');
+  }
+
+  function closeWidgetPicker() {
+    $('#widget-picker-overlay').hide();
+    widgetPickerContainer = null;
+  }
+
+  $(document).on('keydown', function (e) {
+    if (e.key === 'Escape' && $('#widget-picker-overlay').is(':visible')) {
+      closeWidgetPicker();
+    }
+  });
+
+  function insertWidget(widgetName, widgetLabel) {
+    var container = widgetPickerContainer;
+    if (!container) {
+      return;
+    }
     var gm = $("#mycanvas").data("gridmanager");
-    // gm.addEditableAreaClick(container, btnElem);
     var cTagOpen = '<!--' + gm.options.gmEditRegion + '-->',
       cTagClose = '<!--\/' + gm.options.gmEditRegion + '-->',
       elem = null;
+    // The data-widget attribute must be on the <h4>, not (only) on the wrapping gm-content div:
+    // gm.deinitCanvas() (called on Save) unwraps that div entirely, keeping only its children -- an
+    // attribute placed solely on the wrapper is silently lost before the server ever sees it. Confirmed
+    // live: the original hardcoded "prototype" insertion carried this same attribute on both the div and
+    // the <h4> for exactly this reason; it looked redundant and wasn't.
     $(('.' + gm.options.gmToolClass + ':last'), container)
       .before(elem = $('<div>').addClass(gm.options.gmEditRegion + ' ' + gm.options.contentDraggableClass)
-        .append(gm.options.controlContentElem + '<div class="' + gm.options.gmContentRegion + ' callout prototype" data-widget="prototype"><h4 data-widget="prototype">Headline</h4><p>Write a description</p></div>')).before(cTagClose).prev().before(cTagOpen);
+        .append(gm.options.controlContentElem + '<div class="' + gm.options.gmContentRegion + ' callout prototype" data-widget="' + widgetName + '"><h4 data-widget="' + widgetName + '">' + widgetLabel + '</h4><p>Write a description</p></div>')).before(cTagClose).prev().before(cTagOpen);
     gm.initNewContentElem(elem);
+  }
+
+  function widget_callback(container, btnElem) {
+    openWidgetPicker(container);
   }
 
   $(document).ready(function () {
@@ -85,7 +269,7 @@
         redirectURL: "${ctx}${js:escape(webPage.link)}",
         controlButtons: [[12], [7, 5], [8, 4], [9, 3], [3, 3, 3, 3], [4, 4, 4], [6, 6], [2, 8, 2], [3, 6, 3], [3, 9], [4, 8]],
         customControls: {
-          global_col: [{callback: 'widget_callback', loc: 'top', iconClass: '${font:far()} fa-bars'}]
+          global_col: [{callback: 'widget_callback', loc: 'top', iconClass: '${font:far()} fa-bars', title: 'Choose a Widget Type'}]
         },
         rowButtonsPrepend: [
           {

--- a/src/test/java/com/simisinc/platform/application/cms/WebPageDesignerToXmlCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/WebPageDesignerToXmlCommandTest.java
@@ -16,9 +16,15 @@
 
 package com.simisinc.platform.application.cms;
 
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Map;
+
+import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * @author matt rajkowski
@@ -26,8 +32,23 @@ import org.junit.jupiter.api.Test;
  */
 class WebPageDesignerToXmlCommandTest {
 
+  // The real registry (WebPageXmlLayoutCommand.getWidgetLibrary()) is loaded once at app startup from
+  // widget-library.xml via a ServletContext -- not populated in a plain unit test, so every test here
+  // mocks it, matching the established pattern in MutateLayoutCommandTest.
+  private static final Map<String, String> REGISTERED_WIDGETS = Map.of(
+      "content", "com.simisinc.platform.presentation.widgets.cms.ContentWidget",
+      "prototype", "com.simisinc.platform.presentation.widgets.cms.PrototypeWidget",
+      "map", "com.simisinc.platform.presentation.widgets.maps.MapWidget");
+
+  private static String convert(WebPage webPage, String content) throws DataException {
+    try (MockedStatic<WebPageXmlLayoutCommand> cmd = mockStatic(WebPageXmlLayoutCommand.class)) {
+      cmd.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
+      return WebPageDesignerToXmlCommand.convertFromBootstrapHtml(webPage, content);
+    }
+  }
+
   @Test
-  void convertFromBootstrapHtml() {
+  void convertFromBootstrapHtml() throws DataException {
 
     String content =
         "<div class=\"row\">\n" +
@@ -41,11 +62,11 @@ class WebPageDesignerToXmlCommandTest {
             "</div>\n" +
             "\n" +
             "<div class=\"row\">\n" +
-            "  <div class=\"column col-sm-12 col-md-12 col-xs-12\"><!--gm-editable-region--><p>Write your content</p><!--/gm-editable-region--><!--gm-editable-region--><h3 data-widget=\"widget-prototype\"><span style=\"font-size: inherit;\">Some</span></h3><!--/gm-editable-region--></div>\n" +
+            "  <div class=\"column col-sm-12 col-md-12 col-xs-12\"><!--gm-editable-region--><p>Write your content</p><!--/gm-editable-region--><!--gm-editable-region--><h3 data-widget=\"content\"><span style=\"font-size: inherit;\">Some</span></h3><!--/gm-editable-region--></div>\n" +
             "</div>\n" +
             "div class=\"row\">\n" +
             " <div class=\"column col-md-7 col-sm-7 col-xs-7\">\n" +
-            "   <!--gm-editable-region--><h3 data-widget=\"widget-prototype\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
+            "   <!--gm-editable-region--><h3 data-widget=\"content\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
             " </div>\n" +
             " <div class=\"column col-md-5 col-sm-5 col-xs-5\">\n" +
             "   <!--gm-editable-region--><p>Write your content</p><!--/gm-editable-region-->\n" +
@@ -57,10 +78,10 @@ class WebPageDesignerToXmlCommandTest {
             "</div>\n" +
             "<div class=\"row\">\n" +
             "  <div class=\"column col-md-7 col-sm-7 col-xs-7\">\n" +
-            "    <!--gm-editable-region--><h3 data-widget=\"widget-prototype\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
+            "    <!--gm-editable-region--><h3 data-widget=\"content\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
             "  </div>\n" +
             "  <div class=\"column col-md-5 col-sm-5 col-xs-5 callout radius primary text-center\">\n" +
-            "    <!--gm-editable-region--><h3 data-widget=\"widget-prototype\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
+            "    <!--gm-editable-region--><h3 data-widget=\"content\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
             "  </div>\n" +
             "</div>";
 
@@ -96,13 +117,13 @@ class WebPageDesignerToXmlCommandTest {
             "      <widget name=\"content\">\n" +
             "        <uniqueId>web-page-content-area-5</uniqueId>\n" +
             "      </widget>\n" +
-            "      <widget name=\"widget-prototype\">\n" +
+            "      <widget name=\"content\">\n" +
             "        <html><![CDATA[<h3>Some</h3>]]></html>\n" +
             "        <uniqueId>web-page-content-area-6</uniqueId>\n" +
             "      </widget>\n" +
             "    </column>\n" +
             "    <column class=\"small-7 cell\">\n" +
-            "      <widget name=\"widget-prototype\">\n" +
+            "      <widget name=\"content\">\n" +
             "        <html><![CDATA[<h3>Headline</h3><p>Write a description</p>]]></html>\n" +
             "        <uniqueId>web-page-content-area-7</uniqueId>\n" +
             "      </widget>\n" +
@@ -124,13 +145,13 @@ class WebPageDesignerToXmlCommandTest {
             "\n" +
             "  <section>\n" +
             "    <column class=\"small-7 cell\">\n" +
-            "      <widget name=\"widget-prototype\">\n" +
+            "      <widget name=\"content\">\n" +
             "        <html><![CDATA[<h3>Headline</h3><p>Write a description</p>]]></html>\n" +
             "        <uniqueId>web-page-content-area-10</uniqueId>\n" +
             "      </widget>\n" +
             "    </column>\n" +
             "    <column class=\"small-5 cell text-center callout radius primary\">\n" +
-            "      <widget name=\"widget-prototype\">\n" +
+            "      <widget name=\"content\">\n" +
             "        <html><![CDATA[<h3>Headline</h3><p>Write a description</p>]]></html>\n" +
             "        <uniqueId>web-page-content-area-11</uniqueId>\n" +
             "      </widget>\n" +
@@ -141,7 +162,48 @@ class WebPageDesignerToXmlCommandTest {
 
     WebPage webPage = new WebPage();
     webPage.setLink("/web-page");
-    String result = WebPageDesignerToXmlCommand.convertFromBootstrapHtml(webPage, content);
+    String result = convert(webPage, content);
     Assertions.assertEquals(xml, result);
+  }
+
+  // Regression coverage for issue #532: the legacy page designer's widget picker had no real widget-type
+  // chooser, so a click always inserted a hardcoded "prototype" placeholder. Fixing that meant letting the
+  // client insert any widget name it wants -- which meant the server-side conversion could no longer trust
+  // it blindly. Before this, an unregistered data-widget value saved successfully and then silently
+  // vanished at render time (XMLContainerCommands.appendWidgets() drops unknown widgets with no error
+  // anywhere), which is a worse failure mode than never adding it at all on this save path specifically
+  // (no draft/publish safety net -- see WebPageDesignerWidget.post()).
+
+  @Test
+  void convertFromBootstrapHtmlRejectsAnUnregisteredWidgetName() {
+    String content =
+        "<div class=\"row\">\n" +
+            "  <div class=\"column col-sm-12 col-md-12 col-xs-12\">\n" +
+            "    <!--gm-editable-region--><h3 data-widget=\"not-a-real-widget\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
+            "  </div>\n" +
+            "</div>";
+
+    WebPage webPage = new WebPage();
+    webPage.setLink("/web-page");
+    DataException exception = Assertions.assertThrows(DataException.class, () -> convert(webPage, content));
+    Assertions.assertTrue(exception.getMessage().contains("not-a-real-widget"),
+        "the error should name the offending widget type, not just say something failed");
+  }
+
+  @Test
+  void convertFromBootstrapHtmlAcceptsARealNonContentWidgetType() throws DataException {
+    // The whole point of #532: a real widget type (map, per the issue's own example), not just content.
+    String content =
+        "<div class=\"row\">\n" +
+            "  <div class=\"column col-sm-12 col-md-12 col-xs-12\">\n" +
+            "    <!--gm-editable-region--><h3 data-widget=\"map\">Map</h3><p>Write a description</p><!--/gm-editable-region-->\n" +
+            "  </div>\n" +
+            "</div>";
+
+    WebPage webPage = new WebPage();
+    webPage.setLink("/web-page");
+    String result = convert(webPage, content);
+
+    Assertions.assertTrue(result.contains("<widget name=\"map\">"), result);
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidgetTest.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.cms;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.SaveWebPageCommand;
+import com.simisinc.platform.application.cms.WebPageXmlLayoutCommand;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.cms.WebPageTemplate;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
@@ -31,6 +32,7 @@ import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -159,6 +161,67 @@ class WebPageDesignerWidgetTest extends WidgetBase {
         Assertions.assertNotNull(widgetContext.getErrorMessage());
         Assertions.assertNull(widgetContext.getRedirect());
       }
+    }
+  }
+
+  // Regression coverage for issue #532: post()'s gridmanager-designer branch (triggered by the "content"
+  // parameter, distinct from the raw-XML "pageXmlValue" branch the tests above exercise) used to call
+  // WebPageDesignerToXmlCommand.convertFromBootstrapHtml() OUTSIDE the try/catch that wraps the save --
+  // an exception from conversion itself (which #532's fix makes possible, via the new widget-name
+  // validation) would have propagated up uncaught instead of producing the same clean error response a
+  // save failure gets. These two tests exercise that branch directly, the one no existing test above did.
+
+  private static final Map<String, String> REGISTERED_WIDGETS = Map.of(
+      "content", "com.simisinc.platform.presentation.widgets.cms.ContentWidget",
+      "map", "com.simisinc.platform.presentation.widgets.maps.MapWidget");
+
+  @Test
+  void postDesignerContentWithARealWidgetTypeSaves() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/web-page");
+    addQueryParameter(widgetContext, "content",
+        "<div class=\"row\"><div class=\"column col-sm-12 col-md-12 col-xs-12\">"
+            + "<!--gm-editable-region--><h3 data-widget=\"map\">Map</h3><p>Write a description</p><!--/gm-editable-region-->"
+            + "</div></div>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
+      saveWebPageCommand.when(() -> SaveWebPageCommand.saveWebPage(any())).thenReturn(new WebPage());
+      widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      Assertions.assertEquals("[{\"status\":\"0\"}]", widgetContext.getJson());
+      saveWebPageCommand.verify(() -> SaveWebPageCommand.saveWebPage(any()));
+    }
+  }
+
+  @Test
+  void postDesignerContentWithAnUnregisteredWidgetTypeFailsCleanly() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/web-page");
+    addQueryParameter(widgetContext, "content",
+        "<div class=\"row\"><div class=\"column col-sm-12 col-md-12 col-xs-12\">"
+            + "<!--gm-editable-region--><h3 data-widget=\"not-a-real-widget\">Headline</h3><p>Write a description</p><!--/gm-editable-region-->"
+            + "</div></div>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
+      widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      // Must fail the same clean way a save failure does -- not throw uncaught, not silently succeed.
+      Assertions.assertTrue(widgetContext.getJson().contains("could not be saved"), widgetContext.getJson());
+      saveWebPageCommand.verifyNoInteractions();
     }
   }
 }


### PR DESCRIPTION
## Problem

Closes #532. The gridmanager-based page designer (\`/admin/web-page-designer?editor=designer\`, the tool used to set a brand-new page's initial layout — reachable from \`/admin/web-pages\`' code icon, the persistent "XML" button on any admin-context page, and "Set a Page Layout" for pages with no layout yet) has had a stub widget picker since this repo's first commit: \`widget_callback()\`'s chooser was commented out (\`// alert("The widget chooser is unavailable")\`), and every click unconditionally inserted the same hardcoded "prototype" placeholder. There was never a way to add a real widget type (map, button, card, etc.) through this tool — anything beyond generic content required hand-editing the page's raw XML afterward.

Confirmed via \`git log -S\`/blame: not a regression, present since \`62a60bb1\` ("Initial public code drop").

## Fix

Per your direction, built the fuller version rather than a minimal patch: a real, searchable, categorized widget-type picker.

- **Source of the widget list**: \`widget-schema.json\`, a curated 29-widget catalog (label, category, FA icon) built in an earlier phase for exactly this purpose but never wired to anything. Deliberately used instead of mirroring the modern composition-canvas "+Widget" picker, which just lists the 244 raw internal registry names alphabetically with no labels, icons, or categories (including several that make no sense to hand-place on a page, like \`sendMail\`/\`healthDashboard\`) — the schema gives a strictly better picker for the same intent, not a rougher parity copy.
- Selecting a type inserts it with the same free-text content-editing affordance the old "prototype" block had.
- **Server-side registry validation added** (\`WebPageDesignerToXmlCommand.createWidget()\`): since the client can now request any widget type instead of one hardcoded value, an unrecognized name is now rejected instead of saved. Before this, a bad name saved successfully and then silently vanished at render time with no error anywhere (\`XMLContainerCommands.appendWidgets()\` drops unregistered widgets) — worse than not adding it at all, especially since this save path writes straight to the live page with no draft/publish safety net. Mirrors \`MutateLayoutCommand.addWidget()\`'s existing check for the modern editor. \`WebPageDesignerWidget.post()\` now wraps the conversion step in its existing save try/catch so a rejection fails the same clean way a save failure does (no uncaught exception, no silent success).

## Two more root causes, found only by testing the real click-through

Static reading didn't catch either of these — both needed an actual save round-trip to surface:

1. **\`widget-schema.json\` was never reachable in a packaged build.** \`build.xml\`'s \`WEB-INF\` resource-copy step whitelists file extensions (\`.html/.xml/.yml/.tld/.mmdb/.properties\`) and \`.json\` wasn't among them — the file silently never made it into the WAR, regardless of any Java code trying to load it. Added \`.json\` to the include list.
2. **The chosen widget name has to live on the inserted \`<h4>\`, not (only) the wrapping div.** \`gm.deinitCanvas()\` (called on Save) unwraps that div entirely, keeping only its children — an attribute placed solely on the wrapper never reaches the server. The original hardcoded "prototype" insertion carried this same \`data-widget\` attribute on *both* the wrapper and the \`<h4>\`; it looked like redundant duplication and wasn't — first attempt at this fix dropped it, saved successfully, and silently produced a generic "content" widget instead of the chosen type.

## Testing

- \`ant -lib lib/war -lib lib/tests ci-test\`: full suite green.
- Updated \`WebPageDesignerToXmlCommandTest\` for the new validation (its \`data-widget="widget-prototype"\` fixture was never actually a registered widget name — silently accepted before this fix, correctly rejected now; changed to a real widget name, \`content\`, to keep testing the same non-"prototype" code path). Added tests for: rejecting an unregistered name (error names the offending type), accepting a real non-content type (\`map\`).
- Added \`WebPageDesignerWidgetTest\` coverage for \`post()\`'s designer-content branch specifically (no existing test exercised it — all 4 pre-existing tests use the separate raw-XML-textarea path): a valid widget type saves successfully, an invalid one fails the same clean way a save failure does.
- Live-verified end-to-end in a docker-compose rehearsal, real click-through: opened the designer, clicked the (now-labeled) "Choose a Widget Type" button, searched/selected Map, saved, confirmed \`<widget name="map">\` in the actual saved \`page_xml\`, confirmed the live page renders without error. This is how both root-cause findings above were actually caught.

## Scope note

Building a full preferences-editing UI for non-content widget types (map's lat/long, card's link, etc.) is a separate, larger gap — this designer has no preferences panel at all (unlike the modern editor's "⚙ Prefs"), so a freshly-inserted \`map\` widget renders with defaults until someone edits the raw XML. Out of scope here; this PR is specifically about letting the *type* be chosen correctly, which the issue was about.