### PR TITLE
Fix mislabeled logger in HttpPostCommand

### DIFF
--- a/src/main/java/com/simisinc/platform/application/http/HttpPostCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpPostCommand.java
@@ -50,7 +50,7 @@ import com.simisinc.platform.provided.net.ConnectAddressPin;
  */
 public class HttpPostCommand {
 
-  private static Log LOG = LogFactory.getLog(HttpDownloadFileCommand.class);
+  private static Log LOG = LogFactory.getLog(HttpPostCommand.class);
 
   public static final int POST = 1;
   public static final int PATCH = 2;


### PR DESCRIPTION
## Summary
- \`HttpPostCommand\`'s logger was instantiated with \`HttpDownloadFileCommand.class\` instead of its own class, so log lines from this class showed up under the wrong class name.
- Same bug shape was already fixed in \`HttpGetCommand\` (d1d253b8); this brings \`HttpPostCommand\` in line.

Note: the identical mislabel also exists in \`HttpPutCommand\` and \`HttpPatchCommand\`, tracked separately to keep this PR to one defect.

## Test plan
- [x] \`ant compile\`
- [x] \`ant compile-test\` (no test references the old logger class name)