### PR TITLE
Add a search box to /admin/folders (#502)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidget.java
@@ -16,11 +16,16 @@
 
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.simisinc.platform.application.cms.LoadFolderCommand;
 import com.simisinc.platform.domain.model.cms.Folder;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
@@ -48,6 +53,22 @@ public class FolderListWidget extends GenericWidget {
       folderList = FolderRepository.findAll();
     } else {
       folderList = LoadFolderCommand.findAllAuthorizedForUser(context.getUserId());
+    }
+
+    // Optionally filter by name -- the list is admin-curated and small (dozens, not
+    // pages, of folders), so an in-memory filter here avoids touching the two
+    // different data-access paths above (each with its own authorization logic)
+    String query = context.getParameter("query");
+    context.getRequest().setAttribute(RequestConstants.RECORD_QUERY, query);
+    if (StringUtils.isNotBlank(query)) {
+      String needle = query.trim().toLowerCase(Locale.ROOT);
+      List<Folder> matchingFolderList = new ArrayList<>();
+      for (Folder folder : folderList) {
+        if (folder.getName() != null && folder.getName().toLowerCase(Locale.ROOT).contains(needle)) {
+          matchingFolderList.add(folder);
+        }
+      }
+      folderList = matchingFolderList;
     }
     context.getRequest().setAttribute("folderList", folderList);
 

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-list.jsp
@@ -20,12 +20,21 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="folderList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="query" class="java.lang.String" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <c:if test="${userSession.hasRole('admin')}">
   <a class="button small radius primary" href="${ctx}/admin/folder?returnPage=/admin/folders">Add a Folder <i class="fa fa-arrow-circle-right"></i></a>
 </c:if>
+<form method="get" autocomplete="off" class="float-right">
+  <div class="input-group no-gap width-auto">
+    <input class="input-group-field" type="search" name="query" aria-label="Search folders" placeholder="<c:if test="${empty query}">Search folders...</c:if>"<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if> autocomplete="off">
+    <div class="input-group-button">
+      <button type="submit" class="button search" aria-label="Search"><i class="fa fa-search" aria-hidden="true"></i></button>
+    </div>
+  </div>
+</form>
 <%@include file="../page_messages.jspf" %>
 <table class="unstriped">
   <thead>
@@ -94,7 +103,12 @@
     </c:forEach>
     <c:if test="${empty folderList}">
       <tr>
-        <td colspan="3">No folders were found</td>
+        <td colspan="3">
+          <c:choose>
+            <c:when test="${!empty query}">No folders match "<c:out value="${query}" />"</c:when>
+            <c:otherwise>No folders were found</c:otherwise>
+          </c:choose>
+        </td>
       </tr>
     </c:if>
   </tbody>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidgetTest.java
@@ -63,4 +63,55 @@ class FolderListWidgetTest extends WidgetBase {
     List<Folder> folderListRequest = (List) request.getAttribute("folderList");
     Assertions.assertEquals(folder.getId(), folderListRequest.get(0).getId());
   }
+
+  @Test
+  void executeFiltersByQueryCaseInsensitively() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    Folder hrForms = new Folder();
+    hrForms.setId(1L);
+    hrForms.setName("HR Forms");
+    Folder laborLaws = new Folder();
+    laborLaws.setId(2L);
+    laborLaws.setName("Alabama Labor Laws");
+    List<Folder> folderList = new ArrayList<>();
+    folderList.add(hrForms);
+    folderList.add(laborLaws);
+
+    addQueryParameter(widgetContext, "query", "labor");
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals(1, folderListRequest.size());
+    Assertions.assertEquals(laborLaws.getId(), folderListRequest.get(0).getId());
+  }
+
+  @Test
+  void executeReturnsAllFoldersWhenQueryIsBlank() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    List<Folder> folderList = new ArrayList<>();
+    Folder folder = new Folder();
+    folder.setId(1L);
+    folder.setName("HR Forms");
+    folderList.add(folder);
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals(1, folderListRequest.size());
+  }
 }


### PR DESCRIPTION
## Summary
#502's headline claim ("# of files column is empty") is false -- `folder.fileCount` is a real, working, denormalized counter. The rest of the issue bundles a small UI-polish gap with several much larger, separate features. Split into:
- #874 -- Audit trail for folder/file access (CMMC AU-2)
- #875 -- File versioning for folder documents
- #876 -- Document expiration/retention workflow
- #877 -- Training Submission review workflow
- #878 -- Bulk upload/download
- (advanced/speculative items -- tagging, watermarking, link validation, storage sync -- filed internally for later prioritization)

This PR ships the one genuinely small piece from #502: a name search box on the folder list, matching the existing pattern on `/admin/users`.

## Test plan
- [x] New tests: `executeFiltersByQueryCaseInsensitively`, `executeReturnsAllFoldersWhenQueryIsBlank`
- [x] `ant compile-jsp` / `tools/check-unescaped-el.py . --strict` -- 0 unallowlisted
- [x] Full `ant ci-test` -- BUILD SUCCESSFUL, 0 failures