### PR TITLE
Wire ContentAccessibilityCommand into the two real content-save paths

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentAccessibilityCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentAccessibilityCommand.java
@@ -17,9 +17,12 @@
 package com.simisinc.platform.application.cms;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
@@ -122,6 +125,47 @@ public class ContentAccessibilityCommand {
   /** @return true if the content has no accessibility findings. */
   public static boolean isClean(String html) {
     return check(html).isEmpty();
+  }
+
+  /**
+   * Turns a list of findings into a terse, human-readable summary for a non-blocking author-facing
+   * notice -- e.g. "3 accessibility issues found: missing alt text (2), skipped heading level (1)".
+   * Shared by every caller that surfaces {@link #check(String)}'s results directly to an author (a
+   * JSON response, a warning banner) so the phrasing stays consistent rather than being
+   * reformatted ad hoc at each call site.
+   *
+   * @return the summary, or null if there is nothing to report.
+   */
+  public static String summarize(List<Finding> findings) {
+    if (findings == null || findings.isEmpty()) {
+      return null;
+    }
+    // Group by rule, preserving the order rules first appear in.
+    Map<String, Long> countByRule = findings.stream()
+        .collect(Collectors.groupingBy(Finding::getRule, LinkedHashMap::new, Collectors.counting()));
+
+    String noun = findings.size() == 1 ? "issue" : "issues";
+    String breakdown = countByRule.size() == 1
+        ? readableRule(countByRule.keySet().iterator().next())
+        : countByRule.entrySet().stream()
+            .map(entry -> readableRule(entry.getKey()) + " (" + entry.getValue() + ")")
+            .collect(Collectors.joining(", "));
+
+    return findings.size() + " accessibility " + noun + " found: " + breakdown;
+  }
+
+  /** @return a short author-facing label for a rule constant, falling back to the rule name itself. */
+  private static String readableRule(String rule) {
+    if (RULE_IMAGE_MISSING_ALT.equals(rule)) {
+      return "missing alt text";
+    } else if (RULE_HEADING_SKIPPED.equals(rule)) {
+      return "skipped heading level";
+    } else if (RULE_LINK_TEXT_UNCLEAR.equals(rule)) {
+      return "unclear link text";
+    } else if (RULE_LINK_NO_TEXT.equals(rule)) {
+      return "link without text";
+    }
+    return rule;
   }
 
   private static String describe(Element element, String detail) {

--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -17,12 +17,15 @@
 package com.simisinc.platform.application.cms;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
@@ -45,6 +48,7 @@ import com.simisinc.platform.presentation.widgets.cms.BlogPostWidget;
 public class ContentHtmlCommand {
 
   private static Log LOG = LogFactory.getLog(ContentHtmlCommand.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   static String HTML_JSP = "/cms/content-html.jsp";
 
@@ -451,15 +455,47 @@ public class ContentHtmlCommand {
       return context;
     }
     try {
-      SaveContentCommand.saveSafeContent(content.getUniqueId(), html, context.getUserId(), false);
+      Content savedContent = SaveContentCommand.saveSafeContent(content.getUniqueId(), html, context.getUserId(), false);
       AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.saveDraft", AuditEventCommand.SUCCESS,
           "content", String.valueOf(content.getId()), content.getUniqueId(), null);
+      // The save above has already succeeded -- everything from here is a non-blocking, purely
+      // additive author-facing notice (#258). It must never turn a successful save into a reported
+      // failure, so the baseline response is set first and only replaced if the enrichment fully
+      // succeeds.
       context.setJson("{\"success\":true}");
+      try {
+        String savedHtml = savedContent != null && savedContent.getDraftContent() != null
+            ? savedContent.getDraftContent()
+            : html;
+        List<ContentAccessibilityCommand.Finding> findings = ContentAccessibilityCommand.check(savedHtml);
+        if (!findings.isEmpty()) {
+          Map<String, Object> response = new LinkedHashMap<>();
+          response.put("success", true);
+          response.put("a11yFindings", toA11yFindingList(findings));
+          context.setJson(MAPPER.writeValueAsString(response));
+        }
+      } catch (Exception a11yException) {
+        LOG.warn("Accessibility check failed for uniqueId " + content.getUniqueId(), a11yException);
+      }
     } catch (Exception e) {
       LOG.error("saveDraft failed for uniqueId " + content.getUniqueId(), e);
       context.setJson("{\"success\":false,\"error\":\"Save failed\"}");
     }
     return context;
+  }
+
+  /** Converts a11y findings to plain maps for JSON serialization, in document order. */
+  private static List<Map<String, String>> toA11yFindingList(List<ContentAccessibilityCommand.Finding> findings) {
+    List<Map<String, String>> result = new ArrayList<>();
+    for (ContentAccessibilityCommand.Finding finding : findings) {
+      Map<String, String> map = new LinkedHashMap<>();
+      map.put("rule", finding.getRule());
+      map.put("criterion", finding.getCriterion());
+      map.put("message", finding.getMessage());
+      map.put("context", finding.getContext());
+      result.add(map);
+    }
+    return result;
   }
 
   private static WidgetContext publishContent(WidgetContext context, Content content, boolean reviewRequired) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
@@ -18,8 +18,11 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
+
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.ContentAccessibilityCommand;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.DateCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
@@ -179,6 +182,19 @@ public class ContentEditorWidget extends GenericWidget {
               WorkflowManager.triggerWorkflowForEvent(new WebPageUpdatedEvent(webPage));
             }
           }
+        }
+        // Non-blocking author-facing a11y notice (#258): the save above has already succeeded, so
+        // this only ever adds information -- it never prevents or delays the save. Checked against
+        // whatever actually persisted (the live content if this was a publish, the draft otherwise).
+        try {
+          String savedHtml = publish ? content.getContent() : content.getDraftContent();
+          List<ContentAccessibilityCommand.Finding> findings =
+              ContentAccessibilityCommand.check(savedHtml != null ? savedHtml : contentHtml);
+          if (!findings.isEmpty()) {
+            context.setWarningMessage(ContentAccessibilityCommand.summarize(findings));
+          }
+        } catch (Exception a11yException) {
+          LOG.warn("Accessibility check failed for uniqueId " + uniqueId, a11yException);
         }
       }
     } catch (DataException e) {

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -453,8 +453,17 @@
     })
     .then(function (data) {
       if (data.success) {
-        setStatus(bar, 'Saved');
-        setToolbarStatus('Draft saved');
+        // Purely informational (#258) -- never blocks or delays the save above, which already
+        // succeeded. Reuse the existing transient-status convention (setStatus/#sc-editor-status)
+        // rather than adding a new floating-toast component.
+        if (data.a11yFindings && data.a11yFindings.length) {
+          var count = data.a11yFindings.length;
+          setStatus(bar, 'Draft saved — ' + count + ' accessibility issue' + (count === 1 ? '' : 's') + ' found');
+          setToolbarStatus('Draft saved — ' + count + ' accessibility issue' + (count === 1 ? '' : 's') + ' found');
+        } else {
+          setStatus(bar, 'Saved');
+          setToolbarStatus('Draft saved');
+        }
         originalHtml = activeContent.innerHTML;
         saveBtn.disabled = false;
         saveBtn.textContent = 'Save Draft';

--- a/src/test/java/com/simisinc/platform/application/cms/ContentAccessibilityCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentAccessibilityCommandTest.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.application.cms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -132,5 +133,40 @@ class ContentAccessibilityCommandTest {
     assertTrue(found.contains(ContentAccessibilityCommand.RULE_IMAGE_MISSING_ALT));
     assertTrue(found.contains(ContentAccessibilityCommand.RULE_LINK_TEXT_UNCLEAR));
     assertFalse(ContentAccessibilityCommand.isClean(html));
+  }
+
+  // ── summarize() -- shared by both #258 author-facing notice call sites ────────────────────────
+
+  @Test
+  void summarizeReturnsNullForNoFindings() {
+    assertNull(ContentAccessibilityCommand.summarize(List.of()));
+    assertNull(ContentAccessibilityCommand.summarize(null));
+  }
+
+  @Test
+  void summarizeSingleFindingIsSingularAndNamesTheRule() {
+    List<Finding> findings = ContentAccessibilityCommand.check("<img src=\"/a.png\">");
+    String summary = ContentAccessibilityCommand.summarize(findings);
+    assertEquals("1 accessibility issue found: missing alt text", summary);
+  }
+
+  @Test
+  void summarizeMultipleFindingsOfOneRuleDoesNotRepeatTheBreakdown() {
+    String html = "<img src=\"/a.png\"><img src=\"/b.png\">";
+    List<Finding> findings = ContentAccessibilityCommand.check(html);
+    assertEquals("2 accessibility issues found: missing alt text", ContentAccessibilityCommand.summarize(findings));
+  }
+
+  @Test
+  void summarizeGroupsMultipleRulesWithCounts() {
+    // check() runs its three passes -- image, then heading, then link -- in that order, so the
+    // summary's rule breakdown follows that same first-seen order.
+    String html = "<h2>Title</h2><h5>Skipped</h5>"
+        + "<img src=\"/a.png\">"
+        + "<a href=\"/b\">click here</a>";
+    List<Finding> findings = ContentAccessibilityCommand.check(html);
+    assertEquals(
+        "3 accessibility issues found: missing alt text (1), skipped heading level (1), unclear link text (1)",
+        ContentAccessibilityCommand.summarize(findings));
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidgetTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.SaveContentCommand;
+import com.simisinc.platform.domain.model.cms.Content;
+
+/**
+ * Covers wiring ContentAccessibilityCommand (#258) into the classic /content-editor page's save
+ * path as a non-blocking author-facing notice.
+ *
+ * @author elizabeth houser
+ */
+class ContentEditorWidgetTest extends WidgetBase {
+
+  @Test
+  void postSurfacesAccessibilityFindingsAsAWarningWhenPresent() {
+    // #258: a11y-lint is wired in as a non-blocking, purely additive notice -- it must never
+    // prevent or delay the save, which SaveContentCommand.saveSafeContent (mocked here) already
+    // completed successfully by the time the check runs.
+    addQueryParameter(widgetContext, "uniqueId", "hello-content");
+    addQueryParameter(widgetContext, "content", "<p>Text</p><img src=\"/assets/foo.jpg\">");
+    addQueryParameter(widgetContext, "save", "Save as Draft");
+
+    Content savedContent = new Content();
+    savedContent.setId(42L);
+    savedContent.setUniqueId("hello-content");
+    savedContent.setDraftContent("<p>Text</p><img src=\"/assets/foo.jpg\">");
+
+    try (MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class)) {
+      saveContent
+          .when(() -> SaveContentCommand.saveSafeContent(eq("hello-content"),
+              eq("<p>Text</p><img src=\"/assets/foo.jpg\">"), anyLong(), eq(false)))
+          .thenReturn(savedContent);
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.post(widgetContext);
+
+      Assertions.assertNull(widgetContext.getErrorMessage());
+      Assertions.assertNotNull(widgetContext.getWarningMessage());
+      Assertions.assertTrue(widgetContext.getWarningMessage().contains("accessibility"),
+          widgetContext.getWarningMessage());
+      Assertions.assertTrue(widgetContext.getWarningMessage().contains("missing alt text"),
+          widgetContext.getWarningMessage());
+    }
+  }
+
+  @Test
+  void postDoesNotSetAWarningWhenContentIsClean() {
+    // The flip side: a clean save must not set warningMessage at all. page_messages.jspf only
+    // renders the warning callout when the field is non-empty, so an unset field is the contract.
+    addQueryParameter(widgetContext, "uniqueId", "hello-content");
+    addQueryParameter(widgetContext, "content", "<p>Edited content</p>");
+    addQueryParameter(widgetContext, "save", "Save as Draft");
+
+    Content savedContent = new Content();
+    savedContent.setId(42L);
+    savedContent.setUniqueId("hello-content");
+    savedContent.setDraftContent("<p>Edited content</p>");
+
+    try (MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class)) {
+      saveContent
+          .when(() -> SaveContentCommand.saveSafeContent(eq("hello-content"), eq("<p>Edited content</p>"), anyLong(),
+              eq(false)))
+          .thenReturn(savedContent);
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.post(widgetContext);
+
+      Assertions.assertNull(widgetContext.getErrorMessage());
+      Assertions.assertNull(widgetContext.getWarningMessage());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -208,4 +208,72 @@ class ContentWidgetTest extends WidgetBase {
       Assertions.assertTrue(widgetContext.getJson().contains("\"success\":true"));
     }
   }
+
+  @Test
+  void postSaveDraftSurfacesAccessibilityFindingsWhenPresent() {
+    // #258: ContentAccessibilityCommand is wired into this save path as a non-blocking, purely
+    // additive author-facing notice. The save itself (verified above by the other saveDraft test)
+    // is unaffected either way -- this only proves the JSON response gets enriched when the saved
+    // content has a real, checkable violation.
+    preferences.put("uniqueId", "hello-content");
+    addQueryParameter(widgetContext, "action", "saveDraft");
+    addQueryParameter(widgetContext, "html", "<p>Text</p><img src=\"/assets/foo.jpg\">");
+
+    Content content = new Content();
+    content.setId(42L);
+    content.setUniqueId("hello-content");
+    content.setContent("<p>Original content</p>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class);
+        MockedStatic<AuditEventCommand> auditEvent = mockStatic(AuditEventCommand.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.post(widgetContext);
+
+      Assertions.assertTrue(widgetContext.hasJson());
+      String json = widgetContext.getJson();
+      Assertions.assertTrue(json.contains("\"success\":true"), json);
+      Assertions.assertTrue(json.contains("\"a11yFindings\""), json);
+      Assertions.assertTrue(json.contains("image-missing-alt"), json);
+      Assertions.assertTrue(json.contains("WCAG 1.1.1"), json);
+    }
+  }
+
+  @Test
+  void postSaveDraftOmitsAccessibilityFindingsWhenContentIsClean() {
+    // The flip side of the above: a clean save must not add the field at all. Existing clients
+    // (platform-editor.js) only read success/error and must keep working unchanged.
+    preferences.put("uniqueId", "hello-content");
+    addQueryParameter(widgetContext, "action", "saveDraft");
+    addQueryParameter(widgetContext, "html", "<p>Edited content</p>");
+
+    Content content = new Content();
+    content.setId(42L);
+    content.setUniqueId("hello-content");
+    content.setContent("<p>Original content</p>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class);
+        MockedStatic<AuditEventCommand> auditEvent = mockStatic(AuditEventCommand.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.post(widgetContext);
+
+      Assertions.assertTrue(widgetContext.hasJson());
+      String json = widgetContext.getJson();
+      Assertions.assertEquals("{\"success\":true}", json);
+      Assertions.assertFalse(json.contains("a11yFindings"), json);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes the "wire it in" half of #258. `ContentAccessibilityCommand` (added in #293) is a real, tested a11y-lint library but was called from nowhere except its own test file. This wires it into the two real content-save paths as a **non-blocking, purely additive** author-facing notice -- per #258's framing ("a NICE-TO-HAVE pursued where cheap and right -- it is NOT the differentiation thesis and never gates a release"), it never prevents or delays a save, only adds information after a successful one.

- **`ContentHtmlCommand.saveDraft()`** (Visual Editor inline overlay, the path #813 fixed dispatch for): on a successful save, adds an `"a11yFindings"` JSON array to the response when findings are non-empty, built with Jackson (not string concatenation). The baseline `{"success":true}` response is set immediately after the real save succeeds; it's only replaced if the enrichment step (check + serialize) also fully succeeds, so a bug in the lint check can never turn a successful save into a reported failure. `platform-editor.js`'s `saveContentDraft()` reads the new field and shows a terse status through the existing `setStatus()`/`setToolbarStatus()` transient-status convention -- no new UI component.
- **`ContentEditorWidget.post()`** (classic `/content-editor` page): on a successful save, calls `context.setWarningMessage()` with a terse summary when findings are non-empty. This renders automatically through the already-wired `warningMessage` callout in `page_messages.jspf` (included by `content-editor.jsp:116`) -- verified no JSP changes were needed rather than assuming.

Both hooks check the actually-persisted (cleaned) HTML returned by `SaveContentCommand.saveSafeContent()`, share a new `ContentAccessibilityCommand.summarize()` helper for consistent terse phrasing grouped by rule, and each wraps its own a11y-check block in its own try/catch so a check failure is logged but never surfaces as a save failure.

## Out of scope

- `PageServlet.saveWidgetContent()` (the Quill-delta save path) also renders Content-widget HTML this check would apply to -- confirmed by reading the code, not assumed. Left as a follow-up candidate for a third hook rather than added here, to keep this change scoped to the two paths named in #258.
- The other half of #258 (new "compliance page types") is untouched -- this PR is only the a11y-lint wiring half.

## Test plan

- [x] New tests in `ContentAccessibilityCommandTest` cover `summarize()`: null/empty input, singular vs. plural, single-rule grouping, multi-rule grouping with counts.
- [x] New tests in `ContentWidgetTest` (`postSaveDraftSurfacesAccessibilityFindingsWhenPresent` / `...OmitsAccessibilityFindingsWhenContentIsClean`) drive `ContentWidget.post()` -> `ContentHtmlCommand.saveDraft()` end-to-end and assert the JSON response gains `a11yFindings` for a real violation (missing alt text) and stays exactly `{"success":true}` for clean content.
- [x] New `ContentEditorWidgetTest` (`postSurfacesAccessibilityFindingsAsAWarningWhenPresent` / `postDoesNotSetAWarningWhenContentIsClean`) drives `ContentEditorWidget.post()` and asserts `warningMessage` is set for a real violation and left null for clean content.
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ant -lib lib/war -lib lib/tests clean ci-test` -- BUILD SUCCESSFUL, 1439 tests run, 0 failures.