### PR TITLE
Add pages-per-session, return-visitor-rate, and avg-time-on-page tiles to /admin/content/analytics (#495)

### DIFF
--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1148,6 +1148,35 @@
         </widget>
       </column>
     </section>
+    <section>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-book-open</icon>
+          <title>Pages per Session</title>
+          <report>pages-per-session</report>
+          <days>30</days>
+        </widget>
+      </column>
+      <column class="small-12 medium-6 large-3 cell callout">
+        <widget name="siteStats">
+          <icon>fa-user-clock</icon>
+          <title>Return Visitor Rate</title>
+          <report>return-visitor-rate</report>
+          <days>30</days>
+        </widget>
+      </column>
+      <column class="small-12 large-6 cell">
+        <widget name="siteStats" class="stats card">
+          <icon>fa-hourglass-half</icon>
+          <title>Avg Time on Page</title>
+          <report>avg-time-on-page</report>
+          <label>Page</label>
+          <value>Avg Time</value>
+          <days>30</days>
+          <limit>10</limit>
+        </widget>
+      </column>
+    </section>
   </page>
 
   <page name="/admin/sitemap" role="admin,content-manager" title="Navigation Menu Editor">


### PR DESCRIPTION
## Summary
Closes the one real remaining piece of #495 -- nearly every other claim in the issue is false against current code (bot filtering, admin-path exclusion, and the date-range filter buttons all already work), and the one confirmed real bug (\`/login\` polluting Top Pages) was already fixed by merged PR #855.

Adds three engagement-metric tiles to \`/admin/content/analytics\` -- pages-per-session, return-visitor-rate, avg-time-on-page -- reusing the exact \`siteStats\` widget configuration already working on the sibling \`/admin/community/analytics\` page. XML-only, no backend changes: \`SiteStatsWidget\` and the underlying repository methods already implement these reports correctly.

Internal-traffic IP filtering, multi-domain referral self-exclusion, the wildcard-then-404 hit-overcounting edge case, and the larger "redesign" wishlist (funnels, device/browser breakdown, geo data, anomaly detection, export) are each separate, larger asks left out of this change.

## Test plan
- [x] \`ant compile-jsp\` -- BUILD SUCCESSFUL
- [x] \`tools/check-unescaped-el.py . --strict\` -- 0 unallowlisted
- [x] Confirmed all three report keys (\`pages-per-session\`, \`return-visitor-rate\`, \`avg-time-on-page\`) are handled in \`SiteStatsWidget.java\` and already proven working on \`/admin/community/analytics\`