### PR TITLE
Fix mailing list edits silently overwriting the original createdBy

### DIFF
--- a/src/main/java/com/simisinc/platform/application/mailinglists/SaveMailingListCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/SaveMailingListCommand.java
@@ -53,12 +53,14 @@ public class SaveMailingListCommand {
       if (mailingList == null) {
         throw new DataException("The existing record could not be found");
       }
+      // createdBy is set once, below, only for a genuinely new record -- an edit must not
+      // reassign the original creator to whoever happens to be editing it today
     } else {
       LOG.debug("Saving a new record... ");
       mailingList = new MailingList();
       mailingList.setEnabled(true);
+      mailingList.setCreatedBy(mailingListBean.getCreatedBy());
     }
-    mailingList.setCreatedBy(mailingListBean.getCreatedBy());
     mailingList.setModifiedBy(mailingListBean.getCreatedBy());
     mailingList.setName(mailingListBean.getName());
     mailingList.setTitle(mailingListBean.getTitle());

--- a/src/test/java/com/simisinc/platform/application/mailinglists/SaveMailingListCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/SaveMailingListCommandTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+
+/**
+ * saveMailingList() used to unconditionally overwrite createdBy on every save, including an edit
+ * of an existing record -- so editing a mailing list's name silently reassigned its original
+ * creator to whoever happened to be editing it that day. modifiedBy is correctly re-set on every
+ * save; createdBy must be set once, only when the record is genuinely new.
+ *
+ * @author elizabeth houser
+ */
+class SaveMailingListCommandTest {
+
+  @Test
+  void newRecordGetsCreatedByFromTheSubmitter() throws DataException {
+    MailingList bean = new MailingList();
+    bean.setName("Newsletter");
+    bean.setCreatedBy(42L); // the current submitter, per MailingListFormWidget.post()
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveMailingListCommand.saveMailingList(bean);
+
+      repository.verify(() -> MailingListRepository.save(argThat(saved -> saved.getCreatedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void editingAnExistingRecordDoesNotChangeItsOriginalCreatedBy() throws DataException {
+    MailingList existing = new MailingList();
+    existing.setId(1L);
+    existing.setCreatedBy(7L); // the original creator
+
+    MailingList bean = new MailingList();
+    bean.setId(1L);
+    bean.setName("Newsletter Renamed");
+    bean.setCreatedBy(42L); // a different user editing it today
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.findById(1L)).thenReturn(existing);
+      repository.when(() -> MailingListRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveMailingListCommand.saveMailingList(bean);
+
+      repository.verify(() -> MailingListRepository.save(argThat(saved -> saved.getCreatedBy() == 7L)));
+    }
+  }
+
+  @Test
+  void editingAnExistingRecordStillUpdatesModifiedBy() throws DataException {
+    // modifiedBy is a different field with different, correct semantics -- must keep working
+    MailingList existing = new MailingList();
+    existing.setId(1L);
+    existing.setCreatedBy(7L);
+    existing.setModifiedBy(7L);
+
+    MailingList bean = new MailingList();
+    bean.setId(1L);
+    bean.setName("Newsletter Renamed");
+    bean.setCreatedBy(42L);
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.findById(1L)).thenReturn(existing);
+      repository.when(() -> MailingListRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveMailingListCommand.saveMailingList(bean);
+
+      repository.verify(() -> MailingListRepository.save(argThat(saved -> saved.getModifiedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void editingAMissingRecordThrowsBeforeTouchingCreatedBy() {
+    MailingList bean = new MailingList();
+    bean.setId(99L);
+    bean.setName("Ghost list");
+
+    try (MockedStatic<MailingListRepository> repository = mockStatic(MailingListRepository.class)) {
+      repository.when(() -> MailingListRepository.findById(99L)).thenReturn(null);
+
+      assertThrows(DataException.class, () -> SaveMailingListCommand.saveMailingList(bean));
+
+      repository.verify(() -> MailingListRepository.save(any()), org.mockito.Mockito.never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`SaveMailingListCommand.saveMailingList()` unconditionally set `createdBy` from
the incoming form bean on every save. `MailingListFormWidget.post()` always
passes the current submitter's user id as `createdBy`, so editing an existing
mailing list (e.g. renaming it) silently reassigned its original creator to
whoever happened to make the edit. `modifiedBy` is correctly re-set on every
save; `createdBy` should only be set once, when the record is first created.

Found in passing while working on #753 (mailing list CRUD audit logging) and
scoped out separately per this repo's one-defect-per-PR convention.

## Changes
- `createdBy` is now only set in the "new record" branch of `saveMailingList()`
- Added `SaveMailingListCommandTest` covering: new record gets `createdBy` from
  the submitter; editing an existing record preserves the original `createdBy`;
  editing still updates `modifiedBy`; editing a missing record throws before
  touching the repository

## Test plan
- [x] `ant ci-test` — full suite (1394 tests) passes
- [x] Verified the new regression test actually catches the bug: reverted the
      fix, confirmed `editingAnExistingRecordDoesNotChangeItsOriginalCreatedBy`
      fails (mock saw the edit overwrite `createdBy`), restored the fix,
      confirmed green again
- [x] `ant package` — JSP compile gate passes