### PR TITLE
Add a status-count summary to /admin/web-pages (#497)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidget.java
@@ -81,6 +81,33 @@ public class WebPageListWidget extends GenericWidget {
     }
     context.getRequest().setAttribute("webPageMap", webPageMap);
 
+    // Status-count summary (issue #497): always computed over the full, unfiltered list so it
+    // stays a stable "at a glance" total regardless of the active search/status filter below.
+    // Every page falls into exactly one bucket, using the same live/broken/draft/redirect
+    // derivation as the status filters further down.
+    int webPageDraftCount = 0;
+    int webPageRedirectCount = 0;
+    int webPageLiveCount = 0;
+    int webPageBrokenCount = 0;
+    for (WebPage webPage : webPageList) {
+      if (webPage.getDraft()) {
+        webPageDraftCount++;
+      } else if (StringUtils.isNotBlank(webPage.getRedirectUrl())) {
+        webPageRedirectCount++;
+      } else if (standardPages.containsKey(webPage.getLink())
+          || webPage.getLink().startsWith("/directory/")
+          || StringUtils.isNotBlank(webPage.getPageXml())) {
+        webPageLiveCount++;
+      } else {
+        webPageBrokenCount++;
+      }
+    }
+    context.getRequest().setAttribute("webPageTotalCount", webPageList.size());
+    context.getRequest().setAttribute("webPageLiveCount", webPageLiveCount);
+    context.getRequest().setAttribute("webPageDraftCount", webPageDraftCount);
+    context.getRequest().setAttribute("webPageRedirectCount", webPageRedirectCount);
+    context.getRequest().setAttribute("webPageBrokenCount", webPageBrokenCount);
+
     // Filter the "All Web Pages" list (search box + status dropdown)
     String searchTerm = context.getParameter("q");
     String status = context.getParameter("status");

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-list.jsp
@@ -212,6 +212,14 @@
     <td colspan="7">
       <strong>All Web Pages</strong>
       <small class="subheader">Every page record in the system, including the ones already shown above in the navigation menu.</small>
+      <br />
+      <small class="subheader">
+        <fmt:formatNumber value="${webPageTotalCount}" /> total &ndash;
+        <fmt:formatNumber value="${webPageLiveCount}" /> live,
+        <fmt:formatNumber value="${webPageDraftCount}" /> draft,
+        <fmt:formatNumber value="${webPageRedirectCount}" /> redirects,
+        <fmt:formatNumber value="${webPageBrokenCount}" /> broken
+      </small>
     </td>
   </tr>
   <tr>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidgetTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.LoadMenuTabsCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
+
+/**
+ * Tests the /admin/web-pages status-count summary (issue #497): a stable "X total -- Y live, Z
+ * draft, ..." line that always reflects the full page set, independent of the active search/status
+ * filter. Every page falls into exactly one of the four buckets, mirroring the same derivation the
+ * existing status filters use.
+ *
+ * @author elizabeth houser
+ */
+class WebPageListWidgetTest extends WidgetBase {
+
+  private WebPage draftPage() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/draft-page");
+    webPage.setDraft(true);
+    return webPage;
+  }
+
+  private WebPage redirectPage() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/old-page");
+    webPage.setDraft(false);
+    webPage.setRedirectUrl("/new-page");
+    return webPage;
+  }
+
+  private WebPage livePage() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/about");
+    webPage.setDraft(false);
+    webPage.setPageXml("<page><section/></page>");
+    return webPage;
+  }
+
+  private WebPage brokenPage() {
+    // Not draft, no redirect, no page_xml, not a standard/built-in page (the mocked
+    // ServletContext resolves no XML resources, so standardPages stays empty), not /directory/
+    WebPage webPage = new WebPage();
+    webPage.setLink("/broken-page");
+    webPage.setDraft(false);
+    return webPage;
+  }
+
+  @Test
+  void statusCountsCoverEveryPageExactlyOnce() {
+    List<WebPage> webPageList = new ArrayList<>();
+    webPageList.add(draftPage());
+    webPageList.add(redirectPage());
+    webPageList.add(livePage());
+    webPageList.add(livePage());
+    webPageList.add(brokenPage());
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+      repository.when(WebPageRepository::findAll).thenReturn(webPageList);
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+
+      new WebPageListWidget().execute(widgetContext);
+    }
+
+    assertEquals(5, request.getAttribute("webPageTotalCount"));
+    assertEquals(2, request.getAttribute("webPageLiveCount"));
+    assertEquals(1, request.getAttribute("webPageDraftCount"));
+    assertEquals(1, request.getAttribute("webPageRedirectCount"));
+    assertEquals(1, request.getAttribute("webPageBrokenCount"));
+  }
+
+  @Test
+  void statusCountsStayStableWhenAStatusFilterIsActive() {
+    List<WebPage> webPageList = new ArrayList<>();
+    webPageList.add(draftPage());
+    webPageList.add(livePage());
+    webPageList.add(brokenPage());
+
+    addQueryParameter(widgetContext, "status", "draft");
+    List<WebPage> draftOnly = new ArrayList<>(List.of(draftPage()));
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+      repository.when(WebPageRepository::findAll).thenReturn(webPageList);
+      repository.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any())).thenReturn(draftOnly);
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+
+      new WebPageListWidget().execute(widgetContext);
+
+      // The filtered display list narrows to just the draft page...
+      List<WebPage> filtered = (List) request.getAttribute("webPageList");
+      assertEquals(1, filtered.size());
+    }
+
+    // ...but the summary counts must still reflect the full, unfiltered set
+    assertEquals(3, request.getAttribute("webPageTotalCount"));
+    assertEquals(1, request.getAttribute("webPageLiveCount"));
+    assertEquals(1, request.getAttribute("webPageDraftCount"));
+    assertEquals(0, request.getAttribute("webPageRedirectCount"));
+    assertEquals(1, request.getAttribute("webPageBrokenCount"));
+  }
+
+  @Test
+  void emptyPageListProducesAllZeroCounts() {
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+      repository.when(WebPageRepository::findAll).thenReturn(new ArrayList<>());
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+
+      new WebPageListWidget().execute(widgetContext);
+    }
+
+    assertEquals(0, request.getAttribute("webPageTotalCount"));
+    assertEquals(0, request.getAttribute("webPageLiveCount"));
+    assertEquals(0, request.getAttribute("webPageDraftCount"));
+    assertEquals(0, request.getAttribute("webPageRedirectCount"));
+    assertEquals(0, request.getAttribute("webPageBrokenCount"));
+  }
+}


### PR DESCRIPTION
## Summary
A prior comment on #497 bucketed "No Status Visibility" under "Confirmed real, now fixed" alongside PR #860's search/filter work, but re-verified against current code, no such summary was ever built -- only pre-existing per-row status labels.

Adds a plain-text "X total -- Y live, Z draft, N redirects, M broken" line above the search/filter form on \`/admin/web-pages\`, computed once over the full, unfiltered page list so it stays stable regardless of the active filter. Reuses the exact live/broken/draft/redirect derivation the existing status filters already use -- no click-to-filter interactivity, audience breakdown, or health icons, those are separate, larger asks.

## Test plan
- [x] New tests in \`WebPageListWidgetTest\` (didn't exist before): counts cover every page exactly once, counts stay stable under an active filter, empty-list produces all-zero counts
- [x] \`ant compile-jsp\` / \`tools/check-unescaped-el.py . --strict\` -- 0 unallowlisted
- [x] Full \`ant ci-test\` -- BUILD SUCCESSFUL, 0 failures