### PR TITLE
Fix collection item deactivate being a no-op

### DIFF
--- a/src/main/java/com/simisinc/platform/application/datasets/DeleteDatasetItemsCommand.java
+++ b/src/main/java/com/simisinc/platform/application/datasets/DeleteDatasetItemsCommand.java
@@ -47,6 +47,11 @@ public class DeleteDatasetItemsCommand {
     if (optionalSyncTimestamp != null) {
       specification.setDatasetSyncTimestampThreshold(optionalSyncTimestamp);
     }
+    // This must remove every item tied to the dataset, including ones a user deactivated (issue
+    // #814's default query filter excludes those) -- otherwise they'd never be found by the loop
+    // below, constraints.getTotalRecordCount() would already read 0 on entry, and they'd be
+    // orphaned in the items table instead of deleted with the rest of the dataset.
+    specification.setIncludeArchived(true);
 
     // Limit to the record count
     long maxRuns = (constraints.getTotalRecordCount() / 100);

--- a/src/main/java/com/simisinc/platform/application/items/LoadItemCommand.java
+++ b/src/main/java/com/simisinc/platform/application/items/LoadItemCommand.java
@@ -62,6 +62,11 @@ public class LoadItemCommand {
     ItemSpecification specification = new ItemSpecification();
     specification.setUniqueId(uniqueId);
     specification.setForUserId(userId);
+    // This resolves a single, already-known item (item detail page, edit form) rather than
+    // browsing/listing a collection, so a deactivated item must still be reachable here -- issue
+    // #814 only hides archived items from listing/search results, not from direct access by a
+    // known id/uniqueId. See ItemSpecification#includeArchived javadoc.
+    specification.setIncludeArchived(true);
     List<Item> itemList = ItemRepository.findAll(specification, null);
     if (itemList.size() == 1) {
       return itemList.get(0);
@@ -73,6 +78,9 @@ public class LoadItemCommand {
     ItemSpecification specification = new ItemSpecification();
     specification.setId(item.getId());
     specification.setForUserId(user.getId());
+    // See loadItemByUniqueIdForAuthorizedUser above: a known item must remain reachable here even
+    // once archived (issue #814).
+    specification.setIncludeArchived(true);
     List<Item> itemList = ItemRepository.findAll(specification, null);
     if (itemList.size() == 1) {
       return itemList.get(0);

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -338,6 +338,15 @@ public class ItemRepository {
   private static SqlUtils createSearchWhereStatement(ItemSpecification specification) {
     SqlUtils where = new SqlUtils();
 
+    // Issue #814: exclude deactivated items from normal listing/search queries by default. Callers
+    // that must still reach a specific archived item (single-item access checks, dataset cleanup)
+    // opt in via ItemSpecification#setIncludeArchived(true); see the field javadoc there for why
+    // this defaults to excluding rather than mirroring the opt-out-per-caller convention used
+    // elsewhere (WebPage/Medicine/FormData).
+    if (!specification.getIncludeArchived()) {
+      where.add("items.archived IS NULL");
+    }
+
     if (specification.getApprovedOnly()) {
       where.add("approved is not null");
     } else if (specification.getUnapprovedOnly()) {
@@ -407,6 +416,7 @@ public class ItemRepository {
     ItemSpecification facetSpec = new ItemSpecification();
     facetSpec.setApprovedOnly(specification.getApprovedOnly());
     facetSpec.setUnapprovedOnly(specification.getUnapprovedOnly());
+    facetSpec.setIncludeArchived(specification.getIncludeArchived());
     facetSpec.setForUserId(specification.getForUserId());
     facetSpec.setSearchName(specification.getSearchName());
     facetSpec.setSearchLocation(specification.getSearchLocation());
@@ -425,6 +435,7 @@ public class ItemRepository {
     ItemSpecification facetSpec = new ItemSpecification();
     facetSpec.setApprovedOnly(specification.getApprovedOnly());
     facetSpec.setUnapprovedOnly(specification.getUnapprovedOnly());
+    facetSpec.setIncludeArchived(specification.getIncludeArchived());
     facetSpec.setForUserId(specification.getForUserId());
     facetSpec.setSearchName(specification.getSearchName());
     facetSpec.setSearchLocation(specification.getSearchLocation());

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
@@ -47,6 +47,17 @@ public class ItemSpecification {
   private int hasCoordinates = DataConstants.UNDEFINED;
   private boolean approvedOnly = false;
   private boolean unapprovedOnly = false;
+  // Issue #814: items have no separate active/enabled flag -- archivedBy/archived (set by
+  // PageServlet's deactivateCollectionItem action) is how an item is soft-hidden. Unlike the
+  // opt-out-per-caller convention used for WebPageSpecification.enabled/draft,
+  // MedicineSpecification.archivedOnly, and FormDataSpecification.dismissed (all default to no
+  // filtering, relying on each caller to opt out), this defaults to excluding archived items: no
+  // current caller of ItemRepository's query path ever wants to browse/list archived items, so an
+  // opt-out-per-caller default would just leave the door open for the next listing call site to
+  // reintroduce this same bug. The few call sites that do need to reach an archived item by a
+  // known id/uniqueId (single-item access checks backing edit/detail pages, and dataset cleanup
+  // that must remove archived items too) opt IN explicitly via setIncludeArchived(true).
+  private boolean includeArchived = false;
   private long datasetId = -1L;
   private Timestamp datasetSyncTimestampThreshold = null;
   private Timestamp dateRangeStart = null;
@@ -205,6 +216,14 @@ public class ItemSpecification {
 
   public void setUnapprovedOnly(boolean unapprovedOnly) {
     this.unapprovedOnly = unapprovedOnly;
+  }
+
+  public boolean getIncludeArchived() {
+    return includeArchived;
+  }
+
+  public void setIncludeArchived(boolean includeArchived) {
+    this.includeArchived = includeArchived;
   }
 
   public int getHasCoordinates() {

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
@@ -280,6 +280,74 @@ class ItemRepositoryTest {
     assertEquals(1, count, "a guest-visible collection's category count must still come through for a guest requester");
   }
 
+  @Test
+  void countByCategoryExcludesArchivedItemsByDefault() {
+    // Issue #814: PageServlet's deactivateCollectionItem sets Item.archived, but nothing ever
+    // filtered query results on it, so a deactivated item never actually left the collection's
+    // listing. createSearchWhereStatement (shared by query() and the facet-count methods below)
+    // is where that filter now lives; verified here through countByCategory since it exercises
+    // the exact same WHERE-building path as a real listing query without needing the full items
+    // column set that ItemRepository.buildRecord expects.
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long activeItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkCategory(activeItem, categoryA, collectionId);
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkCategory(archivedItem, categoryA, collectionId);
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+
+    assertEquals(1, ItemRepository.countByCategory(specification, categoryA),
+        "a deactivated item must not be counted by a normal (non-includeArchived) query");
+  }
+
+  @Test
+  void countByCategoryIncludesArchivedItemsWhenIncludeArchivedIsSet() {
+    long collectionId = addCollection();
+    long categoryA = 10;
+    long activeItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkCategory(activeItem, categoryA, collectionId);
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkCategory(archivedItem, categoryA, collectionId);
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setIncludeArchived(true);
+
+    assertEquals(2, ItemRepository.countByCategory(specification, categoryA),
+        "a caller that explicitly opts in (e.g. dataset cleanup, single-item access checks) must still see archived items");
+  }
+
+  @Test
+  void countByDateRangeExcludesArchivedItemsByDefault() {
+    long collectionId = addCollection();
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-01 00:00:00"));
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+    long count = ItemRepository.countByDateRange(specification,
+        Timestamp.valueOf("2026-01-01 00:00:00"), Timestamp.valueOf("2027-01-01 00:00:00"));
+
+    assertEquals(1, count, "the archived-exclusion filter must apply to date-facet counts too, not just the main listing");
+  }
+
+  @Test
+  void countByDateRangeIncludesArchivedItemsWhenIncludeArchivedIsSet() {
+    long collectionId = addCollection();
+    addItem(collectionId, null, Timestamp.valueOf("2026-06-01 00:00:00"));
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setIncludeArchived(true);
+    long count = ItemRepository.countByDateRange(specification,
+        Timestamp.valueOf("2026-01-01 00:00:00"), Timestamp.valueOf("2027-01-01 00:00:00"));
+
+    assertEquals(2, count, "facet counts must not drift from what a real includeArchived(true) listing query would return");
+  }
+
   private static boolean isDockerAvailable() {
     try {
       return DockerClientFactory.instance().isDockerAvailable();
@@ -308,6 +376,7 @@ class ItemRepositoryTest {
           + "collection_id BIGINT, "
           + "approved TIMESTAMP, "
           + "created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+          + "archived TIMESTAMP, "
           + "geom TEXT)"); // placeholder column: only IS NOT NULL is exercised here, real
                            // geometry semantics (PostGIS) aren't available in the plain
                            // postgres:15-alpine test image
@@ -364,6 +433,18 @@ class ItemRepositoryTest {
       }
     } catch (SQLException se) {
       throw new IllegalStateException("Could not insert an item", se);
+    }
+  }
+
+  private static void archiveItem(long itemId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "UPDATE items SET archived = ? WHERE item_id = ?")) {
+      pst.setTimestamp(1, Timestamp.valueOf("2026-01-01 00:00:00"));
+      pst.setLong(2, itemId);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not archive an item", se);
     }
   }
 


### PR DESCRIPTION
Fixes #814

## Problem

`PageServlet.deactivateCollectionItem` sets `Item.archived`/`archivedBy` and saves, but `ItemRepository`/`ItemSpecification` never filtered any query on those columns. Deactivating an item from the canvas editor round-tripped successfully but the item never actually left the collection's listing anywhere (canvas, public page, search, any other `ItemsListWidget` view). The `items_archived_idx` index existed for exactly this and was unused.

## Fix

- `ItemSpecification` gains an `includeArchived` flag, default `false`.
- `ItemRepository.createSearchWhereStatement` — the single WHERE-builder shared by `findAll()`/`query()` and the `countByCategory`/`countByDateRange` facet counts — now excludes `archived IS NOT NULL` items unless `includeArchived` is set, and both facet-count methods propagate the flag.
- Two call sites need archived items regardless of the new default and opt in via `setIncludeArchived(true)`:
  - `LoadItemCommand`'s two authorized single-item loaders (an item's own detail/edit page should still resolve after deactivation — there's no unarchive UI yet, so this keeps the item reachable rather than making deactivation irreversible)
  - `DeleteDatasetItemsCommand` (a dataset delete should still be able to find/clean up an already-archived item)
- This defaults to excluding rather than mirroring the opt-out-per-caller convention used elsewhere in the codebase (`WebPageSpecification.enabled/draft`, `MedicineSpecification.archivedOnly`, `FormDataSpecification.dismissed` all default to no filtering): no current caller of `ItemRepository`'s query path wants to browse archived items, so an opt-out default would leave the door open for the next listing call site to reintroduce this bug. No admin screen currently has a "show archived" toggle, so one isn't added here.

## Verified

- Every `new ItemSpecification()` call site in the codebase audited: each either goes through the shared `createSearchWhereStatement` path (correctly excluded by default now) or bypasses it via `findById`/`findByUniqueId` (correctly unaffected — direct PK/unique-id lookups).
- `ant -lib lib/war -lib lib/tests clean ci-test`: full suite passes, including 4 new `ItemRepositoryTest` cases run against a real Postgres (Testcontainers).
- Live end-to-end verification against a running instance: deactivating an item makes it disappear from edit-mode listing, public listing, anonymous/guest listing, and search results, while its own detail page (`/show/...`) intentionally continues to resolve. DB state (`archived`, `archived_by`) confirmed directly.

## Not in scope here

While reviewing the surrounding code, `deactivateCollectionItem` (along with `reorderCollectionItem` and `saveCollectionItem`) was found to lack any check that the target item/collection actually belongs to what the current page is showing, or any collection-level access check — pre-existing, and now consequential since deactivation actually does something. Tracked separately, not part of this fix.
