### PR TITLE
Fix ContentWidget's inline-editor Save Draft silently no-oping (#812)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentWidget.java
@@ -106,6 +106,12 @@ public class ContentWidget extends GenericWidget {
       }
       return ContentHtmlCommand.performContentApproval(context);
     }
+    // The inline editor's Save Draft button submits via a real POST (platform-editor.js
+    // saveContentDraft()), so it arrives here rather than in action() below -- forward it through
+    // the same dispatch action() uses for a GET caller (issue #812).
+    if ("saveDraft".equals(action)) {
+      return action(context);
+    }
     return context;
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -32,6 +32,7 @@ import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
+import com.simisinc.platform.application.cms.SaveContentCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
@@ -160,6 +161,44 @@ class ContentWidgetTest extends WidgetBase {
       new ContentWidget().action(widgetContext);
 
       contentReview.verify(() -> ContentReviewCommand.approve(any(), anyLong(), anyString()), never());
+    }
+  }
+
+  @Test
+  void postSaveDraftForwardsToActionAndPersistsContent() {
+    // The inline visual editor's Save Draft button (platform-editor.js saveContentDraft()) submits
+    // action=saveDraft via a real POST, so WebContainerContext routes the request to post(), not
+    // action() above. Before issue #812 was fixed, post() only recognized "approve" and silently
+    // fell through to `return context` for everything else -- the draft was never persisted and no
+    // error was shown. This test calls post() directly, the same method a real request now reaches,
+    // so it fails if that forwarding gap reopens.
+    preferences.put("uniqueId", "hello-content");
+    addQueryParameter(widgetContext, "action", "saveDraft");
+    addQueryParameter(widgetContext, "html", "<p>Edited content</p>");
+
+    Content content = new Content();
+    content.setId(42L);
+    content.setUniqueId("hello-content");
+    content.setContent("<p>Original content</p>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class);
+        MockedStatic<AuditEventCommand> auditEvent = mockStatic(AuditEventCommand.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      // performWebAction() unconditionally reads this site property before branching on the action
+      // name, even though saveDraft never uses it -- must be stubbed regardless, same as action().
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.post(widgetContext);
+
+      saveContent.verify(
+          () -> SaveContentCommand.saveSafeContent(eq("hello-content"), eq("<p>Edited content</p>"), anyLong(), eq(false)));
+      Assertions.assertTrue(widgetContext.hasJson());
+      Assertions.assertTrue(widgetContext.getJson().contains("\"success\":true"));
     }
   }
 }


### PR DESCRIPTION
## What

Fixes #812: `ContentWidget`'s inline-editor "Save Draft" button silently no-oped instead of persisting the edited content.

## Why

Same dispatch-precedence shape as #799/#800, one level down: `WebContainerContext` still checks `isPost()` before `action != null`, so any request that's a real POST *and* carries `action=X` always reaches `post()`, never `action()`. `ContentWidget.post()` only forwarded `approve` (deliberately, for step-up re-auth). It didn't forward `saveDraft`, which the inline visual editor's Save Draft button submits via a real `fetch(..., {method:'POST'})`. The request landed in `post()`, which fell through to `return context;` — a silent no-op. `ContentHtmlCommand.saveDraft()` (the code that actually persists via `SaveContentCommand.saveSafeContent(...)`) was never reached.

Issue #812 has the full investigation: audited all 20 widgets defining `action(WidgetContext)` in the codebase for this exact shape. This is the only confirmed-broken instance — everything else is already forwarded, GET-only triggered (unaffected), or has no `action()` at all. Also confirms a global `WebContainerContext` reorder (checking `action != null` before `isPost()`) is **not** safe here, unlike the `command=delete` case: `UserDetailsWidget` and `ContentWidget` itself both deliberately depend on the current precedence to keep step-up-gated actions (`resetPassword`/`approveUnsuspend`/`approve`) unreachable via a GET-shaped `action()` call. So this is a per-widget fix, mirroring the existing `approve` forward and the precedent set by `WebPageFormWidget`/`CartWidget`/`FormDataListWidget`/`ThemeEditorWidget`/`BlogPostWidget`/`ItemRelationshipsListWidget`.

## Change

`ContentWidget.post()`: forward `action=saveDraft` to `action()`, same pattern as the existing `approve` handling right above it.

## Test plan

- [x] New regression test (`ContentWidgetTest.postSaveDraftForwardsToActionAndPersistsContent`) calls `post()` directly — the method a real request now reaches — and verifies `SaveContentCommand.saveSafeContent(...)` is invoked and the JSON response is `{"success":true}`.
- [x] Full `ant -lib lib/war -lib lib/tests ci-test` green.
- [x] Live-verified in a docker-compose rehearsal: reproduced the exact request `platform-editor.js`'s `saveContentDraft()` sends (`POST <pageUri>?action=saveDraft&widget=<id>&token=<csrf>`, body `html=<content>`) against a running instance — confirmed the draft was not persisted before this fix and is persisted after.
