### PR TITLE
Add help text explaining the APIs page (#510)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/apis-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/apis-list.jsp
@@ -22,6 +22,7 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <%@include file="../page_messages.jspf" %>
+<p class="help-text">This is a read-only listing of every REST endpoint currently registered under <code>/api/</code> -- it's generated from the actual service registrations, so it always reflects what's really there, not something you edit here. Every call is IP-rate-limited and (outside local requests) requires an app key, managed on the <a href="${ctx}/admin/apps">Apps</a> page. The "medicine" endpoints are a real, working feature -- data for a companion mobile app's medication tracking -- not leftover or orphaned code; they simply have no admin UI of their own since nothing about them is meant to be managed from this console.</p>
 <table class="unstriped">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
Closes #510, but not as filed -- the issue's specific claims turned out to be false on inspection:
- "orphaned medicine endpoints" -- false, they're a real, fully-built REST service backing a companion mobile app's medication tracking, just with no admin UI (nothing about them needs managing from this console)
- "no key management UI" -- false, that already exists at `/admin/apps`
- "no rate limiting" -- false, `RateLimitCommand` is already wired into `RestRequestFilter` for every `/api/` call

The one real, actionable gap: the page never explained what it's showing. Adds a single help-text paragraph, same style as #507's.

## Test plan
- [x] `ant compile-jsp`
- [x] `tools/check-unescaped-el.py . --strict` -- 0 unallowlisted