### PR TITLE
Add a date facet to WebPage search, filtering on Content.modified (#634)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -143,6 +143,28 @@ public class ContentRepository {
     return DB.selectCountFrom(TABLE_NAME, new SqlUtils().add("draft_status = ?", draftStatus));
   }
 
+  /**
+   * Count of content rows matching searchTerm whose modified timestamp falls in [start, end)
+   * (either bound may be null for open-ended), for the WebPage search date facet (issue #634).
+   * This is a content-match count, not the final displayed web page count -- WebPageSearchResultsWidget
+   * cross-references each matching content item against which pages embed it and are visible/
+   * navigable to the current user, so the true result count can be slightly lower than this in the
+   * rare case a matched content item turns out to live only on an unlisted or permission-restricted
+   * page. Exact parity would require re-running that whole cross-reference per bucket; this
+   * approximation was chosen instead, mirroring the same search-term matching query() uses.
+   */
+  public static long countByDateRange(String searchTerm, Timestamp start, Timestamp end) {
+    SqlUtils where = new SqlUtils();
+    if (StringUtils.isNotBlank(searchTerm)) {
+      String term = searchTerm.trim();
+      where.add("(content_unique_id ILIKE ? OR tsv @@ PLAINTO_TSQUERY('content_stem', ?))",
+          new Object[]{"%" + term + "%", term});
+    }
+    where.addIfExists("modified >= ?", start);
+    where.addIfExists("modified < ?", end);
+    return DB.selectCountFrom(TABLE_NAME, where);
+  }
+
   public static Content save(Content record) {
     if (record.getId() > -1) {
       return update(record);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidget.java
@@ -16,11 +16,13 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import com.simisinc.platform.application.FacetUrlCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.application.cms.LoadMenuTabsCommand;
 import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
 import com.simisinc.platform.application.cms.WebPageXmlLayoutCommand;
+import com.simisinc.platform.application.items.ItemDateFacetCommand;
 import com.simisinc.platform.domain.model.cms.*;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.*;
@@ -28,6 +30,7 @@ import com.simisinc.platform.presentation.controller.*;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +46,7 @@ public class WebPageSearchResultsWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908893L;
 
   static String JSP = "/cms/web-page-search-results.jsp";
+  static String DATE_FACET_LABEL = "Last Updated";
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -63,6 +67,38 @@ public class WebPageSearchResultsWidget extends GenericWidget {
       return null;
     }
 
+    // Determine the active facet filter (issue #634). Filters on Content.modified rather than
+    // WebPage's own created/publishAt, since the actual search is content-driven (see the
+    // cross-reference loop below) and ContentSpecification's dateModifiedAfter/Before are already
+    // fully wired end-to-end -- a WebPage-side date filter would need much more invasive changes
+    // for comparatively little semantic gain.
+    String dateFacetParam = context.getParameter("dateFacet");
+    ItemDateFacetCommand.DateFacetBucket selectedDateBucket = ItemDateFacetCommand.findByKey(dateFacetParam);
+
+    // Facet panel: one option per fixed date bucket with a non-zero count (or the currently
+    // selected one). Counts are content-match counts, not the final cross-referenced page count
+    // (see ContentRepository.countByDateRange's javadoc for why) -- an approximation chosen over
+    // re-running the expensive page cross-reference below once per bucket.
+    List<FacetUrlCommand.FacetOption> dateFacets = new ArrayList<>();
+    for (ItemDateFacetCommand.DateFacetBucket bucket : ItemDateFacetCommand.buckets()) {
+      boolean selected = selectedDateBucket != null && selectedDateBucket.getKey().equals(bucket.getKey());
+      long count = ContentRepository.countByDateRange(query, bucket.getStart(), bucket.getEnd());
+      if (count > 0 || selected) {
+        String url = FacetUrlCommand.buildFacetLinkUrl(context, "dateFacet", bucket.getKey());
+        dateFacets.add(new FacetUrlCommand.FacetOption(bucket.getKey(), bucket.getLabel(), count, selected, url));
+      }
+    }
+    context.getRequest().setAttribute("dateFacets", dateFacets);
+    context.getRequest().setAttribute("dateFacetLabel", DATE_FACET_LABEL);
+
+    // Active filter chip, with a URL that clears just the dateFacet filter (issue #634)
+    List<FacetUrlCommand.ActiveFacetFilter> activeFilters = new ArrayList<>();
+    if (selectedDateBucket != null) {
+      activeFilters.add(new FacetUrlCommand.ActiveFacetFilter(DATE_FACET_LABEL, selectedDateBucket.getLabel(),
+          FacetUrlCommand.buildClearFilterUrl(context, "dateFacet")));
+    }
+    context.getRequest().setAttribute("activeFilters", activeFilters);
+
     // Load the menu tabs, these are the directly linkable web pages
     List<MenuTab> menuTabList = LoadMenuTabsCommand.findAllActiveIncludeMenuItemList();
 
@@ -72,6 +108,10 @@ public class WebPageSearchResultsWidget extends GenericWidget {
     // Search the content and figure out the matching web pages
     ContentSpecification contentSpecification = new ContentSpecification();
     contentSpecification.setSearchTerm(query);
+    if (selectedDateBucket != null) {
+      contentSpecification.setDateModifiedAfter(selectedDateBucket.getStart());
+      contentSpecification.setDateModifiedBefore(selectedDateBucket.getEnd());
+    }
     List<Content> contentList = ContentRepository.findAll(contentSpecification, constraints);
     SearchAnalyticsCommand.record(context, query, "content", contentList == null ? 0 : contentList.size());
 
@@ -79,6 +119,7 @@ public class WebPageSearchResultsWidget extends GenericWidget {
     Map<String, SearchResult> resultsMap = new LinkedHashMap<>();
     if (contentList == null) {
       // No content was found, return early
+      context.getRequest().setAttribute("searchResultList", resultsMap.values());
       return finishRequest(context, resultsMap);
     }
 

--- a/src/main/webapp/WEB-INF/jsp/cms/web-page-search-results.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/web-page-search-results.jsp
@@ -23,22 +23,76 @@
 <%@ taglib prefix="number" uri="/WEB-INF/tlds/number-functions.tld" %>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="sitePropertyMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="activeFilters" class="java.util.ArrayList" scope="request"/>
 <c:if test="${!empty title}">
   <h4 class="margin-bottom-20"><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
-<c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
-  <div class="platform-content-search-result margin-top-10">
+<c:if test="${!empty activeFilters}">
+  <div class="margin-bottom-10">
+    <c:forEach items="${activeFilters}" var="activeFilter">
+      <span class="label secondary" style="margin-right:5px">
+        <c:out value="${activeFilter.facetLabel}"/>: <c:out value="${activeFilter.valueLabel}"/>
+        <%-- clearUrl is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+        <a href="${activeFilter.clearUrl}" style="color:inherit" title="Remove this filter"><i class="fa fa-times"></i></a>
+      </span>
+    </c:forEach>
+  </div>
+</c:if>
+<div class="grid-x grid-margin-x">
+  <c:if test="${!empty dateFacets}">
+    <div class="cell medium-3">
+      <h6><c:out value="${dateFacetLabel}"/></h6>
+      <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+        <c:forEach items="${dateFacets}" var="facet">
+          <li>
+            <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+            <a href="${facet.url}">
+              <c:choose>
+                <c:when test="${facet.selected}"><i class="fa fa-circle-check"></i></c:when>
+                <c:otherwise><i class="fa fa-circle-o"></i></c:otherwise>
+              </c:choose>
+              <c:out value="${facet.label}"/>
+            </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+          </li>
+        </c:forEach>
+      </ul>
+    </div>
+  </c:if>
+  <div class="cell ${!empty dateFacets ? 'medium-9' : 'medium-12'}">
     <c:choose>
-      <c:when test="${!empty searchResult.pageTitle}">
-        <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a></h5>
+      <c:when test="${empty searchResultList}">
+        <c:choose>
+          <c:when test="${!empty activeFilters}">
+            <p>No pages match the current filters.</p>
+            <ul class="no-bullet">
+              <c:forEach items="${activeFilters}" var="activeFilter">
+                <li><a href="${activeFilter.clearUrl}">Remove "<c:out value="${activeFilter.valueLabel}"/>"</a></li>
+              </c:forEach>
+            </ul>
+          </c:when>
+          <c:otherwise>
+            <p>No pages were found</p>
+          </c:otherwise>
+        </c:choose>
       </c:when>
       <c:otherwise>
-        <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.link}"/></a></h5>
+        <c:forEach items="${searchResultList}" var="searchResult" varStatus="status">
+          <div class="platform-content-search-result margin-top-10">
+            <c:choose>
+              <c:when test="${!empty searchResult.pageTitle}">
+                <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.pageTitle}"/></a></h5>
+              </c:when>
+              <c:otherwise>
+                <h5><a href="${ctx}${searchResult.link}"><c:out value="${searchResult.link}"/></a></h5>
+              </c:otherwise>
+            </c:choose>
+            <c:if test="${!empty searchResult.pageDescription}">
+              <p><c:out value="${searchResult.pageDescription}" /></p>
+            </c:if>
+            <p>${searchResult.htmlExcerpt}</p>
+          </div>
+        </c:forEach>
       </c:otherwise>
     </c:choose>
-    <c:if test="${!empty searchResult.pageDescription}">
-      <p><c:out value="${searchResult.pageDescription}" /></p>
-    </c:if>
-    <p>${searchResult.htmlExcerpt}</p>
   </div>
-</c:forEach>
+</div>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -366,6 +366,52 @@ class ContentRepositoryTest {
   }
 
   @Test
+  void countByDateRangeCountsOnlyRowsInTheOpenClosedWindow() {
+    // Same open-closed semantics as dateModifiedRangeFiltersCorrectly above (issue #634's
+    // WebPage search date facet) -- exercised here as a count rather than a fetch.
+    addContent("count-early", "<p>Early</p>");
+    addContent("count-middle", "<p>Middle</p>");
+    addContent("count-late", "<p>Late</p>");
+    setModified("count-early", Timestamp.valueOf(LocalDateTime.of(2026, 1, 1, 9, 0)));
+    setModified("count-middle", Timestamp.valueOf(LocalDateTime.of(2026, 6, 15, 9, 0)));
+    setModified("count-late", Timestamp.valueOf(LocalDateTime.of(2026, 12, 31, 9, 0)));
+
+    long count = ContentRepository.countByDateRange(null,
+        Timestamp.valueOf(LocalDateTime.of(2026, 6, 1, 0, 0)),
+        Timestamp.valueOf(LocalDateTime.of(2026, 7, 1, 0, 0)));
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countByDateRangeWithAnOpenEndedStartCountsEverythingFromThatPointOn() {
+    addContent("open-early", "<p>Early</p>");
+    addContent("open-late", "<p>Late</p>");
+    setModified("open-early", Timestamp.valueOf(LocalDateTime.of(2020, 1, 1, 9, 0)));
+    setModified("open-late", Timestamp.valueOf(LocalDateTime.of(2026, 12, 31, 9, 0)));
+
+    long count = ContentRepository.countByDateRange(null,
+        Timestamp.valueOf(LocalDateTime.of(2026, 1, 1, 0, 0)), null);
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void countByDateRangeCombinesWithTheSearchTermAsAnd() {
+    addContent("term-match-in-range", "<p>career opportunities await</p>");
+    addContent("term-match-out-of-range", "<p>career opportunities await</p>");
+    addContent("no-term-in-range", "<p>unrelated content</p>");
+    setModified("term-match-in-range", Timestamp.valueOf(LocalDateTime.of(2026, 6, 15, 9, 0)));
+    setModified("term-match-out-of-range", Timestamp.valueOf(LocalDateTime.of(2020, 1, 1, 9, 0)));
+    setModified("no-term-in-range", Timestamp.valueOf(LocalDateTime.of(2026, 6, 15, 9, 0)));
+
+    long count = ContentRepository.countByDateRange("career",
+        Timestamp.valueOf(LocalDateTime.of(2026, 1, 1, 0, 0)), null);
+
+    assertEquals(1, count);
+  }
+
+  @Test
   void characterCountRangeFiltersCorrectly() {
     addContent("chars-short", "<p>short</p>");
     addContent("chars-medium", "<p>medium</p>");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageSearchResultsWidgetTest.java
@@ -16,11 +16,31 @@
 
 package com.simisinc.platform.presentation.widgets.cms;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
 import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.FacetUrlCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.LoadMenuTabsCommand;
+import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.TableOfContentsRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
 import com.simisinc.platform.presentation.controller.DataConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 /**
  * @author matt rajkowski
@@ -77,5 +97,90 @@ class WebPageSearchResultsWidgetTest extends WidgetBase {
     setRoles(widgetContext, ADMIN, CONTENT_MANAGER);
     Assertions.assertFalse(WebPageSearchResultsWidget.shouldRestrictToPublishedSearchableWebPages(widgetContext),
         "an admin+content-manager combination is still privileged");
+  }
+
+  // --- dateFacet (issue #634) ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheDateFacetParamAndOnlyListsBucketsWithResultsOrSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "dateFacet", "last7");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<TableOfContentsRepository> tocRepository = mockStatic(TableOfContentsRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllActiveIncludeMenuItemList).thenReturn(new ArrayList<>());
+      tocRepository.when(() -> TableOfContentsRepository.findAll(null, null)).thenReturn(new ArrayList<>());
+      contentRepository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any())).thenReturn(null);
+      // "last7" is the only bucket with a non-null start and a null end -- give it the only
+      // non-zero count so the others must be omitted from dateFacets below
+      contentRepository.when(() -> ContentRepository.countByDateRange(eq("widgets"), any(), any()))
+          .thenAnswer(invocation -> {
+            Timestamp start = invocation.getArgument(1);
+            Timestamp end = invocation.getArgument(2);
+            return (start != null && end == null) ? 5L : 0L;
+          });
+
+      WidgetContext result = new WebPageSearchResultsWidget().execute(widgetContext);
+
+      List<FacetUrlCommand.FacetOption> dateFacets = (List<FacetUrlCommand.FacetOption>) result.getRequest().getAttribute("dateFacets");
+      assertEquals(1, dateFacets.size(), "only the bucket with a non-zero count (or selected) should be listed");
+      assertEquals("last7", dateFacets.get(0).getKey());
+      assertEquals(5L, dateFacets.get(0).getCount());
+      assertTrue(dateFacets.get(0).isSelected());
+
+      List<FacetUrlCommand.ActiveFacetFilter> activeFilters = (List<FacetUrlCommand.ActiveFacetFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Last Updated", activeFilters.get(0).getFacetLabel());
+    }
+  }
+
+  @Test
+  void executeWithNoDateFacetSelectedHasNoActiveFilters() {
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<TableOfContentsRepository> tocRepository = mockStatic(TableOfContentsRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllActiveIncludeMenuItemList).thenReturn(new ArrayList<>());
+      tocRepository.when(() -> TableOfContentsRepository.findAll(null, null)).thenReturn(new ArrayList<>());
+      contentRepository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any())).thenReturn(null);
+      contentRepository.when(() -> ContentRepository.countByDateRange(eq("widgets"), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new WebPageSearchResultsWidget().execute(widgetContext);
+
+      assertTrue(((List<?>) result.getRequest().getAttribute("activeFilters")).isEmpty());
+    }
+  }
+
+  @Test
+  void executeSetsAnEmptySearchResultListWhenNoContentMatches() {
+    // Regression check: the early-return path used to call finishRequest without ever setting
+    // searchResultList, leaving it null instead of an empty collection.
+    addQueryParameter(widgetContext, "query", "widgets");
+
+    try (MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<TableOfContentsRepository> tocRepository = mockStatic(TableOfContentsRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllActiveIncludeMenuItemList).thenReturn(new ArrayList<>());
+      tocRepository.when(() -> TableOfContentsRepository.findAll(null, null)).thenReturn(new ArrayList<>());
+      contentRepository.when(() -> ContentRepository.findAll(any(ContentSpecification.class), any())).thenReturn(null);
+      contentRepository.when(() -> ContentRepository.countByDateRange(eq("widgets"), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new WebPageSearchResultsWidget().execute(widgetContext);
+
+      assertTrue(((java.util.Collection<?>) result.getRequest().getAttribute("searchResultList")).isEmpty());
+      assertEquals(WebPageSearchResultsWidget.JSP, result.getJsp());
+    }
   }
 }

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -171,6 +171,8 @@ ALLOWLIST: dict[str, str] = {
         "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${!empty wikiFacets ? 'medium-9' : 'medium-12'}":
         "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
+    "${!empty dateFacets ? 'medium-9' : 'medium-12'}":
+        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634, web-page-search-results.jsp) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${faqQuestion.answerHtml}":
         "Same trust boundary as ${widget.content} below: an admin/content-manager-authored widget preference (FaqWidget.java), not user input. The question text is rendered via <c:out> in the same JSP; only the answer is intentionally raw, since it's meant to render as HTML.",
     "${file.baseUrl}":


### PR DESCRIPTION
## Summary
Final slice of #634 (facet-panel pattern rollout). Follow-up to #421/PR #631, #867.

`WebPageSearchResultsWidget`'s search is actually content-driven — it queries `Content`, then cross-references which pages embed each match — rather than querying `WebPage` directly. `ContentSpecification.dateModifiedAfter`/`dateModifiedBefore` were already fully wired end-to-end (`ContentRepository` honors both), so this date facet filters on when the matched *content* was last edited, not `WebPage`'s own `created`/`publishAt`. That was a deliberate choice discussed on the parent issue: filtering on `WebPage`'s own timestamps would need much more invasive changes (new `WebPageSpecification` fields, new repository wiring, and a real per-request cost to keep facet counts exact) for comparatively little semantic gain.

**Facet counts are approximate by design:** they're content-match counts (new `ContentRepository.countByDateRange`), not the final cross-referenced page count. The true result count can rarely be slightly lower than the shown count, in the case a matched content item turns out to live only on an unlisted or permission-restricted page — getting exact parity would mean re-running the whole page cross-reference/permission-check pipeline once per bucket (up to 4x the work per search). This tradeoff was discussed and the approximate approach was chosen deliberately.

**Also fixes** the same "zero-result path skips standard attrs" bug the Wiki slice (#867) found: a web-page search that matched no content used to call `finishRequest` without ever setting `searchResultList` (or, on other preference paths, without setting `icon`/`title`), so a zero-result search silently rendered nothing — not even a "no results" message. Now it always sets an empty collection and shows a proper message, with a per-filter "remove" link when a facet is active.

## Test plan
- [x] `ant compile` / `ant compile-test` — clean
- [x] `ant compile-jsp` — all JSPs translate and compile
- [x] `python3 tools/check-unescaped-el.py . --strict` — 0 unallowlisted (1 new allowlist entry, same reasoning as the existing facet-column-width ternaries)
- [x] `ant ci-test` — full suite green, 0 failures
- [x] New tests: `ContentRepository.countByDateRange` (Testcontainers — open/closed window, open-ended bound, combines with search term as AND), `WebPageSearchResultsWidgetTest` (facet options/counts, active filter, and the empty-result regression)

## Related
- #634 (parent) — this closes out the issue's originally-scoped widgets: Calendar/Wiki via #867 (merged), WebPage via this PR.
- #866 — `WebPageTitleSearchResultsWidget`'s architecture blocker split out as a separate follow-up, since #634 never specified a target facet dimension for it.