### PR TITLE
Roll the facet-panel pattern out to Calendar and Wiki search (#634)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/FacetUrlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/FacetUrlCommand.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared URL-building helpers for search-results facet links (issue #634), extracted from
+ * ItemsSearchResultsWidget's original issue #421 implementation once a second widget needed the
+ * same single-select facet-link/clear-filter behavior, per that issue's own suggestion rather than
+ * copy-pasting a third time. Multi-select toggle behavior (issue #636's categoryId checkbox group)
+ * stays private to ItemsSearchResultsWidget, since it's the only widget with a multi-select facet.
+ *
+ * @author SimIS
+ * @created 8/2/2026
+ */
+public class FacetUrlCommand {
+
+  /**
+   * The current request's URL with the given single-value param set to the given value, all other
+   * current params preserved, and paging reset to page 1 (a facet selection changes the result
+   * set, so whatever page the user was on may no longer exist).
+   */
+  public static String buildFacetLinkUrl(WidgetContext context, String paramName, String paramValue) {
+    Map<String, List<String>> overrides = new LinkedHashMap<>();
+    overrides.put(paramName, Collections.singletonList(paramValue));
+    return buildUrl(context, overrides, paramName);
+  }
+
+  /** The current request's URL with the given param removed entirely, all other current params preserved. */
+  public static String buildClearFilterUrl(WidgetContext context, String paramName) {
+    return buildUrl(context, new LinkedHashMap<>(), paramName);
+  }
+
+  /**
+   * The current request's URL with excludeParam's current value(s) dropped and replaced by
+   * overrides (if any), every OTHER param preserved with EVERY one of its repeated values (not
+   * just the first) -- so, for example, clicking a dateFacet link doesn't silently drop all but
+   * one of the currently selected categoryId values -- and paging reset to page 1. Public so
+   * ItemsSearchResultsWidget's own multi-select toggle can reuse this same engine.
+   */
+  public static String buildUrl(WidgetContext context, Map<String, List<String>> overrides, String excludeParam) {
+    LinkedHashMap<String, List<String>> params = new LinkedHashMap<>();
+    for (Map.Entry<String, String[]> entry : context.getParameterMap().entrySet()) {
+      String name = entry.getKey();
+      if (name.equals(excludeParam) || "page".equals(name)) {
+        continue;
+      }
+      if (entry.getValue() == null) {
+        continue;
+      }
+      List<String> values = new ArrayList<>();
+      for (String value : entry.getValue()) {
+        if (StringUtils.isNotBlank(value)) {
+          values.add(value);
+        }
+      }
+      if (!values.isEmpty()) {
+        params.put(name, values);
+      }
+    }
+    params.putAll(overrides);
+
+    StringBuilder url = new StringBuilder(context.getUri());
+    boolean first = true;
+    for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+      for (String value : entry.getValue()) {
+        url.append(first ? '?' : '&');
+        first = false;
+        url.append(UrlCommand.encodeUri(entry.getKey())).append('=').append(UrlCommand.encodeUri(value));
+      }
+    }
+    return url.toString();
+  }
+
+  /** One facet's rendered option: display label, result count, whether it's currently selected, and its link. */
+  public static class FacetOption {
+    private final String key;
+    private final String label;
+    private final long count;
+    private final boolean selected;
+    private final String url;
+
+    public FacetOption(String key, String label, long count, boolean selected, String url) {
+      this.key = key;
+      this.label = label;
+      this.count = count;
+      this.selected = selected;
+      this.url = url;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public boolean isSelected() {
+      return selected;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+  }
+
+  /** One active-filter chip: which facet dimension, the selected value's label, and the URL to clear just this filter. */
+  public static class ActiveFacetFilter {
+    private final String facetLabel;
+    private final String valueLabel;
+    private final String clearUrl;
+
+    public ActiveFacetFilter(String facetLabel, String valueLabel, String clearUrl) {
+      this.facetLabel = facetLabel;
+      this.valueLabel = valueLabel;
+      this.clearUrl = clearUrl;
+    }
+
+    public String getFacetLabel() {
+      return facetLabel;
+    }
+
+    public String getValueLabel() {
+      return valueLabel;
+    }
+
+    public String getClearUrl() {
+      return clearUrl;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidget.java
@@ -16,12 +16,15 @@
 
 package com.simisinc.platform.presentation.widgets.calendar;
 
+import com.simisinc.platform.application.FacetUrlCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.domain.model.cms.Calendar;
 import com.simisinc.platform.domain.model.cms.CalendarEvent;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -31,6 +34,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,6 +48,7 @@ public class CalendarSearchResultsWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908893L;
 
   static String JSP = "/calendar/calendar-search-results.jsp";
+  static String CALENDAR_FACET_LABEL = "Calendar";
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -69,14 +74,57 @@ public class CalendarSearchResultsWidget extends GenericWidget {
     Instant instant = Instant.now();
     ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, clientZoneId);
     ZonedDateTime zdtStart = zdt.toLocalDate().atStartOfDay(clientZoneId);
+    Timestamp startingDateRange = Timestamp.valueOf(zdtStart.toLocalDateTime());
+
+    // Determine the active facet filter (issue #634; calendarId is fully supported by
+    // CalendarEventRepository, single-select since an event belongs to exactly one calendar)
+    long selectedCalendarId = context.getParameterAsLong("calendarId", -1);
 
     // Search the calendar events
     CalendarEventSpecification eventSpecification = new CalendarEventSpecification();
     eventSpecification.setPublishedOnly(true);
     eventSpecification.setSearchTerm(query);
-    eventSpecification.setStartingDateRange(Timestamp.valueOf(zdtStart.toLocalDateTime()));
+    eventSpecification.setStartingDateRange(startingDateRange);
+    if (selectedCalendarId != -1) {
+      eventSpecification.setCalendarId(selectedCalendarId);
+    }
     List<CalendarEvent> calendarEventList = CalendarEventRepository.findAll(eventSpecification, constraints);
+    // Not yet passing a facetKey here (issue #638's SearchAnalyticsCommand.record() overload isn't
+    // on main at the time of this PR) -- a trivial follow-up once #638 merges.
     SearchAnalyticsCommand.record(context, query, "calendar", calendarEventList == null ? 0 : calendarEventList.size());
+
+    // Facet panel: one option per calendar with a non-zero count (or the currently selected one),
+    // each counted standalone (ignoring the current calendarId selection) so switching calendars
+    // shows every calendar's own count, not just the selected one's (issue #634)
+    List<FacetUrlCommand.FacetOption> calendarFacets = new ArrayList<>();
+    List<Calendar> calendarList = CalendarRepository.findAll();
+    if (calendarList != null) {
+      for (Calendar calendar : calendarList) {
+        boolean selected = selectedCalendarId == calendar.getId();
+        CalendarEventSpecification countSpecification = new CalendarEventSpecification();
+        countSpecification.setPublishedOnly(true);
+        countSpecification.setSearchTerm(query);
+        countSpecification.setStartingDateRange(startingDateRange);
+        countSpecification.setCalendarId(calendar.getId());
+        long count = CalendarEventRepository.findCount(countSpecification);
+        if (count > 0 || selected) {
+          String url = FacetUrlCommand.buildFacetLinkUrl(context, "calendarId", String.valueOf(calendar.getId()));
+          calendarFacets.add(new FacetUrlCommand.FacetOption(String.valueOf(calendar.getId()), calendar.getName(), count, selected, url));
+        }
+      }
+    }
+    context.getRequest().setAttribute("calendarFacets", calendarFacets);
+    context.getRequest().setAttribute("calendarFacetLabel", CALENDAR_FACET_LABEL);
+
+    // Active filter chip, with a URL that clears just the calendarId filter (issue #634)
+    List<FacetUrlCommand.ActiveFacetFilter> activeFilters = new ArrayList<>();
+    if (selectedCalendarId != -1) {
+      Calendar selectedCalendar = CalendarRepository.findById(selectedCalendarId);
+      String valueLabel = selectedCalendar != null ? selectedCalendar.getName() : "Selected calendar";
+      activeFilters.add(new FacetUrlCommand.ActiveFacetFilter(CALENDAR_FACET_LABEL, valueLabel,
+          FacetUrlCommand.buildClearFilterUrl(context, "calendarId")));
+    }
+    context.getRequest().setAttribute("activeFilters", activeFilters);
 
     // Determine if the widget is shown
     boolean showWhenEmpty = "true".equals(context.getPreferences().getOrDefault("showWhenEmpty", "true"));

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WikiSearchResultsWidget.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.application.FacetUrlCommand;
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
 import com.simisinc.platform.domain.model.cms.SearchResult;
@@ -48,6 +49,7 @@ public class WikiSearchResultsWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908895L;
 
   static String JSP = "/cms/wiki-search-results-list.jsp";
+  static String WIKI_FACET_LABEL = "Wiki";
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -64,14 +66,65 @@ public class WikiSearchResultsWidget extends GenericWidget {
       return null;
     }
 
+    // Determine the active facet filter (issue #634; wikiId is fully supported by
+    // WikiPageRepository, single-select since a page belongs to exactly one wiki)
+    long selectedWikiId = context.getParameterAsLong("wikiId", -1);
+
     // Determine criteria
     WikiPageSpecification specification = new WikiPageSpecification();
     specification.setSearchTerm(query);
+    if (selectedWikiId != -1) {
+      specification.setWikiId(selectedWikiId);
+    }
 
     // Query the data
     List<WikiPage> wikiPageList = WikiPageRepository.findAll(specification, constraints);
+    // Not yet passing a facetKey here (issue #638's SearchAnalyticsCommand.record() overload isn't
+    // on main at the time of this PR) -- a trivial follow-up once #638 merges.
     SearchAnalyticsCommand.record(context, query, "wiki", wikiPageList == null ? 0 : wikiPageList.size());
+
+    // Facet panel: one option per wiki with a non-zero count (or the currently selected one), each
+    // counted standalone (ignoring the current wikiId selection) so switching wikis shows every
+    // wiki's own count, not just the selected one's (issue #634)
+    List<FacetUrlCommand.FacetOption> wikiFacets = new ArrayList<>();
+    List<Wiki> wikiList = WikiRepository.findAll();
+    if (wikiList != null) {
+      for (Wiki wiki : wikiList) {
+        boolean selected = selectedWikiId == wiki.getId();
+        WikiPageSpecification countSpecification = new WikiPageSpecification();
+        countSpecification.setSearchTerm(query);
+        countSpecification.setWikiId(wiki.getId());
+        long count = WikiPageRepository.findCount(countSpecification);
+        if (count > 0 || selected) {
+          String url = FacetUrlCommand.buildFacetLinkUrl(context, "wikiId", String.valueOf(wiki.getId()));
+          wikiFacets.add(new FacetUrlCommand.FacetOption(String.valueOf(wiki.getId()), wiki.getName(), count, selected, url));
+        }
+      }
+    }
+    context.getRequest().setAttribute("wikiFacets", wikiFacets);
+    context.getRequest().setAttribute("wikiFacetLabel", WIKI_FACET_LABEL);
+
+    // Active filter chip, with a URL that clears just the wikiId filter (issue #634)
+    List<FacetUrlCommand.ActiveFacetFilter> activeFilters = new ArrayList<>();
+    if (selectedWikiId != -1) {
+      Wiki selectedWiki = WikiRepository.findById(selectedWikiId);
+      String valueLabel = selectedWiki != null ? selectedWiki.getName() : "Selected wiki";
+      activeFilters.add(new FacetUrlCommand.ActiveFacetFilter(WIKI_FACET_LABEL, valueLabel,
+          FacetUrlCommand.buildClearFilterUrl(context, "wikiId")));
+    }
+    context.getRequest().setAttribute("activeFilters", activeFilters);
+
+    // Standard request items -- set even when the result list is empty (issue #634 fix: this used
+    // to bail out before these were set, so the JSP never even rendered a zero-result message,
+    // let alone one that could offer to clear an active filter)
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+    context.getRequest().setAttribute("showPaging", context.getPreferences().getOrDefault("showPaging", "true"));
+    context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
+
     if (wikiPageList == null || wikiPageList.isEmpty()) {
+      context.getRequest().setAttribute("searchResultList", new ArrayList<SearchResult>());
+      context.setJsp(JSP);
       return context;
     }
 
@@ -102,12 +155,6 @@ public class WikiSearchResultsWidget extends GenericWidget {
       searchResultList.add(searchResult);
     }
     context.getRequest().setAttribute("searchResultList", searchResultList);
-
-    // Standard request items
-    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
-    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
-    context.getRequest().setAttribute("showPaging", context.getPreferences().getOrDefault("showPaging", "true"));
-    context.getRequest().setAttribute("returnPage", context.getRequest().getRequestURI());
 
     // Show the JSP
     context.setJsp(JSP);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
@@ -16,9 +16,9 @@
 
 package com.simisinc.platform.presentation.widgets.items;
 
+import com.simisinc.platform.application.FacetUrlCommand;
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
-import com.simisinc.platform.application.cms.UrlCommand;
 import com.simisinc.platform.application.items.ItemDateFacetCommand;
 import com.simisinc.platform.domain.model.cms.SearchResult;
 import com.simisinc.platform.domain.model.items.Category;
@@ -33,7 +33,6 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,7 +173,7 @@ public class ItemsSearchResultsWidget extends GenericWidget {
         boolean selected = selectedDateBucket != null && selectedDateBucket.getKey().equals(bucket.getKey());
         long count = ItemRepository.countByDateRange(specification, bucket.getStart(), bucket.getEnd());
         if (count > 0 || selected) {
-          String url = buildFacetLinkUrl(context, "dateFacet", bucket.getKey());
+          String url = FacetUrlCommand.buildFacetLinkUrl(context, "dateFacet", bucket.getKey());
           dateFacets.add(new ItemFacetOption(bucket.getKey(), bucket.getLabel(), count, selected, url));
         }
       }
@@ -220,11 +219,11 @@ public class ItemsSearchResultsWidget extends GenericWidget {
         activeFilters.add(new ItemActiveFilter(categoryFacetLabel, valueLabel, clearUrl));
       }
       if (selectedCategoryIds.size() > 1) {
-        activeFilters.add(new ItemActiveFilter(categoryFacetLabel, "All categories", buildClearFilterUrl(context, "categoryId")));
+        activeFilters.add(new ItemActiveFilter(categoryFacetLabel, "All categories", FacetUrlCommand.buildClearFilterUrl(context, "categoryId")));
       }
     }
     if (selectedDateBucket != null) {
-      activeFilters.add(new ItemActiveFilter(dateFacetLabel, selectedDateBucket.getLabel(), buildClearFilterUrl(context, "dateFacet")));
+      activeFilters.add(new ItemActiveFilter(dateFacetLabel, selectedDateBucket.getLabel(), FacetUrlCommand.buildClearFilterUrl(context, "dateFacet")));
     }
     context.getRequest().setAttribute("activeFilters", activeFilters);
 
@@ -277,29 +276,14 @@ public class ItemsSearchResultsWidget extends GenericWidget {
   }
 
   /**
-   * The current request's URL with the given single-value param set to the given value, all other
-   * current params preserved, and paging reset to page 1 (a facet selection changes the result
-   * set, so whatever page the user was on may no longer exist). Used by the (single-select)
-   * dateFacet link; the category facet uses buildCategoryToggleUrl instead (issue #636).
-   */
-  private static String buildFacetLinkUrl(WidgetContext context, String paramName, String paramValue) {
-    Map<String, List<String>> overrides = new LinkedHashMap<>();
-    overrides.put(paramName, Collections.singletonList(paramValue));
-    return buildUrl(context, overrides, paramName);
-  }
-
-  /** The current request's URL with the given param removed entirely, all other current params preserved. */
-  private static String buildClearFilterUrl(WidgetContext context, String paramName) {
-    return buildUrl(context, new LinkedHashMap<>(), paramName);
-  }
-
-  /**
    * The current request's URL with candidateCategoryId toggled in or out of the categoryId
    * selection (issue #636): added if it's not in currentSelection, removed if it is, every OTHER
    * currently selected categoryId preserved. This one method backs both the facet checkbox links
    * (toggling an unchecked category on, or an already-checked one off) and each active-filter
    * chip's "remove just this one" link -- removing a selected category via its chip is exactly the
-   * same toggle-off operation as unchecking its facet checkbox.
+   * same toggle-off operation as unchecking its facet checkbox. Category is the only multi-select
+   * facet in this codebase, so this stays private here rather than in the shared FacetUrlCommand
+   * (issue #634) alongside the single-select buildFacetLinkUrl/buildClearFilterUrl it still uses.
    */
   private static String buildCategoryToggleUrl(WidgetContext context, List<Long> currentSelection, long candidateCategoryId) {
     List<String> newSelection = new ArrayList<>();
@@ -320,48 +304,8 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     }
     // When newSelection ends up empty, categoryId is simply absent from overrides -- combined with
     // excludeParam below dropping the current categoryId values, the result is the same as
-    // buildClearFilterUrl: the param disappears from the URL entirely.
-    return buildUrl(context, overrides, "categoryId");
-  }
-
-  /**
-   * The current request's URL with excludeParam's current value(s) dropped and replaced by
-   * overrides (if any), every OTHER param preserved with EVERY one of its repeated values (not
-   * just the first) -- so, for example, clicking a dateFacet link doesn't silently drop all but
-   * one of the currently selected categoryId values -- and paging reset to page 1.
-   */
-  private static String buildUrl(WidgetContext context, Map<String, List<String>> overrides, String excludeParam) {
-    LinkedHashMap<String, List<String>> params = new LinkedHashMap<>();
-    for (Map.Entry<String, String[]> entry : context.getParameterMap().entrySet()) {
-      String name = entry.getKey();
-      if (name.equals(excludeParam) || "page".equals(name)) {
-        continue;
-      }
-      if (entry.getValue() == null) {
-        continue;
-      }
-      List<String> values = new ArrayList<>();
-      for (String value : entry.getValue()) {
-        if (StringUtils.isNotBlank(value)) {
-          values.add(value);
-        }
-      }
-      if (!values.isEmpty()) {
-        params.put(name, values);
-      }
-    }
-    params.putAll(overrides);
-
-    StringBuilder url = new StringBuilder(context.getUri());
-    boolean first = true;
-    for (Map.Entry<String, List<String>> entry : params.entrySet()) {
-      for (String value : entry.getValue()) {
-        url.append(first ? '?' : '&');
-        first = false;
-        url.append(UrlCommand.encodeUri(entry.getKey())).append('=').append(UrlCommand.encodeUri(value));
-      }
-    }
-    return url.toString();
+    // FacetUrlCommand.buildClearFilterUrl: the param disappears from the URL entirely.
+    return FacetUrlCommand.buildUrl(context, overrides, "categoryId");
   }
 
   /** One facet's rendered option: display label, result count, whether it's currently selected, and its link. */

--- a/src/main/webapp/WEB-INF/jsp/calendar/calendar-search-results.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/calendar-search-results.jsp
@@ -22,16 +22,61 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="calendarEventList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="showMonthName" class="java.lang.String" scope="request"/>
+<jsp:useBean id="activeFilters" class="java.util.ArrayList" scope="request"/>
 <%@include file="../page_messages.jspf" %>
-<c:choose>
-  <c:when test="${empty calendarEventList}">
-    <p>No calendar events were found</p>
-  </c:when>
-  <c:otherwise>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+</c:if>
+<c:if test="${!empty activeFilters}">
+  <div class="margin-bottom-10">
+    <c:forEach items="${activeFilters}" var="activeFilter">
+      <span class="label secondary" style="margin-right:5px">
+        <c:out value="${activeFilter.facetLabel}"/>: <c:out value="${activeFilter.valueLabel}"/>
+        <%-- clearUrl is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+        <a href="${activeFilter.clearUrl}" style="color:inherit" title="Remove this filter"><i class="fa fa-times"></i></a>
+      </span>
+    </c:forEach>
+  </div>
+</c:if>
+<div class="grid-x grid-margin-x">
+  <c:if test="${!empty calendarFacets}">
+    <div class="cell medium-3">
+      <h6><c:out value="${calendarFacetLabel}"/></h6>
+      <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+        <c:forEach items="${calendarFacets}" var="facet">
+          <li>
+            <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+            <a href="${facet.url}">
+              <c:choose>
+                <c:when test="${facet.selected}"><i class="fa fa-circle-check"></i></c:when>
+                <c:otherwise><i class="fa fa-circle-o"></i></c:otherwise>
+              </c:choose>
+              <c:out value="${facet.label}"/>
+            </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+          </li>
+        </c:forEach>
+      </ul>
+    </div>
+  </c:if>
+  <div class="cell ${!empty calendarFacets ? 'medium-9' : 'medium-12'}">
+    <c:choose>
+      <c:when test="${empty calendarEventList}">
+        <c:choose>
+          <c:when test="${!empty activeFilters}">
+            <p>No calendar events match the current filters.</p>
+            <ul class="no-bullet">
+              <c:forEach items="${activeFilters}" var="activeFilter">
+                <li><a href="${activeFilter.clearUrl}">Remove "<c:out value="${activeFilter.valueLabel}"/>"</a></li>
+              </c:forEach>
+            </ul>
+          </c:when>
+          <c:otherwise>
+            <p>No calendar events were found</p>
+          </c:otherwise>
+        </c:choose>
+      </c:when>
+      <c:otherwise>
     <div class="platform-calendar-list-container">
-      <c:if test="${!empty title}">
-        <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
-      </c:if>
       <c:set var="lastMonth" scope="request" value="---"/>
       <c:set var="lastDay" scope="request" value="---"/>
       <c:forEach items="${calendarEventList}" var="calendarEvent">
@@ -117,5 +162,7 @@
         </div>
       </c:forEach>
     </div>
-  </c:otherwise>
-</c:choose>
+      </c:otherwise>
+    </c:choose>
+  </div>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/cms/wiki-search-results-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/wiki-search-results-list.jsp
@@ -15,23 +15,79 @@
   --%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="searchResultList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="activeFilters" class="java.util.ArrayList" scope="request"/>
 <c:if test="${!empty title}">
   <h4 class="margin-bottom-20"><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
-  <div class="platform-content-search-result margin-top-10">
+<c:if test="${!empty activeFilters}">
+  <div class="margin-bottom-10">
+    <c:forEach items="${activeFilters}" var="activeFilter">
+      <span class="label secondary" style="margin-right:5px">
+        <c:out value="${activeFilter.facetLabel}"/>: <c:out value="${activeFilter.valueLabel}"/>
+        <%-- clearUrl is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+        <a href="${activeFilter.clearUrl}" style="color:inherit" title="Remove this filter"><i class="fa fa-times"></i></a>
+      </span>
+    </c:forEach>
+  </div>
+</c:if>
+<div class="grid-x grid-margin-x">
+  <c:if test="${!empty wikiFacets}">
+    <div class="cell medium-3">
+      <h6><c:out value="${wikiFacetLabel}"/></h6>
+      <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+        <c:forEach items="${wikiFacets}" var="facet">
+          <li>
+            <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+            <a href="${facet.url}">
+              <c:choose>
+                <c:when test="${facet.selected}"><i class="fa fa-circle-check"></i></c:when>
+                <c:otherwise><i class="fa fa-circle-o"></i></c:otherwise>
+              </c:choose>
+              <c:out value="${facet.label}"/>
+            </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+          </li>
+        </c:forEach>
+      </ul>
+    </div>
+  </c:if>
+  <div class="cell ${!empty wikiFacets ? 'medium-9' : 'medium-12'}">
     <c:choose>
-      <c:when test="${!empty searchResult.pageTitle}">
-        <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a></h5>
+      <c:when test="${empty searchResultList}">
+        <c:choose>
+          <c:when test="${!empty activeFilters}">
+            <p>No wiki pages match the current filters.</p>
+            <ul class="no-bullet">
+              <c:forEach items="${activeFilters}" var="activeFilter">
+                <li><a href="${activeFilter.clearUrl}">Remove "<c:out value="${activeFilter.valueLabel}"/>"</a></li>
+              </c:forEach>
+            </ul>
+          </c:when>
+          <c:otherwise>
+            <p>No wiki pages were found</p>
+          </c:otherwise>
+        </c:choose>
       </c:when>
       <c:otherwise>
-        <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.link}"/></a></h5>
+        <c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
+          <div class="platform-content-search-result margin-top-10">
+            <c:choose>
+              <c:when test="${!empty searchResult.pageTitle}">
+                <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a></h5>
+              </c:when>
+              <c:otherwise>
+                <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.link}"/></a></h5>
+              </c:otherwise>
+            </c:choose>
+            <c:if test="${!empty searchResult.pageDescription}">
+              <p><c:out value="${searchResult.pageDescription}" /></p>
+            </c:if>
+            <p>${searchResult.htmlExcerpt}</p>
+          </div>
+        </c:forEach>
       </c:otherwise>
     </c:choose>
-    <c:if test="${!empty searchResult.pageDescription}">
-      <p><c:out value="${searchResult.pageDescription}" /></p>
-    </c:if>
-    <p>${searchResult.htmlExcerpt}</p>
   </div>
-</c:forEach>
+</div>

--- a/src/test/java/com/simisinc/platform/application/FacetUrlCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/FacetUrlCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.WidgetBase;
+
+/**
+ * Verifies the URL-building engine extracted from ItemsSearchResultsWidget (issue #634), which
+ * CalendarSearchResultsWidget and WikiSearchResultsWidget now also depend on.
+ *
+ * @author SimIS Inc.
+ */
+class FacetUrlCommandTest extends WidgetBase {
+
+  @Test
+  void buildFacetLinkUrlSetsTheParamAndResetsPaging() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "page", "3");
+
+    String url = FacetUrlCommand.buildFacetLinkUrl(widgetContext, "wikiId", "5");
+
+    assertTrue(url.contains("wikiId=5"));
+    assertTrue(url.contains("query=widgets"));
+    assertFalse(url.contains("page="), "a facet selection changes the result set, so paging must reset");
+  }
+
+  @Test
+  void buildFacetLinkUrlReplacesAnExistingValueForTheSameParam() {
+    addQueryParameter(widgetContext, "wikiId", "5");
+
+    String url = FacetUrlCommand.buildFacetLinkUrl(widgetContext, "wikiId", "6");
+
+    assertTrue(url.contains("wikiId=6"));
+    assertFalse(url.contains("wikiId=5"));
+  }
+
+  @Test
+  void buildFacetLinkUrlPreservesOtherRepeatedParams() {
+    widgetContext.getParameterMap().put("categoryId", new String[] { "1", "2" });
+
+    String url = FacetUrlCommand.buildFacetLinkUrl(widgetContext, "dateFacet", "last7");
+
+    assertTrue(url.contains("categoryId=1"));
+    assertTrue(url.contains("categoryId=2"));
+    assertTrue(url.contains("dateFacet=last7"));
+  }
+
+  @Test
+  void buildClearFilterUrlDropsOnlyTheGivenParam() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "wikiId", "5");
+
+    String url = FacetUrlCommand.buildClearFilterUrl(widgetContext, "wikiId");
+
+    assertTrue(url.contains("query=widgets"));
+    assertFalse(url.contains("wikiId="));
+  }
+
+  @Test
+  void buildClearFilterUrlOnAnUnsetParamLeavesEverythingElseIntact() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    String url = FacetUrlCommand.buildClearFilterUrl(widgetContext, "wikiId");
+
+    assertTrue(url.contains("query=widgets"));
+    assertFalse(url.contains("wikiId="));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidgetTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.FacetUrlCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.domain.model.cms.Calendar;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies the calendarId facet added to CalendarSearchResultsWidget (issue #634), mirroring the
+ * coverage ItemsSearchResultsWidgetTest has for the categoryId/dateFacet facets.
+ *
+ * @author SimIS Inc.
+ */
+class CalendarSearchResultsWidgetTest extends WidgetBase {
+
+  private static Calendar calendar(long id, String name) {
+    Calendar calendar = new Calendar();
+    calendar.setId(id);
+    calendar.setName(name);
+    return calendar;
+  }
+
+  private static CalendarEvent event(long id) {
+    CalendarEvent event = new CalendarEvent();
+    event.setId(id);
+    event.setUniqueId("event-" + id);
+    event.setTitle("Event " + id);
+    return event;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheCalendarIdParamAndOnlyListsCalendarsWithResultsOrSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "calendarId", "5");
+
+    List<CalendarEvent> eventList = new ArrayList<>();
+    eventList.add(event(1L));
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(eventList);
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(List.of(calendar(5, "Team Events"), calendar(6, "Holidays")));
+      calendarRepository.when(() -> CalendarRepository.findById(5L)).thenReturn(calendar(5, "Team Events"));
+      // Calendar 5 has results, calendar 6 does not and is not selected -- omitted entirely
+      repository.when(() -> CalendarEventRepository.findCount(any(CalendarEventSpecification.class)))
+          .thenAnswer(invocation -> {
+            CalendarEventSpecification spec = invocation.getArgument(0);
+            return spec.getCalendarId() == 5L ? 3L : 0L;
+          });
+
+      WidgetContext result = new CalendarSearchResultsWidget().execute(widgetContext);
+
+      List<FacetUrlCommand.FacetOption> calendarFacets = (List<FacetUrlCommand.FacetOption>) result.getRequest().getAttribute("calendarFacets");
+      assertEquals(1, calendarFacets.size(), "calendar 6 has a 0 count and is not selected, so it must not be listed");
+      assertEquals("Team Events", calendarFacets.get(0).getLabel());
+      assertEquals(3L, calendarFacets.get(0).getCount());
+      assertTrue(calendarFacets.get(0).isSelected());
+
+      List<FacetUrlCommand.ActiveFacetFilter> activeFilters = (List<FacetUrlCommand.ActiveFacetFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Calendar", activeFilters.get(0).getFacetLabel());
+      assertEquals("Team Events", activeFilters.get(0).getValueLabel());
+    }
+  }
+
+  @Test
+  void executeWithNoCalendarIdSelectedHasNoActiveFilters() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      WidgetContext result = new CalendarSearchResultsWidget().execute(widgetContext);
+
+      assertTrue(((List<?>) result.getRequest().getAttribute("activeFilters")).isEmpty());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeGivesEveryCalendarsOwnStandaloneCountRegardlessOfSelection() {
+    // Selecting calendar 5 must not zero out calendar 6's own count -- each is counted standalone
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "calendarId", "5");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any())).thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(List.of(calendar(5, "Team Events"), calendar(6, "Holidays")));
+      calendarRepository.when(() -> CalendarRepository.findById(5L)).thenReturn(calendar(5, "Team Events"));
+      repository.when(() -> CalendarEventRepository.findCount(any(CalendarEventSpecification.class)))
+          .thenAnswer(invocation -> {
+            CalendarEventSpecification spec = invocation.getArgument(0);
+            return spec.getCalendarId() == 6L ? 4L : 2L;
+          });
+
+      WidgetContext result = new CalendarSearchResultsWidget().execute(widgetContext);
+
+      List<FacetUrlCommand.FacetOption> calendarFacets = (List<FacetUrlCommand.FacetOption>) result.getRequest().getAttribute("calendarFacets");
+      assertEquals(2, calendarFacets.size());
+      assertEquals(4L, calendarFacets.get(1).getCount(), "calendar 6's own count must not be affected by calendar 5 being selected");
+    }
+  }
+
+  @Test
+  void executeReturnsNullForABlankQuery() {
+    assertNull(new CalendarSearchResultsWidget().execute(widgetContext));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WikiSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WikiSearchResultsWidgetTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.FacetUrlCommand;
+import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.domain.model.cms.Wiki;
+import com.simisinc.platform.domain.model.cms.WikiPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WikiPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WikiPageSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.WikiRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies the wikiId facet added to WikiSearchResultsWidget (issue #634), and the fix to the
+ * zero-result path that used to bail out before setting standard request attrs at all.
+ *
+ * @author SimIS Inc.
+ */
+class WikiSearchResultsWidgetTest extends WidgetBase {
+
+  private static Wiki wiki(long id, String name) {
+    Wiki wiki = new Wiki();
+    wiki.setId(id);
+    wiki.setName(name);
+    wiki.setUniqueId("wiki-" + id);
+    return wiki;
+  }
+
+  private static WikiPage wikiPage(long id, long wikiId) {
+    WikiPage wikiPage = new WikiPage();
+    wikiPage.setId(id);
+    wikiPage.setWikiId(wikiId);
+    wikiPage.setUniqueId("page-" + id);
+    wikiPage.setTitle("Page " + id);
+    return wikiPage;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheWikiIdParamAndOnlyListsWikisWithResultsOrSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "wikiId", "5");
+
+    List<WikiPage> wikiPageList = new ArrayList<>();
+    wikiPageList.add(wikiPage(1L, 5L));
+
+    try (MockedStatic<WikiPageRepository> repository = mockStatic(WikiPageRepository.class);
+        MockedStatic<WikiRepository> wikiRepository = mockStatic(WikiRepository.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      repository.when(() -> WikiPageRepository.findAll(any(WikiPageSpecification.class), any())).thenReturn(wikiPageList);
+      wikiRepository.when(WikiRepository::findAll).thenReturn(List.of(wiki(5, "Engineering"), wiki(6, "Support")));
+      wikiRepository.when(() -> WikiRepository.findById(5L)).thenReturn(wiki(5, "Engineering"));
+      // Wiki 5 has results, wiki 6 does not and is not selected -- omitted entirely
+      repository.when(() -> WikiPageRepository.findCount(any(WikiPageSpecification.class)))
+          .thenAnswer(invocation -> {
+            WikiPageSpecification spec = invocation.getArgument(0);
+            return spec.getWikiId() == 5L ? 2L : 0L;
+          });
+
+      WidgetContext result = new WikiSearchResultsWidget().execute(widgetContext);
+
+      List<FacetUrlCommand.FacetOption> wikiFacets = (List<FacetUrlCommand.FacetOption>) result.getRequest().getAttribute("wikiFacets");
+      assertEquals(1, wikiFacets.size(), "wiki 6 has a 0 count and is not selected, so it must not be listed");
+      assertEquals("Engineering", wikiFacets.get(0).getLabel());
+      assertEquals(2L, wikiFacets.get(0).getCount());
+      assertTrue(wikiFacets.get(0).isSelected());
+
+      List<FacetUrlCommand.ActiveFacetFilter> activeFilters = (List<FacetUrlCommand.ActiveFacetFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Wiki", activeFilters.get(0).getFacetLabel());
+      assertEquals("Engineering", activeFilters.get(0).getValueLabel());
+    }
+  }
+
+  @Test
+  void executeSetsStandardAttrsAndAnEmptySearchResultListWhenNothingMatches() {
+    // Regression check for issue #634's fix: this used to return context before setting icon/
+    // title/showPaging/returnPage/searchResultList at all, so the JSP never rendered anything --
+    // not even a "no results" message.
+    addQueryParameter(widgetContext, "query", "widgets");
+    preferences.put("title", "Wiki Search");
+    preferences.put("icon", "fa-book");
+
+    try (MockedStatic<WikiPageRepository> repository = mockStatic(WikiPageRepository.class);
+        MockedStatic<WikiRepository> wikiRepository = mockStatic(WikiRepository.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      repository.when(() -> WikiPageRepository.findAll(any(WikiPageSpecification.class), any())).thenReturn(new ArrayList<>());
+      wikiRepository.when(WikiRepository::findAll).thenReturn(new ArrayList<>());
+
+      WidgetContext result = new WikiSearchResultsWidget().execute(widgetContext);
+
+      assertEquals(WikiSearchResultsWidget.JSP, result.getJsp());
+      assertEquals("Wiki Search", result.getRequest().getAttribute("title"));
+      assertEquals("fa-book", result.getRequest().getAttribute("icon"));
+      assertEquals("true", result.getRequest().getAttribute("showPaging"));
+      assertTrue(((List<?>) result.getRequest().getAttribute("searchResultList")).isEmpty());
+    }
+  }
+
+  @Test
+  void executeReturnsNullForABlankQuery() {
+    assertNull(new WikiSearchResultsWidget().execute(widgetContext));
+  }
+}

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -167,6 +167,10 @@ ALLOWLIST: dict[str, str] = {
         "Same construction and reasoning as ${facet.url} above -- built by ItemsSearchResultsWidget.buildClearFilterUrl/buildUrl from context.getUri() + UrlCommand.encodeUri()'d params.",
     "${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}":
         "Ternary between two fixed CSS class literals -- same pattern as ${hideChartControls}/${hideChartTitle} below. No other value is possible.",
+    "${!empty calendarFacets ? 'medium-9' : 'medium-12'}":
+        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
+    "${!empty wikiFacets ? 'medium-9' : 'medium-12'}":
+        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${faqQuestion.answerHtml}":
         "Same trust boundary as ${widget.content} below: an admin/content-manager-authored widget preference (FaqWidget.java), not user input. The question text is rendered via <c:out> in the same JSP; only the answer is intentionally raw, since it's meant to render as HTML.",
     "${file.baseUrl}":


### PR DESCRIPTION
## Summary
Slice 1 of #634. Follow-up to #421/PR #631, which scoped the facet-panel + active-filter-chip UI to `ItemsSearchResultsWidget` only.

**Shared extraction:** pulled the single-select URL-building engine (`buildFacetLinkUrl`/`buildClearFilterUrl`/`buildUrl`) out of `ItemsSearchResultsWidget` into a new `FacetUrlCommand`, plus generic `FacetOption`/`ActiveFacetFilter` view-model classes — per the original issue's own suggestion to extract once a second widget needs the pattern rather than copy-paste a third time. `ItemsSearchResultsWidget`'s category *multi*-select toggle (issue #636) stays private to that widget since it's the only multi-select facet in the codebase; it now delegates to `FacetUrlCommand.buildUrl` internally instead of duplicating it.

**Calendar:** `CalendarSearchResultsWidget` gains a `calendarId` facet. `CalendarEventSpecification.calendarId` and `CalendarEventRepository`'s WHERE clause already fully supported this — the widget just never set it. Single-select (an event belongs to exactly one calendar).

**Wiki:** `WikiSearchResultsWidget` gains a `wikiId` facet, same latent-field shape (`WikiPageSpecification.wikiId`, already honored by `WikiPageRepository`). Also fixes a real bug found along the way: the empty-result path used to `return context` before setting *any* standard request attributes (`icon`/`title`/`showPaging`/`returnPage`) or even `searchResultList` — so a zero-result wiki search rendered nothing at all, not even a "no results" message.

**Deliberately deferred to separate slices:**
- WebPage's date facet (filtering on `Content.modified`, per discussion) — separate PR to follow.
- `WebPageTitleSearchResultsWidget`'s architecture blocker (bespoke `search()` method, not `Specification`-based) — split into #866, since #634 never specified a target facet dimension for this widget, only flagged the blocker.

## Test plan
- [x] `ant compile` / `ant compile-test` — clean
- [x] `ant compile-jsp` — all JSPs translate and compile
- [x] `python3 tools/check-unescaped-el.py . --strict` — 0 unallowlisted (2 new allowlist entries for the calendar/wiki facet-column-width ternaries, same reasoning as the existing Items one)
- [x] `ant ci-test` — full suite green, 0 failures
- [x] New tests: `FacetUrlCommandTest` (URL-building engine), `CalendarSearchResultsWidgetTest`, `WikiSearchResultsWidgetTest` (including a regression test for the empty-result standard-attrs fix)