### PR TITLE
Fix rolling-deploy.sh: provision the staging slot, stop guessing which slot is active

### DIFF
--- a/docs/rolling-deploy-workflow.md
+++ b/docs/rolling-deploy-workflow.md
@@ -64,13 +64,18 @@ The `AZURE_*` variables are already configured for ACR login. Reuse them for the
 
 ## Process: Behind the Scenes
 
-### Step 1: Identify slots
+### Step 1: Ensure the staging slot exists
 
-The script checks which slot is currently active:
-- If staging exists and is healthy → production is next (deploy to production, then swap)
-- If staging is absent or old → staging is next (deploy to staging, then swap)
+`production` is the App Service's implicit default slot: it always exists, is never returned by `az webapp deployment slot list`, and can't be created or deleted — only swapped into. `staging` is the only extra slot this workflow uses, and new code always lands there first; production is only ever reached through the health-checked swap in Step 4. There is no path in the routine deploy flow that writes to production directly.
 
-**Idempotency:** Re-running after a partial failure picks up the correct target slot based on current state.
+The staging slot does not persist between deploys — Step 6 deletes it after every successful swap — so this step (re)creates it unconditionally, cloning settings from production:
+```bash
+az webapp deployment slot create \
+  --slot staging \
+  --configuration-source "$APP_SERVICE_NAME"
+```
+
+**Idempotency:** this is safe to run every time regardless of current state — whether staging is missing (first-ever run, or after a normal cleanup) or already present (a prior cleanup failed and left it behind, in which case it's reused as-is and its content is about to be overwritten in Step 2 anyway).
 
 ### Step 2: Deploy image
 
@@ -188,17 +193,18 @@ For combined app + infrastructure deploys, update Bicep first, then push code.
 
 ### Re-running a partial deploy is safe
 
-**Scenario:** Slot swap succeeded, but cleanup script crashed.
+The workflow never tries to auto-detect "which slot is active" — that question doesn't need answering. `production` is always the stable slot bound to the public hostname; `staging` is always the deploy target, unconditionally (re)created in Step 1 if it isn't already there. This holds regardless of how the previous run ended:
 
-**Result:** Old slot still exists. Re-running the workflow:
-1. Detects old slot is now "staging"
-2. Treats it as the current active slot
-3. Deploys to "production" (which is now staging's contents)
-4. Health check passes
-5. Swaps back to "staging" (old → new)
-6. Deletes the new slot (which is really the old one)
+**Scenario: previous run completed cleanly.**
+Staging was deleted in its Step 6. This run's Step 1 recreates it from production's current config, deploys the new image, health-checks it, swaps, and deletes it again.
 
-**Net effect:** Correct slot is active; orphaned slots cleaned up.
+**Scenario: previous run's slot swap succeeded, but cleanup (Step 6) crashed or was killed.**
+Staging is still sitting there holding the pre-swap (old) build. This run's Step 1 finds it already exists and reuses it as-is — its stale content is irrelevant, since Step 2 immediately overwrites it with the new image before anything reads from it.
+
+**Scenario: previous run's health check failed and rollback deleted staging, then the run exited.**
+Same as a clean completion — staging is absent, Step 1 recreates it.
+
+In every case, staging is the only slot ever written to before a swap, staging is always health-checked before the swap happens, and production is only ever changed by the swap itself — never by a direct write. There is no fallback path where a routine deploy pushes new code straight onto production; a swap-then-health-check failure is handled by the rollback block deleting/recreating staging, not by mutating production in place.
 
 ### Connection drain is sufficient
 

--- a/tools/rolling-deploy.sh
+++ b/tools/rolling-deploy.sh
@@ -76,77 +76,66 @@ log "  Health check timeout: ${HEALTH_CHECK_TIMEOUT}s"
 log "  Drain timeout: ${DRAIN_TIMEOUT}s"
 
 # ============================================================================
-# Step 1: Identify current and next slots
+# Step 1: Ensure the staging slot exists
 # ============================================================================
 
-log "Step 1: Identifying current slots..."
+log "Step 1: Ensuring staging slot exists..."
 
-# Get all slots
+# "production" is the App Service's implicit default slot: it is never
+# listed by `deployment slot list` and can't be created or deleted, only
+# swapped into. "staging" is the only extra slot this workflow uses, and
+# it does not persist between deploys -- Step 6 deletes it after every
+# successful swap (cost control), so on a normal run it needs to be
+# (re)created here. This is intentionally unconditional and idempotent:
+# safe whether staging is missing (first run, or after cleanup) or already
+# present (a prior cleanup failed and left it behind).
 SLOTS=$(az webapp deployment slot list \
   --resource-group "$RESOURCE_GROUP" \
   --name "$APP_SERVICE_NAME" \
   --query "[].name" \
   --output tsv 2>/dev/null || echo "")
 
-# Slots are: production (implicit), staging (explicit)
-# If staging exists and is active, production must be old
-STAGING_EXISTS=0
-if echo "$SLOTS" | grep -q "staging"; then
-  STAGING_EXISTS=1
-fi
-
-if [[ $STAGING_EXISTS -eq 1 ]]; then
-  ACTIVE_SLOT="staging"
-  NEXT_SLOT="production"
-  log "  Current active: staging (swap target: production)"
+if echo "$SLOTS" | grep -qx "staging"; then
+  log "  staging slot already exists"
 else
-  ACTIVE_SLOT="production"
-  NEXT_SLOT="staging"
-  log "  Current active: production (swap target: staging)"
-fi
-
-# Get the FQDN for health checks
-if [[ "$NEXT_SLOT" == "staging" ]]; then
-  NEXT_FQDN=$(az webapp show \
+  log "  staging slot not found; creating it (cloning settings from production)..."
+  az webapp deployment slot create \
     --resource-group "$RESOURCE_GROUP" \
     --name "$APP_SERVICE_NAME" \
     --slot staging \
-    --query "defaultHostName" \
-    --output tsv)
-  OLD_SLOT="production"
-else
-  NEXT_FQDN=$(az webapp show \
-    --resource-group "$RESOURCE_GROUP" \
-    --name "$APP_SERVICE_NAME" \
-    --query "defaultHostName" \
-    --output tsv)
-  OLD_SLOT="staging"
+    --configuration-source "$APP_SERVICE_NAME" \
+    2>/dev/null || die "Failed to create staging slot"
+  log "  ✓ staging slot created"
 fi
 
-log "  Deploying to: $NEXT_SLOT (FQDN: $NEXT_FQDN)"
+NEXT_FQDN=$(az webapp show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$APP_SERVICE_NAME" \
+  --slot staging \
+  --query "defaultHostName" \
+  --output tsv)
+
+log "  Deploying to: staging (FQDN: $NEXT_FQDN)"
 
 # ============================================================================
-# Step 2: Deploy new image to staging/next slot
+# Step 2: Deploy new image to the staging slot
 # ============================================================================
+#
+# New code always lands on staging first, and only ever reaches production
+# via the health-checked swap in Step 4. There is no direct-to-production
+# path in the routine deploy flow: that would skip the health check and the
+# rollback safety net entirely, which is exactly the stop-replace-restart
+# failure mode this script exists to eliminate.
 
-log "Step 2: Deploying new image to $NEXT_SLOT..."
+log "Step 2: Deploying new image to staging..."
 
-if [[ "$NEXT_SLOT" == "staging" ]]; then
-  az webapp config container set \
-    --resource-group "$RESOURCE_GROUP" \
-    --name "$APP_SERVICE_NAME" \
-    --slot staging \
-    --docker-custom-image-name "$IMAGE_URI" \
-    --docker-registry-server-url "https://$(echo "$IMAGE_URI" | cut -d'/' -f1)" \
-    2>/dev/null || die "Failed to deploy image to staging slot"
-else
-  az webapp config container set \
-    --resource-group "$RESOURCE_GROUP" \
-    --name "$APP_SERVICE_NAME" \
-    --docker-custom-image-name "$IMAGE_URI" \
-    --docker-registry-server-url "https://$(echo "$IMAGE_URI" | cut -d'/' -f1)" \
-    2>/dev/null || die "Failed to deploy image to production slot"
-fi
+az webapp config container set \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$APP_SERVICE_NAME" \
+  --slot staging \
+  --docker-custom-image-name "$IMAGE_URI" \
+  --docker-registry-server-url "https://$(echo "$IMAGE_URI" | cut -d'/' -f1)" \
+  2>/dev/null || die "Failed to deploy image to staging slot"
 
 log "  Deployment queued. Container pulling..."
 
@@ -179,38 +168,36 @@ done
 
 if [[ $HEALTH_CHECK_PASSED -eq 0 ]]; then
   log "❌ Health check FAILED (timeout after ${HEALTH_CHECK_TIMEOUT}s)"
-  log "Initiating rollback: deleting $NEXT_SLOT slot..."
+  log "Initiating rollback: deleting staging slot (production was never touched)..."
 
-  if [[ "$NEXT_SLOT" == "staging" ]]; then
-    az webapp deployment slot delete \
-      --resource-group "$RESOURCE_GROUP" \
-      --name "$APP_SERVICE_NAME" \
-      --slot staging \
-      --yes 2>/dev/null || log "  Warning: failed to delete staging slot"
-  fi
+  az webapp deployment slot delete \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$APP_SERVICE_NAME" \
+    --slot staging \
+    --yes 2>/dev/null || log "  Warning: failed to delete staging slot"
 
-  die "Health check failed; rolled back $NEXT_SLOT deployment"
+  die "Health check failed; rolled back staging deployment"
 fi
 
 # ============================================================================
 # Step 4: Swap slots (traffic redirect)
 # ============================================================================
 
-log "Step 4: Swapping slots ($OLD_SLOT ↔ $NEXT_SLOT)..."
+log "Step 4: Swapping slots (production ↔ staging)..."
 
 az webapp deployment slot swap \
   --resource-group "$RESOURCE_GROUP" \
   --name "$APP_SERVICE_NAME" \
-  --slot "$NEXT_SLOT" \
+  --slot staging \
   2>/dev/null || die "Failed to swap slots"
 
-log "  ✓ Slot swap complete (traffic now on $NEXT_SLOT)"
+log "  ✓ Slot swap complete (traffic now on production; staging holds the previous build)"
 
 # ============================================================================
 # Step 5: Connection drain window
 # ============================================================================
 
-log "Step 5: Draining old instance ($OLD_SLOT) for ${DRAIN_TIMEOUT}s..."
+log "Step 5: Draining old instance (now sitting in staging) for ${DRAIN_TIMEOUT}s..."
 
 sleep "$DRAIN_TIMEOUT"
 
@@ -220,27 +207,28 @@ log "  ✓ Drain window complete"
 # Step 6: Clean up old slot
 # ============================================================================
 
-if [[ "$OLD_SLOT" == "staging" ]]; then
-  log "Step 6: Deleting old $OLD_SLOT slot (cleanup)..."
+# After a successful swap, staging unconditionally holds the pre-swap
+# (now old) build -- Azure swap semantics move content between slot
+# objects, not hostnames, so this is never in doubt and never needs
+# detection. Delete it so the next run starts from a clean, idempotent
+# Step 1 (recreate staging, deploy, health-check, swap).
+log "Step 6: Deleting staging slot (now holds the pre-swap build; cleanup)..."
 
-  az webapp deployment slot delete \
-    --resource-group "$RESOURCE_GROUP" \
-    --name "$APP_SERVICE_NAME" \
-    --slot staging \
-    --yes \
-    2>/dev/null || log "  Warning: failed to delete $OLD_SLOT slot (manual cleanup may be needed)"
+az webapp deployment slot delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$APP_SERVICE_NAME" \
+  --slot staging \
+  --yes \
+  2>/dev/null || log "  Warning: failed to delete staging slot (manual cleanup may be needed; next run will reuse and overwrite it either way)"
 
-  log "  ✓ Old slot deleted"
-else
-  log "Step 6: Old slot is production (cannot delete; will be staging for next deploy)"
-fi
+log "  ✓ Old slot deleted"
 
 # ============================================================================
 # Success
 # ============================================================================
 
 log "✓ Rolling deploy complete ($(date))"
-log "  Active instance: $NEXT_SLOT"
+log "  Active instance: production"
 log "  Image: $IMAGE_URI"
 
 exit 0


### PR DESCRIPTION
Fixes #398.

Part of #398. Fixes two confirmed, code-only bugs in `tools/rolling-deploy.sh` found during a fact-check of that issue.

## Bug 1: no slot provisioning anywhere

`az webapp deployment slot create` appeared nowhere in the script, and `infra/modules/appservice.bicep` never declares a `Microsoft.Web/sites/slots` resource. The script assumed the `staging` slot already existed (e.g. `az webapp config container set --slot staging`). On the very first real run this would fail outright.

**Fix:** Step 1 now (re)creates the `staging` slot if it isn't already there, cloning config from production via `--configuration-source`. This is unconditional and idempotent — safe on a slot that's missing (first run, or after normal cleanup) or already present (a prior cleanup failed and left it behind).

I deliberately kept this in the script rather than declaring the slot in Bicep. `infra/modules/appservice.bicep` has clear parent/child conventions for persistent resources (`storage.bicep`'s `fileServices`/`shares`, `network.bicep`'s DNS zone links, both via `parent:`), which is what "match existing IaC conventions" would normally point to. But the script's own Step 6 deletes the staging slot after every successful swap — its lifecycle is create → deploy → swap → delete, every single run, not a persistent piece of infrastructure. Declaring it in Bicep would fight that: either the script's delete-after-swap undoes what Bicep just declared, or a Bicep re-apply between deploys races the script's create-on-demand. Since the script already owns the slot's full lifecycle imperatively via `az` CLI calls (create/deploy/swap/delete), extending that same ownership to include creation keeps one thing owning the whole lifecycle instead of splitting it across two systems. It also avoids a real rabbit hole: a Bicep-declared slot gets its own separate system-assigned identity, which would need its own RBAC grants for ACR pull and Key Vault references (`rbac.bicep`, `keyvault.bicep`) that don't exist today for any non-production identity — a materially bigger change than this issue's scope. Flagging that identity/RBAC gap as a separate follow-up rather than folding it in here.

## Bug 2: inverted active/old-slot tracking

The script tried to auto-detect "which slot is active" by checking whether a slot literally named `staging` existed — backwards. In Azure App Service, `production` is always the slot bound to the stable public hostname; `az webapp deployment slot list` never even lists it, only extra slots. After a real swap, the *staging* slot object is left holding the *old* stale content (Azure swap semantics move content between slot objects, not hostnames). The old cleanup branch only fired under a condition (`OLD_SLOT == "staging"`) that never became true after a real swap, so stale content persisted in `staging` — which then made the *next* run misread staging as "active" and push new code straight onto production in place: no slot, no health-check gate, no rollback path. Starting from the second deploy, that becomes the routine path, not an edge case.

**Fix:** removed slot auto-detection entirely.
- New code always deploys to `staging` (never production directly) — the direct-to-production fallback branch is gone, not just gated.
- `staging` is always health-checked before swap.
- Swap is always `staging` ↔ `production`.
- After a successful swap, `staging` is unconditionally treated as holding the old content — deleted in Step 6, no conditional.
- The health-check-failure rollback path (delete the slot that was just deployed to) is now unconditional too, since that slot is always `staging`.

Also fixes a pre-existing shellcheck warning (`SC2034`, unused `ACTIVE_SLOT`) as a side effect of removing the dead-end variable.

## Docs

`docs/rolling-deploy-workflow.md`'s "Idempotency & Safety" section previously documented the broken detect-and-fall-through behavior as an intentional partial-failure recovery mechanism ("Detects old slot is now staging... Deploys to production... Swaps back to staging"). Rewrote it, plus the "Step 1" walkthrough under "Process: Behind the Scenes", to describe the corrected unconditional staging-first behavior and enumerate the actual re-run scenarios (clean completion, swap-succeeded-but-cleanup-crashed, rollback-then-exit) and why each is safe now.

## Testing

No Java/JSP touched, so `ant compile-jsp` / `check-unescaped-el.py` / the full `ant ci-test` suite don't apply here. Checked for an existing shell test convention first — `tools/tests/` only has pytest coverage for the `.py` tools, no bats or equivalent shell-test setup — so per this track's guidance I didn't invent a new test framework for one script. Instead:

- `shellcheck tools/rolling-deploy.sh` — clean (previously had one warning, now fixed as a side effect).
- `bash -n tools/rolling-deploy.sh` — syntax check passes.
- Manual line-by-line trace of every branch in the corrected script (provisioning, deploy, health-check pass/fail, swap, drain, cleanup, and every `die`/rollback exit).
- Ad hoc verification: ran the actual script three times against a hand-written `az`/`curl` shim on `PATH` (not committed — Azure CLI has no local emulator, so this was throwaway scaffolding to catch quoting/argument bugs a pure read-trace could miss, not a permanent test suite):
  1. Fresh App Service (no staging slot) → confirms staging gets created and the deploy completes.
  2. Same state immediately after run 1's cleanup, deploying again → confirms the previously-inverted "second deploy" failure mode is gone (staging is recreated cleanly, no direct-to-production write).
  3. Staging slot pre-seeded as already existing with stale leftover content (the exact precondition the original bug needed) → confirms the fixed script still deploys to staging, health-checks staging, and swaps — never writes to production directly.
  4. Forced health-check failure → confirms rollback deletes staging, exits nonzero, and leaves production untouched.

## Files touched

- `tools/rolling-deploy.sh`
- `docs/rolling-deploy-workflow.md`
