### PR TITLE
Guard against null categoryIdList in ItemRepository.update()

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -214,7 +214,7 @@ public class ItemRepository {
     // Use the previous records for updates
     Item previousRecord = ItemRepository.findById(record.getId());
     List<ItemCategory> existingCategoryList = ItemCategoryRepository.findAllByItemId(record.getId());
-    List<Long> newCategoryList = Arrays.asList(record.getCategoryIdList());
+    List<Long> newCategoryList = record.getCategoryIdList() != null ? Arrays.asList(record.getCategoryIdList()) : Collections.emptyList();
     List<ItemTag> existingTagList = ItemTagRepository.findAllByItemId(record.getId());
     List<Long> newTagList = record.getTagIdList() != null ? Arrays.asList(record.getTagIdList()) : Collections.emptyList();
 


### PR DESCRIPTION
## Summary
- `Item.categoryIdList` defaults to `null`, and `Arrays.asList(null)` throws a `NullPointerException` immediately (the `ArrayList` array constructor calls `Objects.requireNonNull`).
- This was previously masked because every known caller (`EditItemFormWidget.post()`, `CreateAnItemWidget.post()`) always explicitly calls `itemBean.setCategoryIdList(...)` before `SaveItemCommand.saveItem()`, and `SaveItemCommandTest`'s update-path test defensively sets `itemBean.setCategoryIdList(new Long[0])` to work around it — masking rather than fixing the underlying issue.
- Applies the same null-guard already used for `newTagList` (#863) to `newCategoryList` in `ItemRepository.update()`, closing the latent NPE risk for any future caller that forgets to set `categoryIdList`.

## Test plan
- [x] `ant compile`
- [x] `ant ci-test` (all tests pass, including `SaveItemCommandTest`)