### PR TITLE
Surface the governed-publish workflow status on /admin/content-list (issue #499)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentReviewCommand.java
@@ -198,4 +198,42 @@ public class ContentReviewCommand {
           "The approver must be different from the person who submitted the content (separation of duties)");
     }
   }
+
+  /** No draft in progress: {@code content.getContent()} is exactly what visitors see. */
+  public static final String LIST_STATUS_LIVE = "Live";
+  /** A draft was submitted and approved, but has not yet been promoted to live (publish is a separate action). */
+  public static final String LIST_STATUS_APPROVED = "Approved";
+  /** A draft was submitted for review and awaits an approver's decision. */
+  public static final String LIST_STATUS_PENDING_REVIEW = "Pending Review";
+  /** A draft is being edited, not yet submitted -- or was sent back by {@link #reject}. */
+  public static final String LIST_STATUS_DRAFT = "Draft";
+
+  /**
+   * The record's own workflow state, for a bird's-eye list (e.g. {@code /admin/content-list}) that
+   * needs to show many blocks' status at a glance. One of the {@code LIST_STATUS_*} constants.
+   *
+   * <p>Unlike {@link #offerFor}, this is <b>viewer-independent</b> -- it says what state the record
+   * is in, not which action one particular viewer should be offered -- and it deliberately ignores
+   * the {@code content.review.required} site property, so a list label reflects the record's actual
+   * state regardless of whether governed publishing happens to be toggled on right now.
+   *
+   * <p>There is no separate "Rejected" label: {@link #reject} resets {@code draftStatus} back to
+   * {@link #STATUS_DRAFT}, so a rejected-and-not-yet-fixed draft correctly reports as {@link
+   * #LIST_STATUS_DRAFT} here too -- per this class's javadoc on {@code STATUS_DRAFT}, it is "the
+   * author's to change" either way.
+   */
+  public static String listStatusLabel(Content content) {
+    if (content == null || StringUtils.isBlank(content.getDraftContent())) {
+      return LIST_STATUS_LIVE;
+    }
+    if (isApproved(content)) {
+      // Cleared for publish, but publish is a separate, subsequent action -- surface that gap.
+      return LIST_STATUS_APPROVED;
+    }
+    if (isPendingReview(content)) {
+      return LIST_STATUS_PENDING_REVIEW;
+    }
+    // draftStatus is null or STATUS_DRAFT: being edited, or sent back by reject().
+    return LIST_STATUS_DRAFT;
+  }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.infrastructure.persistence.cms;
 
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
@@ -71,8 +72,44 @@ public class ContentRepository {
       // column the full-text search indexes -- not the raw HTML in the content column.
       where.addIfExists("LENGTH(content_text) >= ?", specification.getMinLength(), -1);
       where.addIfExists("LENGTH(content_text) <= ?", specification.getMaxLength(), -1);
+      // Applied in the WHERE clause (not filtered client-side after fetch) so DB.selectAllFrom's
+      // paired COUNT(*) query -- and therefore pagination -- stays correct.
+      addStatusFilter(where, specification.getStatus());
     }
     return DB.selectAllFrom(TABLE_NAME, select, where, orderBy, constraints, ContentRepository::buildRecord);
+  }
+
+  /**
+   * Translates a {@code ContentReviewCommand.LIST_STATUS_*} label into the SQL WHERE fragment that
+   * selects exactly the rows in that state, mirroring {@link ContentReviewCommand#listStatusLabel}'s
+   * derivation column-by-column so the two can't silently drift apart. An unrecognized or blank
+   * status applies no filter (equivalent to "All"), matching this query's existing leniency toward
+   * malformed filter input (e.g. an unparsable date is likewise just ignored).
+   */
+  private static void addStatusFilter(SqlUtils where, String status) {
+    if (StringUtils.isBlank(status)) {
+      return;
+    }
+    // "No draft" -- ContentRepository#add/#update always normalize draft_content through
+    // StringUtils.trimToNull before writing, but TRIM(...) = '' is matched too so this mirrors
+    // StringUtils.isBlank(content.getDraftContent()) exactly rather than assuming that invariant.
+    String hasDraft = "draft_content IS NOT NULL AND TRIM(draft_content) <> ''";
+    if (ContentReviewCommand.LIST_STATUS_LIVE.equals(status)) {
+      where.add("(draft_content IS NULL OR TRIM(draft_content) = '')");
+    } else if (ContentReviewCommand.LIST_STATUS_APPROVED.equals(status)) {
+      // isPendingReview(content) && content.getApprovedBy() > 0
+      where.add("(" + hasDraft + " AND draft_status = ? AND approved_by > 0)",
+          ContentReviewCommand.STATUS_SUBMITTED);
+    } else if (ContentReviewCommand.LIST_STATUS_PENDING_REVIEW.equals(status)) {
+      // isPendingReview(content) && !(approvedBy > 0)
+      where.add("(" + hasDraft + " AND draft_status = ? AND (approved_by IS NULL OR approved_by <= 0))",
+          ContentReviewCommand.STATUS_SUBMITTED);
+    } else if (ContentReviewCommand.LIST_STATUS_DRAFT.equals(status)) {
+      // Has a draft, but draftStatus is null or STATUS_DRAFT (not submitted) -- includes a
+      // rejected-and-not-yet-resubmitted draft, which reject() resets to STATUS_DRAFT.
+      where.add("(" + hasDraft + " AND (draft_status IS NULL OR draft_status <> ?))",
+          ContentReviewCommand.STATUS_SUBMITTED);
+    }
   }
 
   public static Content findByUniqueId(String contentUniqueId) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentSpecification.java
@@ -37,6 +37,10 @@ public class ContentSpecification {
   // the raw HTML -- see ContentRepository#query. -1 means "not set", matching this class's id style.
   private int minLength = -1;
   private int maxLength = -1;
+  // One of ContentReviewCommand.LIST_STATUS_* (Live/Draft/Pending Review/Approved), or null for no
+  // filter. Translated into a SQL WHERE fragment against draft_content/draft_status/approved_by by
+  // ContentRepository#query, mirroring ContentReviewCommand#listStatusLabel's derivation.
+  private String status = null;
 
   public ContentSpecification() {
   }
@@ -103,5 +107,13 @@ public class ContentSpecification {
 
   public void setMaxLength(int maxLength) {
     this.maxLength = maxLength;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentListWidget.java
@@ -20,11 +20,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.ContentUsageCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
@@ -36,8 +38,11 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 
 /**
  * The /admin/content-list admin page (issue #499): search (unique id substring OR body full-text,
- * combined into one box), last-modified date range and character-count range filters, and usage
- * detection (which page(s) reference each content block, "Orphaned" when none do).
+ * combined into one box), last-modified date range and character-count range filters, usage
+ * detection (which page(s) reference each content block, "Orphaned" when none do), and the governed
+ * publish workflow's state (Live/Draft/Pending Review/Approved -- see {@link ContentReviewCommand})
+ * per row, filterable server-side. This is read-only surfacing of that workflow's existing state,
+ * not a new place to submit/approve/reject -- those actions stay in the individual content editor.
  *
  * @author matt rajkowski
  * @created 4/20/18 10:04 AM
@@ -69,6 +74,17 @@ public class ContentListWidget extends GenericWidget {
     Map<String, List<String>> contentUsageMap = ContentUsageCommand.findUsageMap(context.getRequest().getServletContext());
     context.getRequest().setAttribute("contentUsageMap", contentUsageMap);
 
+    // For each content block, its governed-publish-workflow status label -- drives the Status
+    // column. The derivation lives in one place (ContentReviewCommand.listStatusLabel) so the JSP
+    // never re-derives it, matching how contentUsageMap above is computed here and just displayed there.
+    Map<String, String> contentStatusMap = new LinkedHashMap<>();
+    if (contentList != null) {
+      for (Content content : contentList) {
+        contentStatusMap.put(content.getUniqueId(), ContentReviewCommand.listStatusLabel(content));
+      }
+    }
+    context.getRequest().setAttribute("contentStatusMap", contentStatusMap);
+
     // Echo the filter values back so the form keeps its state
     echoFilterParameters(context);
 
@@ -80,6 +96,7 @@ public class ContentListWidget extends GenericWidget {
     appendParam(pagingParams, "toDate", context.getParameter("toDate"));
     appendParam(pagingParams, "minLength", context.getParameter("minLength"));
     appendParam(pagingParams, "maxLength", context.getParameter("maxLength"));
+    appendParam(pagingParams, "status", context.getParameter("status"));
     context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
 
     // Standard request items
@@ -98,10 +115,14 @@ public class ContentListWidget extends GenericWidget {
     String toDate = context.getParameter("toDate");
     int minLength = context.getParameterAsInt("minLength", -1);
     int maxLength = context.getParameterAsInt("maxLength", -1);
+    String status = context.getParameter("status");
 
     ContentSpecification specification = new ContentSpecification();
     if (StringUtils.isNotBlank(q)) {
       specification.setSearchTerm(q.trim());
+    }
+    if (StringUtils.isNotBlank(status)) {
+      specification.setStatus(status.trim());
     }
 
     // Parse the yyyy-MM-dd date range: from = start of that day, to = start of the day AFTER (half-open)
@@ -130,6 +151,7 @@ public class ContentListWidget extends GenericWidget {
     context.getRequest().setAttribute("toDate", context.getParameter("toDate"));
     context.getRequest().setAttribute("minLength", context.getParameter("minLength"));
     context.getRequest().setAttribute("maxLength", context.getParameter("maxLength"));
+    context.getRequest().setAttribute("status", context.getParameter("status"));
   }
 
   /** Appends {@code name=urlEncoded(value)} to the paging query string when the value is present. */

--- a/src/main/webapp/WEB-INF/jsp/admin/content-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/content-list.jsp
@@ -22,6 +22,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="contentList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="contentUsageMap" class="java.util.LinkedHashMap" scope="request"/>
+<jsp:useBean id="contentStatusMap" class="java.util.LinkedHashMap" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
@@ -30,7 +31,7 @@
 <%-- Filters (GET so the criteria live in the URL and paging preserves them) --%>
 <form method="get" autocomplete="off" class="margin-bottom-10">
   <div class="grid-x grid-margin-x">
-    <div class="cell medium-4">
+    <div class="cell medium-3">
       <label>Search
         <input type="text" name="q" placeholder="unique id or content text" value="<c:out value='${q}'/>">
       </label>
@@ -55,6 +56,18 @@
       </label>
     </div>
     <div class="cell medium-2">
+      <%-- Option values must match ContentReviewCommand.LIST_STATUS_* exactly (see ContentReviewCommand.listStatusLabel / ContentRepository#addStatusFilter) --%>
+      <label>Status
+        <select name="status">
+          <option value="">All</option>
+          <option value="Draft" <c:if test="${status == 'Draft'}">selected</c:if>>Draft</option>
+          <option value="Pending Review" <c:if test="${status == 'Pending Review'}">selected</c:if>>Pending Review</option>
+          <option value="Approved" <c:if test="${status == 'Approved'}">selected</c:if>>Approved</option>
+          <option value="Live" <c:if test="${status == 'Live'}">selected</c:if>>Live</option>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-1">
       <label>&nbsp;</label>
       <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Filter</button>
       <a href="${widgetContext.uri}" class="button small secondary radius">Clear</a>
@@ -66,6 +79,9 @@
     <tr>
       <th>
         Unique Id
+      </th>
+      <th width="130" class="text-center">
+        Status
       </th>
       <th>
         Sample
@@ -85,9 +101,27 @@
     <c:forEach items="${contentList}" var="content">
     <c:set var="plainText" value="${html:text(content.content)}" />
     <c:set var="usageList" value="${contentUsageMap[content.uniqueId]}" />
+    <c:set var="contentStatus" value="${contentStatusMap[content.uniqueId]}" />
     <tr>
       <td>
         <a href="${ctx}/content-editor?uniqueId=${content.uniqueId}&returnPage=/admin/content-list"><c:out value="${content.uniqueId}" /></a>
+      </td>
+      <td class="text-center">
+        <%-- Read-only surfacing of the governed publish workflow's existing state (ContentReviewCommand); no submit/approve/reject actions here, those stay in the content editor --%>
+        <c:choose>
+          <c:when test="${contentStatus == 'Live'}">
+            <span class="label success radius"><c:out value="${contentStatus}" /></span>
+          </c:when>
+          <c:when test="${contentStatus == 'Approved'}">
+            <span class="label primary radius"><c:out value="${contentStatus}" /></span>
+          </c:when>
+          <c:when test="${contentStatus == 'Pending Review'}">
+            <span class="label warning radius"><c:out value="${contentStatus}" /></span>
+          </c:when>
+          <c:otherwise>
+            <span class="label radius"><c:out value="${contentStatus}" /></span>
+          </c:otherwise>
+        </c:choose>
       </td>
       <td><span class="subheader"><c:out value="${text:trim(plainText, 50, true)}" /></span></td>
       <td class="text-center"><fmt:formatNumber value="${fn:length(plainText)}" /></td>
@@ -109,7 +143,7 @@
     </c:forEach>
     <c:if test="${empty contentList}">
       <tr>
-        <td colspan="5">No content records were found</td>
+        <td colspan="6">No content records were found</td>
       </tr>
     </c:if>
   </tbody>

--- a/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentReviewCommandTest.java
@@ -195,4 +195,68 @@ class ContentReviewCommandTest {
     ContentReviewCommand.approve(content, APPROVER, null);
     assertTrue(ContentReviewCommand.mayPublish(content, true));
   }
+
+  // --- listStatusLabel (issue #499: the /admin/content-list bird's-eye status column) ---
+
+  @Test
+  void listStatusIsLiveWhenThereIsNoDraft() {
+    Content published = new Content();
+    published.setContent("<p>live</p>");
+    assertEquals(ContentReviewCommand.LIST_STATUS_LIVE, ContentReviewCommand.listStatusLabel(published));
+    // A null content record and blank/whitespace-only draft content are also "no draft in progress".
+    assertEquals(ContentReviewCommand.LIST_STATUS_LIVE, ContentReviewCommand.listStatusLabel(null));
+    Content blankDraft = new Content();
+    blankDraft.setDraftContent("   ");
+    assertEquals(ContentReviewCommand.LIST_STATUS_LIVE, ContentReviewCommand.listStatusLabel(blankDraft));
+  }
+
+  @Test
+  void listStatusIsDraftForAnUnsubmittedDraft() {
+    assertEquals(ContentReviewCommand.LIST_STATUS_DRAFT, ContentReviewCommand.listStatusLabel(draft()));
+  }
+
+  @Test
+  void listStatusIsPendingReviewWhenSubmittedButNotYetApproved() throws DataException {
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW, ContentReviewCommand.listStatusLabel(content));
+  }
+
+  @Test
+  void listStatusIsApprovedWhenClearedButNotYetPublished() throws DataException {
+    // The easy-to-get-wrong case: approved is a distinct, later state than pending review, and
+    // publish is still a separate action after this -- the list must say so, not just "Live".
+    Content content = draft();
+    content.setContent("<p>old live content</p>"); // publish (a separate action) has not run
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.approve(content, APPROVER, "cleared per PA case 2026-114");
+    assertEquals(ContentReviewCommand.LIST_STATUS_APPROVED, ContentReviewCommand.listStatusLabel(content));
+    // Still not "Live": the draft has not been promoted into content yet -- they remain distinct.
+    assertFalse(content.getContent().equals(content.getDraftContent()));
+  }
+
+  @Test
+  void listStatusRevertsToDraftAfterRejection() throws DataException {
+    // The other easy-to-get-wrong case: reject() resets draftStatus to STATUS_DRAFT and there is no
+    // separate "Rejected" label by design (see the class javadoc on STATUS_DRAFT) -- a
+    // rejected-and-not-yet-fixed block must show as Draft, not Pending Review or Approved.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    assertEquals(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW, ContentReviewCommand.listStatusLabel(content));
+
+    ContentReviewCommand.reject(content, APPROVER);
+
+    assertEquals(ContentReviewCommand.LIST_STATUS_DRAFT, ContentReviewCommand.listStatusLabel(content));
+  }
+
+  @Test
+  void listStatusIgnoresTheReviewRequiredSiteProperty() throws DataException {
+    // Unlike offerFor(), listStatusLabel() has no reviewRequired parameter at all -- it reflects the
+    // record's persisted fields only, regardless of whether governed publishing currently happens to
+    // be toggled on. Submitted+approved is "Approved" no matter what the site property would say.
+    Content content = draft();
+    ContentReviewCommand.submitForReview(content, AUTHOR);
+    ContentReviewCommand.approve(content, APPROVER, null);
+    assertEquals(ContentReviewCommand.LIST_STATUS_APPROVED, ContentReviewCommand.listStatusLabel(content));
+  }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -42,6 +42,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
@@ -282,6 +284,17 @@ class ContentRepositoryTest {
     return ContentRepository.save(content);
   }
 
+  /** Runs the status filter and returns the matching unique ids (empty list, never null, when there are none). */
+  private static List<String> uniqueIdsForStatus(String status) {
+    ContentSpecification specification = new ContentSpecification();
+    specification.setStatus(status);
+    List<Content> results = ContentRepository.findAll(specification, new DataConstraints());
+    if (results == null) {
+      return List.of();
+    }
+    return results.stream().map(Content::getUniqueId).toList();
+  }
+
   /** Directly sets the modified timestamp (bypassing ContentRepository.update()'s "now" stamp) so date-range tests can pin known values. */
   private static void setModified(String uniqueId, Timestamp modified) {
     try (Connection connection = DB.getConnection();
@@ -391,5 +404,99 @@ class ContentRepositoryTest {
     assertNotNull(results);
     List<String> uniqueIds = results.stream().map(Content::getUniqueId).toList();
     assertEquals(List.of("combo-in-range"), uniqueIds);
+  }
+
+  // --- Status filter (issue #499: the /admin/content-list status column and dropdown) ---
+
+  @Test
+  void statusFilterReturnsOnlyTheMatchingRowForEachOfTheFourStates() {
+    // Live: no draft in progress.
+    addContent("status-live", "<p>live</p>");
+
+    // Draft: a draft in progress, never submitted.
+    Content draftBlock = addContent("status-draft", "<p>live</p>");
+    draftBlock.setDraftContent("<p>editing</p>");
+    ContentRepository.save(draftBlock);
+
+    // Pending Review: submitted, not yet approved.
+    Content pending = addContent("status-pending", "<p>live</p>");
+    pending.setDraftContent("<p>proposed</p>");
+    pending.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    pending.setSubmittedBy(10L);
+    ContentRepository.save(pending);
+
+    // Approved: submitted AND approved, but not yet published (still a distinct, later state).
+    Content approved = addContent("status-approved", "<p>live</p>");
+    approved.setDraftContent("<p>proposed</p>");
+    approved.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    approved.setSubmittedBy(10L);
+    approved.setApprovedBy(20L);
+    ContentRepository.save(approved);
+
+    // Each filter returns exactly its own row -- this also proves the other three rows are
+    // correctly excluded, not just that the target row is included.
+    assertEquals(List.of("status-live"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_LIVE));
+    assertEquals(List.of("status-draft"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_DRAFT));
+    assertEquals(List.of("status-pending"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW));
+    assertEquals(List.of("status-approved"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_APPROVED));
+  }
+
+  @Test
+  void noStatusFilterReturnsEveryRowRegardlessOfWorkflowState() {
+    addContent("nofilter-live", "<p>live</p>");
+    Content draftBlock = addContent("nofilter-draft", "<p>live</p>");
+    draftBlock.setDraftContent("<p>editing</p>");
+    ContentRepository.save(draftBlock);
+
+    List<String> uniqueIds = uniqueIdsForStatus(null);
+
+    assertTrue(uniqueIds.contains("nofilter-live"));
+    assertTrue(uniqueIds.contains("nofilter-draft"));
+  }
+
+  @Test
+  void aRejectedDraftFiltersAsDraftNotPendingOrApproved() throws DataException {
+    // Exercises the real ContentReviewCommand transitions (submit -> reject), not hand-seeded
+    // columns, so this proves the SQL filter matches what the actual workflow produces: reject()
+    // resets draft_status back to STATUS_DRAFT, and there is no separate "Rejected" state.
+    Content content = addContent("status-rejected", "<p>live</p>");
+    content.setDraftContent("<p>revise me</p>");
+    ContentReviewCommand.submitForReview(content, 10L);
+    ContentRepository.save(content);
+
+    assertEquals(List.of("status-rejected"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW));
+    assertTrue(uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_DRAFT).isEmpty());
+
+    ContentReviewCommand.reject(content, 20L);
+    ContentRepository.save(content);
+
+    assertEquals(List.of("status-rejected"), uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_DRAFT));
+    assertTrue(uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW).isEmpty());
+    assertTrue(uniqueIdsForStatus(ContentReviewCommand.LIST_STATUS_APPROVED).isEmpty());
+  }
+
+  @Test
+  void statusFilterCombinesWithOtherFiltersAsAnd() {
+    // The status filter must AND with the other filters (same convention as combinedFiltersAreAnded
+    // above), not silently override or ignore them.
+    Content matches = addContent("combo-status-match", "<p>career opportunities await</p>");
+    matches.setDraftContent("<p>revised career copy</p>");
+    ContentRepository.save(matches);
+
+    Content wrongTerm = addContent("combo-status-wrong-term", "<p>unrelated</p>");
+    wrongTerm.setDraftContent("<p>also unrelated</p>");
+    ContentRepository.save(wrongTerm);
+
+    addContent("combo-status-live-only", "<p>career opportunities await</p>"); // no draft -- wrong status
+
+    ContentSpecification specification = new ContentSpecification();
+    specification.setSearchTerm("career");
+    specification.setStatus(ContentReviewCommand.LIST_STATUS_DRAFT);
+
+    List<Content> results = ContentRepository.findAll(specification, new DataConstraints());
+
+    assertNotNull(results);
+    List<String> uniqueIds = results.stream().map(Content::getUniqueId).toList();
+    assertEquals(List.of("combo-status-match"), uniqueIds);
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentListWidgetTest.java
@@ -35,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.ContentUsageCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
@@ -177,6 +178,70 @@ class ContentListWidgetTest extends WidgetBase {
 
       Object exposed = widgetContext.getRequest().getAttribute("contentUsageMap");
       assertSame(usageMap, exposed, "the widget must expose exactly the map ContentUsageCommand built, for the JSP's Used-on/Orphaned display");
+    }
+  }
+
+  @Test
+  void statusParameterMapsOntoTheSpecificationAndPagingParams() {
+    addQueryParameter(widgetContext, "status", ContentReviewCommand.LIST_STATUS_PENDING_REVIEW);
+
+    try (MockedStatic<ContentRepository> repository = mockStatic(ContentRepository.class);
+        MockedStatic<ContentUsageCommand> usageCommand = mockStatic(ContentUsageCommand.class)) {
+      repository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      usageCommand.when(() -> ContentUsageCommand.findUsageMap(any())).thenReturn(new LinkedHashMap<>());
+
+      new ContentListWidget().execute(widgetContext);
+
+      ArgumentCaptor<ContentSpecification> captor = ArgumentCaptor.forClass(ContentSpecification.class);
+      repository.verify(() -> ContentRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      assertEquals(ContentReviewCommand.LIST_STATUS_PENDING_REVIEW, captor.getValue().getStatus());
+
+      // Carried through pagination, URL-encoded (the space in "Pending Review" becomes '+')
+      String pagingParams = (String) widgetContext.getRequest().getAttribute("recordPagingParams");
+      assertTrue(pagingParams.contains("status=Pending+Review"));
+    }
+  }
+
+  @Test
+  void blankStatusParameterLeavesTheSpecificationUnset() {
+    try (MockedStatic<ContentRepository> repository = mockStatic(ContentRepository.class);
+        MockedStatic<ContentUsageCommand> usageCommand = mockStatic(ContentUsageCommand.class)) {
+      repository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      usageCommand.when(() -> ContentUsageCommand.findUsageMap(any())).thenReturn(new LinkedHashMap<>());
+
+      new ContentListWidget().execute(widgetContext);
+
+      ArgumentCaptor<ContentSpecification> captor = ArgumentCaptor.forClass(ContentSpecification.class);
+      repository.verify(() -> ContentRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      assertNull(captor.getValue().getStatus());
+    }
+  }
+
+  @Test
+  void theStatusMapIsBuiltFromEachContentRecordAndExposedToTheRequest() {
+    // A Live block (no draft) and a Draft block (a draft, never submitted) -- exercises
+    // ContentReviewCommand.listStatusLabel through the widget rather than mocking it away, so this
+    // also catches a regression that stops calling it.
+    Content live = new Content();
+    live.setUniqueId("block-live");
+    Content draft = new Content();
+    draft.setUniqueId("block-draft");
+    draft.setDraftContent("<p>editing</p>");
+    List<Content> contentList = new ArrayList<>(List.of(live, draft));
+
+    try (MockedStatic<ContentRepository> repository = mockStatic(ContentRepository.class);
+        MockedStatic<ContentUsageCommand> usageCommand = mockStatic(ContentUsageCommand.class)) {
+      repository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any(DataConstraints.class)))
+          .thenReturn(contentList);
+      usageCommand.when(() -> ContentUsageCommand.findUsageMap(any())).thenReturn(new LinkedHashMap<>());
+
+      new ContentListWidget().execute(widgetContext);
+
+      Map<String, String> statusMap = (Map<String, String>) widgetContext.getRequest().getAttribute("contentStatusMap");
+      assertEquals(ContentReviewCommand.LIST_STATUS_LIVE, statusMap.get("block-live"));
+      assertEquals(ContentReviewCommand.LIST_STATUS_DRAFT, statusMap.get("block-draft"));
     }
   }
 }


### PR DESCRIPTION
## The real finding driving this slice

#499's issue text complains "No Draft/Publish Workflow: All content appears to be live immediately" and "No Approval Workflow." That claim is wrong in the sense that no workflow exists — \`ContentReviewCommand\` already implements a complete draft → submitted → approved/rejected state machine with enforced separation-of-duties (part of a documented governed-publish compliance mechanism for CMMC AC.L1-b.1.iv / NIST 800-171 3.1.22). It's used by the individual content editor already. The real gap is narrower: \`/admin/content-list\` (the bird's-eye list of all 300+ content blocks) showed this state for none of them. This PR closes that visibility gap — it does not change the workflow itself.

## What's here

- **Status column**: Live / Draft / Pending Review / Approved, per content block, derived from the record's own \`draftContent\`/\`draftStatus\`/\`approvedBy\` fields via a new \`ContentReviewCommand.listStatusLabel()\` — viewer-independent (unlike the existing per-viewer \`offerFor\`), and deliberately ignores the \`content.review.required\` site property so the label reflects the record's actual state regardless of whether governed publishing happens to be toggled on.
- **Status filter**, applied server-side in the SQL WHERE clause (this list is paginated, so filtering had to happen there, not client-side) — mirrors the Java-side derivation column-by-column so the two can't silently drift apart.
- No new "Rejected" status: \`ContentReviewCommand.reject()\` resets \`draftStatus\` back to \`STATUS_DRAFT\`, so a rejected-and-not-yet-fixed draft correctly reports as Draft, matching that method's own javadoc ("the author's to change" either way).

Read-only and additive — does not touch \`ContentReviewCommand\`'s transition methods, add any submit/approve/reject buttons to the list, or change \`content.review.required\` behavior.

## Testing

- Tests proving the 4-state derivation for each real field combination, including the two easiest to get wrong: "approved but not yet published" (still shows Approved, not Live) and "rejected reverts to Draft" (no separate Rejected state).
- Repository tests proving the SQL filter returns exactly the right rows for each state.
- `ant -lib lib/war -lib lib/tests clean ci-test`: BUILD SUCCESSFUL, 0 failures.
- `python3 tools/check-unescaped-el.py --strict`: 0 unallowlisted.