### PR TITLE
Enforce folder file-type allowlist on every upload path (#370)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFileCommand.java
@@ -17,7 +17,10 @@
 package com.simisinc.platform.application.cms;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -25,7 +28,9 @@ import org.apache.commons.logging.LogFactory;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.Folder;
 import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
 
 /**
  * Validates and saves file item objects
@@ -60,6 +65,27 @@ public class SaveFileCommand {
       if (fileItemBean.getCreatedBy() == -1) {
         throw new DataException("The user creating this record was not set");
       }
+    }
+  }
+
+  /**
+   * Rejects a new file body whose extension isn't on its destination folder's configured allowlist
+   * (issue #370). Only called for paths that write new file bytes (a new record, or a new version
+   * of an existing one) -- not for renaming an existing record, which can't change the extension.
+   * A blank/unset allowlist means unrestricted, matching every folder's default.
+   */
+  private static void validateAllowedExtension(FileItem fileItemBean) throws DataException {
+    Folder folder = FolderRepository.findById(fileItemBean.getFolderId());
+    if (folder == null || StringUtils.isBlank(folder.getAllowedExtensions())) {
+      return;
+    }
+    Set<String> allowed = Arrays.stream(folder.getAllowedExtensions().split("[,\\s]+"))
+        .map(String::toLowerCase)
+        .filter(StringUtils::isNotBlank)
+        .collect(Collectors.toSet());
+    String ext = StringUtils.lowerCase(fileItemBean.getExtension());
+    if (!allowed.contains(ext)) {
+      throw new DataException("File type '." + ext + "' is not allowed in this folder");
     }
   }
 
@@ -103,6 +129,7 @@ public class SaveFileCommand {
       LOG.debug("FolderId: " + fileItemBean.getFolderId());
     } else {
       LOG.debug("Saving a new record... ");
+      validateAllowedExtension(fileItemBean);
       fileItem = new FileItem();
       fileItem.setFilename(fileItemBean.getFilename());
       fileItem.setFileServerPath(fileItemBean.getFileServerPath());
@@ -132,6 +159,8 @@ public class SaveFileCommand {
   public static FileItem saveNewVersionOfFile(FileItem fileItemBean) throws DataException {
     // Check the fields
     validateFile(fileItemBean);
+    // A new version is new file bytes, so it's subject to the destination folder's allowlist too
+    validateAllowedExtension(fileItemBean);
 
     // Transform the fields and store...
     FileItem fileItem = FileItemRepository.findById(fileItemBean.getId());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFileDropZoneWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFileDropZoneWidget.java
@@ -17,9 +17,6 @@
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -119,9 +116,6 @@ public class FolderFileDropZoneWidget extends GenericWidget {
     // Check for a sub-folder
     long subFolderId = context.getParameterAsLong("subFolderId", -1);
 
-    // Load folder to check allowed extensions
-    Folder folder = FolderRepository.findById(folderId);
-
     FileItem fileItemBean = null;
     try {
       // Check for a file
@@ -135,18 +129,8 @@ public class FolderFileDropZoneWidget extends GenericWidget {
       fileItemBean.setVersion("1.0");
       fileItemBean.setCreatedBy(context.getUserId());
       fileItemBean.setModifiedBy(context.getUserId());
-      // Enforce the folder's extension allowlist when one is configured
-      if (folder != null && StringUtils.isNotBlank(folder.getAllowedExtensions())) {
-        Set<String> allowed = Arrays.stream(folder.getAllowedExtensions().split("[,\\s]+"))
-            .map(String::toLowerCase)
-            .filter(StringUtils::isNotBlank)
-            .collect(Collectors.toSet());
-        String ext = StringUtils.lowerCase(fileItemBean.getExtension());
-        if (!allowed.contains(ext)) {
-          throw new DataException("File type '." + ext + "' is not allowed in this folder");
-        }
-      }
-      // Validate the file
+      // Validate the file (SaveFileCommand.saveFile() below enforces the folder's extension
+      // allowlist, issue #370 -- centralized there so every upload path gets it, not just this one)
       ValidateFileCommand.checkFileExtension(fileItemBean.getExtension());
       ValidateFileCommand.checkFile(fileItemBean);
       // Save it

--- a/src/test/java/com/simisinc/platform/application/cms/SaveFileCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveFileCommandTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+
+/**
+ * Covers the folder extension-allowlist enforcement added for issue #370 -- centralized here so
+ * every upload call site (admin drop zone, public drop zone, form widgets, etc.) gets it for free,
+ * rather than each widget needing its own duplicated check.
+ */
+class SaveFileCommandTest {
+
+  private FileItem newFileBean(long folderId, String extension) {
+    FileItem bean = new FileItem();
+    bean.setFolderId(folderId);
+    bean.setFilename("upload." + extension);
+    bean.setFileServerPath("/uploads/upload." + extension);
+    bean.setExtension(extension);
+    bean.setCreatedBy(1L);
+    bean.setModifiedBy(1L);
+    return bean;
+  }
+
+  @Test
+  void saveFileRejectsAnExtensionNotOnTheFoldersAllowlist() {
+    Folder folder = new Folder();
+    folder.setId(5L);
+    folder.setAllowedExtensions("jpg, png, gif");
+
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(folder);
+
+      FileItem bean = newFileBean(5, "html");
+      DataException thrown = assertThrows(DataException.class, () -> SaveFileCommand.saveFile(bean));
+      assertEquals("File type '.html' is not allowed in this folder", thrown.getMessage());
+    }
+  }
+
+  @Test
+  void saveFileAllowsAnExtensionOnTheFoldersAllowlist() throws DataException {
+    Folder folder = new Folder();
+    folder.setId(5L);
+    folder.setAllowedExtensions("jpg, png, gif");
+
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepository = mockStatic(FileItemRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(folder);
+      fileItemRepository.when(() -> FileItemRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+      FileItem bean = newFileBean(5, "png");
+      FileItem saved = SaveFileCommand.saveFile(bean);
+
+      assertEquals("png", saved.getExtension());
+    }
+  }
+
+  @Test
+  void saveFileIsUnrestrictedWhenTheFolderHasNoAllowlistConfigured() throws DataException {
+    Folder folder = new Folder();
+    folder.setId(5L);
+    folder.setAllowedExtensions(null);
+
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepository = mockStatic(FileItemRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(folder);
+      fileItemRepository.when(() -> FileItemRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+      FileItem bean = newFileBean(5, "exe");
+      FileItem saved = SaveFileCommand.saveFile(bean);
+
+      assertEquals("exe", saved.getExtension());
+    }
+  }
+
+  @Test
+  void saveFileIsUnrestrictedWhenTheFolderCannotBeFound() throws DataException {
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepository = mockStatic(FileItemRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(null);
+      fileItemRepository.when(() -> FileItemRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+      FileItem bean = newFileBean(5, "exe");
+      FileItem saved = SaveFileCommand.saveFile(bean);
+
+      assertEquals("exe", saved.getExtension());
+    }
+  }
+
+  @Test
+  void saveNewVersionOfFileRejectsAnExtensionNotOnTheFoldersAllowlist() {
+    Folder folder = new Folder();
+    folder.setId(5L);
+    folder.setAllowedExtensions("pdf, docx");
+
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepository = mockStatic(FileItemRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(folder);
+
+      FileItem existing = newFileBean(5, "pdf");
+      existing.setId(42L);
+      fileItemRepository.when(() -> FileItemRepository.findById(42L)).thenReturn(existing);
+
+      FileItem newVersion = newFileBean(5, "svg");
+      newVersion.setId(42L);
+      DataException thrown = assertThrows(DataException.class, () -> SaveFileCommand.saveNewVersionOfFile(newVersion));
+      assertEquals("File type '.svg' is not allowed in this folder", thrown.getMessage());
+    }
+  }
+
+  @Test
+  void saveFileDoesNotRecheckTheAllowlistWhenOnlyRenamingAnExistingRecordWithTheSameExtension() throws DataException {
+    // A folder's allowlist can be tightened after files already exist under it -- renaming one of
+    // those legacy files (no new bytes, extension unchanged) must not suddenly start failing.
+    Folder folder = new Folder();
+    folder.setId(5L);
+    folder.setAllowedExtensions("jpg"); // tightened since the existing file's "png" was allowed
+
+    try (MockedStatic<FolderRepository> folderRepository = mockStatic(FolderRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepository = mockStatic(FileItemRepository.class)) {
+      folderRepository.when(() -> FolderRepository.findById(5L)).thenReturn(folder);
+
+      FileItem existing = newFileBean(5, "png");
+      existing.setId(42L);
+      fileItemRepository.when(() -> FileItemRepository.findById(42L)).thenReturn(existing);
+      fileItemRepository.when(() -> FileItemRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+      FileItem rename = new FileItem();
+      rename.setId(42L);
+      rename.setFolderId(5);
+      rename.setFilename("renamed.png");
+      rename.setModifiedBy(1L);
+
+      FileItem saved = SaveFileCommand.saveFile(rename);
+      assertEquals("renamed.png", saved.getFilename());
+      folderRepository.verify(() -> FolderRepository.findById(eq(5L)), org.mockito.Mockito.never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`folders.allowed_extensions` and its enforcement already existed, but only in `FolderFileDropZoneWidget`'s admin drop zone. Every other upload path — the public-facing `FileDropZoneWidget`, `FolderFileFormWidget`, `FolderFilesListWidget`, and new-version uploads — called `SaveFileCommand.saveFile()` directly with no allowlist check, so a direct POST to any of those completely bypassed a folder's configured restriction. That's a real gap against this issue's own acceptance criterion ("server-side validation cannot be bypassed by a direct POST").

- Moves the check into `SaveFileCommand` itself (the one method every upload path calls): enforced on `saveFile()`'s new-record branch and on `saveNewVersionOfFile()` — both are genuine new-file-bytes paths. A metadata-only rename of an existing record is exempt (the extension can't change there, and tightening a folder's allowlist later shouldn't retroactively break existing files).
- Removes the now-redundant duplicate check (and its now-dead imports) from `FolderFileDropZoneWidget`.
- The other half of this issue — serving files outside a safe-inline list with `Content-Disposition: attachment` — was already solidly implemented in `FileDownloadCommand` (safe-inline allowlist, `nosniff`, sandboxed CSP, SVG deliberately excluded from inline). No changes needed there.

## Test plan
- [x] `ant compile` / `compile-test` / `compile-jsp` — BUILD SUCCESSFUL
- [x] `python3 tools/check-unescaped-el.py . --strict` — 0 unallowlisted
- [x] `ant ci-test` — BUILD SUCCESSFUL, 0 failures
- [x] New `SaveFileCommandTest`: rejects a disallowed extension, allows a listed one, no-restriction-when-unconfigured, no-restriction-when-folder-missing, new-version uploads are checked too, and a rename of an existing file with an unchanged extension is *not* re-checked against a since-tightened allowlist