### PR TITLE
Sort Moodle first on /admin/elearning-properties (#521)

### DIFF
--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -245,15 +245,18 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (1, 'Enable e-learning?', 'elearning.enabled', 'true', 'boolean');
 
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (10, 'Enable LRS xAPI?', 'elearning.xapi.enabled', 'false', 'boolean');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'LRS URL', 'elearning.lrs.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (13, 'LRS Key', 'elearning.lrs.key', '', 'text');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (14, 'LRS Secret', 'elearning.lrs.secret', '', 'text');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (16, 'LRS Auth Header', 'elearning.lrs.authHeader', '', 'text');
+-- Moodle sorts first (issue #521) -- it's the only one of the three with a real, working
+-- integration (RemoteCourseListWidget, CalendarAjaxMoodleEvents); LRS/PERLS are kept for
+-- historical/future purposes but sort after it.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (10, 'Enable Moodle?', 'elearning.moodle.enabled', 'false', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'Moodle URL', 'elearning.moodle.url', '', 'url');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (14, 'Moodle Token', 'elearning.moodle.token', '', 'text');
 
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'Enable Moodle?', 'elearning.moodle.enabled', 'false', 'boolean');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (22, 'Moodle URL', 'elearning.moodle.url', '', 'url');
-INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (24, 'Moodle Token', 'elearning.moodle.token', '', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (20, 'Enable LRS xAPI?', 'elearning.xapi.enabled', 'false', 'boolean');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (22, 'LRS URL', 'elearning.lrs.url', '', 'url');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (23, 'LRS Key', 'elearning.lrs.key', '', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (24, 'LRS Secret', 'elearning.lrs.secret', '', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (26, 'LRS Auth Header', 'elearning.lrs.authHeader', '', 'text');
 
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (30, 'Enable PERLS?', 'elearning.perls.enabled', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (32, 'PERLS URL', 'elearning.perls.url', '', 'url');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1002__reorder_elearning_properties_moodle_first.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1002__reorder_elearning_properties_moodle_first.sql
@@ -1,0 +1,14 @@
+-- Issue #521: Moodle is the only e-learning integration with a real, working implementation
+-- (RemoteCourseListWidget, CalendarAjaxMoodleEvents) -- reorder it to sort first on the
+-- /admin/elearning-properties page. LRS and PERLS are kept (not removed) for historical/future
+-- purposes, just sorted after Moodle.
+
+UPDATE site_properties SET property_order = 10 WHERE property_name = 'elearning.moodle.enabled';
+UPDATE site_properties SET property_order = 12 WHERE property_name = 'elearning.moodle.url';
+UPDATE site_properties SET property_order = 14 WHERE property_name = 'elearning.moodle.token';
+
+UPDATE site_properties SET property_order = 20 WHERE property_name = 'elearning.xapi.enabled';
+UPDATE site_properties SET property_order = 22 WHERE property_name = 'elearning.lrs.url';
+UPDATE site_properties SET property_order = 23 WHERE property_name = 'elearning.lrs.key';
+UPDATE site_properties SET property_order = 24 WHERE property_name = 'elearning.lrs.secret';
+UPDATE site_properties SET property_order = 26 WHERE property_name = 'elearning.lrs.authHeader';


### PR DESCRIPTION
## Summary
Per user decision on #521: keep all three e-learning integrations (LRS, Moodle, PERLS) configured for historical/future purposes -- none removed -- but sort Moodle first, since it's the only one with a real, working integration (\`RemoteCourseListWidget\`, \`CalendarAjaxMoodleEvents\`); LRS and PERLS are genuinely unused/dead code today.

Renumbers \`property_order\` for the Moodle and LRS field groups (install seed data + an upgrade migration for existing databases). Purely data-driven ordering -- no Java/JSP changes needed, since each field's help text (PR #657) is already keyed by property name, not position.

## Test plan
- [x] \`ant compile\` -- BUILD SUCCESSFUL
- [x] Full \`ant ci-test\` -- BUILD SUCCESSFUL, 0 failures (one run hit 3 unrelated flaky failures in \`AuditLogRepositoryTest\`/\`FormSubmissionFailureRepositoryTest\` -- neither touches elearning properties; a clean re-run confirmed it's pre-existing flakiness, not caused by this change)