### PR TITLE
Add tag facet to item search results

### DIFF
--- a/src/main/java/com/simisinc/platform/application/FacetUrlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/FacetUrlCommand.java
@@ -30,8 +30,11 @@ import java.util.Map;
  * Shared URL-building helpers for search-results facet links (issue #634), extracted from
  * ItemsSearchResultsWidget's original issue #421 implementation once a second widget needed the
  * same single-select facet-link/clear-filter behavior, per that issue's own suggestion rather than
- * copy-pasting a third time. Multi-select toggle behavior (issue #636's categoryId checkbox group)
- * stays private to ItemsSearchResultsWidget, since it's the only widget with a multi-select facet.
+ * copy-pasting a third time. Multi-select toggle behavior (buildMultiSelectToggleUrl, issue #636's
+ * categoryId checkbox group) was originally kept private to ItemsSearchResultsWidget as
+ * buildCategoryToggleUrl, on the reasoning that category was the only multi-select facet in this
+ * codebase; generalized here for issue #632's tag facet, its second multi-select consumer, per the
+ * same extract-on-the-second-user precedent this class itself was created under.
  *
  * @author SimIS
  * @created 8/2/2026
@@ -93,6 +96,39 @@ public class FacetUrlCommand {
       }
     }
     return url.toString();
+  }
+
+  /**
+   * The current request's URL with candidateValue toggled in or out of paramName's current
+   * multi-select selection (issue #636, generalized for #632): added if it's not in
+   * currentSelection, removed if it is, every OTHER currently selected value for paramName
+   * preserved. This one method backs both a multi-select facet's checkbox links (toggling an
+   * unchecked option on, or an already-checked one off) and each of its active-filter chips'
+   * "remove just this one" link -- removing a selected value via its chip is exactly the same
+   * toggle-off operation as unchecking its facet checkbox.
+   */
+  public static String buildMultiSelectToggleUrl(WidgetContext context, String paramName, List<Long> currentSelection,
+      long candidateValue) {
+    List<String> newSelection = new ArrayList<>();
+    boolean removed = false;
+    for (Long selectedId : currentSelection) {
+      if (selectedId == candidateValue) {
+        removed = true; // omitting it from newSelection toggles it off
+        continue;
+      }
+      newSelection.add(String.valueOf(selectedId));
+    }
+    if (!removed) {
+      newSelection.add(String.valueOf(candidateValue)); // toggles it on
+    }
+    Map<String, List<String>> overrides = new LinkedHashMap<>();
+    if (!newSelection.isEmpty()) {
+      overrides.put(paramName, newSelection);
+    }
+    // When newSelection ends up empty, paramName is simply absent from overrides -- combined with
+    // excludeParam below dropping the current values, the result is the same as
+    // buildClearFilterUrl: the param disappears from the URL entirely.
+    return buildUrl(context, overrides, paramName);
   }
 
   /** One facet's rendered option: display label, result count, whether it's currently selected, and its link. */

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -425,6 +425,25 @@ public class ItemRepository {
           "EXISTS (SELECT 1 FROM item_categories WHERE item_id = items.item_id AND category_id IN (" + placeholders + "))",
           categoryIds.toArray(new Long[0]));
     }
+    // Issue #632: tag facet, mirroring the category multi-select IN-list immediately above
+    // (issue #636) exactly -- any item tagged with at least one of the selected tags matches
+    // (OR-within-dimension). Tags have no "primary" concept (unlike category's legacy single
+    // categoryId column on items itself), but getEffectiveTagIds() still gives a single-value
+    // caller a one-placeholder IN list. Same parameterization discipline: one `?` per id, ids
+    // bound as real PreparedStatement parameters, never concatenated into the SQL text.
+    List<Long> tagIds = specification.getEffectiveTagIds();
+    if (!tagIds.isEmpty()) {
+      StringBuilder tagPlaceholders = new StringBuilder();
+      for (int i = 0; i < tagIds.size(); i++) {
+        if (i > 0) {
+          tagPlaceholders.append(",");
+        }
+        tagPlaceholders.append("?");
+      }
+      where.add(
+          "EXISTS (SELECT 1 FROM item_tags WHERE item_id = items.item_id AND tag_id IN (" + tagPlaceholders + "))",
+          tagIds.toArray(new Long[0]));
+    }
     where.addIfExists("items.created >= ?", specification.getDateRangeStart());
     where.addIfExists("items.created < ?", specification.getDateRangeEnd());
 
@@ -544,6 +563,46 @@ public class ItemRepository {
     // to one candidate at a time, the way the per-candidate countByCategory loop used to.
     SqlUtils where = createSearchWhereStatement(facetSpec);
     List<StatisticsData> rows = DB.selectGroupedFrom(FACET_COUNT_GROUPED_FROM, "item_categories.category_id",
+        "item_count", where, null, -1);
+    Map<Long, Long> counts = new HashMap<>();
+    for (StatisticsData row : rows) {
+      counts.put(Long.valueOf(row.getLabel()), Long.valueOf(row.getValue()));
+    }
+    return counts;
+  }
+
+  /**
+   * FACET_COUNT_FROM plus the item_tags join countGroupedByTag needs to group by tag_id in a
+   * single query. Mirrors FACET_COUNT_GROUPED_FROM above exactly, joined against item_tags
+   * instead of item_categories.
+   */
+  private static final String FACET_COUNT_GROUPED_FROM_TAG = "items " +
+      "JOIN item_tags ON (item_tags.item_id = items.item_id) " +
+      "LEFT JOIN collections ON (items.collection_id = collections.collection_id)";
+
+  /**
+   * Facet counts for every tag in one query (issue #632), mirroring countGroupedByCategory's
+   * exact shape: every other active filter (keyword, date range, access control) from the given
+   * specification is applied, but the specification's own tag selection is ignored -- so, like
+   * countGroupedByCategory, each returned tag's count reflects what selecting THAT tag would
+   * produce, not what's already selected. A tag with zero matches is simply absent from the
+   * returned map. High-cardinality-friendly by design (one grouped query rather than one round
+   * trip per candidate tag), the same motivation issue #637 called out for a future tag cloud.
+   */
+  public static Map<Long, Long> countGroupedByTag(ItemSpecification specification) {
+    ItemSpecification facetSpec = new ItemSpecification();
+    facetSpec.setApprovedOnly(specification.getApprovedOnly());
+    facetSpec.setUnapprovedOnly(specification.getUnapprovedOnly());
+    facetSpec.setIncludeArchived(specification.getIncludeArchived());
+    facetSpec.setForUserId(specification.getForUserId());
+    facetSpec.setSearchName(specification.getSearchName());
+    facetSpec.setSearchLocation(specification.getSearchLocation());
+    facetSpec.setDateRangeStart(specification.getDateRangeStart());
+    facetSpec.setDateRangeEnd(specification.getDateRangeEnd());
+    // tagId/tagIds intentionally left unset: grouping by every tag supersedes filtering to one
+    // candidate at a time, same as countGroupedByCategory leaves categoryId/categoryIds unset.
+    SqlUtils where = createSearchWhereStatement(facetSpec);
+    List<StatisticsData> rows = DB.selectGroupedFrom(FACET_COUNT_GROUPED_FROM_TAG, "item_tags.tag_id",
         "item_count", where, null, -1);
     Map<Long, Long> counts = new HashMap<>();
     for (StatisticsData row : rows) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemSpecification.java
@@ -43,6 +43,15 @@ public class ItemSpecification {
   // just its own field. Callers should generally not read categoryId/categoryIds directly when
   // building a WHERE clause; use getEffectiveCategoryIds() so both representations are honored.
   private List<Long> categoryIds = null;
+  private long tagId = -1L;
+  // Issue #632: multi-select within the tag facet dimension, mirroring categoryId/categoryIds
+  // above exactly -- tagId is kept as a single-value field for any caller that only ever needs
+  // one, tagIds is the list-shaped field a checkbox-group facet actually populates. Unlike
+  // category, no pre-#632 caller ever set a single tagId (tags didn't exist before PR #863), but
+  // the same dual-representation shape is kept for consistency with categoryId/categoryIds and in
+  // case a future single-value caller appears. Use getEffectiveTagIds() when building a WHERE
+  // clause so both representations are honored.
+  private List<Long> tagIds = null;
   private String uniqueId = null;
   private String name = null;
   private String barcode = null;
@@ -135,6 +144,37 @@ public class ItemSpecification {
     }
     if (categoryId > -1) {
       return Collections.singletonList(categoryId);
+    }
+    return Collections.emptyList();
+  }
+
+  public long getTagId() {
+    return tagId;
+  }
+
+  public void setTagId(long tagId) {
+    this.tagId = tagId;
+  }
+
+  public List<Long> getTagIds() {
+    return tagIds;
+  }
+
+  public void setTagIds(List<Long> tagIds) {
+    this.tagIds = tagIds;
+  }
+
+  /**
+   * The effective set of tag ids a WHERE-clause builder should filter on (issue #632), mirroring
+   * getEffectiveCategoryIds() exactly: the multi-select {@code tagIds} list when it's set and
+   * non-empty, otherwise the single {@code tagId} when it's set, otherwise empty.
+   */
+  public List<Long> getEffectiveTagIds() {
+    if (tagIds != null && !tagIds.isEmpty()) {
+      return tagIds;
+    }
+    if (tagId > -1) {
+      return Collections.singletonList(tagId);
     }
     return Collections.emptyList();
   }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/TagRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/TagRepository.java
@@ -80,6 +80,23 @@ public class TagRepository {
     return (List<Tag>) result.getRecords();
   }
 
+  /**
+   * Every tag across every collection, sorted by name (issue #632) -- mirrors
+   * CategoryRepository.findAll() exactly. Used by ItemsSearchResultsWidget to enumerate tag facet
+   * candidates the same way it enumerates category facet candidates.
+   */
+  public static List<Tag> findAll() {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME,
+        null,
+        new DataConstraints().setDefaultColumnToSortBy("name"),
+        TagRepository::buildRecord);
+    if (result.hasRecords()) {
+      return (List<Tag>) result.getRecords();
+    }
+    return null;
+  }
+
   public static List<Tag> findAllByCollectionId(long collectionId) {
     if (collectionId == -1) {
       return null;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidget.java
@@ -23,17 +23,18 @@ import com.simisinc.platform.application.items.ItemDateFacetCommand;
 import com.simisinc.platform.domain.model.cms.SearchResult;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.domain.model.items.Tag;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
+import com.simisinc.platform.infrastructure.persistence.items.TagRepository;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -89,6 +90,20 @@ public class ItemsSearchResultsWidget extends GenericWidget {
         }
       }
     }
+    // Determine the active tag filters (issue #632), same repeated-param checkbox-group pattern
+    // as categoryId above.
+    List<Long> selectedTagIds = new ArrayList<>();
+    String[] tagIdParams = context.getParameterMap().get("tagId");
+    if (tagIdParams != null) {
+      for (String rawTagId : tagIdParams) {
+        if (StringUtils.isNumeric(rawTagId)) {
+          Long parsedTagId = Long.valueOf(rawTagId);
+          if (!selectedTagIds.contains(parsedTagId)) {
+            selectedTagIds.add(parsedTagId);
+          }
+        }
+      }
+    }
     // Computed once and reused below for both filtering and facet-count rendering, so the date
     // boundaries used to narrow the query and the ones used to report that same bucket's count
     // can never drift apart by the few milliseconds between two separate "now" calls
@@ -117,6 +132,9 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     if (!selectedCategoryIds.isEmpty()) {
       specification.setCategoryIds(selectedCategoryIds);
     }
+    if (!selectedTagIds.isEmpty()) {
+      specification.setTagIds(selectedTagIds);
+    }
     if (selectedDateBucket != null) {
       specification.setDateRangeStart(selectedDateBucket.getStart());
       specification.setDateRangeEnd(selectedDateBucket.getEnd());
@@ -132,16 +150,21 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     if (!selectedCategoryIds.isEmpty()) {
       appliedFacetKeys.add("categoryId");
     }
+    if (!selectedTagIds.isEmpty()) {
+      appliedFacetKeys.add("tagId");
+    }
     if (selectedDateBucket != null) {
       appliedFacetKeys.add("dateFacet");
     }
     String facetKey = appliedFacetKeys.isEmpty() ? null : String.join(",", appliedFacetKeys);
     SearchAnalyticsCommand.record(context, query, "items", itemList == null ? 0 : itemList.size(), facetKey);
 
-    // Facet panels + active filter chips (issue #421)
+    // Facet panels + active filter chips (issue #421; tag facet is #632)
     boolean showCategoryFacet = !"false".equals(context.getPreferences().get("showCategoryFacet"));
+    boolean showTagFacet = !"false".equals(context.getPreferences().get("showTagFacet"));
     boolean showDateFacet = !"false".equals(context.getPreferences().get("showDateFacet"));
     String categoryFacetLabel = context.getPreferences().getOrDefault("categoryFacetLabel", "Category");
+    String tagFacetLabel = context.getPreferences().getOrDefault("tagFacetLabel", "Tag");
     String dateFacetLabel = context.getPreferences().getOrDefault("dateFacetLabel", "Date");
 
     // Resolve every category's count in a single grouped query, up front (issue #637 -- replaces
@@ -167,13 +190,45 @@ public class ItemsSearchResultsWidget extends GenericWidget {
           // access-control note above for why "selected" alone must not be enough to reveal a
           // category that turns out to be empty or inaccessible.
           if (count > 0) {
-            String url = buildCategoryToggleUrl(context, selectedCategoryIds, category.getId());
+            String url = FacetUrlCommand.buildMultiSelectToggleUrl(context, "categoryId", selectedCategoryIds, category.getId());
             categoryFacets.add(new ItemFacetOption(String.valueOf(category.getId()), category.getName(), count, selected, url));
           }
         }
       }
       context.getRequest().setAttribute("categoryFacets", categoryFacets);
       context.getRequest().setAttribute("categoryFacetLabel", categoryFacetLabel);
+    }
+
+    // Resolve every tag's count in a single grouped query, up front -- same shape as
+    // categoryCounts above (issue #632 mirrors issue #637's countGroupedByCategory exactly).
+    // Unlike countGroupedByCategory, this map is not affected by the specification's own tag
+    // selection at all (countGroupedByTag never reads it), so this single computation safely
+    // backs both the facet list below AND the active-filter chip disclosure check further down --
+    // no separate "no tag selection" specification is needed the way category's chip logic needs
+    // one (see noCategorySelectionSpec below), because there is nothing to neutralize.
+    Map<Long, Long> tagCounts = null;
+    if (!selectedTagIds.isEmpty() || showTagFacet) {
+      tagCounts = ItemRepository.countGroupedByTag(specification);
+    }
+
+    if (showTagFacet) {
+      List<ItemFacetOption> tagFacets = new ArrayList<>();
+      List<Tag> allTags = TagRepository.findAll();
+      if (allTags != null) {
+        for (Tag tag : allTags) {
+          boolean selected = selectedTagIds.contains(tag.getId());
+          long count = tagCounts.getOrDefault(tag.getId(), 0L);
+          // Tags with a 0 count here are omitted entirely, selected or not -- same
+          // access-control-non-disclosure reasoning as the category facet above: tagId is a
+          // guessable sequential id, so an inaccessible or empty tag's name must not leak.
+          if (count > 0) {
+            String url = FacetUrlCommand.buildMultiSelectToggleUrl(context, "tagId", selectedTagIds, tag.getId());
+            tagFacets.add(new ItemFacetOption(String.valueOf(tag.getId()), tag.getName(), count, selected, url));
+          }
+        }
+      }
+      context.getRequest().setAttribute("tagFacets", tagFacets);
+      context.getRequest().setAttribute("tagFacetLabel", tagFacetLabel);
     }
 
     if (showDateFacet) {
@@ -224,11 +279,36 @@ public class ItemsSearchResultsWidget extends GenericWidget {
             valueLabel = selectedCategory.getName();
           }
         }
-        String clearUrl = buildCategoryToggleUrl(context, selectedCategoryIds, selectedCategoryId);
+        String clearUrl = FacetUrlCommand.buildMultiSelectToggleUrl(context, "categoryId", selectedCategoryIds, selectedCategoryId);
         activeFilters.add(new ItemActiveFilter(categoryFacetLabel, valueLabel, clearUrl));
       }
       if (selectedCategoryIds.size() > 1) {
         activeFilters.add(new ItemActiveFilter(categoryFacetLabel, "All categories", FacetUrlCommand.buildClearFilterUrl(context, "categoryId")));
+      }
+    }
+    if (!selectedTagIds.isEmpty()) {
+      // Unlike the category chip logic above, no separate "no selection" specification is needed
+      // here: tagCounts (computed once, above, from countGroupedByTag) already ignores the
+      // specification's own tag selection entirely -- see the comment on its computation -- so
+      // it's already exactly the "this tag alone" standalone count the disclosure check needs.
+      for (Long selectedTagId : selectedTagIds) {
+        // Only resolve and show the real tag name once its own standalone count has confirmed it
+        // is a non-empty, access-safe tag -- otherwise fall back to a generic label rather than
+        // disclosing the name of a tag the requester may not have access to, or that doesn't
+        // exist. Same reasoning as the category chip above.
+        String valueLabel = "Selected tag";
+        long standaloneCount = tagCounts.getOrDefault(selectedTagId, 0L);
+        if (standaloneCount > 0) {
+          Tag selectedTag = TagRepository.findById(selectedTagId);
+          if (selectedTag != null) {
+            valueLabel = selectedTag.getName();
+          }
+        }
+        String clearUrl = FacetUrlCommand.buildMultiSelectToggleUrl(context, "tagId", selectedTagIds, selectedTagId);
+        activeFilters.add(new ItemActiveFilter(tagFacetLabel, valueLabel, clearUrl));
+      }
+      if (selectedTagIds.size() > 1) {
+        activeFilters.add(new ItemActiveFilter(tagFacetLabel, "All tags", FacetUrlCommand.buildClearFilterUrl(context, "tagId")));
       }
     }
     if (selectedDateBucket != null) {
@@ -282,39 +362,6 @@ public class ItemsSearchResultsWidget extends GenericWidget {
     // Show the JSP
     context.setJsp(JSP);
     return context;
-  }
-
-  /**
-   * The current request's URL with candidateCategoryId toggled in or out of the categoryId
-   * selection (issue #636): added if it's not in currentSelection, removed if it is, every OTHER
-   * currently selected categoryId preserved. This one method backs both the facet checkbox links
-   * (toggling an unchecked category on, or an already-checked one off) and each active-filter
-   * chip's "remove just this one" link -- removing a selected category via its chip is exactly the
-   * same toggle-off operation as unchecking its facet checkbox. Category is the only multi-select
-   * facet in this codebase, so this stays private here rather than in the shared FacetUrlCommand
-   * (issue #634) alongside the single-select buildFacetLinkUrl/buildClearFilterUrl it still uses.
-   */
-  private static String buildCategoryToggleUrl(WidgetContext context, List<Long> currentSelection, long candidateCategoryId) {
-    List<String> newSelection = new ArrayList<>();
-    boolean removed = false;
-    for (Long selectedId : currentSelection) {
-      if (selectedId == candidateCategoryId) {
-        removed = true; // omitting it from newSelection toggles it off
-        continue;
-      }
-      newSelection.add(String.valueOf(selectedId));
-    }
-    if (!removed) {
-      newSelection.add(String.valueOf(candidateCategoryId)); // toggles it on
-    }
-    Map<String, List<String>> overrides = new LinkedHashMap<>();
-    if (!newSelection.isEmpty()) {
-      overrides.put("categoryId", newSelection);
-    }
-    // When newSelection ends up empty, categoryId is simply absent from overrides -- combined with
-    // excludeParam below dropping the current categoryId values, the result is the same as
-    // FacetUrlCommand.buildClearFilterUrl: the param disappears from the URL entirely.
-    return FacetUrlCommand.buildUrl(context, overrides, "categoryId");
   }
 
   /** One facet's rendered option: display label, result count, whether it's currently selected, and its link. */

--- a/src/main/webapp/WEB-INF/jsp/items/items-integrated-search-results-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-integrated-search-results-list.jsp
@@ -44,7 +44,7 @@
 </c:if>
 
 <div class="grid-x grid-margin-x">
-  <c:if test="${!empty categoryFacets || !empty dateFacets}">
+  <c:if test="${!empty categoryFacets || !empty tagFacets || !empty dateFacets}">
     <div class="cell medium-3">
       <c:if test="${!empty categoryFacets}">
         <h6><c:out value="${categoryFacetLabel}"/></h6>
@@ -55,6 +55,25 @@
              vendored in this codebase) already produces the right multi-value URL on its own. --%>
         <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
           <c:forEach items="${categoryFacets}" var="facet">
+            <li>
+              <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
+              <a href="${facet.url}">
+                <c:choose>
+                  <c:when test="${facet.selected}"><i class="${font:fas()} fa-square-check"></i></c:when>
+                  <c:otherwise><i class="${font:far()} fa-square"></i></c:otherwise>
+                </c:choose>
+                <c:out value="${facet.label}"/>
+              </a>&nbsp;<small class="subheader"><fmt:formatNumber value="${facet.count}"/></small>
+            </li>
+          </c:forEach>
+        </ul>
+      </c:if>
+      <c:if test="${!empty tagFacets}">
+        <h6><c:out value="${tagFacetLabel}"/></h6>
+        <%-- Checkbox-style multi-select (issue #632), same toggle-link pattern as the category
+             facet above -- each option's link toggles it in/out of the current tagId selection. --%>
+        <ul class="no-bullet" style="text-indent: -11px; margin-left: 21px !important;">
+          <c:forEach items="${tagFacets}" var="facet">
             <li>
               <%-- facet.url is server-built from the request path + UrlCommand.encodeUri()'d params, so it cannot carry HTML metacharacters --%>
               <a href="${facet.url}">
@@ -86,7 +105,7 @@
       </c:if>
     </div>
   </c:if>
-  <div class="cell ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}">
+  <div class="cell ${(!empty categoryFacets || !empty tagFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}">
     <c:choose>
       <c:when test="${empty searchResultList}">
         <c:choose>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryTest.java
@@ -118,7 +118,7 @@ class ItemRepositoryTest {
     }
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("TRUNCATE TABLE item_categories, items, collections RESTART IDENTITY CASCADE");
+      statement.execute("TRUNCATE TABLE item_categories, item_tags, items, collections RESTART IDENTITY CASCADE");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not reset tables", se);
     }
@@ -535,6 +535,198 @@ class ItemRepositoryTest {
     assertEquals(ItemRepository.countByCategory(specification, categoryC), counts.getOrDefault(categoryC, 0L));
   }
 
+  // Issue #632: the tag WHERE-clause (createSearchWhereStatement's item_tags EXISTS/IN-list),
+  // exercised here via whereClauseCount since there is no per-candidate countByTag -- mirrors the
+  // countByCategory tests above, one dimension over.
+
+  @Test
+  void tagWhereClauseCountsOnlyItemsWithThatTag() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long tagB = 20;
+    addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    long itemWithA = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkTag(itemWithA, tagA, collectionId);
+    long itemWithB = addItem(collectionId, null, Timestamp.valueOf("2026-01-03 00:00:00"));
+    linkTag(itemWithB, tagB, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(tagA);
+    assertEquals(1, whereClauseCount(specification));
+
+    specification = new ItemSpecification();
+    specification.setTagId(999);
+    assertEquals(0, whereClauseCount(specification));
+  }
+
+  @Test
+  void tagWhereClauseOrsMultipleSelectedTagsWithinTheDimension() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long tagB = 20;
+    long tagC = 30;
+    long itemWithA = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(itemWithA, tagA, collectionId);
+    long itemWithB = addItem(collectionId, null, Timestamp.valueOf("2026-06-16 00:00:00"));
+    linkTag(itemWithB, tagB, collectionId);
+    long itemWithC = addItem(collectionId, null, Timestamp.valueOf("2026-06-17 00:00:00"));
+    linkTag(itemWithC, tagC, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagIds(Arrays.asList(tagA, tagB));
+
+    assertEquals(2, whereClauseCount(specification),
+        "tags A and B are both selected (OR-within-dimension) -- C must not be counted");
+  }
+
+  @Test
+  void tagWhereClauseCombinesWithCategoryAndDateRangeAcrossDimensions() {
+    // AND-across-dimensions, same as category-vs-date: a tag selection must still narrow
+    // alongside an active category selection and date range, not override them.
+    long collectionId = addCollection();
+    long tagA = 10;
+    long categoryX = 100;
+    long matches = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(matches, tagA, collectionId);
+    linkCategory(matches, categoryX, collectionId);
+    long wrongCategory = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(wrongCategory, tagA, collectionId);
+    linkCategory(wrongCategory, 999, collectionId);
+    long outOfRange = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkTag(outOfRange, tagA, collectionId);
+    linkCategory(outOfRange, categoryX, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(tagA);
+    specification.setCategoryId(categoryX);
+    specification.setDateRangeStart(Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    assertEquals(1, whereClauseCount(specification));
+  }
+
+  @Test
+  void tagWhereClauseExcludesArchivedItemsByDefaultAndIncludesThemWhenOptedIn() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long activeItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkTag(activeItem, tagA, collectionId);
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkTag(archivedItem, tagA, collectionId);
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(tagA);
+    assertEquals(1, whereClauseCount(specification));
+
+    specification.setIncludeArchived(true);
+    assertEquals(2, whereClauseCount(specification));
+  }
+
+  @Test
+  void tagWhereClauseReturnsZeroForAGuestWhenTheCollectionDoesNotAllowGuests() {
+    long collectionId = addPrivateCollection();
+    long tagA = 10;
+    long item = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(item, tagA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(tagA);
+    specification.setForUserId(UserSession.GUEST_ID);
+
+    assertEquals(0, whereClauseCount(specification),
+        "the tag clause must still be gated by the same guest access-control restriction as every other filter");
+  }
+
+  // Issue #632: countGroupedByTag, mirroring the countGroupedByCategory tests above exactly.
+
+  @Test
+  void countGroupedByTagReturnsEachTagsOwnCountInOneQuery() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long tagB = 20;
+    addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    long itemInA = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkTag(itemInA, tagA, collectionId);
+    long itemInB = addItem(collectionId, null, Timestamp.valueOf("2026-01-03 00:00:00"));
+    linkTag(itemInB, tagB, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    Map<Long, Long> counts = ItemRepository.countGroupedByTag(specification);
+
+    assertEquals(1L, counts.get(tagA));
+    assertEquals(1L, counts.get(tagB));
+    assertFalse(counts.containsKey(999L), "a tag with no matching items must be absent, not present with a 0");
+  }
+
+  @Test
+  void countGroupedByTagOmitsUntaggedItemsAndTagsWithNoMatches() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkTag(addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00")), tagA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    Map<Long, Long> counts = ItemRepository.countGroupedByTag(specification);
+
+    assertEquals(1, counts.size(), "only tags with matching items may appear in the map: " + counts);
+    assertEquals(1L, counts.get(tagA));
+  }
+
+  @Test
+  void countGroupedByTagAppliesTheSpecificationsDateRangeButIgnoresItsOwnTagSelection() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long inRange = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(inRange, tagA, collectionId);
+    long outOfRange = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkTag(outOfRange, tagA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(999); // a different tag -- must be ignored, same as countGroupedByCategory
+    specification.setDateRangeStart(Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    Map<Long, Long> counts = ItemRepository.countGroupedByTag(specification);
+
+    assertEquals(1L, counts.get(tagA),
+        "the date range should still narrow the count, but the specification's own tag selection must not");
+  }
+
+  @Test
+  void countGroupedByTagReturnsZeroTagsForAGuestWhenTheCollectionDoesNotAllowGuests() {
+    long collectionId = addPrivateCollection();
+    long tagA = 10;
+    long item = addItem(collectionId, null, Timestamp.valueOf("2026-06-15 00:00:00"));
+    linkTag(item, tagA, collectionId);
+
+    ItemSpecification specification = new ItemSpecification();
+    specification.setForUserId(UserSession.GUEST_ID);
+
+    Map<Long, Long> counts = ItemRepository.countGroupedByTag(specification);
+
+    assertTrue(counts.isEmpty(),
+        "the same access-control restriction the tag WHERE-clause applies must carry into the grouped form -- "
+            + "otherwise an unauthenticated requester could learn a private tag has items via its count");
+  }
+
+  @Test
+  void countGroupedByTagExcludesArchivedItemsByDefaultAndIncludesThemWhenOptedIn() {
+    long collectionId = addCollection();
+    long tagA = 10;
+    long activeItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-01 00:00:00"));
+    linkTag(activeItem, tagA, collectionId);
+    long archivedItem = addItem(collectionId, null, Timestamp.valueOf("2026-01-02 00:00:00"));
+    linkTag(archivedItem, tagA, collectionId);
+    archiveItem(archivedItem);
+
+    ItemSpecification specification = new ItemSpecification();
+    assertEquals(1L, ItemRepository.countGroupedByTag(specification).get(tagA),
+        "a deactivated item must not be counted by a normal (non-includeArchived) query");
+
+    specification.setIncludeArchived(true);
+    assertEquals(2L, ItemRepository.countGroupedByTag(specification).get(tagA),
+        "a caller that explicitly opts in must still see archived items, same as countGroupedByCategory");
+  }
+
   private static boolean isDockerAvailable() {
     try {
       return DockerClientFactory.instance().isDockerAvailable();
@@ -552,6 +744,7 @@ class ItemRepositoryTest {
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
       statement.execute("DROP TABLE IF EXISTS item_categories CASCADE");
+      statement.execute("DROP TABLE IF EXISTS item_tags CASCADE");
       statement.execute("DROP TABLE IF EXISTS items CASCADE");
       statement.execute("DROP TABLE IF EXISTS collections CASCADE");
       statement.execute("CREATE TABLE collections ("
@@ -570,6 +763,12 @@ class ItemRepositoryTest {
       statement.execute("CREATE TABLE item_categories ("
           + "item_id BIGINT, "
           + "category_id BIGINT, "
+          + "collection_id BIGINT)");
+      // Issue #632: minimal item_tags shape, same as item_categories above -- just enough for the
+      // tag EXISTS/IN clause and countGroupedByTag's GROUP BY item_tags.tag_id.
+      statement.execute("CREATE TABLE item_tags ("
+          + "item_id BIGINT, "
+          + "tag_id BIGINT, "
           + "collection_id BIGINT)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the test schema", se);
@@ -646,5 +845,32 @@ class ItemRepositoryTest {
     } catch (SQLException se) {
       throw new IllegalStateException("Could not link a category", se);
     }
+  }
+
+  private static void linkTag(long itemId, long tagId, long collectionId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO item_tags (item_id, tag_id, collection_id) VALUES (?, ?, ?)")) {
+      pst.setLong(1, itemId);
+      pst.setLong(2, tagId);
+      pst.setLong(3, collectionId);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not link a tag", se);
+    }
+  }
+
+  /**
+   * Runs specification's WHERE clause (via the same createSearchWhereStatement path
+   * countByCategory/countGroupedByCategory/query() all share) against real Postgres, mirroring
+   * exactly what countByCategory does internally -- used here since there is no per-candidate
+   * countByTag (issue #632's countGroupedByTag intentionally ignores its own tag selection, so it
+   * cannot exercise the tag WHERE-clause itself; this proves that clause directly against real
+   * data instead of only checking its generated SQL text, as ItemRepositoryWhereClauseTest does).
+   */
+  private static long whereClauseCount(ItemSpecification specification) {
+    return DB.selectFunction("COUNT(*)",
+        "items LEFT JOIN collections ON (items.collection_id = collections.collection_id)",
+        ItemRepository.createSearchWhereStatement(specification));
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepositoryWhereClauseTest.java
@@ -52,6 +52,15 @@ class ItemRepositoryWhereClauseTest {
     return null;
   }
 
+  private static SqlValue findTagClause(SqlUtils where) {
+    for (SqlValue value : where.getValues()) {
+      if (value.getFieldOrClause() != null && value.getFieldOrClause().contains("item_tags")) {
+        return value;
+      }
+    }
+    return null;
+  }
+
   @Test
   void categoryInClauseIsParameterizedNotStringConcatenated() {
     // The candidate ids must never be baked into the SQL text itself -- one `?` placeholder per
@@ -96,5 +105,60 @@ class ItemRepositoryWhereClauseTest {
     SqlUtils where = ItemRepository.createSearchWhereStatement(specification);
 
     assertNull(findCategoryClause(where), "no category filter should be added when nothing is selected");
+  }
+
+  @Test
+  void tagInClauseIsParameterizedNotStringConcatenated() {
+    // Issue #632: mirrors categoryInClauseIsParameterizedNotStringConcatenated exactly, for the
+    // new item_tags EXISTS clause.
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagIds(Arrays.asList(11L, 22L, 33L));
+
+    SqlUtils where = ItemRepository.createSearchWhereStatement(specification);
+
+    SqlValue tagClause = findTagClause(where);
+    assertNotNull(tagClause, "expected an item_tags EXISTS clause to be present");
+    String clauseText = tagClause.getFieldOrClause();
+    assertFalse(clauseText.contains("11") || clauseText.contains("22") || clauseText.contains("33"),
+        "the candidate ids must never be concatenated into the SQL text itself: " + clauseText);
+    assertEquals(3, StringUtils.countMatches(clauseText, "?"), "one ? placeholder per selected tag id: " + clauseText);
+    assertArrayEquals(new Long[] { 11L, 22L, 33L }, tagClause.getLongValues(),
+        "the ids must be bound as real PreparedStatement parameters, in order");
+  }
+
+  @Test
+  void tagInClauseHasOnePlaceholderForASingleTagId() {
+    ItemSpecification specification = new ItemSpecification();
+    specification.setTagId(7L);
+
+    SqlUtils where = ItemRepository.createSearchWhereStatement(specification);
+
+    SqlValue tagClause = findTagClause(where);
+    assertNotNull(tagClause);
+    assertEquals(1, StringUtils.countMatches(tagClause.getFieldOrClause(), "?"));
+    assertArrayEquals(new Long[] { 7L }, tagClause.getLongValues());
+  }
+
+  @Test
+  void noTagClauseWhenNothingIsSelected() {
+    ItemSpecification specification = new ItemSpecification();
+
+    SqlUtils where = ItemRepository.createSearchWhereStatement(specification);
+
+    assertNull(findTagClause(where), "no tag filter should be added when nothing is selected");
+  }
+
+  @Test
+  void categoryAndTagClausesCoexistWhenBothAreSelected() {
+    // The two facet dimensions are independent EXISTS clauses that both apply (AND-across-
+    // dimensions) -- proves adding the tag clause didn't clobber or replace the category one.
+    ItemSpecification specification = new ItemSpecification();
+    specification.setCategoryId(5L);
+    specification.setTagId(9L);
+
+    SqlUtils where = ItemRepository.createSearchWhereStatement(specification);
+
+    assertNotNull(findCategoryClause(where));
+    assertNotNull(findTagClause(where));
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/items/TagRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/items/TagRepositoryTest.java
@@ -162,6 +162,27 @@ class TagRepositoryTest {
   }
 
   @Test
+  void findAllReturnsEveryTagAcrossCollectionsSortedByName() {
+    // Issue #632: mirrors CategoryRepository.findAll() exactly -- ItemsSearchResultsWidget needs
+    // this to enumerate every tag facet candidate, the same way it enumerates category candidates
+    // via CategoryRepository.findAll(), regardless of which collection a tag belongs to.
+    long collectionA = addCollection();
+    long collectionB = addCollection();
+    addTag(collectionA, "Zebra");
+    addTag(collectionB, "Apple");
+
+    List<Tag> tagList = TagRepository.findAll();
+    assertEquals(2, tagList.size());
+    assertEquals("Apple", tagList.get(0).getName());
+    assertEquals("Zebra", tagList.get(1).getName());
+  }
+
+  @Test
+  void findAllReturnsNullWhenNoTagsExist() {
+    assertNull(TagRepository.findAll(), "mirrors CategoryRepository.findAll()'s null-when-empty shape");
+  }
+
+  @Test
   void saveUpdatesAnExistingTagsName() {
     long collectionId = addCollection();
     long tagId = addTag(collectionId, "Fiction");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/items/ItemsSearchResultsWidgetTest.java
@@ -43,9 +43,11 @@ import com.simisinc.platform.application.cms.SearchAnalyticsCommand;
 import com.simisinc.platform.application.items.ItemDateFacetCommand;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.domain.model.items.Tag;
 import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
+import com.simisinc.platform.infrastructure.persistence.items.TagRepository;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.items.ItemsSearchResultsWidget.ItemActiveFilter;
 import com.simisinc.platform.presentation.widgets.items.ItemsSearchResultsWidget.ItemFacetOption;
@@ -78,6 +80,21 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
     return categoryList;
   }
 
+  private static Tag tag(long id, String name) {
+    Tag tag = new Tag();
+    tag.setId(id);
+    tag.setName(name);
+    return tag;
+  }
+
+  private static List<Tag> tags(Tag... tagArray) {
+    List<Tag> tagList = new ArrayList<>();
+    for (Tag tag : tagArray) {
+      tagList.add(tag);
+    }
+    return tagList;
+  }
+
   @Test
   @SuppressWarnings("unchecked")
   void executeAppliesTheCategoryIdParamAndOnlyListsCategoriesWithResultsOrSelected() {
@@ -91,11 +108,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(itemList);
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets"), category(6, "Gadgets")));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
       Map<Long, Long> categoryCounts = new HashMap<>();
       categoryCounts.put(5L, 3L);
@@ -135,11 +154,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
       new ItemsSearchResultsWidget().execute(widgetContext);
@@ -157,12 +178,14 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets")));
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countGroupedByCategory(any())).thenReturn(new HashMap<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -194,6 +217,7 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
@@ -202,6 +226,7 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
       // findById is stubbed to return the real name deliberately, to prove the widget does NOT
       // trust/render it once the count check below has failed
       categoryRepository.when(() -> CategoryRepository.findById(99L)).thenReturn(category(99, "Confidential HR Records"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countGroupedByCategory(any())).thenReturn(new HashMap<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -233,11 +258,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<ItemDateFacetCommand> dateFacetCommand = mockStatic(ItemDateFacetCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       dateFacetCommand.when(ItemDateFacetCommand::buckets).thenReturn(fixedBuckets);
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
       new ItemsSearchResultsWidget().execute(widgetContext);
@@ -252,10 +279,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
     preferences.put("showCategoryFacet", "false");
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(new HashMap<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
       WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
@@ -283,11 +313,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -308,11 +340,13 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -333,12 +367,14 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets"), category(7, "Doohickeys")));
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countGroupedByCategory(any())).thenReturn(Map.of(5L, 1L, 7L, 1L));
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
@@ -367,6 +403,7 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
@@ -374,6 +411,7 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets"), category(7, "Doohickeys")));
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
       categoryRepository.when(() -> CategoryRepository.findById(7L)).thenReturn(category(7, "Doohickeys"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -404,12 +442,14 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets")));
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
@@ -430,12 +470,14 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(categories(category(5, "Widgets")));
       categoryRepository.when(() -> CategoryRepository.findById(5L)).thenReturn(category(5, "Widgets"));
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByCategory(any(), anyLong())).thenReturn(1L);
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(1L);
 
@@ -454,17 +496,283 @@ class ItemsSearchResultsWidgetTest extends WidgetBase {
 
     try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
         MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
       siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
       repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
       categoryRepository.when(CategoryRepository::findAll).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
       repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
 
       new ItemsSearchResultsWidget().execute(widgetContext);
 
       analytics.verify(() -> SearchAnalyticsCommand.record(any(), any(), any(), anyInt(), facetKeyCaptor.capture()));
       assertNull(facetKeyCaptor.getValue());
+    }
+  }
+
+  // Issue #632: the tag facet, mirroring the category facet tests above one dimension over.
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeAppliesTheTagIdParamAndOnlyListsTagsWithResultsOrSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "tagId", "5");
+
+    List<Item> itemList = new ArrayList<>();
+    itemList.add(item(1L, "widget-1", "Widget One"));
+
+    ArgumentCaptor<ItemSpecification> specCaptor = ArgumentCaptor.forClass(ItemSpecification.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(itemList);
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(5, "Fiction"), tag(6, "History")));
+      tagRepository.when(() -> TagRepository.findById(5L)).thenReturn(tag(5, "Fiction"));
+      Map<Long, Long> tagCounts = new HashMap<>();
+      tagCounts.put(5L, 3L);
+      // tag 6 is intentionally absent -- countGroupedByTag omits zero-count tags entirely, the
+      // same as countGroupedByCategory
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(tagCounts);
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      assertEquals(List.of(5L), specCaptor.getValue().getTagIds(),
+          "the tagId param must reach the query, via the issue #632 multi-select list");
+
+      List<ItemFacetOption> tagFacets = (List<ItemFacetOption>) result.getRequest().getAttribute("tagFacets");
+      assertEquals(1, tagFacets.size(), "tag 6 has a 0 count and is not selected, so it must not be listed");
+      assertEquals("Fiction", tagFacets.get(0).getLabel());
+      assertEquals(3L, tagFacets.get(0).getCount());
+      assertTrue(tagFacets.get(0).isSelected());
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Tag", activeFilters.get(0).getFacetLabel());
+      assertEquals("Fiction", activeFilters.get(0).getValueLabel());
+      assertFalse(activeFilters.get(0).getClearUrl().contains("tagId="),
+          "the clear link must drop the tagId param entirely: " + activeFilters.get(0).getClearUrl());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeParsesRepeatedTagIdParamsIntoTheMultiSelectList() {
+    // Same repeated-param checkbox-group parsing as categoryId (issue #636's pattern, reused here
+    // for #632): tagId=5&tagId=7 read via getParameterMap() as a String[].
+    addQueryParameter(widgetContext, "query", "widgets");
+    widgetContext.getParameterMap().put("tagId", new String[] { "5", "7" });
+
+    ArgumentCaptor<ItemSpecification> specCaptor = ArgumentCaptor.forClass(ItemSpecification.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(Map.of(5L, 1L, 7L, 1L));
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      assertEquals(List.of(5L, 7L), specCaptor.getValue().getTagIds(),
+          "both repeated tagId values must be parsed, in order, and reach the query");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeBuildsAnAddToSelectionUrlForAnUncheckedTagAndARemoveUrlForAChecked() {
+    // Issue #632: an unchecked tag's facet link must ADD it to the current selection (keeping
+    // whatever's already checked); an already-checked tag's own facet link must REMOVE just it --
+    // proves both add-to-selection and remove-from-selection toggling through the generalized
+    // FacetUrlCommand.buildMultiSelectToggleUrl.
+    addQueryParameter(widgetContext, "query", "widgets");
+    widgetContext.getParameterMap().put("tagId", new String[] { "5" });
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(5, "Fiction"), tag(7, "History")));
+      tagRepository.when(() -> TagRepository.findById(5L)).thenReturn(tag(5, "Fiction"));
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(Map.of(5L, 1L, 7L, 1L));
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      List<ItemFacetOption> tagFacets = (List<ItemFacetOption>) result.getRequest().getAttribute("tagFacets");
+
+      ItemFacetOption uncheckedFacet = tagFacets.stream().filter(f -> "7".equals(f.getKey())).findFirst().orElseThrow();
+      assertFalse(uncheckedFacet.isSelected());
+      assertTrue(uncheckedFacet.getUrl().contains("tagId=5") && uncheckedFacet.getUrl().contains("tagId=7"),
+          "checking an unchecked tag must ADD it, keeping the already-selected tagId=5: " + uncheckedFacet.getUrl());
+
+      ItemFacetOption checkedFacet = tagFacets.stream().filter(f -> "5".equals(f.getKey())).findFirst().orElseThrow();
+      assertTrue(checkedFacet.isSelected());
+      assertFalse(checkedFacet.getUrl().contains("tagId="),
+          "unchecking the only selected tag must drop tagId from the URL entirely: " + checkedFacet.getUrl());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeGivesEachSelectedTagItsOwnRemoveChipPlusAClearAllChipWhenMultipleAreSelected() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    widgetContext.getParameterMap().put("tagId", new String[] { "5", "7" });
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(5, "Fiction"), tag(7, "History")));
+      tagRepository.when(() -> TagRepository.findById(5L)).thenReturn(tag(5, "Fiction"));
+      tagRepository.when(() -> TagRepository.findById(7L)).thenReturn(tag(7, "History"));
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(Map.of(5L, 1L, 7L, 1L));
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      // one chip per selected tag, plus one "clear all tags" chip
+      assertEquals(3, activeFilters.size());
+
+      ItemActiveFilter fictionChip = activeFilters.stream().filter(f -> "Fiction".equals(f.getValueLabel())).findFirst().orElseThrow();
+      assertTrue(fictionChip.getClearUrl().contains("tagId=7"), "removing just Fiction must leave tagId=7 selected: " + fictionChip.getClearUrl());
+      assertFalse(fictionChip.getClearUrl().contains("tagId=5"), "removing Fiction must drop its own id: " + fictionChip.getClearUrl());
+
+      ItemActiveFilter historyChip = activeFilters.stream().filter(f -> "History".equals(f.getValueLabel())).findFirst().orElseThrow();
+      assertTrue(historyChip.getClearUrl().contains("tagId=5"), "removing just History must leave tagId=5 selected: " + historyChip.getClearUrl());
+      assertFalse(historyChip.getClearUrl().contains("tagId=7"), "removing History must drop its own id: " + historyChip.getClearUrl());
+
+      boolean hasClearAllChip = activeFilters.stream().anyMatch(f -> !f.getClearUrl().contains("tagId="));
+      assertTrue(hasClearAllChip, "when 2+ tags are selected, one chip should clear the whole dimension");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeGivesASingleSelectedTagOnlyOneChipNoClearAll() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "tagId", "5");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(5, "Fiction")));
+      tagRepository.when(() -> TagRepository.findById(5L)).thenReturn(tag(5, "Fiction"));
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(Map.of(5L, 1L));
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size(), "a single selection keeps the original one-chip-clears-it behavior, no separate 'clear all' chip");
+    }
+  }
+
+  @Test
+  void executeOmitsTheTagFacetWhenThePreferenceIsFalse() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    preferences.put("showTagFacet", "false");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      // TagRepository is never stubbed above -- with showTagFacet=false and no tagId param
+      // selected, the widget must never even call TagRepository.findAll()/countGroupedByTag(),
+      // the same "don't touch it at all" contract executeOmitsTheCategoryFacetWhenThePreferenceIsFalse
+      // proves for the category facet.
+      assertNull(result.getRequest().getAttribute("tagFacets"));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeDoesNotLeakAnInaccessibleOrEmptyTagsNameInTheFacetListOrActiveFilterChip() {
+    // tagId=99 stands in for either a tag with zero matching items, or one belonging to a
+    // collection the requester has no access to -- countGroupedByTag applies the same
+    // access-control WHERE as the real query, so the two are indistinguishable and neither may
+    // disclose the tag's name (issue: tagId is a guessable sequential id). Mirrors
+    // executeDoesNotLeakAnInaccessibleOrEmptyCategorysNameInTheFacetListOrActiveFilterChip.
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "tagId", "99");
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(99, "Confidential Research Notes")));
+      // findById is stubbed to return the real name deliberately, to prove the widget does NOT
+      // trust/render it once the count check below has failed
+      tagRepository.when(() -> TagRepository.findById(99L)).thenReturn(tag(99, "Confidential Research Notes"));
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(new HashMap<>());
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      WidgetContext result = new ItemsSearchResultsWidget().execute(widgetContext);
+
+      List<ItemFacetOption> tagFacets = (List<ItemFacetOption>) result.getRequest().getAttribute("tagFacets");
+      assertTrue(tagFacets.isEmpty(), "a 0-count tag must not appear in the facet list even though it's selected");
+
+      List<ItemActiveFilter> activeFilters = (List<ItemActiveFilter>) result.getRequest().getAttribute("activeFilters");
+      assertEquals(1, activeFilters.size());
+      assertEquals("Selected tag", activeFilters.get(0).getValueLabel(),
+          "must not render \"Confidential Research Notes\" -- that would disclose the tag's name to a requester with no verified access to it");
+    }
+  }
+
+  @Test
+  void executeRecordsTagIdAsAnAppliedFacetKeyForTheAdoptionRateReport() {
+    addQueryParameter(widgetContext, "query", "widgets");
+    addQueryParameter(widgetContext, "tagId", "5");
+
+    ArgumentCaptor<String> facetKeyCaptor = ArgumentCaptor.forClass(String.class);
+
+    try (MockedStatic<ItemRepository> repository = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepository = mockStatic(CategoryRepository.class);
+        MockedStatic<TagRepository> tagRepository = mockStatic(TagRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<SearchAnalyticsCommand> analytics = mockStatic(SearchAnalyticsCommand.class)) {
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("site.timezone")).thenReturn("America/New_York");
+      repository.when(() -> ItemRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      tagRepository.when(TagRepository::findAll).thenReturn(tags(tag(5, "Fiction")));
+      tagRepository.when(() -> TagRepository.findById(5L)).thenReturn(tag(5, "Fiction"));
+      repository.when(() -> ItemRepository.countGroupedByTag(any())).thenReturn(Map.of(5L, 1L));
+      repository.when(() -> ItemRepository.countByDateRange(any(), any(), any())).thenReturn(0L);
+
+      new ItemsSearchResultsWidget().execute(widgetContext);
+
+      analytics.verify(() -> SearchAnalyticsCommand.record(any(), any(), any(), anyInt(), facetKeyCaptor.capture()));
+      assertEquals("tagId", facetKeyCaptor.getValue());
     }
   }
 }

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -165,14 +165,14 @@ ALLOWLIST: dict[str, str] = {
         "ItemsSearchResultsWidget.buildFacetLinkUrl/buildUrl (ItemsSearchResultsWidget.java) build this from context.getUri() (the request path, which per HTTP semantics cannot legally contain a raw '\"') plus every param run through UrlCommand.encodeUri(), which percent-encodes all HTML metacharacters -- same reasoning as ${wikiLinkPrefix} below.",
     "${activeFilter.clearUrl}":
         "Same construction and reasoning as ${facet.url} above -- built by ItemsSearchResultsWidget.buildClearFilterUrl/buildUrl from context.getUri() + UrlCommand.encodeUri()'d params.",
-    "${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}":
+    "${(!empty categoryFacets || !empty tagFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'}":
         "Ternary between two fixed CSS class literals -- same pattern as ${hideChartControls}/${hideChartTitle} below. No other value is possible.",
     "${!empty calendarFacets ? 'medium-9' : 'medium-12'}":
-        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
+        "Same reasoning as ${(!empty categoryFacets || !empty tagFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${!empty wikiFacets ? 'medium-9' : 'medium-12'}":
-        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
+        "Same reasoning as ${(!empty categoryFacets || !empty tagFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${!empty dateFacets ? 'medium-9' : 'medium-12'}":
-        "Same reasoning as ${(!empty categoryFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634, web-page-search-results.jsp) -- ternary between two fixed CSS class literals, no other value is possible.",
+        "Same reasoning as ${(!empty categoryFacets || !empty tagFacets || !empty dateFacets) ? 'medium-9' : 'medium-12'} above (issue #634, web-page-search-results.jsp) -- ternary between two fixed CSS class literals, no other value is possible.",
     "${faqQuestion.answerHtml}":
         "Same trust boundary as ${widget.content} below: an admin/content-manager-authored widget preference (FaqWidget.java), not user input. The question text is rendered via <c:out> in the same JSP; only the answer is intentionally raw, since it's meant to render as HTML.",
     "${file.baseUrl}":


### PR DESCRIPTION
Fixes #632.

Part of #632.

Wires the Tag domain concept from PR #863 into the actual search facet: `ItemSpecification` gains `tagId`/`tagIds` mirroring `categoryId`/`categoryIds` exactly (issue #636's dual-representation shape), `ItemRepository` gets the matching `item_tags` EXISTS/IN WHERE-clause plus `countGroupedByTag` mirroring `countGroupedByCategory`'s exact shape (issue #637), and `TagRepository` gains `findAll()` mirroring `CategoryRepository.findAll()` so `ItemsSearchResultsWidget` can enumerate facet candidates.

`ItemsSearchResultsWidget` / `items-integrated-search-results-list.jsp` get a tag facet loop and active-filter chips following the pattern #850 (multi-select category facet) and #847 (GROUP BY) established for category, including the same access-control non-disclosure behavior -- a 0-count or inaccessible tag's name never leaks via the facet list or chip.

## Design fork: generalizing the multi-select toggle URL

`FacetUrlCommand`'s and `ItemsSearchResultsWidget.buildCategoryToggleUrl`'s javadoc both stated category was "the only multi-select facet in this codebase" as the reason the toggle-URL logic stayed private/category-specific rather than living in the shared `FacetUrlCommand` that #634 extracted once a second single-select consumer appeared. Tags are multi-select too (no "primary tag" concept, confirmed in #863), so `buildCategoryToggleUrl` is generalized into `FacetUrlCommand.buildMultiSelectToggleUrl(context, paramName, currentSelection, candidateValue)`, per #634's own extract-on-the-second-user precedent -- both `categoryId` and `tagId` toggle links now go through it. The stale "only multi-select facet" javadoc claim is updated.

## A simplification tags enabled

Since `countGroupedByTag` (unlike `countByCategory`) never reads the specification's own tag selection, the same map computed once for the facet list also serves the active-filter chip's standalone-count disclosure check -- no separate "no tag selection" specification or per-candidate `countByTag` round trip is needed the way category's chip logic needs one. No `countByTag` method was added; it isn't needed.

## Note for a follow-up (not fixed here, to keep this PR scoped to the facet wiring)

Category and tag facet counts don't currently AND against each other: mirroring `countGroupedByCategory`'s pre-existing shape (which only ever carried the date-range filter across dimensions), `countGroupedByTag` ignores the specification's active category selection and vice versa. The real result list is correctly narrowed by both facets together via `createSearchWhereStatement` (verified in `ItemRepositoryWhereClauseTest`/`ItemRepositoryTest`), but the sidebar counts shown for one facet don't yet narrow to the other's active selection. Worth a follow-up if both facets end up commonly combined.

## Test plan
- [x] `ItemRepositoryWhereClauseTest`: new tag IN-clause is genuinely parameterized, one placeholder for a single `tagId`, no clause when nothing's selected, coexists with the category clause
- [x] `ItemRepositoryTest` (Testcontainers): the tag WHERE-clause proven directly against real Postgres (there's no per-candidate `countByTag` to exercise it otherwise) -- single-tag match, OR-within-tag-dimension, AND-across-category/date/tag, archived-item exclusion, guest access control -- plus `countGroupedByTag` grouping/omission/date-range/access-control/archived-item coverage mirroring the existing `countGroupedByCategory` tests
- [x] `TagRepositoryTest`: `findAll()` returns every tag sorted by name across collections, and null when none exist
- [x] `ItemsSearchResultsWidgetTest`: tag facet renders with correct counts/selection, `tagId` param(s) reach the query, multi-select toggling in both directions (add-to-selection and remove-from-selection), single vs. multiple selected-tag chip behavior, preference-off omission, and access-control non-disclosure
- [x] Full `ant -lib lib/war -lib lib/tests clean ci-test`: BUILD SUCCESSFUL, 0 failures, no CONTAINER-LEVEL issues
- [x] `ant compile-jsp` and `python3 tools/check-unescaped-el.py . --strict`: both pass (0 unallowlisted)
