### PR TITLE
Add database maintenance dashboard, phase 1 (issue #469)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/DatabaseMaintenanceRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/DatabaseMaintenanceRepository.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.infrastructure.database.DB;
+
+/**
+ * Read-only introspection of PostgreSQL's own statistics catalogs (pg_stat_user_tables,
+ * pg_stat_user_indexes, pg_stat_activity), plus a guarded VACUUM (ANALYZE) trigger, for the
+ * admin-facing database maintenance dashboard (issue #469).
+ *
+ * <p>
+ * Deliberately scoped to what's queryable with no extra Postgres extension and no locking risk:
+ * REINDEX, query-plan/slow-query analysis (needs pg_stat_statements), and bloat estimation (needs
+ * pgstattuple or heavy heuristics) are left for a follow-up.
+ * </p>
+ *
+ * @author SimIS
+ * @created 8/2/2026
+ */
+public class DatabaseMaintenanceRepository {
+
+  private static Log LOG = LogFactory.getLog(DatabaseMaintenanceRepository.class);
+
+  public static DatabaseOverview findOverview() {
+    String sql = "SELECT pg_database_size(current_database()) AS db_size, "
+        + "pg_size_pretty(pg_database_size(current_database())) AS db_size_pretty, "
+        + "(SELECT COUNT(*) FROM pg_stat_user_tables) AS table_count, "
+        + "(SELECT COUNT(*) FROM pg_stat_user_indexes) AS index_count";
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery(sql)) {
+      if (rs.next()) {
+        return new DatabaseOverview(
+            rs.getLong("db_size"),
+            rs.getString("db_size_pretty"),
+            rs.getInt("table_count"),
+            rs.getInt("index_count"));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return null;
+  }
+
+  /** Ordered largest-first; a page with heavy churn but small size is still useful to see, so no filtering. */
+  public static List<TableStats> findTableStats() {
+    String sql = "SELECT relname, n_live_tup, n_dead_tup, "
+        + "pg_total_relation_size(relid) AS total_size, pg_size_pretty(pg_total_relation_size(relid)) AS total_size_pretty, "
+        + "last_vacuum, last_autovacuum, last_analyze, last_autoanalyze "
+        + "FROM pg_stat_user_tables ORDER BY pg_total_relation_size(relid) DESC";
+    List<TableStats> results = new ArrayList<>();
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery(sql)) {
+      while (rs.next()) {
+        results.add(new TableStats(
+            rs.getString("relname"),
+            rs.getLong("n_live_tup"),
+            rs.getLong("n_dead_tup"),
+            rs.getLong("total_size"),
+            rs.getString("total_size_pretty"),
+            rs.getTimestamp("last_vacuum"),
+            rs.getTimestamp("last_autovacuum"),
+            rs.getTimestamp("last_analyze"),
+            rs.getTimestamp("last_autoanalyze")));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return results;
+  }
+
+  /** Ordered least-used first, so unused/rarely-used indexes surface at the top. */
+  public static List<IndexStats> findIndexStats() {
+    String sql = "SELECT indexrelname, relname AS table_name, idx_scan, "
+        + "pg_relation_size(indexrelid) AS index_size, pg_size_pretty(pg_relation_size(indexrelid)) AS index_size_pretty "
+        + "FROM pg_stat_user_indexes ORDER BY idx_scan ASC, pg_relation_size(indexrelid) DESC";
+    List<IndexStats> results = new ArrayList<>();
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery(sql)) {
+      while (rs.next()) {
+        results.add(new IndexStats(
+            rs.getString("indexrelname"),
+            rs.getString("table_name"),
+            rs.getLong("idx_scan"),
+            rs.getLong("index_size"),
+            rs.getString("index_size_pretty")));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return results;
+  }
+
+  /** Excludes this monitoring connection's own idle/active query and other idle connections -- noise, not activity. */
+  public static List<ActiveQuery> findActiveQueries() {
+    String sql = "SELECT pid, state, query_start, wait_event_type, application_name, LEFT(query, 500) AS query "
+        + "FROM pg_stat_activity "
+        + "WHERE datname = current_database() AND state IS DISTINCT FROM 'idle' AND pid != pg_backend_pid() "
+        + "ORDER BY query_start ASC NULLS LAST";
+    List<ActiveQuery> results = new ArrayList<>();
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery(sql)) {
+      while (rs.next()) {
+        results.add(new ActiveQuery(
+            rs.getInt("pid"),
+            rs.getString("state"),
+            rs.getTimestamp("query_start"),
+            rs.getString("wait_event_type"),
+            rs.getString("application_name"),
+            rs.getString("query")));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return results;
+  }
+
+  /** The current set of user table names -- used to validate a requested VACUUM target before it's interpolated into SQL. */
+  public static Set<String> findTableNames() {
+    Set<String> names = new HashSet<>();
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT relname FROM pg_stat_user_tables")) {
+      while (rs.next()) {
+        names.add(rs.getString("relname"));
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return names;
+  }
+
+  /**
+   * Runs VACUUM (ANALYZE) on a single table -- non-locking, safe to run against a live table
+   * (unlike VACUUM FULL, which isn't offered here). {@code tableName} MUST already be verified
+   * against {@link #findTableNames()} by the caller: VACUUM's target can't be a bind parameter,
+   * so it is quoted as an identifier and executed as-is.
+   */
+  public static boolean vacuumAnalyzeTable(String tableName) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("VACUUM (ANALYZE) \"" + tableName.replace("\"", "\"\"") + "\"");
+      return true;
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+      return false;
+    }
+  }
+
+  public static class DatabaseOverview {
+    private final long sizeBytes;
+    private final String sizePretty;
+    private final int tableCount;
+    private final int indexCount;
+
+    public DatabaseOverview(long sizeBytes, String sizePretty, int tableCount, int indexCount) {
+      this.sizeBytes = sizeBytes;
+      this.sizePretty = sizePretty;
+      this.tableCount = tableCount;
+      this.indexCount = indexCount;
+    }
+
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    public String getSizePretty() {
+      return sizePretty;
+    }
+
+    public int getTableCount() {
+      return tableCount;
+    }
+
+    public int getIndexCount() {
+      return indexCount;
+    }
+  }
+
+  public static class TableStats {
+    private final String tableName;
+    private final long liveRowEstimate;
+    private final long deadRowEstimate;
+    private final long totalSizeBytes;
+    private final String totalSizePretty;
+    private final Timestamp lastVacuum;
+    private final Timestamp lastAutovacuum;
+    private final Timestamp lastAnalyze;
+    private final Timestamp lastAutoanalyze;
+
+    public TableStats(String tableName, long liveRowEstimate, long deadRowEstimate, long totalSizeBytes,
+        String totalSizePretty, Timestamp lastVacuum, Timestamp lastAutovacuum, Timestamp lastAnalyze,
+        Timestamp lastAutoanalyze) {
+      this.tableName = tableName;
+      this.liveRowEstimate = liveRowEstimate;
+      this.deadRowEstimate = deadRowEstimate;
+      this.totalSizeBytes = totalSizeBytes;
+      this.totalSizePretty = totalSizePretty;
+      this.lastVacuum = lastVacuum;
+      this.lastAutovacuum = lastAutovacuum;
+      this.lastAnalyze = lastAnalyze;
+      this.lastAutoanalyze = lastAutoanalyze;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public long getLiveRowEstimate() {
+      return liveRowEstimate;
+    }
+
+    public long getDeadRowEstimate() {
+      return deadRowEstimate;
+    }
+
+    public long getTotalSizeBytes() {
+      return totalSizeBytes;
+    }
+
+    public String getTotalSizePretty() {
+      return totalSizePretty;
+    }
+
+    /** The most recent of last_vacuum/last_autovacuum, or null if neither has ever run. */
+    public Timestamp getLastVacuumAny() {
+      if (lastVacuum == null) {
+        return lastAutovacuum;
+      }
+      if (lastAutovacuum == null) {
+        return lastVacuum;
+      }
+      return lastVacuum.after(lastAutovacuum) ? lastVacuum : lastAutovacuum;
+    }
+
+    /** The most recent of last_analyze/last_autoanalyze, or null if neither has ever run. */
+    public Timestamp getLastAnalyzeAny() {
+      if (lastAnalyze == null) {
+        return lastAutoanalyze;
+      }
+      if (lastAutoanalyze == null) {
+        return lastAnalyze;
+      }
+      return lastAnalyze.after(lastAutoanalyze) ? lastAnalyze : lastAutoanalyze;
+    }
+  }
+
+  public static class IndexStats {
+    private final String indexName;
+    private final String tableName;
+    private final long scanCount;
+    private final long sizeBytes;
+    private final String sizePretty;
+
+    public IndexStats(String indexName, String tableName, long scanCount, long sizeBytes, String sizePretty) {
+      this.indexName = indexName;
+      this.tableName = tableName;
+      this.scanCount = scanCount;
+      this.sizeBytes = sizeBytes;
+      this.sizePretty = sizePretty;
+    }
+
+    public String getIndexName() {
+      return indexName;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public long getScanCount() {
+      return scanCount;
+    }
+
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    public String getSizePretty() {
+      return sizePretty;
+    }
+
+    public boolean isUnused() {
+      return scanCount == 0;
+    }
+  }
+
+  public static class ActiveQuery {
+    private final int pid;
+    private final String state;
+    private final Timestamp queryStart;
+    private final String waitEventType;
+    private final String applicationName;
+    private final String query;
+
+    public ActiveQuery(int pid, String state, Timestamp queryStart, String waitEventType, String applicationName,
+        String query) {
+      this.pid = pid;
+      this.state = state;
+      this.queryStart = queryStart;
+      this.waitEventType = waitEventType;
+      this.applicationName = applicationName;
+      this.query = query;
+    }
+
+    public int getPid() {
+      return pid;
+    }
+
+    public String getState() {
+      return state;
+    }
+
+    public Timestamp getQueryStart() {
+      return queryStart;
+    }
+
+    public String getWaitEventType() {
+      return waitEventType;
+    }
+
+    public String getApplicationName() {
+      return applicationName;
+    }
+
+    public String getQuery() {
+      return query;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/DatabaseMaintenanceWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/DatabaseMaintenanceWidget.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.util.Set;
+
+import com.simisinc.platform.infrastructure.persistence.DatabaseMaintenanceRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Admin-only database maintenance dashboard (issue #469): database/table/index size and activity
+ * introspection via PostgreSQL's own stats catalogs, plus a VACUUM (ANALYZE) trigger per table.
+ *
+ * <p>
+ * Deliberately scoped to what's low-risk and needs no extra Postgres extension -- REINDEX,
+ * query-plan/slow-query analysis, bloat estimation, per-table autovacuum tuning, and maintenance
+ * scheduling are left for a follow-up (see the issue for the full wishlist).
+ * </p>
+ *
+ * @author SimIS
+ * @created 8/2/2026
+ */
+public class DatabaseMaintenanceWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/database-maintenance.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    loadDashboardData(context);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("vacuumAnalyze".equals(command)) {
+      String tableName = context.getParameter("table");
+      Set<String> knownTables = DatabaseMaintenanceRepository.findTableNames();
+      if (tableName == null || !knownTables.contains(tableName)) {
+        context.setErrorMessage("Unknown table");
+      } else if (DatabaseMaintenanceRepository.vacuumAnalyzeTable(tableName)) {
+        context.setSuccessMessage("VACUUM (ANALYZE) completed for " + tableName);
+      } else {
+        context.setErrorMessage("VACUUM (ANALYZE) failed for " + tableName + " -- see the server log");
+      }
+    }
+
+    context.setRedirect("/admin/database-maintenance");
+    return context;
+  }
+
+  private void loadDashboardData(WidgetContext context) {
+    context.getRequest().setAttribute("overview", DatabaseMaintenanceRepository.findOverview());
+    context.getRequest().setAttribute("tableStatsList", DatabaseMaintenanceRepository.findTableStats());
+    context.getRequest().setAttribute("indexStatsList", DatabaseMaintenanceRepository.findIndexStats());
+    context.getRequest().setAttribute("activeQueryList", DatabaseMaintenanceRepository.findActiveQueries());
+
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/admin/database-maintenance.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/database-maintenance.jsp
@@ -1,0 +1,170 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="tableStatsList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="indexStatsList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="activeQueryList" class="java.util.ArrayList" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="small">
+  Live introspection of PostgreSQL's own statistics catalogs -- nothing here is persisted or historical.
+  This first slice covers table/index size and activity monitoring plus a safe VACUUM (ANALYZE) trigger;
+  REINDEX, query-plan analysis, and bloat estimation are intentionally not offered yet.
+</p>
+<c:if test="${!empty overview}">
+  <div class="grid-x grid-margin-x">
+    <div class="small-12 medium-4 cell">
+      <div class="callout secondary text-center">
+        <span class="stat-label">Database Size</span>
+        <h3><c:out value="${overview.sizePretty}" /></h3>
+      </div>
+    </div>
+    <div class="small-12 medium-4 cell">
+      <div class="callout secondary text-center">
+        <span class="stat-label">Tables</span>
+        <h3><c:out value="${overview.tableCount}" /></h3>
+      </div>
+    </div>
+    <div class="small-12 medium-4 cell">
+      <div class="callout secondary text-center">
+        <span class="stat-label">Indexes</span>
+        <h3><c:out value="${overview.indexCount}" /></h3>
+      </div>
+    </div>
+  </div>
+</c:if>
+
+<h5>Tables</h5>
+<div style="overflow-x: auto">
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Table</th>
+      <th>Rows (est.)</th>
+      <th>Dead Rows (est.)</th>
+      <th>Size</th>
+      <th>Last Vacuum</th>
+      <th>Last Analyze</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${tableStatsList}" var="tableStats">
+      <tr>
+        <td><c:out value="${tableStats.tableName}" /></td>
+        <td><fmt:formatNumber value="${tableStats.liveRowEstimate}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${tableStats.deadRowEstimate > 0}"><span class="label warning radius"><fmt:formatNumber value="${tableStats.deadRowEstimate}" /></span></c:when>
+            <c:otherwise>0</c:otherwise>
+          </c:choose>
+        </td>
+        <td><c:out value="${tableStats.totalSizePretty}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${empty tableStats.lastVacuumAny}">&#8212;</c:when>
+            <c:otherwise><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${tableStats.lastVacuumAny}' />"><c:out value="${date:relative(tableStats.lastVacuumAny)}" /></span></c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:choose>
+            <c:when test="${empty tableStats.lastAnalyzeAny}">&#8212;</c:when>
+            <c:otherwise><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${tableStats.lastAnalyzeAny}' />"><c:out value="${date:relative(tableStats.lastAnalyzeAny)}" /></span></c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <a href="#" onclick="return confirmPostAction('Run VACUUM (ANALYZE) on ${fn:escapeXml(tableStats.tableName)}?', '${widgetContext.uri}?command=vacuumAnalyze&table=${fn:escapeXml(tableStats.tableName)}&widget=${widgetContext.uniqueId}&token=${userSession.formToken}');" class="button tiny secondary">Vacuum</a>
+        </td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
+</div>
+
+<h5>Indexes</h5>
+<p class="small">Sorted by scan count, least-used first -- a 0-scan index on a table with real traffic may be a candidate to drop.</p>
+<div style="overflow-x: auto">
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Index</th>
+      <th>Table</th>
+      <th>Scans</th>
+      <th>Size</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${indexStatsList}" var="indexStats">
+      <tr>
+        <td>
+          <c:out value="${indexStats.indexName}" />
+          <c:if test="${indexStats.unused}"> <span class="label alert radius">unused</span></c:if>
+        </td>
+        <td><c:out value="${indexStats.tableName}" /></td>
+        <td><fmt:formatNumber value="${indexStats.scanCount}" /></td>
+        <td><c:out value="${indexStats.sizePretty}" /></td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
+</div>
+
+<h5>Active Activity</h5>
+<c:choose>
+  <c:when test="${empty activeQueryList}">
+    <p class="small">No active (non-idle) queries right now.</p>
+  </c:when>
+  <c:otherwise>
+    <div style="overflow-x: auto">
+    <table class="unstriped">
+      <thead>
+        <tr>
+          <th>PID</th>
+          <th>State</th>
+          <th>Started</th>
+          <th>Waiting On</th>
+          <th>Application</th>
+          <th>Query</th>
+        </tr>
+      </thead>
+      <tbody>
+        <c:forEach items="${activeQueryList}" var="activeQuery">
+          <tr>
+            <td><c:out value="${activeQuery.pid}" /></td>
+            <td><c:out value="${activeQuery.state}" /></td>
+            <td>
+              <c:choose>
+                <c:when test="${empty activeQuery.queryStart}">&#8212;</c:when>
+                <c:otherwise><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${activeQuery.queryStart}' />"><c:out value="${date:relative(activeQuery.queryStart)}" /></span></c:otherwise>
+              </c:choose>
+            </td>
+            <td><c:out value="${activeQuery.waitEventType}" /></td>
+            <td><c:out value="${activeQuery.applicationName}" /></td>
+            <td><code><c:out value="${activeQuery.query}" /></code></td>
+          </tr>
+        </c:forEach>
+      </tbody>
+    </table>
+    </div>
+  </c:otherwise>
+</c:choose>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -429,6 +429,7 @@
             <c:if test="${userSession.hasRole('admin')}">
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/health-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/health-dashboard"><i class="${font:far()} fa-heart-pulse fa-fw"></i> <span>System Health</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/job-queue-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/job-queue-dashboard"><i class="${font:far()} fa-list-check fa-fw"></i> <span>Job Queue</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/database-maintenance')}"> class="is-active"</c:if>><a href="${ctx}/admin/database-maintenance"><i class="${font:far()} fa-database fa-fw"></i> <span>Database Maintenance</span></a></li>
             </c:if>
           </ul>
           <%-- Community menu --%>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1903,6 +1903,17 @@
     </section>
   </page>
 
+  <page name="/admin/database-maintenance" role="admin" title="Database Maintenance">
+    <section>
+      <column class="small-12 cell">
+        <widget name="databaseMaintenance">
+          <icon>fa-database</icon>
+          <title>Database Maintenance</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/job-queue-dashboard" role="admin" title="Job Queue Dashboard">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -274,6 +274,7 @@
   <widget name="xapiStatementList" class="com.simisinc.platform.presentation.widgets.admin.xapi.XapiStatementListWidget" />
   <widget name="auditLogList" class="com.simisinc.platform.presentation.widgets.admin.audit.AuditLogListWidget" />
   <widget name="healthDashboard" class="com.simisinc.platform.presentation.widgets.admin.HealthDashboardWidget" />
+  <widget name="databaseMaintenance" class="com.simisinc.platform.presentation.widgets.admin.DatabaseMaintenanceWidget" />
   <widget name="jobQueueDashboard" class="com.simisinc.platform.presentation.widgets.admin.JobQueueDashboardWidget" />
   <!-- Not implemented -->
   <widget name="profilePhoto" class="com.simisinc.platform.presentation.widgets.GenericWidget" />

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/DatabaseMaintenanceRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/DatabaseMaintenanceRepositoryTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link DatabaseMaintenanceRepository} against a real PostgreSQL instance (#469) -- these
+ * queries are against Postgres's own pg_stat_* catalogs, which don't exist in any mock and behave
+ * identically to a real deployment once a table has had at least one query run against it.
+ *
+ * @author elizabeth houser
+ */
+class DatabaseMaintenanceRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping DatabaseMaintenanceRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchemaAndSeedStats();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @Test
+  void findOverviewReturnsARealDatabaseSizeAndCounts() {
+    DatabaseMaintenanceRepository.DatabaseOverview overview = DatabaseMaintenanceRepository.findOverview();
+
+    assertNotNull(overview);
+    assertTrue(overview.getSizeBytes() > 0);
+    assertNotNull(overview.getSizePretty());
+    assertTrue(overview.getTableCount() >= 1, "the seeded table should be counted");
+    assertTrue(overview.getIndexCount() >= 1, "the seeded primary key index should be counted");
+  }
+
+  @Test
+  void findTableStatsIncludesTheSeededTableWithASize() {
+    List<DatabaseMaintenanceRepository.TableStats> tableStatsList = DatabaseMaintenanceRepository.findTableStats();
+
+    DatabaseMaintenanceRepository.TableStats widgets = tableStatsList.stream()
+        .filter(t -> "widgets".equals(t.getTableName()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull(widgets, "the seeded 'widgets' table should appear in the stats");
+    assertTrue(widgets.getTotalSizeBytes() > 0);
+    assertNotNull(widgets.getTotalSizePretty());
+    assertNotNull(widgets.getLastAnalyzeAny(), "the setup's explicit ANALYZE should be reflected here");
+  }
+
+  @Test
+  void findIndexStatsFlagsAnIndexWithZeroScansAsUnused() {
+    List<DatabaseMaintenanceRepository.IndexStats> indexStatsList = DatabaseMaintenanceRepository.findIndexStats();
+
+    DatabaseMaintenanceRepository.IndexStats pk = indexStatsList.stream()
+        .filter(i -> "widgets".equals(i.getTableName()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull(pk, "the seeded table's primary key index should appear in the stats");
+    // A freshly-created index with no SELECTs run against its table has never been scanned.
+    assertEquals(0, pk.getScanCount());
+    assertTrue(pk.isUnused());
+  }
+
+  @Test
+  void findTableNamesIncludesTheSeededTable() {
+    Set<String> names = DatabaseMaintenanceRepository.findTableNames();
+
+    assertTrue(names.contains("widgets"));
+  }
+
+  @Test
+  void vacuumAnalyzeTableSucceedsForARealTable() {
+    boolean result = DatabaseMaintenanceRepository.vacuumAnalyzeTable("widgets");
+
+    assertTrue(result);
+  }
+
+  @Test
+  void vacuumAnalyzeTableFailsGracefullyForANonexistentTable() {
+    boolean result = DatabaseMaintenanceRepository.vacuumAnalyzeTable("this_table_does_not_exist");
+
+    assertFalse(result);
+  }
+
+  @Test
+  void findActiveQueriesExcludesThisConnectionsOwnBackend() {
+    List<DatabaseMaintenanceRepository.ActiveQuery> activeQueries = DatabaseMaintenanceRepository.findActiveQueries();
+
+    // Every connection in this pool is either idle (excluded) or, if caught mid-query, would show up as
+    // running this exact SELECT -- pg_backend_pid() in the repository's own query excludes its own PID,
+    // so this just proves the call doesn't blow up and returns a (possibly empty) real list.
+    assertNotNull(activeQueries);
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchemaAndSeedStats() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS widgets");
+      statement.execute("CREATE TABLE widgets (widget_id BIGSERIAL PRIMARY KEY, name VARCHAR(255))");
+      statement.execute("INSERT INTO widgets (name) VALUES ('a'), ('b'), ('c')");
+      // pg_stat_user_tables/pg_stat_user_indexes only populate after the stats collector has seen
+      // activity on the relation -- an explicit ANALYZE forces that immediately rather than waiting
+      // on autovacuum's own schedule, which the test can't control.
+      statement.execute("ANALYZE widgets");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create/seed the widgets table", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/DatabaseMaintenanceWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/DatabaseMaintenanceWidgetTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.infrastructure.persistence.DatabaseMaintenanceRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author elizabeth houser
+ */
+class DatabaseMaintenanceWidgetTest extends WidgetBase {
+
+  @Test
+  void executeLoadsAllFourSectionsForAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+    DatabaseMaintenanceRepository.DatabaseOverview overview =
+        new DatabaseMaintenanceRepository.DatabaseOverview(1024L, "1024 bytes", 5, 8);
+    List<DatabaseMaintenanceRepository.TableStats> tableStatsList = List.of();
+    List<DatabaseMaintenanceRepository.IndexStats> indexStatsList = List.of();
+    List<DatabaseMaintenanceRepository.ActiveQuery> activeQueryList = List.of();
+
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      repository.when(DatabaseMaintenanceRepository::findOverview).thenReturn(overview);
+      repository.when(DatabaseMaintenanceRepository::findTableStats).thenReturn(tableStatsList);
+      repository.when(DatabaseMaintenanceRepository::findIndexStats).thenReturn(indexStatsList);
+      repository.when(DatabaseMaintenanceRepository::findActiveQueries).thenReturn(activeQueryList);
+
+      WidgetContext result = new DatabaseMaintenanceWidget().execute(widgetContext);
+
+      assertEquals("/admin/database-maintenance.jsp", result.getJsp());
+      assertEquals(overview, result.getRequest().getAttribute("overview"));
+      assertEquals(tableStatsList, result.getRequest().getAttribute("tableStatsList"));
+      assertEquals(indexStatsList, result.getRequest().getAttribute("indexStatsList"));
+      assertEquals(activeQueryList, result.getRequest().getAttribute("activeQueryList"));
+    }
+  }
+
+  @Test
+  void executeDoesNothingForAUserWithoutAdmin() {
+    // WidgetBase's default logged-in test user has no roles at all
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      WidgetContext result = new DatabaseMaintenanceWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+      repository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postVacuumAnalyzeRunsForAKnownTableAndRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "vacuumAnalyze");
+    addQueryParameter(widgetContext, "table", "web_pages");
+
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      repository.when(DatabaseMaintenanceRepository::findTableNames).thenReturn(Set.of("web_pages", "users"));
+      repository.when(() -> DatabaseMaintenanceRepository.vacuumAnalyzeTable("web_pages")).thenReturn(true);
+
+      WidgetContext result = new DatabaseMaintenanceWidget().post(widgetContext);
+
+      repository.verify(() -> DatabaseMaintenanceRepository.vacuumAnalyzeTable("web_pages"));
+      assertEquals("/admin/database-maintenance", result.getRedirect());
+      assertEquals("VACUUM (ANALYZE) completed for web_pages", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postVacuumAnalyzeRejectsATableNameNotInTheLiveAllowlist() {
+    // Guards the VACUUM target: it's string-interpolated into raw SQL (VACUUM can't take a bind
+    // parameter for its target), so a table name must be verified against a live catalog query
+    // before it's ever handed to vacuumAnalyzeTable -- this is that guard, exercised directly.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "vacuumAnalyze");
+    addQueryParameter(widgetContext, "table", "web_pages; DROP TABLE users;--");
+
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      repository.when(DatabaseMaintenanceRepository::findTableNames).thenReturn(Set.of("web_pages", "users"));
+
+      WidgetContext result = new DatabaseMaintenanceWidget().post(widgetContext);
+
+      repository.verify(() -> DatabaseMaintenanceRepository.vacuumAnalyzeTable(anyString()), never());
+      assertEquals("Unknown table", result.getErrorMessage());
+      assertEquals("/admin/database-maintenance", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postDoesNothingForAUserWithoutAdmin() {
+    addQueryParameter(widgetContext, "command", "vacuumAnalyze");
+    addQueryParameter(widgetContext, "table", "web_pages");
+
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      WidgetContext result = new DatabaseMaintenanceWidget().post(widgetContext);
+
+      assertNull(result.getRedirect());
+      repository.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postIgnoresAnUnrecognizedCommandButStillRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "somethingElse");
+
+    try (MockedStatic<DatabaseMaintenanceRepository> repository = mockStatic(DatabaseMaintenanceRepository.class)) {
+      WidgetContext result = new DatabaseMaintenanceWidget().post(widgetContext);
+
+      repository.verify(() -> DatabaseMaintenanceRepository.vacuumAnalyzeTable(anyString()), never());
+      assertEquals("/admin/database-maintenance", result.getRedirect());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Partially addresses #469. This issue's full wishlist is large (VACUUM/ANALYZE/REINDEX, query-plan analysis, bloat detection, per-table autovacuum tuning, activity monitoring, maintenance scheduling) -- this PR ships a scoped, low-risk first slice and leaves the rest for a follow-up.

New admin-only `/admin/database-maintenance` page, built entirely on PostgreSQL's own stats catalogs (no extra extension required):
- **Database overview**: total size, table count, index count
- **Table stats**: row/dead-row estimates, size, last vacuum/analyze, with a **VACUUM (ANALYZE)** trigger per table
- **Index stats**: size and scan count, flagging 0-scan indexes as **unused**
- **Active activity**: current non-idle queries/connections (state, wait event, truncated query text)

## Security note
VACUUM's target can't be a bind parameter, so the table name is interpolated into raw SQL as a quoted identifier -- `DatabaseMaintenanceWidget.post()` validates the requested table against a live `pg_stat_user_tables` query (`findTableNames()`) before it's ever passed to `vacuumAnalyzeTable()`. Covered by `DatabaseMaintenanceWidgetTest.postVacuumAnalyzeRejectsATableNameNotInTheLiveAllowlist`.

## Deliberately deferred (left open on #469)
- REINDEX (needs stronger locking guardrails than a plain button)
- Query-plan / slow-query analysis and missing-index suggestions (need the `pg_stat_statements` extension -- a deployment-level decision)
- Bloat estimation (needs `pgstattuple` or heavy heuristics)
- Per-table autovacuum tuning UI
- Maintenance scheduling windows (overlaps the existing scheduler infrastructure)
- Health-status-over-time tracking (could extend #466's SystemHealthCheck rather than duplicate it)

## Test plan
- [x] `ant compile` / `compile-test` / `compile-jsp`
- [x] `python3 tools/check-unescaped-el.py . --strict` -- 0 unallowlisted
- [x] New tests: `DatabaseMaintenanceRepositoryTest` (Testcontainers, real pg_stat_* queries), `DatabaseMaintenanceWidgetTest` -- all passing
- [x] Full `ant ci-test` -- BUILD SUCCESSFUL, 0 failures