### PR TITLE
Add a queryable REST API for the audit log (issue #754)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/audit/BuildAuditLogSpecificationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/audit/BuildAuditLogSpecificationCommand.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.audit;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+
+/**
+ * Builds an {@link AuditLogSpecification} from raw, untyped filter values (query/form parameters). Shared
+ * filter-parsing logic for anywhere the audit log can be queried -- currently the REST API
+ * ({@code AuditLogListService}); the in-app review UI ({@code AuditLogListWidget}) predates this command
+ * and has its own equivalent, unmigrated copy.
+ *
+ * <p>Every parameter is optional; a blank value leaves the corresponding specification field unset. A
+ * quick range preset (1h/24h/7d/30d) takes precedence over an explicit fromDate/toDate range -- it is finer
+ * grained (hour precision) than the date-only fields can express.
+ *
+ * @author SimIS Inc.
+ */
+public class BuildAuditLogSpecificationCommand {
+
+  private BuildAuditLogSpecificationCommand() {
+    // Static utility
+  }
+
+  public static AuditLogSpecification build(String eventCategory, String eventType, String outcome,
+      String actor, String sourceIp, String targetType, String targetLabel,
+      String range, String fromDate, String toDate) {
+
+    AuditLogSpecification specification = new AuditLogSpecification();
+    if (StringUtils.isNotBlank(eventCategory)) {
+      specification.setEventCategory(eventCategory.trim());
+    }
+    if (StringUtils.isNotBlank(eventType)) {
+      specification.setEventType(eventType.trim());
+    }
+    if (StringUtils.isNotBlank(outcome)) {
+      specification.setOutcome(outcome.trim());
+    }
+    if (StringUtils.isNotBlank(actor)) {
+      specification.setActorUsername(actor.trim());
+    }
+    if (StringUtils.isNotBlank(sourceIp)) {
+      specification.setSourceIp(sourceIp.trim());
+    }
+    if (StringUtils.isNotBlank(targetType)) {
+      specification.setTargetType(targetType.trim());
+    }
+    if (StringUtils.isNotBlank(targetLabel)) {
+      specification.setTargetLabel(targetLabel.trim());
+    }
+
+    Timestamp rangeCutoff = resolveRangeCutoff(range);
+    if (rangeCutoff != null) {
+      specification.setOccurredAfter(rangeCutoff);
+    } else {
+      // Parse the yyyy-MM-dd date range: from = start of that day, to = start of the day AFTER (half-open)
+      Timestamp from = parseDate(fromDate, 0);
+      Timestamp to = parseDate(toDate, 1);
+      if (from != null) {
+        specification.setOccurredAfter(from);
+      }
+      if (to != null) {
+        specification.setOccurredBefore(to);
+      }
+    }
+    return specification;
+  }
+
+  /** Parses a yyyy-MM-dd string to a start-of-day Timestamp plus {@code plusDays}; null when blank/invalid. */
+  static Timestamp parseDate(String value, int plusDays) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    try {
+      LocalDate date = LocalDate.parse(value.trim()).plusDays(plusDays);
+      return Timestamp.valueOf(date.atStartOfDay());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** Resolves a quick range preset to an "occurred after" cutoff; null when absent or unrecognized. */
+  static Timestamp resolveRangeCutoff(String range) {
+    if (StringUtils.isBlank(range)) {
+      return null;
+    }
+    Instant now = Instant.now();
+    switch (range.trim()) {
+      case "1h":
+        return Timestamp.from(now.minus(1, ChronoUnit.HOURS));
+      case "24h":
+        return Timestamp.from(now.minus(24, ChronoUnit.HOURS));
+      case "7d":
+        return Timestamp.from(now.minus(7, ChronoUnit.DAYS));
+      case "30d":
+        return Timestamp.from(now.minus(30, ChronoUnit.DAYS));
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/audit/AuditLogEntryResponse.java
+++ b/src/main/java/com/simisinc/platform/rest/services/audit/AuditLogEntryResponse.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.simisinc.platform.domain.model.audit.AuditLog;
+
+/**
+ * One audit_log record as returned by the REST API (see AuditLogListService). Field selection mirrors the
+ * existing CSV/JSON export ({@code AuditLogRepository#exportJson}) plus the record id -- the tamper-evidence
+ * hash chain fields (previousHash/recordHash) are an internal integrity-verification detail
+ * (see AuditLogIntegrityCommand) and are not exposed here.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLogEntryResponse {
+
+  Long id;
+  String occurred;
+  String eventCategory;
+  String eventType;
+  String outcome;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  Long actorUserId;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String actorUsername;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String sourceIp;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String targetType;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String targetId;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String targetLabel;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String sessionId;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String details;
+
+  public AuditLogEntryResponse(AuditLog record) {
+    id = record.getId();
+    occurred = record.getOccurred() != null ? record.getOccurred().toInstant().toString() : null;
+    eventCategory = record.getEventCategory();
+    eventType = record.getEventType();
+    outcome = record.getOutcome();
+    if (record.getActorUserId() > -1L) {
+      actorUserId = record.getActorUserId();
+    }
+    actorUsername = record.getActorUsername();
+    sourceIp = record.getSourceIp();
+    targetType = record.getTargetType();
+    targetId = record.getTargetId();
+    targetLabel = record.getTargetLabel();
+    sessionId = record.getSessionId();
+    details = record.getDetails();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getOccurred() {
+    return occurred;
+  }
+
+  public String getEventCategory() {
+    return eventCategory;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public String getOutcome() {
+    return outcome;
+  }
+
+  public Long getActorUserId() {
+    return actorUserId;
+  }
+
+  public String getActorUsername() {
+    return actorUsername;
+  }
+
+  public String getSourceIp() {
+    return sourceIp;
+  }
+
+  public String getTargetType() {
+    return targetType;
+  }
+
+  public String getTargetId() {
+    return targetId;
+  }
+
+  public String getTargetLabel() {
+    return targetLabel;
+  }
+
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/audit/AuditLogListService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/audit/AuditLogListService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.audit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.audit.BuildAuditLogSpecificationCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogRepository;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Queryable REST API for the security audit log (issue #754). Lets an authenticated API client filter and
+ * page through audit_log records without going through the browser admin UI
+ * ({@code AuditLogListWidget}). Filtering matches what that UI already supports (category, event type,
+ * outcome, actor, source IP, target type, target label, and an occurred date range, either a quick
+ * 1h/24h/7d/30d preset or an explicit fromDate/toDate range).
+ *
+ * <p>Gated the same way every other endpoint under {@code /api/} is -- {@code RestRequestFilter}'s
+ * API-key + {@code site.api} toggle check runs first -- plus an admin-role check here, since the audit log
+ * is sensitive and every other consumer of it (the widget, the CSV/JSON export) is admin-only too. A guest
+ * (API-key-only, no bearer token) or a non-admin authenticated user gets 403.
+ *
+ * @author SimIS Inc.
+ */
+public class AuditLogListService {
+
+  private static Log LOG = LogFactory.getLog(AuditLogListService.class);
+
+  private static final int DEFAULT_PAGE_SIZE = 50;
+  private static final int MAX_PAGE_SIZE = 200;
+
+  // GET /audit-log?category=&eventType=&outcome=&actor=&sourceIp=&targetType=&targetLabel=
+  //     &range=&fromDate=&toDate=&page=&size=
+  public ServiceResponse get(ServiceContext context) {
+
+    if (!context.hasRole("admin")) {
+      LOG.debug("Non-admin API request for the audit log rejected");
+      ServiceResponse response = new ServiceResponse(403);
+      response.getError().put("title", "Forbidden");
+      return response;
+    }
+
+    // Determine the constraints
+    int pageNumber = context.getParameterAsInt("page", 1);
+    if (pageNumber < 1) {
+      pageNumber = 1;
+    }
+    int pageSize = context.getParameterAsInt("size", DEFAULT_PAGE_SIZE);
+    if (pageSize < 1) {
+      pageSize = DEFAULT_PAGE_SIZE;
+    } else if (pageSize > MAX_PAGE_SIZE) {
+      pageSize = MAX_PAGE_SIZE;
+    }
+    DataConstraints constraints = new DataConstraints(pageNumber, pageSize);
+
+    // Determine the filters
+    AuditLogSpecification specification = BuildAuditLogSpecificationCommand.build(
+        context.getParameter("category"),
+        context.getParameter("eventType"),
+        context.getParameter("outcome"),
+        context.getParameter("actor"),
+        context.getParameter("sourceIp"),
+        context.getParameter("targetType"),
+        context.getParameter("targetLabel"),
+        context.getParameter("range"),
+        context.getParameter("fromDate"),
+        context.getParameter("toDate"));
+
+    // Retrieve the records
+    List<AuditLog> auditLogList = AuditLogRepository.findAll(specification, constraints);
+
+    // Querying the audit log via the API is itself a data-access event worth auditing, same as the
+    // in-app CSV/JSON export. Never let this break the response.
+    try {
+      User user = context.getUser();
+      SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.DATA_ACCESS, "audit_log.api_query",
+          AuditEventCommand.SUCCESS,
+          user != null ? user.getId() : -1L,
+          user != null ? user.getEmail() : null,
+          context.getRequest() != null ? context.getRequest().getRemoteAddr() : null,
+          null,
+          "audit_log", "filtered", null,
+          "page=" + pageNumber + "; size=" + pageSize);
+    } catch (Exception e) {
+      LOG.warn("Could not record the audit_log.api_query event: " + e.getMessage());
+    }
+
+    // Set the fields to return
+    List<AuditLogEntryResponse> recordList = new ArrayList<>();
+    for (AuditLog record : auditLogList) {
+      recordList.add(new AuditLogEntryResponse(record));
+    }
+
+    // Prepare the response
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "audit_log", auditLogList, constraints);
+    response.setData(recordList);
+    return response;
+  }
+}

--- a/src/main/webapp/WEB-INF/rest-services/rest-services.xml
+++ b/src/main/webapp/WEB-INF/rest-services/rest-services.xml
@@ -24,6 +24,16 @@
   <service method="get" endpoint="items/{collectionUniqueId}?category=${categoryUniqueId}&amp;query=value" class="com.simisinc.platform.rest.services.items.ItemListService" />
   <service method="get" endpoint="item/{itemUniqueId}" class="com.simisinc.platform.rest.services.items.ItemService" />
   <!--
+  audit-log?category=&eventType=&outcome=&actor=&sourceIp=&targetType=&targetLabel=&range=&fromDate=&toDate=&page=&size=
+  NOTE: XMLServiceLoader only strips a query string when it follows a "/{pathParam}" segment (see
+  addServices()); a plain endpoint like this one must NOT have "?..." appended to the endpoint
+  attribute itself, or the literal query string becomes part of the registered lookup key and the
+  route silently 404s. Keep this comment free of two consecutive hyphens: that sequence inside an
+  XML comment fails Tomcat's strict parser at deploy time, same landmine as PR #178's context.xml
+  incident.
+  -->
+  <service method="get" endpoint="audit-log" class="com.simisinc.platform.rest.services.audit.AuditLogListService" />
+  <!--
   /item-blog/unique-id
   /item-blog-post/unique-id/post-id
   /item-gallery/unique-id

--- a/src/test/java/com/simisinc/platform/application/audit/BuildAuditLogSpecificationCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/audit/BuildAuditLogSpecificationCommandTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+
+/**
+ * Tests the shared audit-log filter-parsing logic used by the REST API (AuditLogListService).
+ *
+ * @author SimIS Inc.
+ */
+class BuildAuditLogSpecificationCommandTest {
+
+  @Test
+  void blankParametersLeaveEveryFieldUnset() {
+    AuditLogSpecification spec = BuildAuditLogSpecificationCommand.build(
+        null, "", "  ", null, null, null, null, null, null, null);
+
+    assertNull(spec.getEventCategory());
+    assertNull(spec.getEventType());
+    assertNull(spec.getOutcome());
+    assertNull(spec.getActorUsername());
+    assertNull(spec.getSourceIp());
+    assertNull(spec.getTargetType());
+    assertNull(spec.getTargetLabel());
+    assertNull(spec.getOccurredAfter());
+    assertNull(spec.getOccurredBefore());
+  }
+
+  @Test
+  void everyFilterMapsOntoTheSpecification() {
+    AuditLogSpecification spec = BuildAuditLogSpecificationCommand.build(
+        "user_management", "user.disable", "failure", "Admin@Example.com", "203.0.113.4",
+        "user", "203.0.113.5", null, "2026-07-01", "2026-07-20");
+
+    assertEquals("user_management", spec.getEventCategory());
+    assertEquals("user.disable", spec.getEventType());
+    assertEquals("failure", spec.getOutcome());
+    assertEquals("Admin@Example.com", spec.getActorUsername());
+    assertEquals("203.0.113.4", spec.getSourceIp());
+    assertEquals("user", spec.getTargetType());
+    assertEquals("203.0.113.5", spec.getTargetLabel());
+    assertEquals(Timestamp.valueOf(LocalDate.parse("2026-07-01").atStartOfDay()), spec.getOccurredAfter());
+    // The "to" bound is half-open: the start of the day AFTER the picked date, so that whole day is included
+    assertEquals(Timestamp.valueOf(LocalDate.parse("2026-07-21").atStartOfDay()), spec.getOccurredBefore());
+  }
+
+  @Test
+  void aQuickRangePresetTakesPrecedenceOverAnExplicitDateRange() {
+    Instant before = Instant.now().minus(24, ChronoUnit.HOURS);
+    AuditLogSpecification spec = BuildAuditLogSpecificationCommand.build(
+        null, null, null, null, null, null, null, "24h", "2020-01-01", "2020-01-02");
+    Instant after = Instant.now().minus(24, ChronoUnit.HOURS);
+
+    assertTrue(!spec.getOccurredAfter().toInstant().isBefore(before) && !spec.getOccurredAfter().toInstant().isAfter(after),
+        "expected a cutoff around 24h ago, got " + spec.getOccurredAfter());
+    assertNull(spec.getOccurredBefore(), "a range preset has no upper bound, unlike the explicit date-range fields");
+  }
+
+  @Test
+  void resolveRangeCutoffRecognizesEveryPreset() {
+    Instant now = Instant.now();
+    assertTrue(BuildAuditLogSpecificationCommand.resolveRangeCutoff("1h").toInstant().isBefore(now));
+    assertTrue(BuildAuditLogSpecificationCommand.resolveRangeCutoff("24h").toInstant().isBefore(now.minus(1, ChronoUnit.HOURS)));
+    assertTrue(BuildAuditLogSpecificationCommand.resolveRangeCutoff("7d").toInstant().isBefore(now.minus(6, ChronoUnit.DAYS)));
+    assertTrue(BuildAuditLogSpecificationCommand.resolveRangeCutoff("30d").toInstant().isBefore(now.minus(29, ChronoUnit.DAYS)));
+  }
+
+  @Test
+  void resolveRangeCutoffReturnsNullForBlankOrUnrecognizedValues() {
+    assertNull(BuildAuditLogSpecificationCommand.resolveRangeCutoff(null));
+    assertNull(BuildAuditLogSpecificationCommand.resolveRangeCutoff(""));
+    assertNull(BuildAuditLogSpecificationCommand.resolveRangeCutoff("3 weeks ago"));
+  }
+
+  @Test
+  void malformedDatesAreIgnoredRatherThanThrowing() {
+    AuditLogSpecification spec = BuildAuditLogSpecificationCommand.build(
+        null, null, null, null, null, null, null, null, "not-a-date", "also-not-a-date");
+    assertNull(spec.getOccurredAfter());
+    assertNull(spec.getOccurredBefore());
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/audit/AuditLogListServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/audit/AuditLogListServiceTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.audit.AuditLog;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogRepository;
+import com.simisinc.platform.infrastructure.persistence.audit.AuditLogSpecification;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Tests the queryable audit-log REST endpoint (issue #754): admin-only, filters map onto the
+ * specification the same way the admin UI's do, and pagination is applied and clamped.
+ *
+ * @author SimIS Inc.
+ */
+class AuditLogListServiceTest {
+
+  private ServiceContext contextWithParams(Map<String, String> params) {
+    ServiceContext context = new ServiceContext();
+    Map<String, String[]> parameterMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : params.entrySet()) {
+      parameterMap.put(entry.getKey(), new String[] { entry.getValue() });
+    }
+    context.setParameterMap(parameterMap);
+    return context;
+  }
+
+  private User adminUser() {
+    User user = new User();
+    user.setId(5L);
+    user.setEmail("admin@example.com");
+    List<Role> roleList = new ArrayList<>();
+    roleList.add(new Role("System Administrator", "admin"));
+    user.setRoleList(roleList);
+    return user;
+  }
+
+  @Test
+  void aNonAdminRequestIsRejectedWithoutQueryingTheRepository() {
+    ServiceContext context = contextWithParams(new HashMap<>());
+    User user = new User();
+    user.setId(9L);
+    user.setRoleList(new ArrayList<>()); // logged in, but no admin role
+    context.setUser(user);
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class)) {
+      ServiceResponse response = new AuditLogListService().get(context);
+
+      assertEquals(403, response.getStatus());
+      repository.verify(
+          () -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)), never());
+    }
+  }
+
+  @Test
+  void aGuestRequestIsRejected() {
+    // No bearer token -> RestRequestFilter demotes to a guest User with no roles and userId == -1
+    ServiceContext context = contextWithParams(new HashMap<>());
+    context.setUser(new User());
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class)) {
+      ServiceResponse response = new AuditLogListService().get(context);
+
+      assertEquals(403, response.getStatus());
+      repository.verify(
+          () -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)), never());
+    }
+  }
+
+  @Test
+  void filterParametersMapOntoTheSpecification() {
+    Map<String, String> params = new HashMap<>();
+    params.put("category", "user_management");
+    params.put("eventType", "user.disable");
+    params.put("outcome", "failure");
+    params.put("actor", "jdoe@example.com");
+    params.put("targetType", "user");
+    params.put("fromDate", "2026-07-01");
+    params.put("toDate", "2026-07-20");
+    ServiceContext context = contextWithParams(params);
+    context.setUser(adminUser());
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class)) {
+      repository.when(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+
+      ServiceResponse response = new AuditLogListService().get(context);
+
+      assertEquals(200, response.getStatus());
+      ArgumentCaptor<AuditLogSpecification> specCaptor = ArgumentCaptor.forClass(AuditLogSpecification.class);
+      repository.verify(() -> AuditLogRepository.findAll(specCaptor.capture(), any(DataConstraints.class)));
+      AuditLogSpecification spec = specCaptor.getValue();
+
+      assertEquals("user_management", spec.getEventCategory());
+      assertEquals("user.disable", spec.getEventType());
+      assertEquals("failure", spec.getOutcome());
+      assertEquals("jdoe@example.com", spec.getActorUsername());
+      assertEquals("user", spec.getTargetType());
+      assertEquals(Timestamp.valueOf("2026-07-01 00:00:00"), spec.getOccurredAfter());
+      assertEquals(Timestamp.valueOf("2026-07-21 00:00:00"), spec.getOccurredBefore());
+
+      // Querying the audit log via the API is itself audited
+      auditEvent.verify(() -> SaveAuditEventCommand.recordAdminEvent(
+          eq("data_access"), eq("audit_log.api_query"), eq("success"),
+          eq(5L), eq("admin@example.com"), any(), any(), eq("audit_log"), eq("filtered"), any(), anyString()));
+    }
+  }
+
+  @Test
+  void defaultPaginationIsAppliedWhenNoPageParamsAreGiven() {
+    ServiceContext context = contextWithParams(new HashMap<>());
+    context.setUser(adminUser());
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class)) {
+      repository.when(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+
+      new AuditLogListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      repository.verify(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), constraintsCaptor.capture()));
+      assertEquals(1, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(50, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void pageSizeIsClampedToTheMaximum() {
+    Map<String, String> params = new HashMap<>();
+    params.put("size", "5000");
+    ServiceContext context = contextWithParams(params);
+    context.setUser(adminUser());
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class)) {
+      repository.when(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+
+      new AuditLogListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      repository.verify(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), constraintsCaptor.capture()));
+      assertEquals(200, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void responseDataOmitsTheTamperEvidenceHashFields() {
+    ServiceContext context = contextWithParams(new HashMap<>());
+    context.setUser(adminUser());
+
+    AuditLog record = new AuditLog();
+    record.setId(101L);
+    record.setOccurred(Timestamp.valueOf("2026-07-20 14:19:22"));
+    record.setEventCategory("authentication");
+    record.setEventType("authentication.login.success");
+    record.setOutcome("success");
+    record.setActorUserId(5L);
+    record.setActorUsername("admin@example.com");
+    record.setPreviousHash("deadbeef");
+    record.setRecordHash("cafebabe");
+
+    try (MockedStatic<AuditLogRepository> repository = mockStatic(AuditLogRepository.class);
+        MockedStatic<SaveAuditEventCommand> auditEvent = mockStatic(SaveAuditEventCommand.class)) {
+      repository.when(() -> AuditLogRepository.findAll(any(AuditLogSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of(record));
+
+      ServiceResponse response = new AuditLogListService().get(context);
+
+      @SuppressWarnings("unchecked")
+      List<AuditLogEntryResponse> data = (List<AuditLogEntryResponse>) response.getData();
+      assertEquals(1, data.size());
+      assertEquals(101L, data.get(0).getId());
+      assertEquals("authentication", data.get(0).getEventCategory());
+      // AuditLogEntryResponse has no getters for previousHash/recordHash at all -- the chain-integrity
+      // internals are simply not part of the response shape. getDeclaredMethods() (not getMethods())
+      // so this doesn't trip over the inherited, unrelated Object.hashCode().
+      assertTrue(java.util.Arrays.stream(AuditLogEntryResponse.class.getDeclaredMethods())
+          .noneMatch(m -> m.getName().toLowerCase().contains("hash")));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #754. External compliance tooling had no programmatic way to query the audit log -- the only export path was an admin-session CSV/JSON download through the browser UI. Adds `GET /api/audit-log`.

## What changed

- `BuildAuditLogSpecificationCommand` — shared, independently-testable filter parsing: category, event type, outcome, actor, source IP, target type, target label, and an occurred date range (a quick 1h/24h/7d/30d preset or explicit `fromDate`/`toDate`).
- `AuditLogListService` — the endpoint itself, gated the same way every other endpoint under `/api/` is (`RestRequestFilter`'s API-key + `site.api` toggle), plus an admin-role check on top, since every other consumer of the audit log (the review widget, the CSV/JSON export) is admin-only too. Paginated, capped at 200 per page. Querying the API is itself audited (`audit_log.api_query`), matching the existing export's self-audit behavior.
- `AuditLogEntryResponse` — response DTO mirroring the existing JSON export's field selection, deliberately omitting the tamper-evidence hash-chain fields (`record_hash`/`previous_hash`) as an internal integrity-verification detail that shouldn't be part of the public response shape.
- Registered in `rest-services.xml`, with an inline comment on a real landmine this caught (see below).

## A real deploy-blocking bug caught during verification, not by unit tests

`rest-services.xml`'s entries are separated by `<!-- -->` comment blocks. The comment added for this endpoint's documentation originally contained a double-hyphen sequence, which fails Tomcat's strict XML comment parser at deploy time -- the same landmine class as the `context.xml` incident from PR #178. This would have silently broken *every* REST endpoint registered in the file, not just the new one. Fixed by rewording the comment to avoid `--`, and the comment itself now documents the landmine so it doesn't recur.

## Testing

- `BuildAuditLogSpecificationCommandTest` (5 tests) and `AuditLogListServiceTest` (6 tests), new.
- Full `ant ci-test`: 1426 tests, 0 failures.
- Live Docker rehearsal: real authenticated bearer-token requests against the endpoint confirming correct filtering (individually and combined) and pagination against real DB rows; confirmed a guest/non-admin token gets 403; confirmed `site.api` toggled off gets 403 "API is disabled"; confirmed the tamper-evidence hash fields are absent from every response.

## Note on this PR's history

This work was originally reported complete by an earlier process, but that report turned out to be entirely fabricated -- no code existed anywhere in this repository's history to back it (verified via `git fsck`, branch diffing, and searching for the claimed class names, which returned zero hits). This PR is the actual implementation, built and verified from scratch after that was caught.