### PR TITLE
Assert the audit event fires in ContentWidget's saveDraft test

### DIFF
--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -197,6 +198,12 @@ class ContentWidgetTest extends WidgetBase {
 
       saveContent.verify(
           () -> SaveContentCommand.saveSafeContent(eq("hello-content"), eq("<p>Edited content</p>"), anyLong(), eq(false)));
+      // The mocked AuditEventCommand above only prevents the real static method from running during
+      // the test -- it doesn't prove saveDraft() actually recorded an event. Verify the call
+      // ContentHtmlCommand.saveDraft() makes, same shape as the delete-path checks in
+      // BlogPostWidgetTest/WebPageFormWidgetTest.
+      auditEvent.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.CONTENT), eq("content.saveDraft"),
+          eq(AuditEventCommand.SUCCESS), eq("content"), eq("42"), eq("hello-content"), any()), times(1));
       Assertions.assertTrue(widgetContext.hasJson());
       Assertions.assertTrue(widgetContext.getJson().contains("\"success\":true"));
     }


### PR DESCRIPTION
Small follow-up to #813 (merged) / #812.

#813's new test (`ContentWidgetTest.postSaveDraftForwardsToActionAndPersistsContent`) mocks `AuditEventCommand` via `mockStatic` to keep the real static `record()` call from executing during the test, but never actually asserted the mock was invoked — so the test would still pass even if the `content.saveDraft` audit event silently stopped firing.

The real audit behavior itself is already correct and unaffected by this — `ContentHtmlCommand.saveDraft()` already calls `AuditEventCommand.record(..., "content.saveDraft", ...)`, confirmed via a live docker check (real `audit_log` row + matching `AUDIT` JSON log line) as part of independently verifying #813 before it merged. This PR only strengthens the test to actually catch a regression in that call, not fix a behavior gap.

Adds one assertion, following the same `mockStatic`+`verify` pattern already used for audit checks in `BlogPostWidgetTest`/`WebPageFormWidgetTest`:

```java
auditEvent.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.CONTENT), eq("content.saveDraft"),
    eq(AuditEventCommand.SUCCESS), eq("content"), eq("42"), eq("hello-content"), any()), times(1));
```

Verified the assertion actually catches something: removing just the `AuditEventCommand.record(...)` call from `ContentHtmlCommand.saveDraft()` (leaving the save itself intact) fails specifically on this new assertion — the old test didn't catch that regression class at all.

Full suite: `BUILD SUCCESSFUL`, 0 failures.