### PR TITLE
Show a configure placeholder for an unconfigured itemsList widget (issue #817)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.items;
 
+import com.simisinc.platform.application.cms.EditorPermissionCommand;
 import com.simisinc.platform.application.items.LoadCollectionCommand;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Collection;
@@ -47,6 +48,7 @@ public class ItemsListWidget extends GenericWidget {
   static String TABLE_VIEW_JSP = "/items/items-table.jsp";
   static String JOBS_LIST_JSP = "/items/items-jobs-list.jsp";
   static String SEARCH_RESULTS_JSP = "/items/items-search-results-list.jsp";
+  static String NO_COLLECTION_JSP = "/items/items-list-no-collection.jsp";
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -75,6 +77,26 @@ public class ItemsListWidget extends GenericWidget {
     Collection collection = LoadCollectionCommand.loadCollectionByUniqueIdForAuthorizedUser(collectionUniqueId, context.getUserId());
     if (collection == null) {
       LOG.warn("Set a collection or collectionUniqueId preference, or user does not have access");
+      // A freshly-added widget (or one pointed at a collection the viewer can no longer reach) has
+      // nothing else to render -- without a visible placeholder here, there is zero markup in the
+      // canvas to hover, so the per-widget "Prefs" affordance that would let someone fix this is
+      // itself unreachable (issue #817). Mirrors ContentWidget/ContentHtmlCommand's "Add Content
+      // Here" empty state: show a configure prompt instead of silently rendering nothing.
+      //
+      // Gate on pageEditMode AND canBuildLayout, not pageEditMode alone -- matching the precedent
+      // set by TableWidget.execute() for this exact widget-level decision. pageEditMode (published
+      // by PageServlet) already implies EditorPermissionCommand.canEditContent, but the "+Widget"
+      // picker and "Prefs" panel that make this placeholder useful are layout-builder-tier
+      // (canBuildLayout), not just content-editor-tier -- see EditorPermissionCommand's javadoc
+      // ("authors get content guardrails, designers get the canvas"). A content-editor in edit mode
+      // without layout-build rights, and any real site visitor, must still see nothing.
+      boolean pageEditMode = "true".equals(context.getRequest().getAttribute("pageEditMode"));
+      if (pageEditMode && EditorPermissionCommand.canBuildLayout(context.getUserSession())) {
+        context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+        context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+        context.setJsp(NO_COLLECTION_JSP);
+        return context;
+      }
       return null;
     }
     context.getRequest().setAttribute("collection", collection);

--- a/src/main/webapp/WEB-INF/jsp/items/items-list-no-collection.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-list-no-collection.jsp
@@ -1,0 +1,36 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%--
+  Editor-only placeholder for ItemsListWidget (issue #817). Rendered only when
+  ItemsListWidget.execute() has already confirmed pageEditMode && canBuildLayout -- this JSP does
+  not re-check permissions itself, the same way content-html.jsp trusts ContentHtmlCommand. A real
+  site visitor, or an editor without layout-build rights, never reaches this file.
+--%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<div class="callout radius warning text-center" role="alert" data-widget-placeholder="itemsList">
+  <p><i class="${font:fas()} fa-triangle-exclamation"></i> This Items List widget has no collection configured, or the configured collection could not be found.</p>
+  <p>
+    <a class="button tiny radius primary" href="${ctx}/admin/collections">
+      <i class="${font:fas()} fa-database"></i> Select a Collection
+    </a>
+  </p>
+</div>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsListWidgetTest.java
@@ -17,6 +17,8 @@
 package com.simisinc.platform.presentation.widgets.items;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
@@ -108,5 +110,134 @@ class ItemsListWidgetTest extends WidgetBase {
     WidgetContext result = executeWithCollection();
 
     assertEquals("false", result.getRequest().getAttribute("isEditMode"));
+  }
+
+  // ── No-collection placeholder (issue #817) ────────────────────────────────
+  //
+  // Before the fix, a widget with no collectionUniqueId preference (the state of every
+  // freshly-added itemsList widget -- there is no default and no picker) rendered nothing at all:
+  // execute() returned null with zero markup, so there was nothing in the composition canvas to
+  // hover to reach the per-widget "Prefs" affordance that would let an editor fix it. These tests
+  // cover the fix: an edit-mode, layout-builder-permitted placeholder that points at
+  // /admin/collections, with the real-visitor/no-permission/valid-collection paths left unchanged.
+
+  @Test
+  void executeRendersAnEditorPlaceholderWhenNoCollectionUniqueIdIsSetAndUserCanBuildLayout() {
+    // No "collectionUniqueId" preference at all -- the exact state of a widget just added via the
+    // canvas's "+Widget" picker with no prefsJson.
+    setRoles(widgetContext, CONTENT_MANAGER);
+    request.setAttribute("pageEditMode", "true");
+
+    WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+    assertNotNull(result, "must render a placeholder, not silently return null");
+    assertEquals(ItemsListWidget.NO_COLLECTION_JSP, result.getJsp());
+  }
+
+  @Test
+  void executeRendersAnEditorPlaceholderWhenCollectionUniqueIdDoesNotResolve() {
+    // A collectionUniqueId preference IS set, but points at a collection that no longer exists (or
+    // that the current user cannot access) -- LoadCollectionCommand still returns null, same as the
+    // unset case, and the issue calls out both as needing the same placeholder.
+    preferences.put("collectionUniqueId", "does-not-exist");
+    setRoles(widgetContext, ADMIN);
+    request.setAttribute("pageEditMode", "true");
+
+    try (MockedStatic<LoadCollectionCommand> loadCollection = mockStatic(LoadCollectionCommand.class)) {
+      loadCollection.when(() -> LoadCollectionCommand.loadCollectionByUniqueIdForAuthorizedUser(any(), anyLong()))
+          .thenReturn(null);
+
+      WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+      assertNotNull(result, "must render a placeholder, not silently return null");
+      assertEquals(ItemsListWidget.NO_COLLECTION_JSP, result.getJsp());
+    }
+  }
+
+  @Test
+  void executeReturnsNullForAnAnonymousVisitorEvenWithNoCollectionConfigured() {
+    // The regression that matters most: this placeholder is an editor-only affordance and must
+    // never leak to a real site visitor, regardless of what pageEditMode happens to be.
+    logout(widgetContext);
+    request.setAttribute("pageEditMode", "true");
+
+    WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+    assertNull(result, "an anonymous visitor must still see nothing, not the configure placeholder");
+  }
+
+  @Test
+  void executeReturnsNullWhenPageEditModeIsFalseAndNoCollectionIsConfigured() {
+    // The ordinary, out-of-canvas page render: no visual editor session at all.
+    setRoles(widgetContext, CONTENT_MANAGER);
+
+    WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+    assertNull(result, "outside edit mode, a misconfigured widget must still render nothing");
+  }
+
+  @Test
+  void executeReturnsNullWhenPageEditModeTrueButUserCannotBuildLayout() {
+    // content-editor holds EditorPermissionCommand.canEditContent() (so pageEditMode can be "true"
+    // for them) but is deliberately excluded from canBuildLayout() -- the "+Widget"/"Prefs" canvas
+    // controls this placeholder points an editor toward are layout-builder-tier, matching
+    // TableWidget's precedent for the same pageEditMode-is-not-enough-on-its-own decision.
+    setRoles(widgetContext, CONTENT_EDITOR);
+    request.setAttribute("pageEditMode", "true");
+
+    WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+    assertNull(result, "a content-editor without layout-build rights must still see nothing");
+  }
+
+  @Test
+  void executeReturnsNullWhenPageEditModeTrueButUserHasNoRolesAtAll() {
+    // The default logged-in test user (see WidgetBase.login) has no roles -- pageEditMode alone
+    // must not be sufficient.
+    request.setAttribute("pageEditMode", "true");
+
+    WidgetContext result = new ItemsListWidget().execute(widgetContext);
+
+    assertNull(result);
+  }
+
+  @Test
+  void executeWithAValidAccessibleCollectionRendersNormallyEvenInEditModeWithPermission() {
+    // The fix must not change anything about the already-working path: a real, accessible
+    // collection renders its normal list JSP, never the placeholder, regardless of edit mode.
+    // showWhenEmpty=true so execute() runs all the way through to setJsp() instead of taking its
+    // (pre-existing, unrelated) early "no items found" return -- see the plain
+    // executeWithCollection() tests below for that default-empty-list path.
+    setRoles(widgetContext, CONTENT_MANAGER);
+    request.setAttribute("pageEditMode", "true");
+    preferences.put("showWhenEmpty", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals(ItemsListWidget.JSP, result.getJsp());
+    assertNotNull(result.getRequest().getAttribute("collection"));
+  }
+
+  @Test
+  void executeWithAValidAccessibleCollectionRendersNormallyOutsideEditMode() {
+    preferences.put("showWhenEmpty", "true");
+
+    WidgetContext result = executeWithCollection();
+
+    assertEquals(ItemsListWidget.JSP, result.getJsp());
+    assertNotNull(result.getRequest().getAttribute("collection"));
+  }
+
+  @Test
+  void executeWithAValidAccessibleCollectionButNoItemsStillReturnsContextNotThePlaceholder() {
+    // Pre-existing behavior for a real, empty collection (showWhenEmpty defaults to false): execute()
+    // returns the context without ever calling setJsp(). The fix must not divert this path to the
+    // no-collection placeholder -- a collection that resolved successfully is not a "no collection"
+    // case, even when it happens to have zero items.
+    WidgetContext result = executeWithCollection();
+
+    assertNotNull(result);
+    assertNull(result.getJsp());
+    assertNotNull(result.getRequest().getAttribute("collection"));
   }
 }


### PR DESCRIPTION
## Summary

Closes #817. `ItemsListWidget.execute()` returned `null` whenever `collectionUniqueId` was unset or unresolvable -- the state of every freshly-added `itemsList` widget, since there's no default and no picker. With zero rendered output, there was nothing in the canvas to hover to reach the per-widget "Prefs" configuration affordance, so the widget was completely unreachable/unconfigurable from the UI once added -- an editor had to already know to hand-edit the page's raw XML via the "</> XML" toggle before the widget became visible at all.

## Fix

When the collection fails to resolve AND the request is in edit mode AND the viewer has `canBuildLayout()` (the same tier that can reach the "+Widget" picker and "Prefs" panel in the first place, matching the precedent `TableWidget.execute()` already set for this exact kind of gate), render a placeholder instead of returning `null` -- mirroring `ContentWidget`/`content-html.jsp`'s "Add Content Here" empty-state pattern. The placeholder links to `/admin/collections`. View mode, non-builder editors, and anonymous visitors are completely unaffected -- they still get `null`/no output, exactly as before.

## Testing

- 8 new `ItemsListWidgetTest` cases covering: placeholder renders for missing/unresolvable collection with `canBuildLayout` (admin and content-manager); anonymous, no-role, and content-editor-without-layout-build-rights all still get `null`; valid/accessible collection rendering is completely unaffected in and out of edit mode, including the pre-existing (unrelated) empty-collection `showWhenEmpty=false` early return.
- Full `ant ci-test`: 1440 tests, 0 failures.
- `check-unescaped-el.py --strict`: 0 unallowlisted.
- Live Docker rehearsal verified over real HTTP with a real authenticated session (not just UI narration): added a zero-prefs `itemsList` widget via the real `action=addWidget` mutation, confirmed the exact placeholder text and `/admin/collections` link byte-for-byte in the edit-mode HTML; published the page and confirmed a **fully anonymous** (no-cookie) fetch shows zero occurrences of the placeholder while the rest of the page renders normally; set a real collection and confirmed normal item-list rendering for both authenticated and anonymous visitors.

## Not fixed, left alone (in scope discipline)

The pre-existing collection-item-management UI (reorder/deactivate/add-item, issues #814/#815) gates only on `pageEditMode`, not `canBuildLayout` -- a narrower permission tier than this placeholder uses. `TableWidget`'s own code comments already flag this as a pre-existing, un-replicated gap. Not touched here: it's ambiguous whether item curation should require layout-build tier or just content-edit tier (unlike widget *configuration*, which is unambiguously layout-builder territory), and #817 itself explicitly scopes this as unrelated to #814/#815.