### PR TITLE
Fix dead date-range columns in WikiPageRepository

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageRepository.java
@@ -49,10 +49,6 @@ public class WikiPageRepository {
           .addIfExists("wiki_page_id = ?", specification.getId(), -1)
           .addIfExists("wiki_id = ?", specification.getWikiId(), -1)
           .addIfExists("page_unique_id = ?", specification.getUniqueId());
-      if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
-        where.add("((start_date >= ? AND start_date < ?) OR (end_date >= ? AND end_date < ?))",
-            new Timestamp[]{specification.getStartingDateRange(), specification.getEndingDateRange(), specification.getStartingDateRange(), specification.getEndingDateRange()});
-      }
       if (StringUtils.isNotBlank(specification.getSearchTerm())) {
         where.add("tsv @@ PLAINTO_TSQUERY('title_stem', ?)", specification.getSearchTerm().trim());
       }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageSpecification.java
@@ -16,8 +16,6 @@
 
 package com.simisinc.platform.infrastructure.persistence.cms;
 
-import java.sql.Timestamp;
-
 /**
  * Properties for querying objects from the wiki page repository
  *
@@ -30,8 +28,6 @@ public class WikiPageSpecification {
   private long wikiId = -1L;
   private String uniqueId = null;
   private String searchTerm = null;
-  private Timestamp startingDateRange = null;
-  private Timestamp endingDateRange = null;
 
   public WikiPageSpecification() {
   }
@@ -74,21 +70,5 @@ public class WikiPageSpecification {
 
   public void setSearchTerm(String searchTerm) {
     this.searchTerm = searchTerm;
-  }
-
-  public Timestamp getStartingDateRange() {
-    return startingDateRange;
-  }
-
-  public void setStartingDateRange(Timestamp startingDateRange) {
-    this.startingDateRange = startingDateRange;
-  }
-
-  public Timestamp getEndingDateRange() {
-    return endingDateRange;
-  }
-
-  public void setEndingDateRange(Timestamp endingDateRange) {
-    this.endingDateRange = endingDateRange;
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageSearchTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WikiPageSearchTest.java
@@ -150,6 +150,14 @@ class WikiPageSearchTest {
     assertEquals(3, results.size());
   }
 
+  @Test
+  void findCountMatchesTheNumberOfPagesInTheWiki() {
+    WikiPageSpecification spec = new WikiPageSpecification();
+    spec.setWikiId(wikiId);
+
+    assertEquals(3, WikiPageRepository.findCount(spec));
+  }
+
   private static void createSchemaAndSeedPages() {
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {


### PR DESCRIPTION
## Summary
- `WikiPageRepository.createWhereStatement()` had a WHERE clause filtering on `start_date`/`end_date`, columns that `wiki_pages` has never had (only `created`/`modified`, per `NEW_10050__new_wikis.sql`). The block was copy-pasted from `CalendarEventRepository.createWhereStatement()`, whose `calendar_events` table genuinely has those columns, and never adapted for wikis.
- No caller anywhere sets `WikiPageSpecification.startingDateRange`/`endingDateRange` (confirmed via repo-wide grep), so this has never actually thrown at runtime — but the first caller that did set those fields would hit `column start_date does not exist` in `findAll()`/`findCount()`.
- Checked whether the fields were meant to describe `created` or `modified` before guessing: issue #634's wiki-facet slice (PR #867) already covers the real latent filter gap on `WikiSearchResultsWidget` — `wikiId`, not a date range — and the issue thread's next date-facet slice targets `WebPageSearchResultsWidget`'s `Content.modified`, not Wiki. There's no planned wiki date-range filter anywhere in the codebase or the issue tracker, so removing the dead fields is cleaner than guessing at intent.

## Changes
- Removed the broken WHERE-clause block from `WikiPageRepository.createWhereStatement()`.
- Removed the now-unused `startingDateRange`/`endingDateRange` fields (and getters/setters) from `WikiPageSpecification`.
- Added `findCountMatchesTheNumberOfPagesInTheWiki` to `WikiPageSearchTest`, which previously had no coverage of `WikiPageRepository.findCount()` despite it sharing the edited `createWhereStatement()` method.

## Test plan
- [x] `ant compile`
- [x] `ant ci-test` — full suite passes, including the updated `WikiPageSearchTest` (5/5)