### PR TITLE
Add help text explaining wikis (#503)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/wiki-list.jsp
@@ -36,6 +36,7 @@
 </c:if>
 <a class="button small radius primary" href="${ctx}/admin/wiki?returnPage=/admin/wikis">Add a Wiki <i class="fa fa-arrow-circle-right"></i></a>
 <%@include file="../page_messages.jspf" %>
+<p class="help-text">A wiki is a flat collection of markdown pages with a built-in search and a server-rendered live preview in the editor -- there's no parent/child page hierarchy, each wiki is just a named set of pages with one designated starting page. You can create as many separate wikis as you need (e.g. one per department or topic); each is added to the site as its own set of pages, and which users can reach them is controlled the same way as any other page (via the page's own role/group restrictions), not a per-wiki setting here.</p>
 <table class="unstriped">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
Closes #503, but not as filed -- several of the issue's proposed documentation points describe features that don't exist (a parent/child page hierarchy, a per-wiki tri-state access control setting, a `/wiki/[wiki-id]/home` URL scheme), and its "# of pages is empty" claim is false -- that counter is real and working. The one real gap: `/admin/wikis` never explained what a wiki actually is.

Adds a single help-text paragraph, same style as #507's, describing the real flat page structure (no hierarchy) and the real access model (page-level role/group restriction, not a per-wiki setting).

## Test plan
- [x] `ant compile-jsp`
- [x] `tools/check-unescaped-el.py . --strict` -- 0 unallowlisted