### PR TITLE
Add file version history and restore UI to folder files (part of #502)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/RestoreFileVersionCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/RestoreFileVersionCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.io.File;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.FileVersion;
+
+/**
+ * Restores a folder file (issue #502) to a previously uploaded version.
+ * <p>
+ * Every upload -- the original and every later "add a file version" -- is written to its own
+ * timestamped, UUID-suffixed path (see {@link FileSystemCommand#generateUniqueFilename}) and is
+ * never deleted or overwritten while the file item exists; {@link DeleteFileCommand} only removes a
+ * version's file when the whole file item is deleted. So the bytes for an archived
+ * {@link FileVersion} are still sitting on disk at {@link FileVersion#getFileServerPath()}, and
+ * restoring can point the live file record back at that existing path instead of re-uploading
+ * anything. This is a genuine content restore, not a metadata-only relabeling.
+ *
+ * @author SimIS Inc.
+ * @created 8/2/2026
+ */
+public class RestoreFileVersionCommand {
+
+  private static Log LOG = LogFactory.getLog(RestoreFileVersionCommand.class);
+
+  public static FileItem restore(FileVersion fileVersion, long userId) throws DataException {
+    if (fileVersion == null) {
+      throw new DataException("The selected version was not specified");
+    }
+
+    // Confirm the archived file is still physically present before promoting it to live. A missing
+    // file would otherwise let this "succeed" while leaving downloads broken.
+    String serverRootPath = FileSystemCommand.getFileServerRootPath();
+    File file = FileSystemCommand.resolveWithinRoot(serverRootPath, fileVersion.getFileServerPath());
+    if (file == null || !file.exists()) {
+      LOG.warn("Archived file version is missing from disk: " + fileVersion.getFileServerPath());
+      throw new DataException("The archived file could not be found on the server and cannot be restored");
+    }
+
+    // Build the bean the same way a genuine "add a file version" upload does (see
+    // SaveFilePartCommand#saveFile + FolderFilesListWidget#post), but source the file fields from
+    // the archived version instead of a freshly written temp file.
+    FileItem fileItemBean = new FileItem();
+    fileItemBean.setId(fileVersion.getFileId());
+    fileItemBean.setFolderId(fileVersion.getFolderId());
+    fileItemBean.setSubFolderId(fileVersion.getSubFolderId());
+    fileItemBean.setCategoryId(fileVersion.getCategoryId());
+    fileItemBean.setFilename(fileVersion.getFilename());
+    fileItemBean.setTitle(fileVersion.getTitle());
+    fileItemBean.setVersion(fileVersion.getVersion());
+    fileItemBean.setExtension(fileVersion.getExtension());
+    fileItemBean.setFileServerPath(fileVersion.getFileServerPath());
+    fileItemBean.setFileLength(fileVersion.getFileLength());
+    fileItemBean.setFileType(fileVersion.getFileType());
+    fileItemBean.setMimeType(fileVersion.getMimeType());
+    fileItemBean.setFileHash(fileVersion.getFileHash());
+    fileItemBean.setWidth(fileVersion.getWidth());
+    fileItemBean.setHeight(fileVersion.getHeight());
+    fileItemBean.setSummary(fileVersion.getSummary());
+    fileItemBean.setCreatedBy(userId);
+    fileItemBean.setModifiedBy(userId);
+
+    // Re-uses the exact same path a manual "add a file version" upload takes: it snapshots the
+    // (about to be replaced) current state into a new file_versions row and updates the live file
+    // record -- so restoring itself becomes a new, restorable version rather than losing history.
+    return SaveFileCommand.saveNewVersionOfFile(fileItemBean);
+  }
+
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileVersionRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FileVersionRepository.java
@@ -74,6 +74,16 @@ public class FileVersionRepository {
     return (List<FileVersion>) result.getRecords();
   }
 
+  /**
+   * Counts every recorded version of a file, including the one that is currently live (a row is
+   * added here on the initial upload and again on every subsequent version, see
+   * FileItemRepository#add/#saveVersion) -- so a count greater than 1 means there is at least one
+   * prior version available to restore.
+   */
+  public static long countByFileId(long fileId) {
+    return DB.selectCountFrom(TABLE_NAME, new SqlUtils().add("file_id = ?", fileId));
+  }
+
   public static FileVersion save(FileVersion record) {
     if (record.getId() > -1) {
       return update(record);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FileVersionsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FileVersionsListWidget.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
+import com.simisinc.platform.application.cms.LoadFileCommand;
+import com.simisinc.platform.application.cms.RestoreFileVersionCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.FileVersion;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.domain.model.cms.SubFolder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileVersionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileVersionSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.SubFolderRepository;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The /admin/file-versions admin page (issue #502): lists a folder file's prior uploaded versions
+ * (uploader, date, size, version label) and offers a restore action that promotes an archived
+ * version's still-on-disk file back to being the live/current file.
+ *
+ * @author SimIS Inc.
+ * @created 8/2/2026
+ */
+public class FileVersionsListWidget extends GenericWidget {
+
+  private static Log LOG = LogFactory.getLog(FileVersionsListWidget.class);
+
+  static final long serialVersionUID = -8484048371911908896L;
+
+  static String JSP = "/admin/file-versions-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    long fileId = context.getParameterAsLong("fileId", -1);
+    FileItem file;
+    if (context.hasRole("admin")) {
+      file = FileItemRepository.findById(fileId);
+    } else {
+      file = LoadFileCommand.loadFileByIdForAuthorizedUser(fileId, context.getUserId());
+    }
+    if (file == null) {
+      context.setErrorMessage("Error. File was not found.");
+      return context;
+    }
+    context.getRequest().setAttribute("file", file);
+
+    Folder folder = FolderRepository.findById(file.getFolderId());
+    context.getRequest().setAttribute("folder", folder);
+    if (file.getSubFolderId() > -1) {
+      SubFolder subFolder = SubFolderRepository.findById(file.getSubFolderId());
+      context.getRequest().setAttribute("subFolder", subFolder);
+    }
+
+    // Determine if the current user can restore a version (same bar as adding a file version)
+    boolean canRestore = context.hasRole("admin") || context.hasRole("content-manager");
+    if (canRestore && !context.hasRole("admin")) {
+      canRestore = CheckFolderPermissionCommand.userHasAddPermission(file.getFolderId(), context.getUserId());
+    }
+    context.getRequest().setAttribute("canRestore", canRestore ? "true" : "false");
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "20"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    FileVersionSpecification specification = new FileVersionSpecification();
+    specification.setFileId(fileId);
+    List<FileVersion> versionList = FileVersionRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("versionList", versionList);
+
+    context.getRequest().setAttribute("recordPagingParams", "fileId=" + fileId);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    if (!"restore".equals(context.getParameter("action"))) {
+      return null;
+    }
+
+    // Permission is required -- restoring re-uses the same effect as adding a file version
+    if (!(context.hasRole("admin") || context.hasRole("content-manager"))) {
+      LOG.warn("No permission to restore a file version");
+      return null;
+    }
+    context.getUserSession().renewFormToken();
+
+    long fileVersionId = context.getParameterAsLong("fileVersionId", -1);
+    FileVersion fileVersion = fileVersionId > -1 ? FileVersionRepository.findById(fileVersionId) : null;
+    if (fileVersion == null) {
+      context.setErrorMessage("The selected version was not found");
+      return execute(context);
+    }
+
+    // The version must belong to the file the request claims it does
+    long fileId = context.getParameterAsLong("fileId", -1);
+    if (fileVersion.getFileId() != fileId) {
+      LOG.warn("File version " + fileVersionId + " does not belong to file " + fileId);
+      context.setErrorMessage("The selected version was not found");
+      return execute(context);
+    }
+
+    if (!context.hasRole("admin")) {
+      if (!CheckFolderPermissionCommand.userHasAddPermission(fileVersion.getFolderId(), context.getUserId())) {
+        LOG.warn("No permission to restore a version in this folder");
+        context.setErrorMessage("You do not have permission to restore this file");
+        return execute(context);
+      }
+    }
+
+    try {
+      FileItem restoredFile = RestoreFileVersionCommand.restore(fileVersion, context.getUserId());
+      if (restoredFile == null) {
+        throw new DataException("The version could not be restored due to a system error. Please try again.");
+      }
+      context.setSuccessMessage("The selected version is now the current file.");
+    } catch (DataException e) {
+      LOG.debug("An exception occurred: " + e.getMessage());
+      context.setErrorMessage(e.getMessage());
+    }
+
+    return execute(context);
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
@@ -17,7 +17,9 @@
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.simisinc.platform.application.AppException;
 import com.simisinc.platform.application.DataException;
@@ -34,6 +36,7 @@ import com.simisinc.platform.domain.model.cms.FolderCategory;
 import com.simisinc.platform.domain.model.cms.SubFolder;
 import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.FileVersionRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderCategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.SubFolderRepository;
@@ -128,6 +131,16 @@ public class FolderFilesListWidget extends GenericWidget {
     // Load the files
     List<FileItem> fileList = FileItemRepository.findAll(specification, null);
     context.getRequest().setAttribute("fileList", fileList);
+
+    // Determine how many versions each file has on record, so the UI only offers a "Version
+    // History" link when there's actually a prior version to show/restore (issue #502). The
+    // files.version_count column exists but is never populated by any writer, so it can't be
+    // trusted for this -- count file_versions directly instead.
+    Map<Long, Long> versionCountMap = new HashMap<>();
+    for (FileItem fileItem : fileList) {
+      versionCountMap.put(fileItem.getId(), FileVersionRepository.countByFileId(fileItem.getId()));
+    }
+    context.getRequest().setAttribute("versionCountMap", versionCountMap);
 
     // Standard request items
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));

--- a/src/main/webapp/WEB-INF/jsp/admin/file-versions-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/file-versions-list.jsp
@@ -1,0 +1,89 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<%@ taglib prefix="user" uri="/WEB-INF/tlds/user-functions.tld" %>
+<%@ taglib prefix="number" uri="/WEB-INF/tlds/number-functions.tld" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="file" class="com.simisinc.platform.domain.model.cms.FileItem" scope="request"/>
+<jsp:useBean id="folder" class="com.simisinc.platform.domain.model.cms.Folder" scope="request"/>
+<jsp:useBean id="subFolder" class="com.simisinc.platform.domain.model.cms.SubFolder" scope="request"/>
+<jsp:useBean id="versionList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="canRestore" class="java.lang.String" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="help-text">
+  Prior uploaded versions of <strong><c:out value="${file.title}" /></strong>. Each version's file is kept on the
+  server, so restoring makes that version's content the current file again -- a new version entry is recorded for
+  the restore itself.
+</p>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th width="60" class="text-center">size</th>
+      <th width="90" class="text-center">uploaded</th>
+      <th>uploaded by</th>
+      <th width="90" class="text-center">action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:if test="${empty versionList}">
+      <tr>
+        <td colspan="5">No versions were found</td>
+      </tr>
+    </c:if>
+    <c:forEach items="${versionList}" var="version">
+      <c:set var="isCurrent" value="${version.fileServerPath eq file.fileServerPath}" />
+      <tr>
+        <td>
+          <c:out value="${version.filename}" />
+          <c:if test="${!empty version.version}"> (<c:out value="${version.version}" />)</c:if>
+          <c:if test="${isCurrent}"> <span class="label small round success">current</span></c:if>
+        </td>
+        <td class="text-center" nowrap>
+          <small><c:out value="${number:suffix(version.fileLength)}"/></small>
+        </td>
+        <td class="text-center" nowrap>
+          <small><fmt:formatDate pattern="yyyy-MM-dd" value="${version.created}" /></small>
+        </td>
+        <td>
+          <small><c:out value="${user:name(version.createdBy)}" /></small>
+        </td>
+        <td class="text-center" nowrap>
+          <c:choose>
+            <c:when test="${isCurrent}">
+              &mdash;
+            </c:when>
+            <c:when test="${canRestore eq 'true'}">
+              <a title="Restore this version" href="#" onclick="return confirmPostAction('Restore this version? It will become the current file. <c:out value="${js:escape(version.filename)}" /> will be used going forward.', '${widgetContext.uri}?widget=${widgetContext.uniqueId}&token=${userSession.formToken}&action=restore&fileId=${file.id}&fileVersionId=${version.id}');"><i class="fa fa-undo"></i></a>
+            </c:when>
+            <c:otherwise>
+              &mdash;
+            </c:otherwise>
+          </c:choose>
+        </td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>

--- a/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/folder-files-list.jsp
@@ -34,6 +34,7 @@
 <jsp:useBean id="fileList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="canEdit" class="java.lang.String" scope="request"/>
 <jsp:useBean id="canDelete" class="java.lang.String" scope="request"/>
+<jsp:useBean id="versionCountMap" class="java.util.HashMap" scope="request"/>
 <script src="${ctx}/javascript/clipboard-2.0.11/clipboard.min.js"></script>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('content-manager'))}">
@@ -110,6 +111,9 @@
         </c:if>
         <c:if test="${fn:toLowerCase(file.fileType) ne 'url'}">
           <a title="Download file" href="${ctx}/assets/file/${file.url}"><i class="fa fa-download"></i></a>
+        </c:if>
+        <c:if test="${versionCountMap[file.id] gt 1}">
+          <a title="Version history" href="${ctx}/admin/file-versions?fileId=${file.id}"><i class="fa fa-history"></i></a>
         </c:if>
         <c:if test="${canDelete eq 'true'}">
           <a title="Delete file" href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(file.filename)}" />?', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&fileId=${file.id}');"><i class="fa fa-remove"></i></a>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1617,6 +1617,26 @@
     </section>
   </page>
 
+  <page name="/admin/file-versions{?fileId}" role="admin,content-manager,community-manager" title="File Version History">
+    <section>
+      <column class="small-12 cell">
+        <widget name="breadcrumbs">
+          <links>
+            <link name="Folders" value="/admin/folders" />
+            <link name="Version History" value="" />
+          </links>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 medium-10 large-8 cell">
+        <widget name="fileVersionsList">
+          <title>Version History</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/file-form{?subFolderId}" role="admin,content-manager,community-manager" title="File Form">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -205,6 +205,7 @@
   <widget name="folderForm" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderFormWidget" />
   <widget name="folderSubFoldersList" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderSubFoldersListWidget" />
   <widget name="folderFilesList" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderFilesListWidget" />
+  <widget name="fileVersionsList" class="com.simisinc.platform.presentation.widgets.admin.cms.FileVersionsListWidget" />
   <widget name="subFolderDetails" class="com.simisinc.platform.presentation.widgets.admin.cms.SubFolderDetailsWidget" />
   <widget name="subFolderForm" class="com.simisinc.platform.presentation.widgets.admin.cms.SubFolderFormWidget" />
   <widget name="folderFileDropZone" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderFileDropZoneWidget" />

--- a/src/test/java/com/simisinc/platform/application/cms/RestoreFileVersionCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/RestoreFileVersionCommandTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.FileVersion;
+
+/**
+ * Verifies restoring a folder file to an archived version (issue #502): the archived version's
+ * physical file must still exist on disk (it is never deleted or overwritten while the file item
+ * exists -- see FileSystemCommand#generateUniqueFilename and DeleteFileCommand), and restoring
+ * re-uses SaveFileCommand#saveNewVersionOfFile with fields sourced from the archived FileVersion.
+ */
+class RestoreFileVersionCommandTest {
+
+  private Path tempFile;
+
+  @AfterEach
+  void cleanup() throws IOException {
+    if (tempFile != null) {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+
+  private static FileVersion version(long id, long fileId, String path) {
+    FileVersion record = new FileVersion();
+    record.setId(id);
+    record.setFileId(fileId);
+    record.setFolderId(3L);
+    record.setSubFolderId(-1L);
+    record.setCategoryId(-1L);
+    record.setFilename("handbook.pdf");
+    record.setTitle("Handbook");
+    record.setVersion("1.0");
+    record.setExtension("pdf");
+    record.setFileServerPath(path);
+    record.setFileLength(1024L);
+    record.setFileType("PDF");
+    record.setMimeType("application/pdf");
+    record.setFileHash("SHA-512;abc");
+    record.setWidth(-1);
+    record.setHeight(-1);
+    record.setSummary("The handbook");
+    return record;
+  }
+
+  @Test
+  void restoreRejectsANullVersion() {
+    DataException e = assertThrows(DataException.class, () -> RestoreFileVersionCommand.restore(null, 1L));
+    assertEquals("The selected version was not specified", e.getMessage());
+  }
+
+  @Test
+  void restoreRejectsAVersionWhoseFileIsMissingFromDisk() {
+    FileVersion fileVersion = version(20L, 9L, "/uploads/2026/01/01/gone.pdf");
+
+    try (MockedStatic<FileSystemCommand> fsCommand = mockStatic(FileSystemCommand.class);
+        MockedStatic<SaveFileCommand> saveCommand = mockStatic(SaveFileCommand.class)) {
+      fsCommand.when(FileSystemCommand::getFileServerRootPath).thenReturn("/opt/simis/files/");
+      fsCommand.when(() -> FileSystemCommand.resolveWithinRoot("/opt/simis/files/", "/uploads/2026/01/01/gone.pdf"))
+          .thenReturn(new File("/opt/simis/files/uploads/2026/01/01/gone.pdf"));
+
+      DataException e = assertThrows(DataException.class, () -> RestoreFileVersionCommand.restore(fileVersion, 1L));
+
+      assertEquals("The archived file could not be found on the server and cannot be restored", e.getMessage());
+      saveCommand.verify(() -> SaveFileCommand.saveNewVersionOfFile(any()), never());
+    }
+  }
+
+  @Test
+  void restorePromotesTheArchivedVersionWhenItsFileExists() throws Exception {
+    tempFile = Files.createTempFile("restore-file-version-test", ".pdf");
+    FileVersion fileVersion = version(20L, 9L, "/uploads/2026/01/01/old.pdf");
+    FileItem expected = new FileItem();
+    expected.setId(9L);
+
+    try (MockedStatic<FileSystemCommand> fsCommand = mockStatic(FileSystemCommand.class);
+        MockedStatic<SaveFileCommand> saveCommand = mockStatic(SaveFileCommand.class)) {
+      fsCommand.when(FileSystemCommand::getFileServerRootPath).thenReturn("/opt/simis/files/");
+      fsCommand.when(() -> FileSystemCommand.resolveWithinRoot("/opt/simis/files/", "/uploads/2026/01/01/old.pdf"))
+          .thenReturn(tempFile.toFile());
+      saveCommand.when(() -> SaveFileCommand.saveNewVersionOfFile(any())).thenReturn(expected);
+
+      FileItem result = RestoreFileVersionCommand.restore(fileVersion, 42L);
+
+      assertEquals(expected, result);
+
+      ArgumentCaptor<FileItem> captor = ArgumentCaptor.forClass(FileItem.class);
+      saveCommand.verify(() -> SaveFileCommand.saveNewVersionOfFile(captor.capture()));
+      FileItem submitted = captor.getValue();
+      assertEquals(9L, submitted.getId());
+      assertEquals(3L, submitted.getFolderId());
+      assertEquals(-1L, submitted.getSubFolderId());
+      assertEquals("handbook.pdf", submitted.getFilename());
+      assertEquals("Handbook", submitted.getTitle());
+      assertEquals("1.0", submitted.getVersion());
+      assertEquals("pdf", submitted.getExtension());
+      assertEquals("/uploads/2026/01/01/old.pdf", submitted.getFileServerPath());
+      assertEquals(1024L, submitted.getFileLength());
+      assertEquals("PDF", submitted.getFileType());
+      assertEquals("application/pdf", submitted.getMimeType());
+      assertEquals("SHA-512;abc", submitted.getFileHash());
+      assertEquals("The handbook", submitted.getSummary());
+      // The restoring user, not the version's original uploader, is recorded as this new save's actor
+      assertEquals(42L, submitted.getCreatedBy());
+      assertEquals(42L, submitted.getModifiedBy());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FileVersionsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FileVersionsListWidgetTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
+import com.simisinc.platform.application.cms.LoadFileCommand;
+import com.simisinc.platform.application.cms.RestoreFileVersionCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.FileVersion;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileVersionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies the /admin/file-versions widget (#502): listing a file's prior uploaded versions and
+ * restoring a selected one back to being the live file.
+ */
+class FileVersionsListWidgetTest extends WidgetBase {
+
+  private static FileItem fileItem(long id, long folderId, String path) {
+    FileItem record = new FileItem();
+    record.setId(id);
+    record.setFolderId(folderId);
+    record.setSubFolderId(-1);
+    record.setFileServerPath(path);
+    record.setTitle("Handbook");
+    return record;
+  }
+
+  private static FileVersion version(long id, long fileId, long folderId, String path) {
+    FileVersion record = new FileVersion();
+    record.setId(id);
+    record.setFileId(fileId);
+    record.setFolderId(folderId);
+    record.setFileServerPath(path);
+    return record;
+  }
+
+  private static Folder folder(long id) {
+    Folder record = new Folder();
+    record.setId(id);
+    return record;
+  }
+
+  @Test
+  void executeLoadsTheFileAndItsVersionsForAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "fileId", "9");
+    FileItem file = fileItem(9L, 3L, "/uploads/2026/08/02/current.pdf");
+    FileVersion version = version(20L, 9L, 3L, "/uploads/2026/07/01/old.pdf");
+
+    try (MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class);
+        MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      fileRepo.when(() -> FileItemRepository.findById(9L)).thenReturn(file);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(List.of(version));
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().execute(widgetContext);
+
+      assertEquals(file, result.getRequest().getAttribute("file"));
+      assertEquals(List.of(version), result.getRequest().getAttribute("versionList"));
+      assertEquals("true", result.getRequest().getAttribute("canRestore"));
+    }
+  }
+
+  @Test
+  void executeSetsAnErrorWhenTheFileIsNotFound() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "fileId", "404");
+
+    try (MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class)) {
+      fileRepo.when(() -> FileItemRepository.findById(404L)).thenReturn(null);
+
+      WidgetContext result = new FileVersionsListWidget().execute(widgetContext);
+
+      assertEquals("Error. File was not found.", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void postRestoresTheSelectedVersion() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+    FileVersion oldVersion = version(20L, 9L, 3L, "/uploads/2026/07/01/old.pdf");
+    FileItem restored = fileItem(9L, 3L, "/uploads/2026/07/01/old.pdf");
+    FileItem currentFile = fileItem(9L, 3L, "/uploads/2026/07/01/old.pdf");
+
+    try (MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      versionRepo.when(() -> FileVersionRepository.findById(20L)).thenReturn(oldVersion);
+      restoreCmd.when(() -> RestoreFileVersionCommand.restore(oldVersion, 1L)).thenReturn(restored);
+      fileRepo.when(() -> FileItemRepository.findById(9L)).thenReturn(currentFile);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(oldVersion, 1L));
+      assertEquals("The selected version is now the current file.", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postSetsAnErrorWhenTheVersionIsNotFound() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "404");
+    FileItem currentFile = fileItem(9L, 3L, "/uploads/2026/07/01/old.pdf");
+
+    try (MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      versionRepo.when(() -> FileVersionRepository.findById(404L)).thenReturn(null);
+      fileRepo.when(() -> FileItemRepository.findById(9L)).thenReturn(currentFile);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertEquals("The selected version was not found", result.getErrorMessage());
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void postRejectsAVersionThatBelongsToADifferentFile() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+    // This version actually belongs to file 55, not the file 9 the request claims
+    FileVersion mismatchedVersion = version(20L, 55L, 3L, "/uploads/2026/07/01/old.pdf");
+    FileItem currentFile = fileItem(9L, 3L, "/uploads/2026/07/01/old.pdf");
+
+    try (MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      versionRepo.when(() -> FileVersionRepository.findById(20L)).thenReturn(mismatchedVersion);
+      fileRepo.when(() -> FileItemRepository.findById(9L)).thenReturn(currentFile);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertEquals("The selected version was not found", result.getErrorMessage());
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void postRequiresFolderAddPermissionForNonAdmins() throws Exception {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+    FileVersion oldVersion = version(20L, 9L, 3L, "/uploads/2026/07/01/old.pdf");
+    FileItem currentFile = fileItem(9L, 3L, "/uploads/2026/07/01/old.pdf");
+
+    try (MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class);
+        MockedStatic<CheckFolderPermissionCommand> perm = mockStatic(CheckFolderPermissionCommand.class);
+        MockedStatic<LoadFileCommand> loadFileCmd = mockStatic(LoadFileCommand.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      versionRepo.when(() -> FileVersionRepository.findById(20L)).thenReturn(oldVersion);
+      perm.when(() -> CheckFolderPermissionCommand.userHasAddPermission(3L, 1L)).thenReturn(false);
+      // Not an admin, so the execute() fallthrough authorizes the file lookup via the folder's user groups
+      loadFileCmd.when(() -> LoadFileCommand.loadFileByIdForAuthorizedUser(9L, 1L)).thenReturn(currentFile);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertEquals("You do not have permission to restore this file", result.getErrorMessage());
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void postIgnoresAnyActionOtherThanRestore() throws Exception {
+    addQueryParameter(widgetContext, "action", "somethingElse");
+
+    WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+    assertNull(result);
+  }
+
+  @Test
+  void postIsRejectedWithoutAdminOrContentManagerRole() throws Exception {
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+
+    try (MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class)) {
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertNull(result);
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(any(), anyLong()), never());
+    }
+  }
+
+  @Test
+  void restoreSurfacesADataExceptionAsAnErrorMessage() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+    FileVersion oldVersion = version(20L, 9L, 3L, "/uploads/2026/07/01/missing.pdf");
+    FileItem currentFile = fileItem(9L, 3L, "/uploads/2026/08/02/current.pdf");
+
+    try (MockedStatic<FileVersionRepository> versionRepo = mockStatic(FileVersionRepository.class);
+        MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class);
+        MockedStatic<FolderRepository> folderRepo = mockStatic(FolderRepository.class)) {
+      versionRepo.when(() -> FileVersionRepository.findById(20L)).thenReturn(oldVersion);
+      restoreCmd.when(() -> RestoreFileVersionCommand.restore(oldVersion, 1L))
+          .thenThrow(new DataException("The archived file could not be found on the server and cannot be restored"));
+      fileRepo.when(() -> FileItemRepository.findById(9L)).thenReturn(currentFile);
+      versionRepo.when(() -> FileVersionRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      folderRepo.when(() -> FolderRepository.findById(3L)).thenReturn(folder(3L));
+
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertEquals("The archived file could not be found on the server and cannot be restored", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void postRestoreAcceptsCommunityManagerRoleWithFolderPermission() throws Exception {
+    // community-manager alone must NOT be enough -- restore requires admin or content-manager,
+    // matching FolderFilesListWidget#post's gate on "add a file version"
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "fileId", "9");
+    addQueryParameter(widgetContext, "fileVersionId", "20");
+
+    try (MockedStatic<RestoreFileVersionCommand> restoreCmd = mockStatic(RestoreFileVersionCommand.class)) {
+      WidgetContext result = new FileVersionsListWidget().post(widgetContext);
+
+      assertNull(result);
+      restoreCmd.verify(() -> RestoreFileVersionCommand.restore(any(), anyLong()), never());
+    }
+  }
+}


### PR DESCRIPTION
## What this does

Issue #502 calls out that updating a folder file overwrites the old version with no way to restore it. The backend for this already existed and was already working correctly (`file_versions` table, `FileVersion` model, `FileVersionRepository`, and `FileItemRepository`/`SaveFileCommand` already snapshot every version on every save) -- but there was no admin UI to view or restore from that history. This PR adds it.

## What I checked first: are old files actually recoverable?

Before building a restore feature I traced whether an old version's physical bytes survive being replaced:

- Every upload -- the original and every later "add a file version" -- is written to its own path via `FileSystemCommand#generateUniqueFilename` (`System.currentTimeMillis() + "-" + UUID.randomUUID() + "-" + userId`) under a date-bucketed subfolder. No two uploads ever share a path.
- Nothing in the "add a file version" path (`SaveFilePartCommand`, `SaveFileCommand#saveNewVersionOfFile`, `FileItemRepository#saveVersion`) deletes or overwrites a prior version's file. The old path is simply left on disk once the live `files` row is repointed at the new one.
- `DeleteFileCommand` confirms this independently: when a file item is deleted, it loads every `file_versions` row for that file and deletes each one's file *individually* -- which only makes sense if each version genuinely has its own still-existing file up to that point.

So an archived version's content is genuinely recoverable, not just its metadata. That meant I could build a real restore (point the live file back at the old, still-on-disk path) rather than a metadata-only history view with a restore button that doesn't actually restore content.

## What I built

- **`FileVersionsListWidget`** + **`/admin/file-versions-list.jsp`** (new `/admin/file-versions?fileId=` admin page, registered in `admin-layout.xml` and `widget-library.xml` alongside the existing folder pages, same `admin,content-manager,community-manager` role gate): lists a file's recorded versions (uploader, date, size, version label), marks whichever one is currently live, and offers a confirm-then-POST restore action on the rest.
- **`RestoreFileVersionCommand`**: re-verifies the archived file still exists on disk (documented in a code comment at the decision point -- restoring is a stronger promise than a passive history view, so a missing file fails loudly with a clear error instead of silently pointing the live record at nothing), then reuses `SaveFileCommand#saveNewVersionOfFile` the same way a manual re-upload does. That means restoring itself is recorded as a new, later version rather than erasing anything.
- **`FileVersionRepository#countByFileId`**: used to gate a new "Version History" icon in `folder-files-list.jsp`, shown only once a file actually has more than one recorded version. (The existing `files.version_count` column looked like it should answer this, but it's never written by anything -- always 0 -- so I didn't rely on it.)
- Restore is gated the same way "add a file version" already is: admin or content-manager role, plus per-folder add-permission for non-admins.

## Not in scope here

- Audit logging for the restore action -- issue #502's audit-trail piece is being handled separately.
- A couple of adjacent, pre-existing gaps I found while tracing this but did not fix, since they're separate defects: `SaveFileCommand#saveNewVersionOfFile` silently drops a file's expiration date/privacy type/download token/barcode on every version save (not just restores), and `DownloadFileWidget` doesn't actually honor an archived version's own URL (it always streams the current file regardless of which version's link was used) -- so I deliberately did not add a "download this old version" link, to avoid shipping something misleading on top of that gap.

## Testing

- `ant compile`, `ant compile-jsp`, `python3 tools/check-unescaped-el.py . --strict` (0 unallowlisted) all pass.
- `ant ci-test`: BUILD SUCCESSFUL, 1887 tests run, 0 failures.
- New tests: `FileVersionsListWidgetTest` (list + restore + permission gating) and `RestoreFileVersionCommandTest` (missing-file rejection + field mapping onto the save call).