### PR TITLE
Record which facet dimension narrowed a search, for adoption tracking (#638)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SearchAnalyticsCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SearchAnalyticsCommand.java
@@ -35,6 +35,18 @@ import org.apache.commons.lang3.StringUtils;
 public class SearchAnalyticsCommand {
 
   public static void record(WidgetContext context, String query, String searchType, int resultCount) {
+    record(context, query, searchType, resultCount, null);
+  }
+
+  /**
+   * @param facetKey which facet dimension(s) were applied to this search, e.g. "categoryId",
+   *                 "dateFacet", or "categoryId,dateFacet" when more than one is active -- or null
+   *                 when no facet was applied, or the widget has no facet concept (issue #638). A
+   *                 facet click re-runs this same search with the facet param set, so there's no
+   *                 separate "facet selected" event to fire -- the search event that included the
+   *                 facet param already is that event.
+   */
+  public static void record(WidgetContext context, String query, String searchType, int resultCount, String facetKey) {
     if (StringUtils.isBlank(query)) {
       return;
     }
@@ -58,6 +70,7 @@ public class SearchAnalyticsCommand {
     searchAnalytics.setSearchType(searchType);
     searchAnalytics.setResultCount(Math.max(resultCount, 0));
     searchAnalytics.setPagePath(context.getRequest().getRequestURI());
+    searchAnalytics.setFacetKey(facetKey);
     SearchAnalyticsRepository.save(searchAnalytics);
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/cms/SearchAnalytics.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/SearchAnalytics.java
@@ -34,6 +34,7 @@ public class SearchAnalytics extends Entity {
   private String searchType = null;
   private int resultCount = 0;
   private String pagePath = null;
+  private String facetKey = null;
   private Timestamp created = null;
 
   public SearchAnalytics() {
@@ -77,6 +78,14 @@ public class SearchAnalytics extends Entity {
 
   public void setPagePath(String pagePath) {
     this.pagePath = pagePath;
+  }
+
+  public String getFacetKey() {
+    return facetKey;
+  }
+
+  public void setFacetKey(String facetKey) {
+    this.facetKey = facetKey;
   }
 
   public Timestamp getCreated() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SearchAnalyticsRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/SearchAnalyticsRepository.java
@@ -58,7 +58,8 @@ public class SearchAnalyticsRepository {
         .add("query", record.getQuery(), 255)
         .add("search_type", record.getSearchType(), 50)
         .add("result_count", record.getResultCount())
-        .add("page_path", record.getPagePath(), 255);
+        .add("page_path", record.getPagePath(), 255)
+        .add("facet_key", record.getFacetKey(), 100);
     record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
     if (record.getId() == -1) {
       LOG.error("An id was not set!");
@@ -137,6 +138,57 @@ public class SearchAnalyticsRepository {
       LOG.error("SQLException: " + se.getMessage());
     }
     return 0;
+  }
+
+  /** Count of all searches over the last {@code daysToLimit} days, the denominator for the facet-
+   * adoption-rate tile (issue #638). daysToLimit is an int, so placing it in the interval cannot
+   * inject SQL. */
+  public static long countSearches(int daysToLimit) {
+    String SQL_QUERY =
+        "SELECT count(*) AS record_count " +
+            "FROM " + TABLE_NAME + " " +
+            "WHERE created > NOW() - INTERVAL '" + daysToLimit + " days'";
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+         ResultSet rs = pst.executeQuery()) {
+      if (rs.next()) {
+        return rs.getLong("record_count");
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return 0;
+  }
+
+  /** Count of searches over the last {@code daysToLimit} days that had at least one facet/filter
+   * applied (facet_key is set), the numerator for the facet-adoption-rate tile (issue #638). */
+  public static long countSearchesWithFacetApplied(int daysToLimit) {
+    String SQL_QUERY =
+        "SELECT count(*) AS record_count " +
+            "FROM " + TABLE_NAME + " " +
+            "WHERE created > NOW() - INTERVAL '" + daysToLimit + " days' " +
+            "AND facet_key IS NOT NULL";
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+         ResultSet rs = pst.executeQuery()) {
+      if (rs.next()) {
+        return rs.getLong("record_count");
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return 0;
+  }
+
+  /** Breakdown of which facet dimension(s) were applied over the last {@code daysToLimit} days,
+   * most-used first (issue #638). Searches with no facet applied (facet_key IS NULL) are excluded --
+   * this is a breakdown of facet usage, not of all searches. */
+  public static List<StatisticsData> findFacetUsageBreakdown(int daysToLimit, int recordLimit) {
+    SqlUtils where = new SqlUtils()
+        .add("created > NOW() - INTERVAL '" + daysToLimit + " days'")
+        .add("facet_key IS NOT NULL");
+    SqlUtils orderBy = new SqlUtils().add("facet_key_count DESC");
+    return DB.selectGroupedFrom(TABLE_NAME, "facet_key", "facet_key_count", where, orderBy, recordLimit);
   }
 
   /** Resolves the configurable zero-result-search alert threshold (search.zeroResultAlertThreshold),

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
@@ -375,6 +375,22 @@ public class SiteStatsWidget extends GenericWidget {
       context.getRequest().setAttribute("label", context.getPreferences().getOrDefault("label", "Search Term"));
       context.getRequest().setAttribute("value", context.getPreferences().getOrDefault("value", "Searches This Week"));
       return TABLE_JSP;
+    } else if ("facet-adoption-rate".equalsIgnoreCase(report)) {
+      // issue #638: what fraction of searches were narrowed by a facet/filter. Only ItemsSearchResultsWidget
+      // sets facet_key today -- the other five search-results widgets have no facet concept yet, so this
+      // is necessarily a rate over all searches, not just faceted-capable ones.
+      long totalSearches = SearchAnalyticsRepository.countSearches(intervalValue);
+      long facetedSearches = SearchAnalyticsRepository.countSearchesWithFacetApplied(intervalValue);
+      double adoptionRate = totalSearches == 0 ? 0.0 : (100.0 * facetedSearches / totalSearches);
+      context.getRequest().setAttribute("numberValue", String.valueOf(Math.round(adoptionRate * 10) / 10.0));
+      context.getRequest().setAttribute("severity", "ok");
+      return ALERT_CARD_JSP;
+    } else if ("facet-usage-breakdown".equalsIgnoreCase(report)) {
+      List<StatisticsData> statisticsDataList = SearchAnalyticsRepository.findFacetUsageBreakdown(intervalValue, limit);
+      context.getRequest().setAttribute("statisticsDataList", statisticsDataList);
+      context.getRequest().setAttribute("label", context.getPreferences().getOrDefault("label", "Facet"));
+      context.getRequest().setAttribute("value", context.getPreferences().getOrDefault("value", "Searches"));
+      return TABLE_JSP;
     } else if ("total-form-submissions".equalsIgnoreCase(report)) {
       Long count = FormDataRepository.countTotalSubmissions();
       context.getRequest().setAttribute("numberValue", String.valueOf(count));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
@@ -128,7 +128,16 @@ public class ItemsSearchResultsWidget extends GenericWidget {
 
     // Query the data
     List<Item> itemList = ItemRepository.findAll(specification, constraints);
-    SearchAnalyticsCommand.record(context, query, "items", itemList == null ? 0 : itemList.size());
+    // Which facet dimension(s) narrowed this search, for the facet-adoption-rate report (issue #638)
+    List<String> appliedFacetKeys = new ArrayList<>();
+    if (!selectedCategoryIds.isEmpty()) {
+      appliedFacetKeys.add("categoryId");
+    }
+    if (selectedDateBucket != null) {
+      appliedFacetKeys.add("dateFacet");
+    }
+    String facetKey = appliedFacetKeys.isEmpty() ? null : String.join(",", appliedFacetKeys);
+    SearchAnalyticsCommand.record(context, query, "items", itemList == null ? 0 : itemList.size(), facetKey);
 
     // Facet panels + active filter chips (issue #421)
     boolean showCategoryFacet = !"false".equals(context.getPreferences().get("showCategoryFacet"));

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -290,6 +290,7 @@ CREATE TABLE search_analytics (
   search_type VARCHAR(50) NOT NULL,
   result_count INTEGER NOT NULL DEFAULT 0,
   page_path VARCHAR(255),
+  facet_key VARCHAR(100),
   created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX search_analytics_created_idx ON search_analytics(created);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1001__search_analytics_facet_key.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1001__search_analytics_facet_key.sql
@@ -1,0 +1,4 @@
+-- Adds a facet dimension column so search analytics can distinguish a plain search from one
+-- narrowed by a facet/filter (issue #638). Nullable: most searches have no facet applied, and
+-- several search-results widgets have no facet concept at all yet.
+ALTER TABLE search_analytics ADD COLUMN IF NOT EXISTS facet_key VARCHAR(100);

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -94,6 +94,14 @@
           <report>zero-result-search-alert</report>
         </widget>
       </column>
+      <column class="small-6 medium-4 large-3 cell">
+        <widget name="siteStats">
+          <icon>fa-filter</icon>
+          <title>Faceted Search Adoption % (7d)</title>
+          <report>facet-adoption-rate</report>
+          <days>7</days>
+        </widget>
+      </column>
       <column class="small-12 cell">
         <widget name="siteStats">
           <title>Recent Admin Activity</title>
@@ -906,6 +914,17 @@
           <report>trending-search-terms</report>
           <label>Search Term</label>
           <value>Searches This Week</value>
+          <limit>10</limit>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 cell">
+        <widget name="siteStats" class="stats card">
+          <icon>fa-filter</icon>
+          <title>Facet Usage Breakdown</title>
+          <report>facet-usage-breakdown</report>
+          <label>Facet</label>
+          <value>Searches</value>
+          <days>30</days>
           <limit>10</limit>
         </widget>
       </column>

--- a/src/test/java/com/simisinc/platform/application/cms/SearchAnalyticsCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SearchAnalyticsCommandTest.java
@@ -125,6 +125,43 @@ class SearchAnalyticsCommandTest extends WidgetBase {
     }
   }
 
+  @Test
+  void recordWithNoFacetKeyArgumentLeavesItNull() {
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class);
+        MockedStatic<DoNotTrackCommand> dnt = mockStatic(DoNotTrackCommand.class)) {
+      dnt.when(() -> DoNotTrackCommand.isDoNotTrack(any(), any())).thenReturn(false);
+
+      SearchAnalyticsCommand.record(widgetContext, "widgets", "pages", 3);
+
+      ArgumentCaptor<SearchAnalytics> captor = ArgumentCaptor.forClass(SearchAnalytics.class);
+      repository.verify(() -> SearchAnalyticsRepository.save(captor.capture()));
+      assertEquals(null, captor.getValue().getFacetKey());
+    }
+  }
+
+  @Test
+  void recordWithAFacetKeySavesIt() {
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class);
+        MockedStatic<DoNotTrackCommand> dnt = mockStatic(DoNotTrackCommand.class)) {
+      dnt.when(() -> DoNotTrackCommand.isDoNotTrack(any(), any())).thenReturn(false);
+
+      SearchAnalyticsCommand.record(widgetContext, "widgets", "items", 3, "categoryId,dateFacet");
+
+      ArgumentCaptor<SearchAnalytics> captor = ArgumentCaptor.forClass(SearchAnalytics.class);
+      repository.verify(() -> SearchAnalyticsRepository.save(captor.capture()));
+      assertEquals("categoryId,dateFacet", captor.getValue().getFacetKey());
+    }
+  }
+
+  @Test
+  void recordWithAFacetKeyStillSkipsABlankQuery() {
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class)) {
+      SearchAnalyticsCommand.record(widgetContext, "   ", "items", 3, "categoryId");
+
+      repository.verify(() -> SearchAnalyticsRepository.save(any()), never());
+    }
+  }
+
   private static void assertEqualsAll(SearchAnalytics saved, String query, String searchType, int resultCount, String pagePath) {
     assertEquals(query, saved.getQuery());
     assertEquals(searchType, saved.getSearchType());

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/SearchAnalyticsRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/SearchAnalyticsRepositoryTest.java
@@ -218,6 +218,56 @@ class SearchAnalyticsRepositoryTest {
   }
 
   @Test
+  void countSearchesCountsEveryEventInTheWindowRegardlessOfFacet() {
+    addEvent("widgets", "pages", 3);
+    addEvent("gadgets", "items", 5, "categoryId");
+    backdate(addEvent("ancient", "pages", 1).getId(), 40);
+
+    long count = SearchAnalyticsRepository.countSearches(30);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  void countSearchesWithFacetAppliedCountsOnlyEventsThatCarryAFacetKey() {
+    addEvent("widgets", "pages", 3);
+    addEvent("gadgets", "items", 5, "categoryId");
+    addEvent("gizmos", "items", 2, "dateFacet");
+    backdate(addEvent("ancient", "items", 1, "categoryId").getId(), 40);
+
+    long count = SearchAnalyticsRepository.countSearchesWithFacetApplied(30);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  void findFacetUsageBreakdownGroupsByFacetKeyAndExcludesUnfaceted() {
+    addEvent("widgets", "pages", 3);
+    addEvent("a", "items", 5, "categoryId");
+    addEvent("b", "items", 5, "categoryId");
+    addEvent("c", "items", 5, "categoryId,dateFacet");
+
+    List<StatisticsData> results = SearchAnalyticsRepository.findFacetUsageBreakdown(30, 10);
+
+    assertEquals(2, results.size());
+    assertEquals("categoryId", results.get(0).getLabel());
+    assertEquals("2", results.get(0).getValue());
+    assertEquals("categoryId,dateFacet", results.get(1).getLabel());
+    assertEquals("1", results.get(1).getValue());
+  }
+
+  @Test
+  void findFacetUsageBreakdownExcludesEventsOutsideTheWindow() {
+    backdate(addEvent("old", "items", 1, "categoryId").getId(), 40);
+    addEvent("recent", "items", 1, "dateFacet");
+
+    List<StatisticsData> results = SearchAnalyticsRepository.findFacetUsageBreakdown(30, 10);
+
+    assertEquals(1, results.size());
+    assertEquals("dateFacet", results.get(0).getLabel());
+  }
+
+  @Test
   void resolveZeroResultAlertThresholdFallsBackToDefaultWhenBlankOrUnparseable() {
     assertEquals(20, SearchAnalyticsRepository.resolveZeroResultAlertThreshold(null));
     assertEquals(20, SearchAnalyticsRepository.resolveZeroResultAlertThreshold(""));
@@ -253,6 +303,7 @@ class SearchAnalyticsRepositoryTest {
           + "search_type VARCHAR(50) NOT NULL, "
           + "result_count INTEGER NOT NULL DEFAULT 0, "
           + "page_path VARCHAR(255), "
+          + "facet_key VARCHAR(100), "
           + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the search_analytics schema", se);
@@ -260,10 +311,15 @@ class SearchAnalyticsRepositoryTest {
   }
 
   private static SearchAnalytics addEvent(String query, String searchType, int resultCount) {
+    return addEvent(query, searchType, resultCount, null);
+  }
+
+  private static SearchAnalytics addEvent(String query, String searchType, int resultCount, String facetKey) {
     SearchAnalytics searchAnalytics = new SearchAnalytics();
     searchAnalytics.setQuery(query);
     searchAnalytics.setSearchType(searchType);
     searchAnalytics.setResultCount(resultCount);
+    searchAnalytics.setFacetKey(facetKey);
     return SearchAnalyticsRepository.save(searchAnalytics);
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
@@ -800,6 +800,76 @@ class SiteStatsWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeFacetAdoptionRateComputesAPercentage() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\">\n" +
+            "  <title>Faceted Search Adoption % (7d)</title>\n" +
+            "  <report>facet-adoption-rate</report>\n" +
+            "  <days>7</days>\n" +
+            "</widget>");
+
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class)) {
+      repository.when(() -> SearchAnalyticsRepository.countSearches(7)).thenReturn(200L);
+      repository.when(() -> SearchAnalyticsRepository.countSearchesWithFacetApplied(7)).thenReturn(50L);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("25.0", request.getAttribute("numberValue"));
+    Assertions.assertEquals("ok", request.getAttribute("severity"));
+  }
+
+  @Test
+  void executeFacetAdoptionRateIsZeroWhenThereAreNoSearches() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\">\n" +
+            "  <title>Faceted Search Adoption % (7d)</title>\n" +
+            "  <report>facet-adoption-rate</report>\n" +
+            "  <days>7</days>\n" +
+            "</widget>");
+
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class)) {
+      repository.when(() -> SearchAnalyticsRepository.countSearches(7)).thenReturn(0L);
+      repository.when(() -> SearchAnalyticsRepository.countSearchesWithFacetApplied(7)).thenReturn(0L);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals("0.0", request.getAttribute("numberValue"),
+        "a zero-search denominator must not divide by zero");
+  }
+
+  @Test
+  void executeFacetUsageBreakdown() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>Facet Usage Breakdown</title>\n" +
+            "  <report>facet-usage-breakdown</report>\n" +
+            "  <days>30</days>\n" +
+            "  <limit>10</limit>\n" +
+            "</widget>");
+
+    List<StatisticsData> data = List.of(statistic("categoryId", "12"));
+    try (MockedStatic<SearchAnalyticsRepository> repository = mockStatic(SearchAnalyticsRepository.class)) {
+      repository.when(() -> SearchAnalyticsRepository.findFacetUsageBreakdown(30, 10)).thenReturn(data);
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.TABLE_JSP, widgetContext.getJsp());
+    Assertions.assertEquals(data, request.getAttribute("statisticsDataList"));
+    Assertions.assertEquals("Facet", request.getAttribute("label"));
+    Assertions.assertEquals("Searches", request.getAttribute("value"));
+  }
+
+  @Test
   void executeConversionRate() {
     addPreferencesFromWidgetXml(widgetContext,
         "<widget name=\"siteStats\" class=\"stats card\">\n" +

--- a/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -416,6 +417,54 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
       List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
       assertEquals(1, activeFilters.size(), "a single selection keeps the original one-chip-clears-it behavior, no separate 'clear all' chip");
+    }
+  }
+
+  @Test
+  void executeRecordsWhichFacetsWereAppliedForTheAdoptionRateReport() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "categoryId", "5");
+    addQueryParameter(widgetContext, "dateFacet", "last7");
+
+    ArgumentCaptor<String> facetKeyCaptor = ArgumentCaptor.forClass(String.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets")));
+      categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(1L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      analytics.verify(() -> SearchAnalyticsCommand.record(any(), any(), any(), anyInt(), facetKeyCaptor.capture()));
+      assertEquals("categoryId,dateFacet", facetKeyCaptor.getValue());
+    }
+  }
+
+  @Test
+  void executeRecordsNoFacetKeyWhenNoFacetWasSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    ArgumentCaptor<String> facetKeyCaptor = ArgumentCaptor.forClass(String.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      analytics.verify(() -> SearchAnalyticsCommand.record(any(), any(), any(), anyInt(), facetKeyCaptor.capture()));
+      assertNull(facetKeyCaptor.getValue());
     }
   }
 }


### PR DESCRIPTION
## Summary
Closes #638. Follow-up to #421/#424: extends search analytics so it can distinguish a plain search from one narrowed by a facet/filter.

- Adds a nullable `facet_key VARCHAR(100)` column to `search_analytics` (both `NEW_10010__new_cms.sql` and a new upgrade migration).
- `SearchAnalyticsCommand.record()` gains a 5-arg overload taking `facetKey`; the existing 4-arg version delegates with `null`, so the other 5 search-results widgets (none of which have a facet concept yet) are untouched.
- `ItemsSearchResultsWidget` computes `facetKey` from whichever of `categoryId`/`dateFacet` were actually applied (e.g. `"categoryId"`, `"dateFacet"`, or `"categoryId,dateFacet"`) and passes it at its existing `record()` call site — no new event, since a facet click just re-runs the same search request with the facet param set.
- Two new `SiteStatsWidget` report branches, wired into the admin dashboard next to the existing search-analytics tiles:
  - `facet-adoption-rate` — an alert-card tile showing what % of searches (last 7 days) had a facet applied.
  - `facet-usage-breakdown` — a table tile showing which facet dimension(s) get used, most-used first.
- The new column is covered by the existing `search_analytics` retention job automatically, since it's a column on that table rather than a separate one.

## Test plan
- [x] `ant compile` / `ant compile-test` — clean
- [x] `python3 tools/check-unescaped-el.py . --strict` — 0 unallowlisted
- [x] `ant ci-test` — full suite green, 0 failures
- [x] New/extended tests: `SearchAnalyticsRepositoryTest` (Testcontainers — `countSearches`, `countSearchesWithFacetApplied`, `findFacetUsageBreakdown`), `SearchAnalyticsCommandTest` (facetKey pass-through + blank-query guard), `ItemsSearchResultsWidgetTest` (facetKey computed correctly with 0/1/2 facets applied), `SiteStatsWidgetTest` (both new report branches, including the zero-searches divide-by-zero case)