### PR TITLE
Warn before publishing shared content affects other pages (issue #499, slice 3)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -99,8 +99,19 @@ public class ContentHtmlCommand {
             context.getRequest().setAttribute("isDraft", "true");
           }
           // Which review affordance to render, decided here rather than in a JSP expression
-          context.getRequest().setAttribute("reviewOffer", ContentReviewCommand.offerFor(content,
-              context.getUserId(), LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required")));
+          String reviewOffer = ContentReviewCommand.offerFor(content,
+              context.getUserId(), LoadSitePropertyCommand.loadByNameAsBoolean("content.review.required"));
+          context.getRequest().setAttribute("reviewOffer", reviewOffer);
+          // The DRAFT badge's "Publish this content?" confirm (content.jsp) is only rendered for
+          // OFFER_PUBLISH (ungoverned direct publish); warn there with the real list of affected
+          // pages when this block is shared (issue #499 slice 2). Scoped to that one state so the
+          // bulk usage scan (ContentUsageCommand#findUsageMap) only runs for the content managers
+          // who will actually see the confirm, not on every content-widget render on every page.
+          if (ContentReviewCommand.OFFER_PUBLISH.equals(reviewOffer)) {
+            Map<String, List<String>> usageMap = ContentUsageCommand.findUsageMap(context.getRequest().getServletContext());
+            context.getRequest().setAttribute("reusabilityWarning",
+                ContentUsageCommand.buildReusabilityWarning(uniqueId, usageMap));
+          }
         }
       }
     }

--- a/src/main/java/com/simisinc/platform/application/cms/ContentUsageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentUsageCommand.java
@@ -138,6 +138,39 @@ public class ContentUsageCommand {
     return usageMap;
   }
 
+  /**
+   * Builds the "this will affect other pages" warning shown before a shared content block is
+   * republished (issue #499 slice 2), or {@code null} when there is nothing to warn about. A
+   * block used on 0 or 1 locations isn't "shared" -- publishing it only ever affects the page the
+   * author is already looking at, so no warning is needed.
+   *
+   * <p>
+   * Shared by the two real publish surfaces that can affect other pages: {@code
+   * ContentEditorWidget}'s "Publish Immediately" button on the full {@code /content-editor} page,
+   * and the DRAFT-badge "Publish this content?" confirm in {@code content.jsp}. Both describe the
+   * same locations the same way rather than duplicating the message-building logic. (A third
+   * publish surface, the step-up APPROVE flow reached from {@code content.jsp}, is a different UI
+   * shape -- a full re-authentication form, not a single confirm-on-click -- and is intentionally
+   * out of scope for this slice.)
+   * </p>
+   *
+   * @param uniqueId the content block being published
+   * @param usageMap the result of {@link #findUsageMap(ServletContext)}
+   * @return a warning message with the affected page/template locations, or {@code null} if the
+   *     block is not shared
+   */
+  public static String buildReusabilityWarning(String uniqueId, Map<String, List<String>> usageMap) {
+    if (uniqueId == null || usageMap == null) {
+      return null;
+    }
+    List<String> locations = usageMap.get(uniqueId);
+    if (locations == null || locations.size() <= 1) {
+      return null;
+    }
+    return "This content appears on " + locations.size() + " pages. Update will affect: "
+        + String.join(", ", locations) + ".";
+  }
+
   private static void addUsageFromXml(Map<String, List<String>> usageMap, String xml, String location) {
     if (StringUtils.isBlank(xml) || StringUtils.isBlank(location)) {
       return;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidget.java
@@ -21,11 +21,13 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.ContentAccessibilityCommand;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
+import com.simisinc.platform.application.cms.ContentUsageCommand;
 import com.simisinc.platform.application.cms.DateCommand;
 import com.simisinc.platform.application.cms.LoadContentCommand;
 import com.simisinc.platform.application.cms.LoadWebPageCommand;
@@ -95,6 +97,17 @@ public class ContentEditorWidget extends GenericWidget {
       contentHtml = TinyMceCommand.prepareContentForEditor(contentHtml);
     }
     context.getRequest().setAttribute("contentHtml", contentHtml);
+
+    // Determine if this content is shared across multiple pages/templates -- if so, the
+    // client-side confirm on "Publish Immediately" (content-editor.jsp) needs to warn with the
+    // real list of affected pages before the publish takes effect (issue #499 slice 2). Only the
+    // existing-content case renders that button at all (a brand-new, never-yet-saved block has no
+    // "Publish Immediately" to guard, just "Save"), so the usage scan is skipped otherwise.
+    if (content.getId() != -1) {
+      Map<String, List<String>> usageMap = ContentUsageCommand.findUsageMap(context.getRequest().getServletContext());
+      context.getRequest().setAttribute("reusabilityWarning",
+          ContentUsageCommand.buildReusabilityWarning(uniqueId, usageMap));
+    }
 
     // Determine the return page
     String returnPage = UrlCommand.getValidReturnPage(context.getParameter("returnPage"));

--- a/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
@@ -15,10 +15,12 @@
   --%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="content" class="com.simisinc.platform.domain.model.cms.Content" scope="request"/>
 <jsp:useBean id="isDraft" class="java.lang.String" scope="request"/>
+<jsp:useBean id="reusabilityWarning" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/tinymce-7.9.3/tinymce.min.js"></script>
 <script nonce="${cspNonce}">
   $(window).on('resize', function () {
@@ -148,3 +150,41 @@
     <a href="${returnPage}" class="button radius secondary">Cancel</a>
   </div>
 </form>
+<c:if test="${!empty reusabilityWarning}">
+  <%-- #499 slice 2: this content is used on more than one page/template. Warn before "Publish
+       Immediately" takes effect, without gating the other submit buttons in the same form (Save
+       as Draft / Remove this Draft never affect other pages). Scoped to that one button via the
+       submit event's submitter (falling back to a click listener on the button itself for older
+       browsers), not a blanket form-level onsubmit.
+
+       Found the button via a page-wide selector, then its owning form via the .form IDL property
+       -- NOT document.querySelector('form'). The full page chrome this JSP renders inside (header
+       search box, footer widgets, etc.) can and does contain other <form> elements earlier in the
+       DOM (e.g. the header search form), so "the first form on the page" is not reliably this
+       editor's form; .form always resolves to the control's own owning form regardless of how
+       many other forms precede it. --%>
+  <script nonce="${cspNonce}">
+    (function () {
+      var reusabilityWarning = '${js:escape(reusabilityWarning)}';
+      var publishButton = document.querySelector('input[type="submit"][name="save"][value="Publish Immediately"]');
+      var form = publishButton ? publishButton.form : null;
+      if (!form || !publishButton) {
+        return;
+      }
+      var lastClickedButton = null;
+      publishButton.addEventListener('click', function () {
+        lastClickedButton = publishButton;
+      });
+      form.addEventListener('submit', function (event) {
+        var submitter = event.submitter || lastClickedButton;
+        lastClickedButton = null;
+        if (submitter !== publishButton) {
+          return;
+        }
+        if (!confirm(reusabilityWarning + ' Continue publishing?')) {
+          event.preventDefault();
+        }
+      });
+    })();
+  </script>
+</c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/content.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content.jsp
@@ -21,6 +21,7 @@
 <jsp:useBean id="contentHtml" class="java.lang.String" scope="request"/>
 <jsp:useBean id="videoBackgroundUrl" class="java.lang.String" scope="request"/>
 <jsp:useBean id="isDraft" class="java.lang.String" scope="request"/>
+<jsp:useBean id="reusabilityWarning" class="java.lang.String" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa <c:out value="${icon}"/>"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
@@ -32,7 +33,11 @@
       <c:choose>
         <c:when test="${reviewOffer eq 'publish'}">
           <c:if test="${isDraft eq 'true'}">
-            <a class="hollow button small warning" href="${widgetContext.uri}?action=publish&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('Publish this content?');">DRAFT</a>
+            <%-- #499 slice 2: when this content is used on more than one page/template,
+                 reusabilityWarning carries the real affected-page list (see
+                 ContentUsageCommand#buildReusabilityWarning); the confirm is enriched with it. The
+                 non-shared case renders the exact same 'Publish this content?' confirm as before. --%>
+            <a class="hollow button small warning" href="${widgetContext.uri}?action=publish&widget=${widgetContext.uniqueId}&token=${userSession.formToken}" onclick="return confirm('<c:if test="${!empty reusabilityWarning}"><c:out value="${js:escape(reusabilityWarning)}"/> </c:if>Publish this content?');">DRAFT</a>
           </c:if>
         </c:when>
         <c:when test="${reviewOffer eq 'submit'}">

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentEditorWidgetTest.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -25,6 +26,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 
 import java.sql.Timestamp;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -38,21 +41,137 @@ import com.simisinc.platform.application.cms.SaveContentCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.cache.PublishEventCachePurgeHandler;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 
 /**
- * Covers two independent concerns on the classic /content-editor page's save path:
+ * Covers three independent concerns on the classic /content-editor page's save path:
  * <p>
  * - Wiring ContentAccessibilityCommand (#258) in as a non-blocking author-facing notice.
  * <p>
  * - Wiring PublishEventCachePurgeHandler (#420) so the widget's own post() method triggers an AFD
  * cache purge on publish, and correctly skips it for a plain "Save as Draft".
+ * <p>
+ * - The reusability warning (#499 slice 2) shown before "Publish Immediately" affects other pages.
  *
  * @author elizabeth houser
  */
 class ContentEditorWidgetTest extends WidgetBase {
+
+  @Test
+  void executeExposesAReusabilityWarningWhenContentIsUsedOnMultiplePages() {
+    // "Publish Immediately" affects every page/template that references this uniqueId -- warn
+    // with the real list before it happens (#499 slice 2).
+    addQueryParameter(widgetContext, "uniqueId", "cmmc-header");
+
+    Content content = new Content();
+    content.setId(1L);
+    content.setUniqueId("cmmc-header");
+    content.setContent("<p>Header</p>");
+
+    WebPage careers = new WebPage();
+    careers.setLink("/careers");
+    careers.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>cmmc-header</uniqueId></widget></column></section></page>");
+    WebPage aboutUs = new WebPage();
+    aboutUs.setLink("/about-us");
+    aboutUs.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>cmmc-header</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      contentRepository.when(() -> ContentRepository.findByUniqueId("cmmc-header")).thenReturn(content);
+      webPageRepository.when(WebPageRepository::findAll).thenReturn(List.of(careers, aboutUs));
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.execute(widgetContext);
+
+      String warning = (String) request.getAttribute("reusabilityWarning");
+      Assertions.assertNotNull(warning, "a block used on 2 pages must produce a warning");
+      Assertions.assertTrue(warning.contains("2 pages"), warning);
+      Assertions.assertTrue(warning.contains("/careers"), warning);
+      Assertions.assertTrue(warning.contains("/about-us"), warning);
+    }
+  }
+
+  @Test
+  void executeDoesNotExposeAWarningWhenContentIsUsedOnAtMostOnePage() {
+    // Used on exactly one page (the page being edited itself, in practice) -- nothing to warn
+    // about since nothing else is affected.
+    addQueryParameter(widgetContext, "uniqueId", "solo-block");
+
+    Content content = new Content();
+    content.setId(2L);
+    content.setUniqueId("solo-block");
+    content.setContent("<p>Solo</p>");
+
+    WebPage onlyPage = new WebPage();
+    onlyPage.setLink("/careers");
+    onlyPage.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>solo-block</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      contentRepository.when(() -> ContentRepository.findByUniqueId("solo-block")).thenReturn(content);
+      webPageRepository.when(WebPageRepository::findAll).thenReturn(List.of(onlyPage));
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.execute(widgetContext);
+
+      assertNull(request.getAttribute("reusabilityWarning"));
+    }
+  }
+
+  @Test
+  void executeDoesNotExposeAWarningWhenContentIsUsedNowhere() {
+    // Orphaned content (0 locations) -- also nothing to warn about.
+    addQueryParameter(widgetContext, "uniqueId", "orphaned-block");
+
+    Content content = new Content();
+    content.setId(3L);
+    content.setUniqueId("orphaned-block");
+    content.setContent("<p>Nobody links to me</p>");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      contentRepository.when(() -> ContentRepository.findByUniqueId("orphaned-block")).thenReturn(content);
+      webPageRepository.when(WebPageRepository::findAll).thenReturn(List.of());
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.execute(widgetContext);
+
+      assertNull(request.getAttribute("reusabilityWarning"));
+    }
+  }
+
+  @Test
+  void postNeverSetsAReusabilityWarningRegardlessOfSaveAction() {
+    // The warning is a pre-submit client-side confirm built by execute() and rendered into
+    // content-editor.jsp's "Publish Immediately" onsubmit handler -- post() (the actual save,
+    // reached for Save as Draft/Remove this Draft too) must not also compute or expose it. That
+    // would be a wasted usage-map scan on every save, including the two actions that never affect
+    // other pages at all.
+    addQueryParameter(widgetContext, "uniqueId", "cmmc-header");
+    addQueryParameter(widgetContext, "content", "<p>Text</p>");
+    addQueryParameter(widgetContext, "save", "Save as Draft");
+
+    Content savedContent = new Content();
+    savedContent.setId(1L);
+    savedContent.setUniqueId("cmmc-header");
+    savedContent.setDraftContent("<p>Text</p>");
+
+    try (MockedStatic<SaveContentCommand> saveContent = mockStatic(SaveContentCommand.class)) {
+      saveContent.when(() -> SaveContentCommand.saveSafeContent(eq("cmmc-header"), eq("<p>Text</p>"), anyLong(), eq(false)))
+          .thenReturn(savedContent);
+
+      ContentEditorWidget widget = new ContentEditorWidget();
+      widgetContext = widget.post(widgetContext);
+
+      assertNull(request.getAttribute("reusabilityWarning"));
+    }
+  }
 
   @Test
   void postSurfacesAccessibilityFindingsAsAWarningWhenPresent() {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.cms;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -25,6 +26,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -45,6 +48,7 @@ import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.infrastructure.cache.PublishEventCachePurgeHandler;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 
 /**
@@ -107,6 +111,110 @@ class ContentWidgetTest extends WidgetBase {
     String contentHtml = (String) request.getAttribute("contentHtml");
     Assertions.assertTrue(contentHtml.contains("Hello"));
     Assertions.assertTrue(contentHtml.contains("This is additional content"));
+  }
+
+  @Test
+  void executeExposesAReusabilityWarningWhenTheDraftPublishConfirmIsShownForASharedBlock() {
+    // #499 slice 2: the DRAFT badge's "Publish this content?" confirm (reviewOffer == 'publish',
+    // ungoverned direct publish) affects every page/template that references this uniqueId --
+    // warn with the real list before it happens.
+    preferences.put("uniqueId", "cmmc-header");
+
+    Content content = new Content();
+    content.setUniqueId("cmmc-header");
+    content.setContent("<p>Live</p>");
+    content.setDraftContent("<p>Draft</p>");
+
+    WebPage careers = new WebPage();
+    careers.setLink("/careers");
+    careers.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>cmmc-header</uniqueId></widget></column></section></page>");
+    WebPage aboutUs = new WebPage();
+    aboutUs.setLink("/about-us");
+    aboutUs.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>cmmc-header</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("cmmc-header"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      // Governed publishing off -> offerFor() returns OFFER_PUBLISH, the state that actually
+      // renders the DRAFT badge's confirm in content.jsp.
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+      webPageRepository.when(WebPageRepository::findAll).thenReturn(List.of(careers, aboutUs));
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.execute(widgetContext);
+
+      Assertions.assertEquals(ContentReviewCommand.OFFER_PUBLISH, request.getAttribute("reviewOffer"));
+      String warning = (String) request.getAttribute("reusabilityWarning");
+      Assertions.assertNotNull(warning, "a block used on 2 pages must produce a warning");
+      Assertions.assertTrue(warning.contains("2 pages"), warning);
+      Assertions.assertTrue(warning.contains("/careers"), warning);
+      Assertions.assertTrue(warning.contains("/about-us"), warning);
+    }
+  }
+
+  @Test
+  void executeDoesNotExposeAWarningWhenTheSharedBlockIsUsedOnAtMostOnePage() {
+    preferences.put("uniqueId", "solo-header");
+
+    Content content = new Content();
+    content.setUniqueId("solo-header");
+    content.setContent("<p>Live</p>");
+    content.setDraftContent("<p>Draft</p>");
+
+    WebPage careers = new WebPage();
+    careers.setLink("/careers");
+    careers.setPageXml(
+        "<page><section><column><widget name=\"content\"><uniqueId>solo-header</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("solo-header"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+      webPageRepository.when(WebPageRepository::findAll).thenReturn(List.of(careers));
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.execute(widgetContext);
+
+      Assertions.assertEquals(ContentReviewCommand.OFFER_PUBLISH, request.getAttribute("reviewOffer"));
+      assertNull(request.getAttribute("reusabilityWarning"));
+    }
+  }
+
+  @Test
+  void executeSkipsTheUsageScanWhenNoPublishConfirmWillBeShown() {
+    // Cost containment: ContentUsageCommand#findUsageMap is a bulk scan of every page and
+    // filesystem template (#499 slice 1). It must only run for the one reviewOffer state that
+    // actually renders the confirm it feeds (OFFER_PUBLISH) -- not on every content-widget render
+    // on every page view. Here there is no draft at all, so offerFor() returns OFFER_NONE.
+    preferences.put("uniqueId", "hello-content");
+
+    Content content = new Content();
+    content.setUniqueId("hello-content");
+    content.setContent("<p>Hello</p>");
+
+    try (MockedStatic<LoadContentCommand> loadContent = mockStatic(LoadContentCommand.class);
+        MockedStatic<EditorPermissionCommand> editorPermission = mockStatic(EditorPermissionCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+      loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
+      editorPermission.when(() -> EditorPermissionCommand.canEditContent(any())).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean(anyString())).thenReturn(false);
+
+      ContentWidget contentWidget = new ContentWidget();
+      widgetContext = contentWidget.execute(widgetContext);
+
+      webPageRepository.verify(WebPageRepository::findAll, never());
+      Assertions.assertEquals(ContentReviewCommand.OFFER_NONE, request.getAttribute("reviewOffer"));
+      assertNull(request.getAttribute("reusabilityWarning"));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Scope

Continuation of #499's scoped slices (#831 search/filter/usage-detection, then this reusability warning). When publishing a content block used on more than one page, warn with the real list of affected pages before it takes effect — issue #499's own example text: "This content appears on 5 pages. Update will affect: /careers, /about-us, /data-center. Confirm?"

## What's here

- `ContentUsageCommand.buildReusabilityWarning(uniqueId, usageMap)` — shared helper, reused by both call sites below.
- `/content-editor?uniqueId=X`'s "Publish Immediately" button now shows the real warning (built server-side, scoped to just this one content block, not an eager full-list scan) before submitting.
- `content.jsp`'s existing DRAFT-badge "Publish this content?" confirm is enriched with the same warning when the block is shared; unchanged for non-shared content.

**Explicitly out of scope**: the step-up APPROVE flow (a different UI shape — a full re-auth form, not a single confirm-on-click) doesn't get this warning yet, flagged as a natural follow-up now that the shared helper exists.

## Testing

- New tests in `ContentEditorWidgetTest`/`ContentWidgetTest` covering shared/solo/orphaned content and that the usage scan is scoped to only the actions that actually affect other pages.
- `ant -lib lib/war -lib lib/tests clean ci-test`: BUILD SUCCESSFUL, 0 failures.
- `python3 tools/check-unescaped-el.py --strict`: 0 unallowlisted.
- Live Docker rehearsal caught and fixed a real bug: the confirm-guard script initially used `document.querySelector('form')`, which silently grabbed the page header's own search form instead of the editor form (the header renders first in the DOM) — the warning never fired. Fixed by locating the button first and using its `.form` property, which resolves correctly regardless of DOM order. Re-verified end-to-end after the fix: confirm fires with the correct message, cancelling blocks the publish, confirming lets it through, and Save as Draft/Remove Draft never trigger it.

## Note

This branch was rebased onto `main` after #829 (a11y-warning redirect fix) and #420 (AFD cache-purge wiring) landed in the same file (`ContentEditorWidget.java`) — both merged cleanly with no logic changes needed on either side; only test-file import/javadoc conflicts, resolved by combining both sets of coverage.