### PR TITLE
Add a searchable, filterable event list to /admin/calendars (#501)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidget.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.cms.Calendar;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The /admin/calendars admin page (issue #501): a searchable, filterable, paginated table of
+ * events across all calendars. This is UI wiring only -- CalendarEventRepository/
+ * CalendarEventSpecification already support calendarId, publishedOnly, a date range, and
+ * full-text search (the same query layer the public CalendarSearchResultsWidget uses), so no new
+ * domain/DB fields or repository methods are needed.
+ *
+ * @author elizabeth houser
+ */
+public class CalendarEventListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/admin/calendar-event-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "25"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    constraints.setDefaultColumnToSortBy("start_date");
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    CalendarEventSpecification specification = buildSpecification(context);
+
+    // Load the list
+    List<CalendarEvent> calendarEventList = CalendarEventRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("calendarEventList", calendarEventList);
+
+    // The Calendar filter dropdown
+    List<Calendar> calendarList = CalendarRepository.findAll();
+    context.getRequest().setAttribute("calendarList", calendarList);
+
+    // Echo the filter values back so the form keeps its state
+    echoFilterParameters(context);
+
+    // Carry the filters through pagination (paging_control.jspf appends this to each page link).
+    // URL-encoded here so the free-text search term cannot break the query string or the href.
+    StringBuilder pagingParams = new StringBuilder();
+    appendParam(pagingParams, "q", context.getParameter("q"));
+    appendParam(pagingParams, "calendarId", context.getParameter("calendarId"));
+    appendParam(pagingParams, "status", context.getParameter("status"));
+    appendParam(pagingParams, "fromDate", context.getParameter("fromDate"));
+    appendParam(pagingParams, "toDate", context.getParameter("toDate"));
+    context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Show the JSP
+    context.setJsp(JSP);
+    return context;
+  }
+
+  /** Builds the filter specification from request parameters. */
+  private CalendarEventSpecification buildSpecification(WidgetContext context) {
+    String q = context.getParameter("q");
+    long calendarId = context.getParameterAsLong("calendarId", -1);
+    String status = context.getParameter("status");
+    String fromDate = context.getParameter("fromDate");
+    String toDate = context.getParameter("toDate");
+
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    if (StringUtils.isNotBlank(q)) {
+      specification.setSearchTerm(q.trim());
+    }
+    if (calendarId > -1) {
+      specification.setCalendarId(calendarId);
+    }
+    if ("published".equals(status)) {
+      specification.setPublishedOnly(true);
+    } else if ("draft".equals(status)) {
+      specification.setPublishedOnly(false);
+    }
+
+    // Parse the yyyy-MM-dd date range: from = start of that day, to = start of the day AFTER (half-open)
+    Timestamp from = parseDate(fromDate, 0);
+    Timestamp to = parseDate(toDate, 1);
+    if (from != null) {
+      specification.setStartingDateRange(from);
+    }
+    if (to != null) {
+      specification.setEndingDateRange(to);
+    }
+    return specification;
+  }
+
+  /** Echoes the raw filter parameters back to the request so the filter form keeps its state. */
+  private void echoFilterParameters(WidgetContext context) {
+    context.getRequest().setAttribute("q", context.getParameter("q"));
+    context.getRequest().setAttribute("calendarId", context.getParameter("calendarId"));
+    context.getRequest().setAttribute("status", context.getParameter("status"));
+    context.getRequest().setAttribute("fromDate", context.getParameter("fromDate"));
+    context.getRequest().setAttribute("toDate", context.getParameter("toDate"));
+  }
+
+  /** Appends {@code name=urlEncoded(value)} to the paging query string when the value is present. */
+  private void appendParam(StringBuilder sb, String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if (sb.length() > 0) {
+      sb.append("&");
+    }
+    sb.append(name).append("=").append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+  }
+
+  /** Parses a yyyy-MM-dd string to a start-of-day Timestamp plus {@code plusDays}; null when blank/invalid. */
+  private Timestamp parseDate(String value, int plusDays) {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    try {
+      LocalDate date = LocalDate.parse(value.trim()).plusDays(plusDays);
+      return Timestamp.valueOf(date.atStartOfDay());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-event-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-event-list.jsp
@@ -1,0 +1,118 @@
+<%--
+  ~ Copyright 2022 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="calendarEventList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="calendarList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<%-- Filters (GET so the criteria live in the URL and paging preserves them) --%>
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <div class="grid-x grid-margin-x">
+    <div class="cell medium-3">
+      <label>Search
+        <input type="text" name="q" placeholder="event title" value="<c:out value='${q}'/>">
+      </label>
+    </div>
+    <div class="cell medium-3">
+      <label>Calendar
+        <select name="calendarId">
+          <option value="">All</option>
+          <c:forEach items="${calendarList}" var="calendar">
+            <option value="${calendar.id}" <c:if test="${calendarId == calendar.id}">selected</c:if>><c:out value="${calendar.name}" /></option>
+          </c:forEach>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-2">
+      <label>Status
+        <select name="status">
+          <option value="">All</option>
+          <option value="published" <c:if test="${status == 'published'}">selected</c:if>>Published</option>
+          <option value="draft" <c:if test="${status == 'draft'}">selected</c:if>>Draft</option>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-2">
+      <label>From
+        <input type="date" name="fromDate" value="<c:out value='${fromDate}'/>">
+      </label>
+    </div>
+    <div class="cell medium-2">
+      <label>To
+        <input type="date" name="toDate" value="<c:out value='${toDate}'/>">
+      </label>
+    </div>
+  </div>
+  <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Filter</button>
+  <a href="${widgetContext.uri}" class="button small secondary radius">Clear</a>
+</form>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th width="160" class="text-center">Date</th>
+      <th width="160">Calendar</th>
+      <th width="100" class="text-center">Status</th>
+      <th width="80" class="text-center">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${calendarEventList}" var="event">
+      <c:set var="eventCalendar" value="${null}" />
+      <c:forEach items="${calendarList}" var="calendar">
+        <c:if test="${calendar.id == event.calendarId}"><c:set var="eventCalendar" value="${calendar}" /></c:if>
+      </c:forEach>
+      <tr>
+        <td>
+          <a href="${ctx}/admin/calendar-event?calendarEventId=${event.id}&returnPage=/admin/calendars"><c:out value="${event.title}" /></a>
+        </td>
+        <td class="text-center"><fmt:formatDate pattern="yyyy-MM-dd" value="${event.startDate}" /></td>
+        <td>
+          <c:if test="${!empty eventCalendar}">
+            <c:if test="${!empty eventCalendar.color}"><small style="padding-right: 10px;border:1px solid #000;background-color:<c:out value="${eventCalendar.color}" />">&nbsp;</small></c:if>
+            <c:out value="${eventCalendar.name}" />
+          </c:if>
+        </td>
+        <td class="text-center">
+          <c:choose>
+            <c:when test="${!empty event.published}">
+              <span class="label success radius">Published</span>
+            </c:when>
+            <c:otherwise>
+              <span class="label radius">Draft</span>
+            </c:otherwise>
+          </c:choose>
+        </td>
+        <td class="text-center">
+          <a href="${ctx}/admin/calendar-event?calendarEventId=${event.id}&returnPage=/admin/calendars"><i class="fa fa-edit"></i></a>
+        </td>
+      </tr>
+    </c:forEach>
+    <c:if test="${empty calendarEventList}">
+      <tr>
+        <td colspan="5">No events match the current filters</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1404,6 +1404,13 @@
         <widget name="calendarList" />
       </column>
     </section>
+    <section>
+      <column class="small-12 cell">
+        <widget name="calendarEventList">
+          <title>Events</title>
+        </widget>
+      </column>
+    </section>
   </page>
 
   <page name="/admin/calendar{?calendarId}" role="admin,content-manager,community-manager" title="Calendar Details">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -178,6 +178,7 @@
   <widget name="blogList" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogListWidget" />
   <widget name="blogForm" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogFormWidget" />
   <widget name="calendarList" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarListWidget" />
+  <widget name="calendarEventList" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarEventListWidget" />
   <widget name="calendarForm" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarFormWidget" />
   <widget name="calendarEventForm" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarEventFormWidget" />
   <widget name="collectionsList" class="com.simisinc.platform.presentation.widgets.admin.items.CollectionsListWidget" />

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.Calendar;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+
+/**
+ * Tests the /admin/calendars event-list widget (issue #501): search/filter request parameters map
+ * onto the existing CalendarEventSpecification query layer (the same one CalendarSearchResultsWidget
+ * uses on the public site), and pagination carries the filters forward.
+ *
+ * @author elizabeth houser
+ */
+class CalendarEventListWidgetTest extends WidgetBase {
+
+  @Test
+  void execute() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"calendarEventList\">\n" +
+        "  <title>Events</title>\n" +
+        "</widget>");
+
+    List<CalendarEvent> eventList = new ArrayList<>();
+    CalendarEvent event = new CalendarEvent();
+    event.setId(1L);
+    eventList.add(event);
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(eventList);
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+    }
+
+    assertEquals(CalendarEventListWidget.JSP, widgetContext.getJsp());
+    assertEquals("Events", request.getAttribute("title"));
+    List<CalendarEvent> eventListRequest = (List) request.getAttribute("calendarEventList");
+    assertEquals(event.getId(), eventListRequest.get(0).getId());
+  }
+
+  @Test
+  void searchAndFilterParametersMapOntoTheSpecification() {
+    addQueryParameter(widgetContext, "q", "town hall");
+    addQueryParameter(widgetContext, "calendarId", "7");
+    addQueryParameter(widgetContext, "status", "published");
+    addQueryParameter(widgetContext, "fromDate", "2026-08-01");
+    addQueryParameter(widgetContext, "toDate", "2026-08-20");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
+      repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      CalendarEventSpecification spec = captor.getValue();
+
+      assertEquals("town hall", spec.getSearchTerm());
+      assertEquals(7L, spec.getCalendarId());
+      assertEquals(1, spec.getPublishedOnly()); // DataConstants.TRUE
+      assertEquals(Timestamp.valueOf(LocalDate.parse("2026-08-01").atStartOfDay()), spec.getStartingDateRange());
+      // The "to" bound is half-open: the start of the day AFTER the picked date, so that whole day is included
+      assertEquals(Timestamp.valueOf(LocalDate.parse("2026-08-21").atStartOfDay()), spec.getEndingDateRange());
+
+      // Pagination must carry the filters forward (URL-encoded) so page 2+ stays filtered
+      String pagingParams = (String) widgetContext.getRequest().getAttribute("recordPagingParams");
+      assertTrue(pagingParams.contains("q=town+hall")); // space is URL-encoded
+      assertTrue(pagingParams.contains("calendarId=7"));
+      assertTrue(pagingParams.contains("status=published"));
+      assertTrue(pagingParams.contains("fromDate=2026-08-01"));
+      assertTrue(pagingParams.contains("toDate=2026-08-20"));
+    }
+  }
+
+  @Test
+  void draftStatusMapsToPublishedOnlyFalse() {
+    addQueryParameter(widgetContext, "status", "draft");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
+      repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      assertEquals(0, captor.getValue().getPublishedOnly()); // DataConstants.FALSE
+    }
+  }
+
+  @Test
+  void blankFiltersLeaveTheSpecificationUnset() {
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
+      repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      CalendarEventSpecification spec = captor.getValue();
+
+      assertNull(spec.getSearchTerm());
+      assertEquals(-1L, spec.getCalendarId());
+      assertEquals(-1, spec.getPublishedOnly()); // DataConstants.UNDEFINED
+      assertNull(spec.getStartingDateRange());
+      assertNull(spec.getEndingDateRange());
+    }
+  }
+
+  @Test
+  void anInvalidDateIsIgnoredRatherThanBreakingTheQuery() {
+    addQueryParameter(widgetContext, "fromDate", "not-a-date");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
+      repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      assertNull(captor.getValue().getStartingDateRange());
+    }
+  }
+
+  @Test
+  void theCalendarListIsExposedToTheRequestForTheFilterDropdown() {
+    List<Calendar> calendarList = new ArrayList<>();
+    Calendar calendar = new Calendar();
+    calendar.setId(3L);
+    calendar.setName("Staff Events");
+    calendarList.add(calendar);
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(calendarList);
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      List<Calendar> exposed = (List) widgetContext.getRequest().getAttribute("calendarList");
+      assertEquals(1, exposed.size());
+      assertEquals("Staff Events", exposed.get(0).getName());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Most of #501's claims are stale or already false: draft/publish workflow (#705), event tags (#717), video/meeting links (#666), multi-calendar organization with color-coding (never actually missing), and the Month/List toggle (#806) all already exist and were verified directly against current \`main\`. The one real, confirmed gap: no admin-facing table to search/filter/browse events across calendars, despite \`CalendarEventRepository\`/\`CalendarEventSpecification\` already supporting calendarId, published/draft, a date range, and full-text search (the same query layer the public calendar search widget uses).

This adds \`CalendarEventListWidget\` + \`calendar-event-list.jsp\`, wired into the existing \`/admin/calendars\` page. Pure UI wiring against the existing query layer -- no new domain/DB fields, no new repository methods -- following the same search+filter+pagination shape as \`/admin/content-list\` (#499/PR #831) and \`/admin/folders\` (#502/PR #879).

Recurring events, capacity/registration tracking, iCal/CSV import-export, bulk operations, an event dashboard tile, richer event fields, and formalizing holiday management as data are each their own separate feature -- split into #880-883 (plus an internal grab-bag for the more speculative pieces) rather than bundled here.

## Test plan
- [x] New tests: 6 in \`CalendarEventListWidgetTest\` (search/filter mapping, blank-filter defaults, invalid-date handling, paging-param carry-forward, calendar-dropdown exposure)
- [x] \`ant compile-jsp\` / \`tools/check-unescaped-el.py . --strict\` -- 0 unallowlisted
- [x] Full \`ant ci-test\` -- BUILD SUCCESSFUL, 0 failures