### PR TITLE
Redesign folder access matrix, add sort/search to admin folder UI (part of #502)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileItemRepository.java
@@ -113,6 +113,14 @@ public class FileItemRepository {
         // Override the order by for rank first
         orderBy.add("rank DESC, file_id");
       }
+
+      // Plain substring search across filename/title (issue #502, folder-files-list.jsp) -- a
+      // WHERE-only match, distinct from searchName's tsvector rank ordering above, so it composes
+      // with an explicit column sort from the caller's DataConstraints instead of overriding it.
+      if (StringUtils.isNotBlank(specification.getSearchTerm())) {
+        String term = "%" + specification.getSearchTerm().trim().toLowerCase() + "%";
+        where.add("(LOWER(files.filename) LIKE ? OR LOWER(files.title) LIKE ?)", new String[] { term, term });
+      }
     }
     return DB.selectAllFrom(
         TABLE_NAME, select, joins, where, orderBy, constraints, FileItemRepository::buildRecord);

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileSpecification.java
@@ -38,6 +38,7 @@ public class FileSpecification extends Entity {
   private String matchesName = null;
   private String searchName = null;
   private String searchContent = null;
+  private String searchTerm = null;
   private int withinLastDays = -1;
   private int inASubFolder = DataConstants.UNDEFINED;
   private String versionWebPath = null;
@@ -139,6 +140,22 @@ public class FileSpecification extends Entity {
 
   public void setSearchContent(String searchContent) {
     this.searchContent = searchContent;
+  }
+
+  /**
+   * A plain case-insensitive substring match against filename/title (issue #502 -- adds search to
+   * the per-folder file list). Deliberately separate from {@link #getSearchName()}, which drives a
+   * tsvector-ranked full-text search: that path forces its own "rank DESC" ORDER BY (see
+   * FileItemRepository#query), which would silently override an explicit column sort requested by
+   * the caller. This field's WHERE-only match leaves ORDER BY entirely under the caller's control,
+   * so search and sort compose correctly together.
+   */
+  public String getSearchTerm() {
+    return searchTerm;
+  }
+
+  public void setSearchTerm(String searchTerm) {
+    this.searchTerm = searchTerm;
   }
 
   public int getWithinLastDays() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
@@ -32,16 +32,19 @@ import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.domain.model.cms.Folder;
 import com.simisinc.platform.domain.model.cms.FolderCategory;
 import com.simisinc.platform.domain.model.cms.SubFolder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderCategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.SubFolderRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.SubFolderSpecification;
+import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Description
@@ -125,8 +128,38 @@ public class FolderFilesListWidget extends GenericWidget {
       specification.setInASubFolder(false);
     }
 
+    // Search by filename/title (issue #502)
+    String query = context.getParameter(RequestConstants.RECORD_QUERY);
+    context.getRequest().setAttribute(RequestConstants.RECORD_QUERY, query);
+    if (StringUtils.isNotBlank(query)) {
+      specification.setSearchTerm(query.trim());
+    }
+
+    // Sort by name/date/size/downloads (issue #502) -- an invalid or missing value falls back to
+    // "date", which maps to the same "created DESC" order this list used before sorting existed,
+    // so a plain page load (no sortBy param) keeps its prior ordering.
+    String sortBy = context.getParameter(RequestConstants.RECORD_SORT_BY, "date");
+    DataConstraints constraints = new DataConstraints();
+    switch (sortBy) {
+      case "name":
+        constraints.setColumnToSortBy("title");
+        break;
+      case "size":
+        constraints.setColumnToSortBy("file_length", "desc");
+        break;
+      case "downloads":
+        constraints.setColumnToSortBy("download_count", "desc");
+        break;
+      case "date":
+      default:
+        sortBy = "date";
+        constraints.setColumnToSortBy("created", "desc");
+        break;
+    }
+    context.getRequest().setAttribute(RequestConstants.RECORD_SORT_BY, sortBy);
+
     // Load the files
-    List<FileItem> fileList = FileItemRepository.findAll(specification, null);
+    List<FileItem> fileList = FileItemRepository.findAll(specification, constraints);
     context.getRequest().setAttribute("fileList", fileList);
 
     // Standard request items

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidget.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -70,7 +71,33 @@ public class FolderListWidget extends GenericWidget {
       }
       folderList = matchingFolderList;
     }
-    context.getRequest().setAttribute("folderList", folderList);
+
+    // Sort by name or # of files (issue #502) -- date/size sort isn't meaningful at the folder
+    // level (a folder has no single date or size of its own), so only these two are offered.
+    // Applied in-memory for the same reason the search filter above is: the list is small and
+    // admin-curated, and re-sorting here avoids touching either findAll() data-access path.
+    String sort = context.getParameter("sort", "name");
+    Comparator<Folder> comparator;
+    switch (sort) {
+      case "name_desc":
+        comparator = Comparator.comparing(Folder::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)).reversed();
+        break;
+      case "files_desc":
+        comparator = Comparator.comparingInt(Folder::getFileCount).reversed();
+        break;
+      case "files_asc":
+        comparator = Comparator.comparingInt(Folder::getFileCount);
+        break;
+      case "name":
+      default:
+        sort = "name";
+        comparator = Comparator.comparing(Folder::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+        break;
+    }
+    List<Folder> sortedFolderList = new ArrayList<>(folderList);
+    sortedFolderList.sort(comparator);
+    context.getRequest().setAttribute("sort", sort);
+    context.getRequest().setAttribute("folderList", sortedFolderList);
 
     // Show the editor
     context.setJsp(JSP);

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -34,11 +34,43 @@
 <jsp:useBean id="fileList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="canEdit" class="java.lang.String" scope="request"/>
 <jsp:useBean id="canDelete" class="java.lang.String" scope="request"/>
+<jsp:useBean id="query" class="java.lang.String" scope="request"/>
+<jsp:useBean id="sortBy" class="java.lang.String" scope="request"/>
 <script src="${ctx}/javascript/clipboard-2.0.11/clipboard.min.js"></script>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
   <a href="${ctx}/admin/file-form?subFolderId=${subFolder.id}&folderId=${folder.id}&returnPage=${widgetContext.uri}%3FsubFolderId=${subFolder.id}%26folderId=${folder.id}" class="button small primary radius float-left"><i class="fa fa-plus"></i> Add File Link</a>
 </c:if>
+<%-- Search/sort (GET so the criteria live in the URL); folderId/subFolderId are carried as hidden
+     fields since a GET form with no action= replaces the current query string with only its own
+     fields --%>
+<form method="get" autocomplete="off" class="clear-float margin-bottom-10">
+  <input type="hidden" name="folderId" value="${folder.id}"/>
+  <c:if test="${subFolder.id gt 0}">
+    <input type="hidden" name="subFolderId" value="${subFolder.id}"/>
+  </c:if>
+  <div class="grid-x grid-margin-x">
+    <div class="cell medium-5">
+      <label for="fileSearchQuery" class="show-for-sr">Search by filename or title</label>
+      <input id="fileSearchQuery" type="search" name="query" placeholder="Search by filename or title..."<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if>>
+    </div>
+    <div class="cell medium-4">
+      <label for="fileSortBy" class="show-for-sr">Sort by</label>
+      <select id="fileSortBy" name="sortBy">
+        <option value="date" <c:if test="${sortBy eq 'date'}">selected</c:if>>Date (Newest First)</option>
+        <option value="name" <c:if test="${sortBy eq 'name'}">selected</c:if>>Name (A-Z)</option>
+        <option value="size" <c:if test="${sortBy eq 'size'}">selected</c:if>>Size (Largest First)</option>
+        <option value="downloads" <c:if test="${sortBy eq 'downloads'}">selected</c:if>>Downloads (Most First)</option>
+      </select>
+    </div>
+    <div class="cell medium-3">
+      <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Apply</button>
+      <c:if test="${!empty query || sortBy ne 'date'}">
+        <a href="${widgetContext.uri}?folderId=${folder.id}<c:if test="${subFolder.id gt 0}">&subFolderId=${subFolder.id}</c:if>" class="button small secondary radius">Clear</a>
+      </c:if>
+    </div>
+  </div>
+</form>
 <table class="unstriped">
   <thead>
     <tr>
@@ -54,7 +86,12 @@
   <tbody>
     <c:if test="${empty fileList}">
       <tr>
-        <td colspan="5">No files were found</td>
+        <td colspan="5">
+          <c:choose>
+            <c:when test="${!empty query}">No files match "<c:out value="${query}" />"</c:when>
+            <c:otherwise>No files were found</c:otherwise>
+          </c:choose>
+        </td>
       </tr>
     </c:if>
     <c:forEach items="${fileList}" var="file">

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-list.jsp
@@ -21,6 +21,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="folderList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="query" class="java.lang.String" scope="request"/>
+<jsp:useBean id="sort" class="java.lang.String" scope="request"/>
 <c:if test="${!empty title}">
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
@@ -30,6 +31,12 @@
 <form method="get" autocomplete="off" class="float-right">
   <div class="input-group no-gap width-auto">
     <input class="input-group-field" type="search" name="query" aria-label="Search folders" placeholder="<c:if test="${empty query}">Search folders...</c:if>"<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if> autocomplete="off">
+    <select class="input-group-field" name="sort" aria-label="Sort folders" onchange="this.form.submit()" style="max-width:180px;">
+      <option value="name" <c:if test="${sort eq 'name'}">selected</c:if>>Name (A-Z)</option>
+      <option value="name_desc" <c:if test="${sort eq 'name_desc'}">selected</c:if>>Name (Z-A)</option>
+      <option value="files_desc" <c:if test="${sort eq 'files_desc'}">selected</c:if>># of Files (High-Low)</option>
+      <option value="files_asc" <c:if test="${sort eq 'files_asc'}">selected</c:if>># of Files (Low-High)</option>
+    </select>
     <div class="input-group-button">
       <button type="submit" class="button search" aria-label="Search"><i class="fa fa-search" aria-hidden="true"></i></button>
     </div>
@@ -57,44 +64,88 @@
           --%>
         </td>
         <td>
-          <c:if test="${folder.allowsGuests}">
-            <span class="label success">All Guests</span>
-            <c:choose>
-              <c:when test="${folder.guestPrivacyType eq 1000}"><span class="label round secondary">Own Files</span></c:when>
-              <c:when test="${folder.guestPrivacyType eq 2000}"><span class="label round secondary">All Files</span></c:when>
-              <c:when test="${folder.guestPrivacyType eq 3000}"><span class="label round secondary">Files By Token Only</span></c:when>
-              <c:when test="${folder.guestPrivacyType eq 4000}"><span class="label round secondary">Drop Box</span></c:when>
-            </c:choose>
-            <c:if test="${!empty folder.folderGroupList}">
-              <br />
-            </c:if>
-          </c:if>
           <c:choose>
-            <c:when test="${empty folder.folderGroupList && !folder.allowsGuests}"><span class="label alert">No access</span></c:when>
+            <c:when test="${empty folder.folderGroupList && !folder.allowsGuests}">
+              <span class="label alert">No access</span>
+              <c:if test="${userSession.hasRole('admin')}">
+                <a href="${ctx}/admin/folder?folderId=${folder.id}&returnPage=/admin/folders" title="Edit access"><i class="fa fa-edit"></i></a>
+              </c:if>
+            </c:when>
             <c:otherwise>
-              <c:forEach items="${folder.folderGroupList}" var="folderGroup" varStatus="status">
-                <c:choose>
-                  <c:when test="${group:name(folderGroup.groupId) eq 'All Users'}">
-                    <span class="label success"><c:out value="${group:name(folderGroup.groupId)}" /></span>
-                  </c:when>
-                  <c:otherwise>
-                    <span class="label primary"><c:out value="${group:name(folderGroup.groupId)}" /></span>
-                  </c:otherwise>
-                </c:choose>
-                <c:choose>
-                  <c:when test="${folderGroup.privacyType eq 1000}"><span class="label secondary round">Own Files</span></c:when>
-                  <c:when test="${folderGroup.privacyType eq 2000}"><span class="label secondary round">All Files</span></c:when>
-                  <c:when test="${folderGroup.privacyType eq 3000}"><span class="label secondary round">Files By Token Only</span></c:when>
-                  <c:when test="${folderGroup.privacyType eq 4000}"><span class="label secondary round">Drop Box</span></c:when>
-                </c:choose>
-                <c:if test="${folderGroup.addPermission}"><small>add</small></c:if>
-                <c:if test="${folderGroup.editPermission}"><small>edit</small></c:if>
-                <c:if test="${folderGroup.deletePermission}"><small>delete</small></c:if>
-                <c:if test="${!status.last}"><br /></c:if>
-              </c:forEach>
+              <table class="folder-access-table">
+                <thead>
+                  <tr>
+                    <th>Who</th>
+                    <th class="text-center">Access</th>
+                    <th class="text-center" title="Can add files">Add</th>
+                    <th class="text-center" title="Can edit files">Edit</th>
+                    <th class="text-center" title="Can delete files">Delete</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <c:if test="${folder.allowsGuests}">
+                    <tr>
+                      <td><span class="label success">All Guests</span></td>
+                      <td class="text-center">
+                        <c:choose>
+                          <c:when test="${folder.guestPrivacyType eq 1000}"><span class="label round secondary">Own Files</span></c:when>
+                          <c:when test="${folder.guestPrivacyType eq 2000}"><span class="label round success">All Files</span></c:when>
+                          <c:when test="${folder.guestPrivacyType eq 3000}"><span class="label round warning">Token Only</span></c:when>
+                          <c:when test="${folder.guestPrivacyType eq 4000}"><span class="label round primary">Drop Box</span></c:when>
+                        </c:choose>
+                      </td>
+                      <td class="text-center" aria-label="No">&ndash;</td>
+                      <td class="text-center" aria-label="No">&ndash;</td>
+                      <td class="text-center" aria-label="No">&ndash;</td>
+                    </tr>
+                  </c:if>
+                  <c:forEach items="${folder.folderGroupList}" var="folderGroup">
+                    <tr>
+                      <td>
+                        <c:choose>
+                          <c:when test="${group:name(folderGroup.groupId) eq 'All Users'}">
+                            <span class="label success"><c:out value="${group:name(folderGroup.groupId)}" /></span>
+                          </c:when>
+                          <c:otherwise>
+                            <span class="label primary"><c:out value="${group:name(folderGroup.groupId)}" /></span>
+                          </c:otherwise>
+                        </c:choose>
+                      </td>
+                      <td class="text-center">
+                        <c:choose>
+                          <c:when test="${folderGroup.privacyType eq 1000}"><span class="label round secondary">Own Files</span></c:when>
+                          <c:when test="${folderGroup.privacyType eq 2000}"><span class="label round success">All Files</span></c:when>
+                          <c:when test="${folderGroup.privacyType eq 3000}"><span class="label round warning">Token Only</span></c:when>
+                          <c:when test="${folderGroup.privacyType eq 4000}"><span class="label round primary">Drop Box</span></c:when>
+                        </c:choose>
+                      </td>
+                      <td class="text-center">
+                        <c:choose>
+                          <c:when test="${folderGroup.addPermission}"><i class="fa fa-check" aria-label="Yes"></i></c:when>
+                          <c:otherwise><span aria-label="No">&ndash;</span></c:otherwise>
+                        </c:choose>
+                      </td>
+                      <td class="text-center">
+                        <c:choose>
+                          <c:when test="${folderGroup.editPermission}"><i class="fa fa-check" aria-label="Yes"></i></c:when>
+                          <c:otherwise><span aria-label="No">&ndash;</span></c:otherwise>
+                        </c:choose>
+                      </td>
+                      <td class="text-center">
+                        <c:choose>
+                          <c:when test="${folderGroup.deletePermission}"><i class="fa fa-check" aria-label="Yes"></i></c:when>
+                          <c:otherwise><span aria-label="No">&ndash;</span></c:otherwise>
+                        </c:choose>
+                      </td>
+                    </tr>
+                  </c:forEach>
+                </tbody>
+              </table>
+              <c:if test="${userSession.hasRole('admin')}">
+                <a href="${ctx}/admin/folder?folderId=${folder.id}&returnPage=/admin/folders" title="Edit access"><i class="fa fa-edit"></i> Edit Access</a>
+              </c:if>
             </c:otherwise>
           </c:choose>
-          <%--<c:forEach items="${collection.privacyTypes}" var="privacyType" varStatus="status"><span class="label round secondary"><c:out value="${privacyType}" /></span><c:if test="${!status.last}" > </c:if></c:forEach>--%>
         </td>
         <td class="text-center">
           <fmt:formatNumber value="${folder.fileCount}" />
@@ -113,3 +164,27 @@
     </c:if>
   </tbody>
 </table>
+<style nonce="${cspNonce}">
+  /* Compact per-folder access matrix (issue #502) -- a plain <table> here would inherit the
+     platform's default Foundation table padding/borders, which is sized for the page-level list
+     and makes this nested table needlessly tall when many folders each show several groups. */
+  .folder-access-table {
+    width: auto;
+    margin: 0 0 4px 0;
+    border-collapse: collapse;
+  }
+  .folder-access-table th,
+  .folder-access-table td {
+    padding: 2px 8px;
+    font-size: 0.75rem;
+    border: none;
+  }
+  .folder-access-table thead th {
+    font-weight: bold;
+    border-bottom: 1px solid #DBDCDD;
+    color: #6f6f6f;
+  }
+  .folder-access-table tbody tr:not(:last-child) td {
+    border-bottom: 1px solid #f0f0f0;
+  }
+</style>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidgetTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.domain.model.cms.FolderCategory;
+import com.simisinc.platform.domain.model.cms.SubFolder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderCategoryRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.SubFolderRepository;
+
+/**
+ * Verifies the search-by-filename/title and sort-by-name/date/size/downloads behavior added to the
+ * per-folder file list (issue #502). Before this, the widget always loaded every file in the
+ * folder with the repository's default "created DESC" order and no way to filter it.
+ *
+ * @author Liz Houser
+ * @created 8/2/2026
+ */
+class FolderFilesListWidgetTest extends WidgetBase {
+
+  private static Folder folderWithId(long id) {
+    Folder folder = new Folder();
+    folder.setId(id);
+    return folder;
+  }
+
+  /** Stubs every collaborator the widget's execute() touches besides FileItemRepository.findAll. */
+  private void stubCommonCollaborators(MockedStatic<FolderRepository> folderRepo,
+      MockedStatic<CheckFolderPermissionCommand> perm, MockedStatic<SubFolderRepository> subFolderRepo,
+      MockedStatic<FolderCategoryRepository> categoryRepo, long folderId) {
+    folderRepo.when(() -> FolderRepository.findById(folderId)).thenReturn(folderWithId(folderId));
+    folderRepo.when(FolderRepository::findAll).thenReturn(new ArrayList<>());
+    perm.when(() -> CheckFolderPermissionCommand.userHasEditPermission(anyLong(), anyLong())).thenReturn(false);
+    perm.when(() -> CheckFolderPermissionCommand.userHasDeletePermission(anyLong(), anyLong())).thenReturn(false);
+    subFolderRepo.when(() -> SubFolderRepository.findAll(any(), any())).thenReturn(new ArrayList<SubFolder>());
+    categoryRepo.when(() -> FolderCategoryRepository.findAllByFolderId(folderId)).thenReturn(new ArrayList<FolderCategory>());
+  }
+
+  @Test
+  void executeWithNoParamsDefaultsToDateDescendingAndNoSearchTerm() {
+    addQueryParameter(widgetContext, "folderId", "5");
+
+    ArgumentCaptor<FileSpecification> specCaptor = ArgumentCaptor.forClass(FileSpecification.class);
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(specCaptor.capture(), constraintsCaptor.capture()));
+    }
+
+    FileSpecification spec = specCaptor.getValue();
+    Assertions.assertEquals(5L, spec.getFolderId());
+    Assertions.assertNull(spec.getSearchTerm());
+
+    DataConstraints constraints = constraintsCaptor.getValue();
+    Assertions.assertArrayEquals(new String[] { "created" }, constraints.getColumnsToSortBy());
+    Assertions.assertArrayEquals(new String[] { "desc" }, constraints.getSortOrder());
+
+    Assertions.assertEquals("date", request.getAttribute("sortBy"));
+  }
+
+  @Test
+  void executeAppliesSearchTermToTheSpecification() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "query", "invoice");
+
+    ArgumentCaptor<FileSpecification> specCaptor = ArgumentCaptor.forClass(FileSpecification.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(specCaptor.capture(), any()));
+    }
+
+    Assertions.assertEquals("invoice", specCaptor.getValue().getSearchTerm());
+    Assertions.assertEquals("invoice", request.getAttribute("query"));
+  }
+
+  @Test
+  void executeSortsByNameAscending() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "sortBy", "name");
+
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(any(), constraintsCaptor.capture()));
+    }
+
+    Assertions.assertArrayEquals(new String[] { "title" }, constraintsCaptor.getValue().getColumnsToSortBy());
+    Assertions.assertEquals("name", request.getAttribute("sortBy"));
+  }
+
+  @Test
+  void executeSortsBySizeDescending() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "sortBy", "size");
+
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(any(), constraintsCaptor.capture()));
+    }
+
+    Assertions.assertArrayEquals(new String[] { "file_length" }, constraintsCaptor.getValue().getColumnsToSortBy());
+    Assertions.assertArrayEquals(new String[] { "desc" }, constraintsCaptor.getValue().getSortOrder());
+  }
+
+  @Test
+  void executeSortsByDownloadsDescending() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "sortBy", "downloads");
+
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(any(), constraintsCaptor.capture()));
+    }
+
+    Assertions.assertArrayEquals(new String[] { "download_count" }, constraintsCaptor.getValue().getColumnsToSortBy());
+    Assertions.assertArrayEquals(new String[] { "desc" }, constraintsCaptor.getValue().getSortOrder());
+  }
+
+  @Test
+  void executeFallsBackToDateSortForAnUnrecognizedValue() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "sortBy", "not-a-real-column");
+
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(any(), constraintsCaptor.capture()));
+    }
+
+    Assertions.assertArrayEquals(new String[] { "created" }, constraintsCaptor.getValue().getColumnsToSortBy());
+    // The echoed value must be the normalized "date", not the unrecognized input -- otherwise the
+    // sort <select> in the JSP would have no matching <option> to mark selected.
+    Assertions.assertEquals("date", request.getAttribute("sortBy"));
+  }
+
+  @Test
+  void executeSearchAndSortComposeTogether() {
+    addQueryParameter(widgetContext, "folderId", "5");
+    addQueryParameter(widgetContext, "query", "report");
+    addQueryParameter(widgetContext, "sortBy", "size");
+
+    ArgumentCaptor<FileSpecification> specCaptor = ArgumentCaptor.forClass(FileSpecification.class);
+    ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+
+    try (MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<SubFolderRepository> subFolderRepo = mockStatic(SubFolderRepository.class);
+        MockedStatic<FolderCategoryRepository> categoryRepo = mockStatic(FolderCategoryRepository.class);
+        MockedStatic<FileItemRepository> fileItemRepo = mockStatic(FileItemRepository.class)) {
+      stubCommonCollaborators(folderRepo, perm, subFolderRepo, categoryRepo, 5L);
+      fileItemRepo.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      new FolderFilesListWidget().execute(widgetContext);
+
+      fileItemRepo.verify(() -> FileItemRepository.findAll(specCaptor.capture(), constraintsCaptor.capture()));
+    }
+
+    // A tsvector search (searchName) would force its own "rank DESC" ORDER BY and silently discard
+    // the caller's column sort -- this proves the plain substring search (searchTerm) is used
+    // instead, since the explicit "size" sort survives alongside it.
+    Assertions.assertEquals("report", specCaptor.getValue().getSearchTerm());
+    Assertions.assertArrayEquals(new String[] { "file_length" }, constraintsCaptor.getValue().getColumnsToSortBy());
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderListWidgetTest.java
@@ -114,4 +114,130 @@ class FolderListWidgetTest extends WidgetBase {
     List<Folder> folderListRequest = (List) request.getAttribute("folderList");
     Assertions.assertEquals(1, folderListRequest.size());
   }
+
+  @Test
+  void executeDefaultsToNameAscendingSort() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    Folder zFolder = new Folder();
+    zFolder.setId(1L);
+    zFolder.setName("Zebra Forms");
+    Folder aFolder = new Folder();
+    aFolder.setId(2L);
+    aFolder.setName("Alabama Labor Laws");
+    List<Folder> folderList = new ArrayList<>();
+    folderList.add(zFolder);
+    folderList.add(aFolder);
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals("Alabama Labor Laws", folderListRequest.get(0).getName());
+    Assertions.assertEquals("Zebra Forms", folderListRequest.get(1).getName());
+    Assertions.assertEquals("name", request.getAttribute("sort"));
+  }
+
+  @Test
+  void executeSortsByNameDescendingWhenRequested() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    Folder aFolder = new Folder();
+    aFolder.setId(1L);
+    aFolder.setName("Alabama Labor Laws");
+    Folder zFolder = new Folder();
+    zFolder.setId(2L);
+    zFolder.setName("Zebra Forms");
+    List<Folder> folderList = new ArrayList<>();
+    folderList.add(aFolder);
+    folderList.add(zFolder);
+
+    addQueryParameter(widgetContext, "sort", "name_desc");
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals("Zebra Forms", folderListRequest.get(0).getName());
+    Assertions.assertEquals("Alabama Labor Laws", folderListRequest.get(1).getName());
+  }
+
+  @Test
+  void executeSortsByFileCountDescendingWhenRequested() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    Folder fewFiles = new Folder();
+    fewFiles.setId(1L);
+    fewFiles.setName("A Folder");
+    fewFiles.setFileCount(2);
+    Folder manyFiles = new Folder();
+    manyFiles.setId(2L);
+    manyFiles.setName("B Folder");
+    manyFiles.setFileCount(50);
+    List<Folder> folderList = new ArrayList<>();
+    folderList.add(fewFiles);
+    folderList.add(manyFiles);
+
+    addQueryParameter(widgetContext, "sort", "files_desc");
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals(50, folderListRequest.get(0).getFileCount());
+    Assertions.assertEquals(2, folderListRequest.get(1).getFileCount());
+  }
+
+  @Test
+  void executeSortWorksTogetherWithQueryFilter() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"folderList\">\n" +
+        "  <title>Folders</title>\n" +
+        "</widget>");
+
+    Folder hrFormsSmall = new Folder();
+    hrFormsSmall.setId(1L);
+    hrFormsSmall.setName("HR Forms Small");
+    hrFormsSmall.setFileCount(1);
+    Folder hrFormsBig = new Folder();
+    hrFormsBig.setId(2L);
+    hrFormsBig.setName("HR Forms Big");
+    hrFormsBig.setFileCount(10);
+    Folder laborLaws = new Folder();
+    laborLaws.setId(3L);
+    laborLaws.setName("Alabama Labor Laws");
+    laborLaws.setFileCount(100);
+    List<Folder> folderList = new ArrayList<>();
+    folderList.add(hrFormsSmall);
+    folderList.add(hrFormsBig);
+    folderList.add(laborLaws);
+
+    addQueryParameter(widgetContext, "query", "HR");
+    addQueryParameter(widgetContext, "sort", "files_desc");
+
+    try (MockedStatic<FolderRepository> folderRepositoryMockedStatic = mockStatic(FolderRepository.class)) {
+      folderRepositoryMockedStatic.when(FolderRepository::findAll).thenReturn(folderList);
+      setRoles(widgetContext, ADMIN);
+      new FolderListWidget().execute(widgetContext);
+    }
+
+    List<Folder> folderListRequest = (List) request.getAttribute("folderList");
+    Assertions.assertEquals(2, folderListRequest.size());
+    Assertions.assertEquals("HR Forms Big", folderListRequest.get(0).getName());
+    Assertions.assertEquals("HR Forms Small", folderListRequest.get(1).getName());
+  }
 }


### PR DESCRIPTION
## What this covers

Tier-1 UI polish for `/admin/folders`, scoped to items 1-4 of issue #502. Everything below was verified directly against `origin/main` before changing anything -- several literal claims in the issue text turned out to be stale or not reproducible, noted explicitly.

## Verified vs. not reproducible

- **Access column readability (real issue, fixed here).** `folder-list.jsp`'s Access column rendered a loose stack of colored `<span class="label">` badges per folder-group (guest access, then each group, each with a privacy-type sub-badge, plus tiny-text `add`/`edit`/`delete` labels) with no table structure and no color differentiation between privacy types -- "All Files" and "Own Files" looked identical apart from wording. Replaced with a compact, color-coded matrix table (Who / Access / Add / Edit / Delete) per folder, plus a one-click "Edit Access" link so getting to the edit form no longer requires going through the folder-details page first.
- **No sort on `/admin/folders` (real gap, fixed here).** The page already had folder-name search; there was no sort control. Added a Name/# of Files sort dropdown that composes with the existing search.
- **No search/sort on the per-folder file list (real gap, fixed here).** `folder-files-list.jsp` had neither. Added search by filename/title and sort by name/date/size/downloads.
- **"Tiny text link" action buttons -- not reproducible.** Checked `folder-list.jsp`, `folder-form.jsp`, `folder-details.jsp`, and `sub-folder-details.jsp`: every existing action (edit, delete) already renders as a Font Awesome icon link (`fa-edit`, `fa-remove`), and `folder-files-list.jsp`'s file-row actions already use `fa-clipboard`/`fa-desktop`/`fa-download`/`fa-remove`. No plain-text action links remain anywhere in the folder admin UI. The only genuinely new "click to edit" affordance added here is the pencil icon in the redesigned Access column, which previously had no direct edit link at all (you had to open folder-details.jsp first).
- **"Training Submission folder shows Drop Box instead of file count" -- not reproducible, traced in detail.** In `folder-list.jsp` the Access column and the "# of files" column are separate, independently-rendered `<td>` cells with no shared code path. `Folder.fileCount` is a maintained integer column (`file_count`) incremented/decremented on every file save/delete via `FolderRepository.updateFileCount`/`updateFileCountForFileId`, called uniformly regardless of a group's privacy type -- there's no branch that skips or substitutes it for Drop Box (privacyType 4000) folders. There's also no responsive/stacking table CSS in this codebase that could visually reorder or merge the two columns. This looks like a misreading of the old badge stack (mistaking the "Drop Box" access-type badge for the count), which the Access column redesign above should resolve going forward.

## What was built

- `FolderListWidget.java` / `folder-list.jsp`: Access column redesigned as a compact per-folder permission matrix with color-coded privacy-type badges (Own Files / All Files / Token Only / Drop Box each get a distinct color) and a one-click Edit Access link; added a Name / # of Files sort dropdown that works alongside the existing search.
- `FolderFilesListWidget.java` / `folder-files-list.jsp`: added a search box (filename/title) and a sort dropdown (name, date, size, downloads), following the existing `FileListByFolderWidget` sortBy/sortOrder param convention. New search uses a plain substring match (`FileSpecification.searchTerm`, `FileItemRepository`) kept deliberately separate from the existing tsvector-ranked `searchName` field, since that path forces its own `rank DESC` order that would silently override an explicit column sort -- the new field composes with sort instead of fighting it.
- Widget tests for both (`FolderListWidgetTest`, new `FolderFilesListWidgetTest`) covering default sort, each sort option, the unrecognized-value fallback, and search+sort composing together.

## Out of scope (untouched, per issue #502 split)

Audit trails, file versioning, and expiration dates are separate parallel PRs in flight; nothing here touches those areas.

## Test plan

- [x] `ant compile`
- [x] `ant compile-test`
- [x] `ant compile-jsp`
- [x] `python3 tools/check-unescaped-el.py . --strict` -- 0 unallowlisted
- [x] `ant ci-test` -- BUILD SUCCESSFUL, 0 failures (full log checked for `Failures: [1-9]` and `CONTAINER-LEVEL`)