### PR TITLE
Add web page version history (issue #405)

### DIFF
--- a/src/main/java/com/simisinc/platform/domain/model/cms/WebPageVersion.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/WebPageVersion.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A snapshot of a web page's page_xml taken at the moment it was replaced by a publish (#405) --
+ * the outgoing content, not the incoming one, so a prior published state can be viewed or restored.
+ *
+ * @author SimIS Inc.
+ * @created 8/2/2026
+ */
+public class WebPageVersion extends Entity {
+
+  private long id = -1;
+  private long webPageId = -1;
+  private String pageXml = null;
+  private long publishedBy = -1;
+  private Timestamp publishedAt = null;
+  private String label = null;
+
+  public WebPageVersion() {
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getWebPageId() {
+    return webPageId;
+  }
+
+  public void setWebPageId(long webPageId) {
+    this.webPageId = webPageId;
+  }
+
+  public String getPageXml() {
+    return pageXml;
+  }
+
+  public void setPageXml(String pageXml) {
+    this.pageXml = pageXml;
+  }
+
+  public long getPublishedBy() {
+    return publishedBy;
+  }
+
+  public void setPublishedBy(long publishedBy) {
+    this.publishedBy = publishedBy;
+  }
+
+  public Timestamp getPublishedAt() {
+    return publishedAt;
+  }
+
+  public void setPublishedAt(Timestamp publishedAt) {
+    this.publishedAt = publishedAt;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -18,6 +18,9 @@ package com.simisinc.platform.infrastructure.persistence.cms;
 
 import com.simisinc.platform.application.cms.WebPageXmlLayoutCommand;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
+import com.simisinc.platform.infrastructure.database.AutoRollback;
+import com.simisinc.platform.infrastructure.database.AutoStartTransaction;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.database.DataResult;
@@ -26,6 +29,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -205,17 +210,87 @@ public class WebPageRepository {
     return null;
   }
 
-  public static void publish(WebPage record) {
+  private static final int DEFAULT_VERSION_HISTORY_LIMIT = 20;
+
+  /** Parses the configured version-history cap to a bounded positive integer, defaulting to 20. */
+  public static int resolveVersionHistoryLimit(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_VERSION_HISTORY_LIMIT;
+    }
+    try {
+      int limit = Integer.parseInt(value.trim());
+      return Math.max(limit, 1);
+    } catch (NumberFormatException e) {
+      return DEFAULT_VERSION_HISTORY_LIMIT;
+    }
+  }
+
+  /**
+   * Promotes draftPageXml to the live pageXml (#405). Before overwriting it, the outgoing pageXml
+   * is snapshotted into web_page_versions -- within the same transaction as the publish itself, so
+   * a failed snapshot can't silently leave a publish with no recoverable prior state -- then pruned
+   * to versionHistoryLimit. A page with no live pageXml yet (first-ever publish) has nothing to
+   * snapshot.
+   */
+  public static void publish(WebPage record, long publishedBy, int versionHistoryLimit) {
     if (record.getId() == -1) {
       return;
     }
-    // Handle publishing and making sure there is content to publish
-    String set = "page_xml = draft_page_xml, draft_page_xml = null, draft = false";
-    SqlUtils where = new SqlUtils().add("draft_page_xml IS NOT NULL AND web_page_id = ?", record.getId());
-    if (DB.update(TABLE_NAME, set, where)) {
-      // Force the page to re-cache
-      WebPageXmlLayoutCommand.removeCustomPage(record.getLink());
+    try (Connection connection = DB.getConnection();
+        AutoStartTransaction ignored = new AutoStartTransaction(connection);
+        AutoRollback transaction = new AutoRollback(connection)) {
+
+      String outgoingPageXml = null;
+      try (PreparedStatement pst = connection.prepareStatement(
+          "SELECT page_xml FROM " + TABLE_NAME + " WHERE web_page_id = ? AND draft_page_xml IS NOT NULL")) {
+        pst.setLong(1, record.getId());
+        try (ResultSet rs = pst.executeQuery()) {
+          if (!rs.next()) {
+            // Nothing to publish (no pending draft) -- matches the prior no-op behavior
+            return;
+          }
+          outgoingPageXml = rs.getString("page_xml");
+        }
+      }
+
+      if (StringUtils.isNotBlank(outgoingPageXml)) {
+        WebPageVersion version = new WebPageVersion();
+        version.setWebPageId(record.getId());
+        version.setPageXml(outgoingPageXml);
+        version.setPublishedBy(publishedBy);
+        if (WebPageVersionRepository.insert(connection, version) == -1) {
+          throw new SQLException("The prior page version was not saved");
+        }
+        WebPageVersionRepository.pruneOldest(connection, record.getId(), versionHistoryLimit);
+      }
+
+      int updated;
+      try (PreparedStatement pst = connection.prepareStatement(
+          "UPDATE " + TABLE_NAME + " SET page_xml = draft_page_xml, draft_page_xml = null, draft = false "
+              + "WHERE draft_page_xml IS NOT NULL AND web_page_id = ?")) {
+        pst.setLong(1, record.getId());
+        updated = pst.executeUpdate();
+      }
+      if (updated > 0) {
+        transaction.commit();
+        // Force the page to re-cache
+        WebPageXmlLayoutCommand.removeCustomPage(record.getLink());
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
     }
+  }
+
+  /**
+   * Loads a prior version's XML into the draft slot (#405) -- never touches the live pageXml, so a
+   * subsequent publish is required to make the restored content live again.
+   */
+  public static boolean restoreDraftFromVersion(long webPageId, String pageXml) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("draft_page_xml", pageXml)
+        .add("draft", true);
+    SqlUtils where = new SqlUtils().add("web_page_id = ?", webPageId);
+    return DB.update(TABLE_NAME, updateValues, where);
   }
 
   public static void markAsModified(WebPage record, long userId) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageVersionRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageVersionRepository.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves web page version snapshots (#405) -- each row is the page_xml that was
+ * overwritten by a publish, so a prior published state can be listed, viewed, or restored.
+ *
+ * @author SimIS Inc.
+ * @created 8/2/2026
+ */
+public class WebPageVersionRepository {
+
+  private static Log LOG = LogFactory.getLog(WebPageVersionRepository.class);
+
+  private static String TABLE_NAME = "web_page_versions";
+  private static String[] PRIMARY_KEY = new String[]{"web_page_version_id"};
+
+  public static WebPageVersion findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (WebPageVersion) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("web_page_version_id = ?", id),
+        WebPageVersionRepository::buildRecord);
+  }
+
+  public static List<WebPageVersion> findByWebPageId(long webPageId, DataConstraints constraints) {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME,
+        new SqlUtils().add("web_page_id = ?", webPageId),
+        (constraints != null ? constraints : new DataConstraints()).setDefaultColumnToSortBy("published_at DESC"),
+        WebPageVersionRepository::buildRecord);
+    if (result.hasRecords()) {
+      return (List<WebPageVersion>) result.getRecords();
+    }
+    return null;
+  }
+
+  /** Inserts a version row within the caller's transaction. Returns the new id, or -1 on failure. */
+  public static long insert(Connection connection, WebPageVersion record) throws SQLException {
+    SqlUtils insertValues = new SqlUtils()
+        .add("web_page_id", record.getWebPageId())
+        .add("page_xml", record.getPageXml())
+        .add("published_by", record.getPublishedBy(), -1)
+        .add("label", record.getLabel());
+    long id = DB.insertInto(connection, TABLE_NAME, insertValues, PRIMARY_KEY);
+    if (id == -1) {
+      LOG.error("A web page version was not saved");
+    }
+    return id;
+  }
+
+  /**
+   * Deletes all but the {@code keepCount} most recent versions for the page, within the caller's
+   * transaction. Called right after {@link #insert}, so the just-inserted row is included in the
+   * kept set as long as {@code keepCount >= 1}.
+   */
+  public static void pruneOldest(Connection connection, long webPageId, int keepCount) {
+    String sql = "DELETE FROM " + TABLE_NAME + " WHERE web_page_id = ? AND web_page_version_id NOT IN ("
+        + "SELECT web_page_version_id FROM " + TABLE_NAME + " WHERE web_page_id = ? "
+        + "ORDER BY published_at DESC, web_page_version_id DESC LIMIT ?)";
+    try (PreparedStatement pst = connection.prepareStatement(sql)) {
+      pst.setLong(1, webPageId);
+      pst.setLong(2, webPageId);
+      pst.setInt(3, Math.max(keepCount, 0));
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+  }
+
+  private static WebPageVersion buildRecord(ResultSet rs) {
+    try {
+      WebPageVersion record = new WebPageVersion();
+      record.setId(rs.getLong("web_page_version_id"));
+      record.setWebPageId(rs.getLong("web_page_id"));
+      record.setPageXml(rs.getString("page_xml"));
+      record.setPublishedBy(DB.getLong(rs, "published_by", -1));
+      Timestamp publishedAt = rs.getTimestamp("published_at");
+      record.setPublishedAt(publishedAt);
+      record.setLabel(rs.getString("label"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -363,7 +363,9 @@ public class PageServlet extends HttpServlet {
           return;
         }
         response.setContentType("application/json");
-        WebPageRepository.publish(webPage);
+        int versionHistoryLimit = WebPageRepository.resolveVersionHistoryLimit(
+            LoadSitePropertyCommand.loadByName("webPage.versionHistoryLimit"));
+        WebPageRepository.publish(webPage, userSession.getUserId(), versionHistoryLimit);
         PublishEventCachePurgeHandler.onPageUpdated(webPage);
         LOG.info("Draft published for " + pagePath + " by user " + userSession.getUserId());
         response.getWriter().print("{\"success\":true}");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageVersionsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageVersionsListWidget.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageVersionRepository;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The /admin/web-page-versions admin page (issue #405): lists a web page's prior published
+ * revisions (author, timestamp) and offers a restore action, which loads the chosen version's XML
+ * into the draft slot for review -- a subsequent publish is required to make it live again.
+ *
+ * @author SimIS Inc.
+ * @created 8/2/2026
+ */
+public class WebPageVersionsListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908895L;
+
+  static String JSP = "/admin/web-page-versions-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    long webPageId = context.getParameterAsLong("webPageId", -1);
+    WebPage webPage = webPageId > -1 ? WebPageRepository.findById(webPageId) : null;
+    if (webPage == null) {
+      context.setErrorMessage("Web page was not found");
+      return context;
+    }
+    context.getRequest().setAttribute("webPage", webPage);
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "20"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    List<WebPageVersion> versionList = WebPageVersionRepository.findByWebPageId(webPageId, constraints);
+    context.getRequest().setAttribute("versionList", versionList);
+
+    // Resolve the author display name for each version shown on this page
+    Map<Long, User> userMap = new HashMap<>();
+    if (versionList != null) {
+      for (WebPageVersion version : versionList) {
+        long publishedBy = version.getPublishedBy();
+        if (publishedBy > -1 && !userMap.containsKey(publishedBy)) {
+          userMap.put(publishedBy, UserRepository.findByUserId(publishedBy));
+        }
+      }
+    }
+    context.getRequest().setAttribute("userMap", userMap);
+
+    context.getRequest().setAttribute("recordPagingParams", "webPageId=" + webPageId);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    if (!"restore".equals(context.getParameter("action"))) {
+      return null;
+    }
+
+    long webPageVersionId = context.getParameterAsLong("webPageVersionId", -1);
+    WebPageVersion version = webPageVersionId > -1 ? WebPageVersionRepository.findById(webPageVersionId) : null;
+    if (version == null) {
+      context.setErrorMessage("The selected version was not found");
+      return execute(context);
+    }
+
+    WebPage webPage = WebPageRepository.findById(version.getWebPageId());
+    if (webPage == null) {
+      context.setErrorMessage("The web page was not found");
+      return execute(context);
+    }
+
+    if (!WebPageRepository.restoreDraftFromVersion(webPage.getId(), version.getPageXml())) {
+      context.setErrorMessage("The version could not be restored");
+      return execute(context);
+    }
+
+    context.setSuccessMessage("The version was restored to the draft. Publish it to make it live.");
+    return execute(context);
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -167,6 +167,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (1, 'Audit log retention (days)', 'audit.retentionDays', '2555');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (2, 'Password Age Warning Threshold (days)', 'password.maxAgeDays', '90', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (11, 'Form submission failure retention (days)', 'formData.failureRetentionDays', '90');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'Web page version history limit (per page)', 'webPage.versionHistoryLimit', '20', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (7, 'Honor Do-Not-Track / Global Privacy Control?', 'analytics.honorDnt', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (9, 'Require visitor consent before loading analytics?', 'analytics.consentRequired', 'false', 'boolean');

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -714,6 +714,19 @@ CREATE TABLE stylesheets (
 );
 CREATE INDEX stylesheets_web_idx ON stylesheets(web_page_id);
 
+-- Web page version history (#405): one row per publish, holding the outgoing page_xml that was
+-- just overwritten -- so a prior published state can be viewed, compared, or restored. Rows are
+-- pruned to a configurable cap (webPage.versionHistoryLimit) on insert; cascades on page deletion.
+CREATE TABLE web_page_versions (
+  web_page_version_id BIGSERIAL PRIMARY KEY,
+  web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE,
+  page_xml TEXT,
+  published_by BIGINT REFERENCES users(user_id),
+  published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  label VARCHAR(255)
+);
+CREATE INDEX web_page_versions_web_idx ON web_page_versions(web_page_id, published_at DESC);
+
 -- Core Web Vitals RUM (Real User Monitoring, #429)
 -- Raw metrics collected from real page loads, one row per metric per page load
 CREATE TABLE web_vitals (

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1007__web_page_versions.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260802.1007__web_page_versions.sql
@@ -1,0 +1,18 @@
+-- Web page version history (issue #405): one row per PUBLISH event, holding the OUTGOING page_xml
+-- (the value about to be overwritten) so a prior published state can be listed, viewed, or restored.
+-- Idempotent so it is safe on any existing install; fresh installs get the identical table from NEW_10010.
+CREATE TABLE IF NOT EXISTS web_page_versions (
+  web_page_version_id BIGSERIAL PRIMARY KEY,
+  web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE,
+  page_xml TEXT,
+  published_by BIGINT REFERENCES users(user_id),
+  published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  label VARCHAR(255)
+);
+CREATE INDEX IF NOT EXISTS web_page_versions_web_idx ON web_page_versions(web_page_id, published_at DESC);
+
+-- Caps how many prior versions are retained per page (WebPageRepository.publish() prunes to this
+-- limit right after each snapshot), mirroring formData.failureRetentionDays/funnel.retentionDays.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (12, 'Web page version history limit (per page)', 'webPage.versionHistoryLimit', '20', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-form.jsp
@@ -177,6 +177,9 @@
     <c:if test="${userSession.hasRole('admin')}">
       <button type="button" class="button radius alert" onclick="deletePage()"><i class="fa fa-trash-o"></i> Delete Page</button>
     </c:if>
+    <c:if test="${webPage.id > -1}">
+      <a href="${ctx}/admin/web-page-versions?webPageId=${webPage.id}" class="button radius secondary"><i class="fa fa-history"></i> Version History</a>
+    </c:if>
   </div>
 </form>
 <div class="reveal large" id="imageBrowserReveal" data-reveal data-animation-in="slide-in-down fast" role="dialog" aria-modal="true" aria-label="Image Browser">

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-versions-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-versions-list.jsp
@@ -1,0 +1,70 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="versionList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="userMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="help-text">
+  Prior published versions of <a href="${ctx}${webPage.link}"><c:out value="${webPage.link}" /></a>.
+  Restoring a version loads it into the draft slot for review -- it will not go live until you publish it again.
+</p>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Published</th>
+      <th>Author</th>
+      <th width="100" class="text-center">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${versionList}" var="version">
+      <c:set var="author" value="${userMap[version.publishedBy]}" />
+      <tr>
+        <td><fmt:formatDate pattern="yyyy-MM-dd HH:mm" value="${version.publishedAt}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty author}"><c:out value="${author.fullName}" /></c:when>
+            <c:otherwise>&mdash;</c:otherwise>
+          </c:choose>
+        </td>
+        <td class="text-center">
+          <form method="post" action="${widgetContext.uri}" onsubmit="return confirm('Restore this version to the draft slot? You will need to publish it to make it live.');">
+            <input type="hidden" name="widget" value="${widgetContext.uniqueId}" />
+            <input type="hidden" name="token" value="${userSession.formToken}" />
+            <input type="hidden" name="action" value="restore" />
+            <input type="hidden" name="webPageId" value="${webPage.id}" />
+            <input type="hidden" name="webPageVersionId" value="${version.id}" />
+            <button type="submit" class="button tiny radius secondary" title="Restore to draft"><i class="fa fa-undo"></i></button>
+          </form>
+        </td>
+      </tr>
+    </c:forEach>
+    <c:if test="${empty versionList}">
+      <tr>
+        <td colspan="3">No prior versions yet -- one is recorded each time this page is published over an existing draft.</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1330,6 +1330,26 @@
     </section>
   </page>
 
+  <page name="/admin/web-page-versions" role="admin,content-manager" title="Web Page Version History">
+    <section>
+      <column class="small-12 cell">
+        <widget name="breadcrumbs">
+          <links>
+            <link name="Web Pages" value="/admin/web-pages" />
+            <link name="Version History" value="" />
+          </links>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 cell">
+        <widget name="webPageVersionsList">
+          <title>Version History</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/web-page-designer" role="admin,content-manager" title="Web Page Designer">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -169,6 +169,7 @@
   <widget name="siteMapEditor" class="com.simisinc.platform.presentation.widgets.cms.SiteMapEditorWidget" />
   <widget name="webPageList" class="com.simisinc.platform.presentation.widgets.admin.cms.WebPageListWidget" />
   <widget name="webPageForm" class="com.simisinc.platform.presentation.widgets.admin.cms.WebPageFormWidget" />
+  <widget name="webPageVersionsList" class="com.simisinc.platform.presentation.widgets.admin.cms.WebPageVersionsListWidget" />
   <widget name="cssEditor" class="com.simisinc.platform.presentation.widgets.cms.CssEditorWidget" />
   <widget name="webContainerDesigner" class="com.simisinc.platform.presentation.widgets.cms.WebContainerDesignerWidget" />
   <widget name="webPageDesigner" class="com.simisinc.platform.presentation.widgets.cms.WebPageDesignerWidget" />

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.infrastructure.persistence.cms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,6 +40,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataSource;
 
@@ -113,7 +115,7 @@ class WebPageRepositoryTest {
     }
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY");
+      statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY CASCADE");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not reset web_pages table", se);
     }
@@ -244,6 +246,117 @@ class WebPageRepositoryTest {
     assertNull(WebPageRepository.findById(saved.getId()).getSolutionType());
   }
 
+  // --- publish() version history (#405) ---
+
+  @Test
+  void publishSnapshotsTheOutgoingPageXmlAndPromotesTheDraft() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/versioned");
+    webPage.setTitle("Versioned Page");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>v1</xml>");
+    webPage.setDraftPageXml("<xml>v2</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+
+    WebPageRepository.publish(saved, 42L, 20);
+
+    WebPage reloaded = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>v2</xml>", reloaded.getPageXml());
+    assertNull(reloaded.getDraftPageXml());
+    assertFalse(reloaded.getDraft());
+
+    List<WebPageVersion> versions = WebPageVersionRepository.findByWebPageId(saved.getId(), null);
+    assertEquals(1, versions.size());
+    assertEquals("<xml>v1</xml>", versions.get(0).getPageXml(), "the outgoing (pre-publish) xml must be snapshotted, not the incoming one");
+    assertEquals(42L, versions.get(0).getPublishedBy());
+  }
+
+  @Test
+  void publishIsANoOpWhenThereIsNoPendingDraft() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/no-draft");
+    webPage.setTitle("No Draft");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>live</xml>");
+    WebPage saved = WebPageRepository.save(webPage);
+
+    WebPageRepository.publish(saved, 42L, 20);
+
+    WebPage reloaded = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>live</xml>", reloaded.getPageXml());
+    assertNull(WebPageVersionRepository.findByWebPageId(saved.getId(), null),
+        "no version should be recorded when there was nothing to publish");
+  }
+
+  @Test
+  void publishDoesNotSnapshotOnTheFirstEverPublish() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/first-publish");
+    webPage.setTitle("First Publish");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setDraftPageXml("<xml>v1</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+
+    WebPageRepository.publish(saved, 42L, 20);
+
+    WebPage reloaded = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>v1</xml>", reloaded.getPageXml());
+    assertNull(WebPageVersionRepository.findByWebPageId(saved.getId(), null),
+        "a page with no prior live content has nothing to snapshot");
+  }
+
+  @Test
+  void publishPrunesVersionsBeyondTheConfiguredLimit() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/many-versions");
+    webPage.setTitle("Many Versions");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>v0</xml>");
+    WebPage saved = WebPageRepository.save(webPage);
+
+    for (int i = 1; i <= 5; i++) {
+      saved.setDraftPageXml("<xml>v" + i + "</xml>");
+      saved.setDraft(true);
+      saved.setModifiedBy(1L);
+      WebPageRepository.save(saved);
+      WebPageRepository.publish(saved, 1L, 3);
+      saved = WebPageRepository.findById(saved.getId());
+    }
+
+    List<WebPageVersion> versions = WebPageVersionRepository.findByWebPageId(saved.getId(), null);
+    assertEquals(3, versions.size(), "only the configured limit of prior versions should be retained");
+  }
+
+  @Test
+  void restoreDraftFromVersionLoadsXmlIntoTheDraftSlotWithoutTouchingTheLivePage() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/restore-me");
+    webPage.setTitle("Restore Me");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>live</xml>");
+    WebPage saved = WebPageRepository.save(webPage);
+
+    boolean result = WebPageRepository.restoreDraftFromVersion(saved.getId(), "<xml>restored</xml>");
+
+    assertTrue(result);
+    WebPage reloaded = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>live</xml>", reloaded.getPageXml(), "restoring must not touch the live page_xml");
+    assertEquals("<xml>restored</xml>", reloaded.getDraftPageXml());
+    assertTrue(reloaded.getDraft());
+  }
+
   private static boolean isDockerAvailable() {
     try {
       return DockerClientFactory.instance().isDockerAvailable();
@@ -308,6 +421,17 @@ class WebPageRepositoryTest {
       statement.execute("CREATE TRIGGER web_pages_tsv_trigger BEFORE INSERT OR UPDATE "
           + "ON web_pages FOR EACH ROW EXECUTE PROCEDURE web_pages_tsv_trigger()");
       statement.execute("CREATE INDEX web_pages_tsv_idx ON web_pages USING gin(tsv)");
+
+      // Version history (#405) -- no users table in this focused schema, so published_by is left
+      // as a plain column rather than an FK
+      statement.execute("DROP TABLE IF EXISTS web_page_versions CASCADE");
+      statement.execute("CREATE TABLE web_page_versions ("
+          + "web_page_version_id BIGSERIAL PRIMARY KEY, "
+          + "web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE, "
+          + "page_xml TEXT, "
+          + "published_by BIGINT, "
+          + "published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL, "
+          + "label VARCHAR(255))");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the web_pages schema", se);
     }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageVersionRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageVersionRepositoryTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link WebPageVersionRepository} against a real PostgreSQL instance (#405).
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class WebPageVersionRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping WebPageVersionRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_page_versions, web_pages RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_page_versions table", se);
+    }
+  }
+
+  @Test
+  void insertedVersionCanBeFoundById() {
+    long webPageId = addWebPage("/insert-find");
+
+    long versionId = insertVersion(webPageId, "<xml>v1</xml>", 7L, "First");
+
+    WebPageVersion found = WebPageVersionRepository.findById(versionId);
+    assertEquals(webPageId, found.getWebPageId());
+    assertEquals("<xml>v1</xml>", found.getPageXml());
+    assertEquals(7L, found.getPublishedBy());
+    assertEquals("First", found.getLabel());
+  }
+
+  @Test
+  void findByIdReturnsNullForAnUnknownId() {
+    assertNull(WebPageVersionRepository.findById(999999L));
+  }
+
+  @Test
+  void findByWebPageIdReturnsNullWhenThereAreNoVersions() {
+    long webPageId = addWebPage("/no-versions");
+
+    assertNull(WebPageVersionRepository.findByWebPageId(webPageId, null));
+  }
+
+  @Test
+  void findByWebPageIdOnlyReturnsVersionsForThatPage() {
+    long pageOne = addWebPage("/page-one");
+    long pageTwo = addWebPage("/page-two");
+    insertVersion(pageOne, "<xml>one</xml>", 1L, null);
+    insertVersion(pageTwo, "<xml>two</xml>", 1L, null);
+
+    List<WebPageVersion> results = WebPageVersionRepository.findByWebPageId(pageOne, null);
+
+    assertEquals(1, results.size());
+    assertEquals("<xml>one</xml>", results.get(0).getPageXml());
+  }
+
+  @Test
+  void findByWebPageIdSortsNewestFirst() throws InterruptedException {
+    long webPageId = addWebPage("/sort-order");
+    long olderId = insertVersion(webPageId, "<xml>older</xml>", 1L, null);
+    Thread.sleep(5);
+    long newerId = insertVersion(webPageId, "<xml>newer</xml>", 1L, null);
+
+    List<WebPageVersion> results = WebPageVersionRepository.findByWebPageId(webPageId, null);
+
+    assertEquals(2, results.size());
+    assertEquals(newerId, results.get(0).getId(), "the most recently published version should be listed first");
+    assertEquals(olderId, results.get(1).getId());
+  }
+
+  @Test
+  void pruneOldestKeepsOnlyTheMostRecentVersions() throws SQLException {
+    long webPageId = addWebPage("/prune-me");
+    for (int i = 0; i < 5; i++) {
+      insertVersion(webPageId, "<xml>v" + i + "</xml>", 1L, null);
+    }
+
+    try (Connection connection = DB.getConnection()) {
+      WebPageVersionRepository.pruneOldest(connection, webPageId, 2);
+    }
+
+    // Rapid-fire inserts can land in the same published_at millisecond, and findByWebPageId only
+    // orders by published_at DESC (no id tiebreaker) -- so which of two same-millisecond rows sorts
+    // first is not guaranteed. Assert the surviving *set* (what pruneOldest is actually responsible
+    // for), not a tie-broken order that belongs to a different method.
+    List<WebPageVersion> results = WebPageVersionRepository.findByWebPageId(webPageId, null);
+    Set<String> remaining = results.stream().map(WebPageVersion::getPageXml).collect(Collectors.toSet());
+    assertEquals(Set.of("<xml>v3</xml>", "<xml>v4</xml>"), remaining);
+  }
+
+  @Test
+  void pruneOldestLeavesEverythingAloneWhenUnderTheLimit() throws SQLException {
+    long webPageId = addWebPage("/under-limit");
+    insertVersion(webPageId, "<xml>only</xml>", 1L, null);
+
+    try (Connection connection = DB.getConnection()) {
+      WebPageVersionRepository.pruneOldest(connection, webPageId, 20);
+    }
+
+    assertEquals(1, WebPageVersionRepository.findByWebPageId(webPageId, null).size());
+  }
+
+  @Test
+  void findByWebPageIdHonorsDataConstraintsPaging() {
+    long webPageId = addWebPage("/paged");
+    for (int i = 0; i < 5; i++) {
+      insertVersion(webPageId, "<xml>v" + i + "</xml>", 1L, null);
+    }
+
+    DataConstraints constraints = new DataConstraints(1, 2);
+    List<WebPageVersion> firstPage = WebPageVersionRepository.findByWebPageId(webPageId, constraints);
+
+    assertEquals(2, firstPage.size());
+    assertNotEquals(firstPage.get(0).getId(), firstPage.get(1).getId());
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real schema -- no users table here, so published_by is a plain
+    // column rather than an FK, matching the same simplification used elsewhere in this test suite.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_page_versions CASCADE");
+      statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
+      statement.execute("CREATE TABLE web_pages ("
+          + "web_page_id BIGSERIAL PRIMARY KEY, "
+          + "link VARCHAR(255) UNIQUE NOT NULL)");
+      statement.execute("CREATE TABLE web_page_versions ("
+          + "web_page_version_id BIGSERIAL PRIMARY KEY, "
+          + "web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE, "
+          + "page_xml TEXT, "
+          + "published_by BIGINT, "
+          + "published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL, "
+          + "label VARCHAR(255))");
+      statement.execute("CREATE INDEX web_page_versions_web_idx ON web_page_versions(web_page_id, published_at DESC)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_page_versions schema", se);
+    }
+  }
+
+  private static long addWebPage(String link) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        java.sql.ResultSet rs = statement.executeQuery(
+            "INSERT INTO web_pages (link) VALUES ('" + link.replace("'", "''") + "') RETURNING web_page_id")) {
+      rs.next();
+      return rs.getLong("web_page_id");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a web page", se);
+    }
+  }
+
+  private static long insertVersion(long webPageId, String pageXml, long publishedBy, String label) {
+    WebPageVersion version = new WebPageVersion();
+    version.setWebPageId(webPageId);
+    version.setPageXml(pageXml);
+    version.setPublishedBy(publishedBy);
+    version.setLabel(label);
+    try (Connection connection = DB.getConnection()) {
+      return WebPageVersionRepository.insert(connection, version);
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a web page version", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageVersionsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageVersionsListWidgetTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPageVersion;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageVersionRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies the /admin/web-page-versions widget (#405): listing a page's prior published versions
+ * and restoring a selected one back into the draft slot.
+ *
+ * @author elizabeth houser
+ */
+class WebPageVersionsListWidgetTest extends WidgetBase {
+
+  private static WebPage webPage(long id) {
+    WebPage record = new WebPage();
+    record.setId(id);
+    record.setLink("/example");
+    return record;
+  }
+
+  private static WebPageVersion version(long id, long webPageId, String pageXml, long publishedBy) {
+    WebPageVersion record = new WebPageVersion();
+    record.setId(id);
+    record.setWebPageId(webPageId);
+    record.setPageXml(pageXml);
+    record.setPublishedBy(publishedBy);
+    return record;
+  }
+
+  @Test
+  void executeLoadsTheWebPageVersionsAndAuthorMap() {
+    addQueryParameter(widgetContext, "webPageId", "3");
+    WebPage page = webPage(3L);
+    WebPageVersion version = version(10L, 3L, "<xml>v1</xml>", 7L);
+    User author = new User();
+    author.setId(7L);
+    author.setFirstName("Jamie");
+
+    try (MockedStatic<WebPageRepository> pageRepo = mockStatic(WebPageRepository.class);
+        MockedStatic<WebPageVersionRepository> versionRepo = mockStatic(WebPageVersionRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      pageRepo.when(() -> WebPageRepository.findById(3L)).thenReturn(page);
+      versionRepo.when(() -> WebPageVersionRepository.findByWebPageId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(List.of(version));
+      userRepo.when(() -> UserRepository.findByUserId(7L)).thenReturn(author);
+
+      WidgetContext result = new WebPageVersionsListWidget().execute(widgetContext);
+
+      assertEquals(page, result.getRequest().getAttribute("webPage"));
+      assertEquals(List.of(version), result.getRequest().getAttribute("versionList"));
+      Map<Long, User> userMap = (Map<Long, User>) result.getRequest().getAttribute("userMap");
+      assertEquals(author, userMap.get(7L));
+    }
+  }
+
+  @Test
+  void executeSetsAnErrorWhenTheWebPageIsNotFound() {
+    addQueryParameter(widgetContext, "webPageId", "999");
+
+    try (MockedStatic<WebPageRepository> pageRepo = mockStatic(WebPageRepository.class)) {
+      pageRepo.when(() -> WebPageRepository.findById(999L)).thenReturn(null);
+
+      WidgetContext result = new WebPageVersionsListWidget().execute(widgetContext);
+
+      assertEquals("Web page was not found", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void postRestoresTheDraftFromTheSelectedVersion() throws Exception {
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "webPageId", "3");
+    addQueryParameter(widgetContext, "webPageVersionId", "10");
+    WebPageVersion version = version(10L, 3L, "<xml>old</xml>", 7L);
+    WebPage page = webPage(3L);
+
+    try (MockedStatic<WebPageVersionRepository> versionRepo = mockStatic(WebPageVersionRepository.class);
+        MockedStatic<WebPageRepository> pageRepo = mockStatic(WebPageRepository.class)) {
+      versionRepo.when(() -> WebPageVersionRepository.findById(10L)).thenReturn(version);
+      pageRepo.when(() -> WebPageRepository.findById(3L)).thenReturn(page);
+      pageRepo.when(() -> WebPageRepository.restoreDraftFromVersion(3L, "<xml>old</xml>")).thenReturn(true);
+      versionRepo.when(() -> WebPageVersionRepository.findByWebPageId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      WidgetContext result = new WebPageVersionsListWidget().post(widgetContext);
+
+      pageRepo.verify(() -> WebPageRepository.restoreDraftFromVersion(3L, "<xml>old</xml>"));
+      assertEquals("The version was restored to the draft. Publish it to make it live.", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postSetsAnErrorWhenTheVersionIsNotFound() throws Exception {
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "webPageId", "3");
+    addQueryParameter(widgetContext, "webPageVersionId", "404");
+    WebPage page = webPage(3L);
+
+    try (MockedStatic<WebPageVersionRepository> versionRepo = mockStatic(WebPageVersionRepository.class);
+        MockedStatic<WebPageRepository> pageRepo = mockStatic(WebPageRepository.class)) {
+      versionRepo.when(() -> WebPageVersionRepository.findById(404L)).thenReturn(null);
+      pageRepo.when(() -> WebPageRepository.findById(3L)).thenReturn(page);
+      versionRepo.when(() -> WebPageVersionRepository.findByWebPageId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      WidgetContext result = new WebPageVersionsListWidget().post(widgetContext);
+
+      assertEquals("The selected version was not found", result.getErrorMessage(),
+          "the fallthrough execute() reload must not clobber the error set here (needs webPageId to succeed)");
+      pageRepo.verify(() -> WebPageRepository.restoreDraftFromVersion(anyLong(), any()), never());
+    }
+  }
+
+  @Test
+  void postIgnoresAnyActionOtherThanRestore() throws Exception {
+    addQueryParameter(widgetContext, "action", "somethingElse");
+
+    WidgetContext result = new WebPageVersionsListWidget().post(widgetContext);
+
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #405. Every publish now snapshots the outgoing `page_xml` into a new `web_page_versions` table before it's overwritten, inside the same transaction as the publish itself (a failed snapshot rolls back the whole publish rather than silently losing history).
- Retention is capped per page by a new `webPage.versionHistoryLimit` site property (default 20), pruned right after each snapshot.
- New admin page `/admin/web-page-versions` (linked from the web page edit form) lists a page's prior published revisions with author/timestamp and a Restore action.
- Restore loads the chosen version's XML into the **draft** slot only -- it never touches the live `page_xml` -- so a subsequent publish is required to make it live again, matching the issue's acceptance criteria.

## Notes for review
- `WebPageRepository.publish()`'s signature changed (now takes `publishedBy` + `versionHistoryLimit`); the single call site in `PageServlet` was updated to resolve the site property and pass the current user.
- A page with no live `page_xml` yet (first-ever publish) has nothing to snapshot, so no version row is written in that case -- covered by `WebPageRepositoryTest`.

## Test plan
- [x] `ant compile` / `compile-test` / `compile-jsp`
- [x] `python3 tools/check-unescaped-el.py . --strict` -- 0 unallowlisted
- [x] New tests: `WebPageVersionRepositoryTest`, `WebPageRepositoryTest` (publish/restore additions), `WebPageVersionsListWidgetTest` -- all passing
- [x] Full `ant ci-test` -- BUILD SUCCESSFUL, 0 failures