### PR TITLE
Widen webhook delivery retry backoff to span ~24 hours

### DIFF
--- a/src/main/java/com/simisinc/platform/application/webhooks/AttemptWebhookDeliveryCommand.java
+++ b/src/main/java/com/simisinc/platform/application/webhooks/AttemptWebhookDeliveryCommand.java
@@ -42,11 +42,14 @@ import com.simisinc.platform.infrastructure.scheduler.webhooks.WebhookDeliveryAt
  * #418).
  *
  * <p>
- * The backoff schedule -- 5s, 30s, 5m, 30m before attempts 2 through 5, then exhausted -- is
- * genuinely new scheduling in this codebase: nothing else here does multi-attempt backoff for
- * outbound HTTP (checked {@code ZeroBounceApiClientCommand}, {@code MailChimpCommand} -- both
- * single-attempt), and JobRunr's own {@code retries=N} job annotation is a single fixed
- * whole-job retry count, not a backoff schedule. Each retry is instead a fresh
+ * The backoff schedule -- 10m, 50m, 3h, 20h before attempts 2 through 5, then exhausted, spanning
+ * ~24 hours from the first attempt to the fifth and final one (issue #418's Scope section calls
+ * for "max 5 attempts over ~24 hours" so a receiver down for a deploy window or a brief outage
+ * still gets retried after it recovers) -- is genuinely new scheduling in this codebase: nothing
+ * else here does multi-attempt backoff for outbound HTTP (checked {@code
+ * ZeroBounceApiClientCommand}, {@code MailChimpCommand} -- both single-attempt), and JobRunr's
+ * own {@code retries=N} job annotation is a single fixed whole-job retry count, not a backoff
+ * schedule. Each retry is instead a fresh
  * {@link WebhookDeliveryAttemptJob} scheduled via {@code BackgroundJobRequest.schedule(Instant,
  * ...)} at the row's own {@code next_retry_at} -- this job's {@code @Job(retries = 1)} means
  * JobRunr itself never auto-retries; every retry decision is made here, once, from the
@@ -81,8 +84,13 @@ public class AttemptWebhookDeliveryCommand {
 
   public static final int MAX_ATTEMPTS = 5;
 
-  /** Delay, in seconds, before attempts 2 through 5 -- 5s, 30s, 5m, 30m (issue #418 / #456). */
-  static final long[] BACKOFF_SECONDS = { 5, 30, 300, 1800 };
+  /**
+   * Delay, in seconds, before attempts 2 through 5 -- 10m, 50m, 3h, 20h, i.e. cumulative offsets
+   * of 10m, 1h, 4h, 24h from the first attempt -- so the fifth and final attempt lands roughly a
+   * full day after the first, per issue #418's "max 5 attempts over ~24 hours" (issue #418 /
+   * #456).
+   */
+  static final long[] BACKOFF_SECONDS = { 600, 3000, 10800, 72000 };
 
   private static final int RESPONSE_SNIPPET_MAX_LENGTH = 500;
 

--- a/src/test/java/com/simisinc/platform/application/webhooks/AttemptWebhookDeliveryCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/webhooks/AttemptWebhookDeliveryCommandTest.java
@@ -68,9 +68,10 @@ import com.simisinc.platform.infrastructure.persistence.webhooks.WebhookSubscrip
 /**
  * Verifies {@link AttemptWebhookDeliveryCommand}'s retry/backoff schedule and idempotency
  * (issue #418 / #456): a failed attempt is rescheduled at roughly the right backoff interval
- * (5s, 30s, 5m, 30m), and the 5th failed attempt is marked {@code exhausted} rather than
- * retried forever. {@link AttemptWebhookDeliveryCommand#scheduleRetry} is swapped out so this
- * never touches the real JobRunr scheduler (which is not configured in a plain unit test).
+ * (10m, 50m, 3h, 20h -- cumulative offsets of 10m, 1h, 4h, 24h from the first attempt), and the
+ * 5th failed attempt is marked {@code exhausted} rather than retried forever.
+ * {@link AttemptWebhookDeliveryCommand#scheduleRetry} is swapped out so this never touches the
+ * real JobRunr scheduler (which is not configured in a plain unit test).
  */
 class AttemptWebhookDeliveryCommandTest {
 
@@ -204,7 +205,7 @@ class AttemptWebhookDeliveryCommandTest {
     assertEquals(WebhookDelivery.FAILED, found.getStatus());
     assertEquals(1, found.getAttemptCount());
     assertEquals(1, scheduledRetryInstants.size());
-    assertWithinTolerance(scheduledRetryInstants.get(0), Duration.ofSeconds(5));
+    assertWithinTolerance(scheduledRetryInstants.get(0), Duration.ofMinutes(10));
   }
 
   @Test
@@ -212,21 +213,21 @@ class AttemptWebhookDeliveryCommandTest {
     long subscriptionId = seedSubscription("https://example.com/hooks", "secret-abc");
     WebhookDelivery delivery = seedDelivery(subscriptionId);
 
-    // Attempt 1 -> failed, retry in ~5s
+    // Attempt 1 -> failed, retry in ~10m
     attemptWithStatus(delivery.getId(), 500, "err");
-    assertWithinTolerance(scheduledRetryInstants.get(0), Duration.ofSeconds(5));
+    assertWithinTolerance(scheduledRetryInstants.get(0), Duration.ofMinutes(10));
 
-    // Attempt 2 -> failed, retry in ~30s
+    // Attempt 2 -> failed, retry in ~50m
     attemptWithStatus(delivery.getId(), 500, "err");
-    assertWithinTolerance(scheduledRetryInstants.get(1), Duration.ofSeconds(30));
+    assertWithinTolerance(scheduledRetryInstants.get(1), Duration.ofMinutes(50));
 
-    // Attempt 3 -> failed, retry in ~5m
+    // Attempt 3 -> failed, retry in ~3h
     attemptWithStatus(delivery.getId(), 500, "err");
-    assertWithinTolerance(scheduledRetryInstants.get(2), Duration.ofMinutes(5));
+    assertWithinTolerance(scheduledRetryInstants.get(2), Duration.ofHours(3));
 
-    // Attempt 4 -> failed, retry in ~30m
+    // Attempt 4 -> failed, retry in ~20h -- the final scheduled retry lands ~24h after attempt 1
     attemptWithStatus(delivery.getId(), 500, "err");
-    assertWithinTolerance(scheduledRetryInstants.get(3), Duration.ofMinutes(30));
+    assertWithinTolerance(scheduledRetryInstants.get(3), Duration.ofHours(20));
 
     // Attempt 5 -> failed, exhausted -- no 6th retry scheduled
     attemptWithStatus(delivery.getId(), 500, "err");


### PR DESCRIPTION
Fixes #418.

## Summary

`AttemptWebhookDeliveryCommand.BACKOFF_SECONDS = {5, 30, 300, 1800}` exhausted all 5 attempts in ~36 minutes, but issue #418's Scope section explicitly requires "max 5 attempts over ~24 hours."

**Fix:** widened the same 4 retry gaps (no new mechanism — reused the existing `Instant`-based scheduling):
- gap before attempt 2: 5s → 10m
- gap before attempt 3: 30s → 50m
- gap before attempt 4: 5m → 3h
- gap before attempt 5 (final): 30m → 20h
- cumulative offset from attempt 1: ~36m → 10m / 1h / 4h / **24h**

Single self-contained change — confirmed via grep that no other file references the old backoff numbers.

## Test plan
- `AttemptWebhookDeliveryCommandTest` updated to match
- Full `ant ci-test` — BUILD SUCCESSFUL, 0 failures
