### PR TITLE
Add bulk archive/move/delete for calendar events (#882)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
@@ -53,7 +53,9 @@ public class CalendarEventRepository {
   // event save failing on a VARCHAR(255) overflow.
   private static int TAGS_LIST_MAX_LENGTH = 255;
 
-  private static SqlUtils createWhereStatement(CalendarEventSpecification specification) {
+  // Package-private (not private) so CalendarEventRepositoryWhereClauseTest can exercise the built
+  // SqlUtils/SqlValue output directly, mirroring ItemRepository.createSearchWhereStatement's visibility.
+  static SqlUtils createWhereStatement(CalendarEventSpecification specification) {
     SqlUtils where = new SqlUtils();
     if (specification != null) {
       where
@@ -66,6 +68,13 @@ public class CalendarEventRepository {
         } else {
           where.add("published IS NULL");
         }
+      }
+      // issue #882: mirrors MedicineRepository's archived filtering shape. UNDEFINED (the default
+      // for every pre-#882 caller) includes archived rows, so this is purely additive.
+      if (specification.getArchivedOnly() == DataConstants.TRUE) {
+        where.add("archived IS NOT NULL");
+      } else if (specification.getArchivedOnly() == DataConstants.FALSE) {
+        where.add("archived IS NULL");
       }
       if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
         where.add("((start_date >= ? AND start_date < ?) OR (end_date >= ? AND end_date < ?))",

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventSpecification.java
@@ -32,6 +32,10 @@ public class CalendarEventSpecification {
   private long calendarId = -1L;
   private String uniqueId = null;
   private int publishedOnly = DataConstants.UNDEFINED;
+  // Mirrors MedicineSpecification's archivedOnly (issue #882): UNDEFINED includes archived rows
+  // (the pre-#882 behavior, unchanged for any caller that never sets this), TRUE returns only
+  // archived rows, FALSE excludes them.
+  private int archivedOnly = DataConstants.UNDEFINED;
   private Timestamp startingDateRange = null;
   private Timestamp endingDateRange = null;
   private String searchTerm = null;
@@ -81,6 +85,18 @@ public class CalendarEventSpecification {
 
   public void setPublishedOnly(int publishedOnly) {
     this.publishedOnly = publishedOnly;
+  }
+
+  public int getArchivedOnly() {
+    return archivedOnly;
+  }
+
+  public void setArchivedOnly(boolean archivedOnly) {
+    this.archivedOnly = (archivedOnly ? DataConstants.TRUE : DataConstants.FALSE);
+  }
+
+  public void setArchivedOnly(int archivedOnly) {
+    this.archivedOnly = archivedOnly;
   }
 
   public Timestamp getStartingDateRange() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidget.java
@@ -20,16 +20,22 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.simisinc.platform.domain.events.cms.CalendarEventRemovedEvent;
 import com.simisinc.platform.domain.model.cms.Calendar;
 import com.simisinc.platform.domain.model.cms.CalendarEvent;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -48,6 +54,12 @@ public class CalendarEventListWidget extends GenericWidget {
   static final long serialVersionUID = -8484048371911908894L;
 
   static String JSP = "/admin/calendar-event-list.jsp";
+
+  // A crafted POST is the only thing this bounds -- normal usage never approaches it, since
+  // selection is scoped to the current page (default page size 25). An id list over this cap is
+  // rejected outright, never silently truncated. Mirrors UsersListWidget/AdminImageBrowserWidget's
+  // MAX_BULK_SELECTION.
+  static final int MAX_BULK_SELECTION = 100;
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -91,6 +103,218 @@ public class CalendarEventListWidget extends GenericWidget {
     return context;
   }
 
+  /**
+   * Bulk actions selected from /admin/calendars' checkbox + action-bar UI (issue #882, mirroring
+   * the bulk-action-bar mechanics PR #731 shipped for /admin/users' users-list.jsp).
+   */
+  public WidgetContext post(WidgetContext context) {
+
+    // Permission is required -- matches CalendarWidget.post()/delete() and AdminImageBrowserWidget,
+    // the codebase's existing admin/content-manager pairing for calendar and CMS-asset mutations.
+    if (!(context.hasRole("admin") || context.hasRole("content-manager"))) {
+      LOG.warn("No permission to modify calendar events");
+      return context;
+    }
+
+    // Don't accept multiple form posts
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("bulkArchive".equals(command)) {
+      return bulkArchiveAction(context);
+    }
+    if ("bulkMove".equals(command)) {
+      return bulkMoveAction(context);
+    }
+    if ("bulkDelete".equals(command)) {
+      return bulkDeleteAction(context);
+    }
+    return context;
+  }
+
+  private WidgetContext bulkArchiveAction(WidgetContext context) {
+    List<Long> eventIds = resolveSelectedEventIds(context);
+    if (eventIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (eventIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    for (Long eventId : eventIds) {
+      CalendarEvent calendarEvent = CalendarEventRepository.findById(eventId);
+      if (calendarEvent == null) {
+        ++notFound;
+        continue;
+      }
+      calendarEvent.setArchived(now);
+      calendarEvent.setModifiedBy(context.getUserId());
+      CalendarEvent result = CalendarEventRepository.update(calendarEvent);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "calendarEvent.archive", outcome,
+          "calendarEvent", String.valueOf(calendarEvent.getId()), calendarEvent.getTitle(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "archived", succeeded, eventIds.size(), notFound, failed);
+    context.setRedirect("/admin/calendars");
+    return context;
+  }
+
+  private WidgetContext bulkMoveAction(WidgetContext context) {
+    long targetCalendarId = context.getParameterAsLong("calendarId", -1);
+    Calendar targetCalendar = targetCalendarId > -1 ? CalendarRepository.findById(targetCalendarId) : null;
+    if (targetCalendar == null) {
+      context.setErrorMessage("The destination calendar was not found");
+      context.setRedirect("/admin/calendars");
+      return context;
+    }
+
+    List<Long> eventIds = resolveSelectedEventIds(context);
+    if (eventIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (eventIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    for (Long eventId : eventIds) {
+      CalendarEvent calendarEvent = CalendarEventRepository.findById(eventId);
+      if (calendarEvent == null) {
+        ++notFound;
+        continue;
+      }
+      calendarEvent.setCalendarId(targetCalendar.getId());
+      calendarEvent.setModifiedBy(context.getUserId());
+      CalendarEvent result = CalendarEventRepository.update(calendarEvent);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "calendarEvent.move", outcome,
+          "calendarEvent", String.valueOf(calendarEvent.getId()), calendarEvent.getTitle(),
+          "movedTo=" + targetCalendar.getName() + " (bulk)");
+    }
+
+    setBulkResultMessage(context, "moved to " + targetCalendar.getName(), succeeded, eventIds.size(), notFound, failed);
+    context.setRedirect("/admin/calendars");
+    return context;
+  }
+
+  private WidgetContext bulkDeleteAction(WidgetContext context) {
+    List<Long> eventIds = resolveSelectedEventIds(context);
+    if (eventIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (eventIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    for (Long eventId : eventIds) {
+      CalendarEvent calendarEvent = CalendarEventRepository.findById(eventId);
+      if (calendarEvent == null) {
+        ++notFound;
+        continue;
+      }
+      boolean removed = CalendarEventRepository.remove(calendarEvent);
+      String outcome = removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (removed) {
+        ++succeeded;
+        // Matches CalendarWidget.delete()'s single-event path
+        WorkflowManager.triggerWorkflowForEvent(new CalendarEventRemovedEvent(calendarEvent));
+      } else {
+        ++failed;
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "calendarEvent.delete", outcome,
+          "calendarEvent", String.valueOf(calendarEvent.getId()), calendarEvent.getTitle(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "deleted", succeeded, eventIds.size(), notFound, failed);
+    context.setRedirect("/admin/calendars");
+    return context;
+  }
+
+  /**
+   * Parses and dedupes the selected event ids from the repeated {@code eventId} hidden inputs the
+   * bulk modals inject, silently dropping any non-numeric entry (a tampered value is not a
+   * batch-ending error). Returns {@code null} when the list exceeds {@link #MAX_BULK_SELECTION} --
+   * the whole request is then rejected rather than silently truncated, since truncation could apply
+   * the action to a different subset of events than the one the admin reviewed and confirmed.
+   * Mirrors UsersListWidget#resolveSelectedUserIds / AdminImageBrowserWidget#resolveSelectedImageIds.
+   */
+  private List<Long> resolveSelectedEventIds(WidgetContext context) {
+    String[] rawIds = context.getParameterMap().get("eventId");
+    Set<Long> ids = new LinkedHashSet<>();
+    if (rawIds != null) {
+      for (String rawId : rawIds) {
+        try {
+          ids.add(Long.parseLong(rawId.trim()));
+        } catch (NumberFormatException e) {
+          // Dropped, not treated as a batch-ending error
+        }
+      }
+    }
+    if (ids.size() > MAX_BULK_SELECTION) {
+      LOG.warn("Bulk calendar event action rejected: " + ids.size() + " ids exceeds MAX_BULK_SELECTION ("
+          + MAX_BULK_SELECTION + ")");
+      return null;
+    }
+    return new ArrayList<>(ids);
+  }
+
+  private WidgetContext rejectBulkSelection(WidgetContext context) {
+    context.setErrorMessage("Too many events were selected (maximum " + MAX_BULK_SELECTION
+        + "). Select fewer events and try again.");
+    context.setRedirect("/admin/calendars");
+    return context;
+  }
+
+  private WidgetContext rejectEmptySelection(WidgetContext context) {
+    context.setErrorMessage("No events were selected");
+    context.setRedirect("/admin/calendars");
+    return context;
+  }
+
+  /**
+   * Sets the single aggregate result message every bulk action reports (page_messages.jspf renders
+   * exactly one of success/warning/error). Mirrors UsersListWidget#setBulkResultMessage.
+   */
+  private void setBulkResultMessage(WidgetContext context, String verb, int succeeded, int totalSelected,
+      int notFound, int failed) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(succeeded).append(" of ").append(totalSelected).append(" selected event")
+        .append(totalSelected == 1 ? "" : "s").append(" ").append(verb).append(".");
+    if (notFound > 0) {
+      sb.append(" Not found: ").append(notFound).append(".");
+    }
+    if (failed > 0) {
+      sb.append(" Failed: ").append(failed).append(".");
+    }
+    if (succeeded == 0) {
+      context.setErrorMessage(sb.toString());
+    } else if (succeeded != totalSelected) {
+      context.setWarningMessage(sb.toString());
+    } else {
+      context.setSuccessMessage(sb.toString());
+    }
+  }
+
   /** Builds the filter specification from request parameters. */
   private CalendarEventSpecification buildSpecification(WidgetContext context) {
     String q = context.getParameter("q");
@@ -106,10 +330,18 @@ public class CalendarEventListWidget extends GenericWidget {
     if (calendarId > -1) {
       specification.setCalendarId(calendarId);
     }
-    if ("published".equals(status)) {
-      specification.setPublishedOnly(true);
-    } else if ("draft".equals(status)) {
-      specification.setPublishedOnly(false);
+    // issue #882: archived events are excluded from this list by default -- "Archived" is its own
+    // status option (rather than combined with published/draft) since an event's archived state is
+    // orthogonal to whether it was ever published.
+    if ("archived".equals(status)) {
+      specification.setArchivedOnly(true);
+    } else {
+      specification.setArchivedOnly(false);
+      if ("published".equals(status)) {
+        specification.setPublishedOnly(true);
+      } else if ("draft".equals(status)) {
+        specification.setPublishedOnly(false);
+      }
     }
 
     // Parse the yyyy-MM-dd date range: from = start of that day, to = start of the day AFTER (half-open)

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEvents.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarAjaxEvents.java
@@ -62,6 +62,10 @@ public class CalendarAjaxEvents {
     if (publishedOnly) {
       specification.setPublishedOnly(true);
     }
+    // issue #882: archived events are never shown on the public calendar, regardless of the
+    // viewer's publishedOnly/preview permission -- archived is a distinct "no longer relevant"
+    // state, not a preview-gate concern.
+    specification.setArchivedOnly(false);
     if (calendarId > -1) {
       specification.setCalendarId(calendarId);
     }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarEventAjax.java
@@ -55,6 +55,10 @@ public class CalendarEventAjax extends GenericWidget {
     if (!canSeeUnpublished) {
       specification.setPublishedOnly(true);
     }
+    // issue #882: archived is a distinct "no longer relevant" state from the published/draft
+    // preview permission above, so this event lookup (used by full-calendar.jsp's click handler)
+    // excludes archived events unconditionally, even for an admin/content-manager viewer.
+    specification.setArchivedOnly(false);
     calendarEventList = CalendarEventRepository.findAll(specification, null);
     if (calendarEventList == null || calendarEventList.isEmpty()) {
       context.setJson("[]");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/CalendarSearchResultsWidget.java
@@ -83,6 +83,8 @@ public class CalendarSearchResultsWidget extends GenericWidget {
     // Search the calendar events
     CalendarEventSpecification eventSpecification = new CalendarEventSpecification();
     eventSpecification.setPublishedOnly(true);
+    // issue #882: archived events are excluded from every public-facing calendar surface
+    eventSpecification.setArchivedOnly(false);
     eventSpecification.setSearchTerm(query);
     eventSpecification.setStartingDateRange(startingDateRange);
     if (selectedCalendarId != -1) {
@@ -103,6 +105,7 @@ public class CalendarSearchResultsWidget extends GenericWidget {
         boolean selected = selectedCalendarId == calendar.getId();
         CalendarEventSpecification countSpecification = new CalendarEventSpecification();
         countSpecification.setPublishedOnly(true);
+        countSpecification.setArchivedOnly(false);
         countSpecification.setSearchTerm(query);
         countSpecification.setStartingDateRange(startingDateRange);
         countSpecification.setCalendarId(calendar.getId());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/calendar/UpcomingCalendarEventsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/calendar/UpcomingCalendarEventsWidget.java
@@ -57,6 +57,8 @@ public class UpcomingCalendarEventsWidget extends GenericWidget {
     // Find the last event
     CalendarEventSpecification eventSpecification = new CalendarEventSpecification();
     eventSpecification.setPublishedOnly(true);
+    // issue #882: archived events are excluded from every public-facing calendar surface
+    eventSpecification.setArchivedOnly(false);
     eventSpecification.setCalendarId(calSpec.getCalendarId());
     eventSpecification.setEndingDateRange(calSpec.getStartingDateRange());
     DataConstraints constraints = new DataConstraints(1, 1);
@@ -120,6 +122,8 @@ public class UpcomingCalendarEventsWidget extends GenericWidget {
     // Build the list of upcoming events with the given specification
     CalendarEventSpecification eventSpecification = new CalendarEventSpecification();
     eventSpecification.setPublishedOnly(true);
+    // issue #882: archived events are excluded from every public-facing calendar surface
+    eventSpecification.setArchivedOnly(false);
     if (calendarId > -1) {
       eventSpecification.setCalendarId(calendarId);
     }

--- a/src/main/webapp/WEB-INF/jsp/admin/calendar-event-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/calendar-event-list.jsp
@@ -49,6 +49,9 @@
           <option value="">All</option>
           <option value="published" <c:if test="${status == 'published'}">selected</c:if>>Published</option>
           <option value="draft" <c:if test="${status == 'draft'}">selected</c:if>>Draft</option>
+          <%-- Archived events are excluded from every other option above by default (issue #882);
+               this is the only way to see them in the admin list. --%>
+          <option value="archived" <c:if test="${status == 'archived'}">selected</c:if>>Archived</option>
         </select>
       </label>
     </div>
@@ -66,9 +69,16 @@
   <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Filter</button>
   <a href="${widgetContext.uri}" class="button small secondary radius">Clear</a>
 </form>
+<div id="bulkActionsBar" class="callout radius" style="display:none;padding:10px 15px;margin-bottom:10px;">
+  <span id="bulkSelectedCount"></span>
+  <button type="button" class="button tiny radius" id="bulkArchiveBtn">Archive</button>
+  <button type="button" class="button tiny radius" id="bulkMoveBtn">Move</button>
+  <button type="button" class="button tiny alert radius" id="bulkDeleteBtn">Delete</button>
+</div>
 <table class="unstriped">
   <thead>
     <tr>
+      <th width="24"><input type="checkbox" id="selectAllEvents" aria-label="Select all events on this page"></th>
       <th>Title</th>
       <th width="160" class="text-center">Date</th>
       <th width="160">Calendar</th>
@@ -83,6 +93,7 @@
         <c:if test="${calendar.id == event.calendarId}"><c:set var="eventCalendar" value="${calendar}" /></c:if>
       </c:forEach>
       <tr>
+        <td><input type="checkbox" class="eventRowCheckbox" value="${event.id}" data-title="${fn:escapeXml(event.title)}" aria-label="Select ${fn:escapeXml(event.title)}"></td>
         <td>
           <a href="${ctx}/admin/calendar-event?calendarEventId=${event.id}&returnPage=/admin/calendars"><c:out value="${event.title}" /></a>
         </td>
@@ -95,6 +106,9 @@
         </td>
         <td class="text-center">
           <c:choose>
+            <c:when test="${!empty event.archived}">
+              <span class="label secondary radius">Archived</span>
+            </c:when>
             <c:when test="${!empty event.published}">
               <span class="label success radius">Published</span>
             </c:when>
@@ -110,9 +124,116 @@
     </c:forEach>
     <c:if test="${empty calendarEventList}">
       <tr>
-        <td colspan="5">No events match the current filters</td>
+        <td colspan="6">No events match the current filters</td>
       </tr>
     </c:if>
   </tbody>
 </table>
 <%@include file="../paging_control.jspf" %>
+<%-- Bulk action reveal modals -- selection is scoped to the events currently checked on this page
+     (see the JS below); each is populated at open time with the live selection, not just a count.
+     Mirrors users-list.jsp's bulk reveal modals (issue #882/PR #731 pattern) and image-browser.jsp's
+     bulkDelete convention. --%>
+<div class="reveal" id="bulkArchiveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkArchiveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkArchiveRevealTitle">Archive <span id="bulkArchiveCount">0</span> Event(s)</h4>
+  <p class="help-text">Archived events are removed from the public calendar and hidden from this list by default. They can still be found with the Archived status filter.</p>
+  <ul id="bulkArchiveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkArchive"/>
+    <input type="submit" class="button radius" value="Archive Events"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkMoveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkMoveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkMoveRevealTitle">Move <span id="bulkMoveCount">0</span> Event(s)</h4>
+  <ul id="bulkMoveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkMove"/>
+    <label for="bulkMoveCalendarId">Destination calendar <span class="required">*</span>
+      <select id="bulkMoveCalendarId" name="calendarId" required>
+        <c:forEach items="${calendarList}" var="calendar">
+          <option value="${calendar.id}"><c:out value="${calendar.name}" /></option>
+        </c:forEach>
+      </select>
+    </label>
+    <input type="submit" class="button radius" value="Move Events"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkDeleteReveal" role="dialog" aria-modal="true" aria-labelledby="bulkDeleteRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkDeleteRevealTitle">Delete <span id="bulkDeleteCount">0</span> Event(s)</h4>
+  <p class="help-text">This permanently removes the selected events. This cannot be undone.</p>
+  <ul id="bulkDeleteList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkDelete"/>
+    <input type="submit" class="button alert radius" value="Delete Events"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<script nonce="${cspNonce}">
+  (function () {
+    var $selectAll = $('#selectAllEvents');
+    var $rows = $('.eventRowCheckbox');
+    var $bar = $('#bulkActionsBar');
+    var $count = $('#bulkSelectedCount');
+
+    function selected() {
+      return $rows.filter(':checked');
+    }
+
+    function refresh() {
+      var n = selected().length;
+      $count.text(n + (n === 1 ? ' event selected  ' : ' events selected  '));
+      $bar.toggle(n > 0);
+      $selectAll.prop('indeterminate', n > 0 && n < $rows.length);
+      $selectAll.prop('checked', n > 0 && n === $rows.length);
+    }
+
+    // Populates one bulk modal's hidden eventId fields and visible title list from the currently
+    // checked rows, so the admin sees exactly what is about to be affected before confirming.
+    function populateBulkModal(revealId, listId) {
+      var $reveal = $('#' + revealId);
+      var $form = $reveal.find('form');
+      var $list = $('#' + listId);
+      $form.find('input[name="eventId"]').remove();
+      $list.empty();
+      selected().each(function () {
+        var $checkbox = $(this);
+        $form.append($('<input type="hidden" name="eventId">').val($checkbox.val()));
+        $list.append($('<li>').text($checkbox.data('title')));
+      });
+      $('#' + revealId + 'Count').text(selected().length);
+      $reveal.foundation('open');
+    }
+
+    $selectAll.on('change', function () {
+      $rows.prop('checked', this.checked);
+      refresh();
+    });
+    $rows.on('change', refresh);
+
+    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList'); });
+    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList'); });
+    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList'); });
+
+    refresh();
+  })();
+</script>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.Calendar;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link CalendarEventRepository} against a real PostgreSQL instance -- specifically the
+ * issue #882 archived filter (mirroring MedicineRepository's archivedOnly shape) and the
+ * update()/remove() paths the /admin/calendars bulk actions (archive/move/delete) drive.
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available, so it does not break the build on hosts without a Docker daemon.
+ * </p>
+ *
+ * <p>
+ * The schema below is a focused subset of the real {@code calendars}/{@code calendar_events} tables
+ * (mirrored from NEW_10010__new_cms.sql): the PostGIS {@code geom} column and the
+ * {@code created_by}/{@code modified_by} foreign keys to {@code users} are intentionally omitted --
+ * nothing under test touches geom, and no {@code users} table exists in this throwaway schema.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+class CalendarEventRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping CalendarEventRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE calendar_events RESTART IDENTITY CASCADE");
+      statement.execute("TRUNCATE TABLE calendars RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset calendar tables", se);
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS calendar_events CASCADE");
+      statement.execute("DROP TABLE IF EXISTS calendars CASCADE");
+      statement.execute("CREATE TABLE calendars ("
+          + "calendar_id BIGSERIAL PRIMARY KEY, "
+          + "calendar_unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "description TEXT, "
+          + "color VARCHAR(7), "
+          + "created_by BIGINT NOT NULL, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT NOT NULL, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "enabled BOOLEAN DEFAULT true, "
+          + "event_count INTEGER DEFAULT 0)");
+      statement.execute("CREATE TABLE calendar_events ("
+          + "event_id BIGSERIAL PRIMARY KEY, "
+          + "calendar_id BIGINT REFERENCES calendars(calendar_id) NOT NULL, "
+          + "event_unique_id VARCHAR(255) NOT NULL, "
+          + "title VARCHAR(255) NOT NULL, "
+          + "body TEXT, "
+          + "summary TEXT, "
+          + "created_by BIGINT NOT NULL, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified_by BIGINT NOT NULL, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "published TIMESTAMP(3) DEFAULT NULL, "
+          + "archived TIMESTAMP(3) DEFAULT NULL, "
+          + "all_day BOOLEAN DEFAULT false, "
+          + "start_date TIMESTAMP(3) NOT NULL, "
+          + "end_date TIMESTAMP(3) NOT NULL, "
+          + "details_url VARCHAR(255), "
+          + "sign_up_url VARCHAR(255), "
+          + "latitude FLOAT DEFAULT 0, "
+          + "longitude FLOAT DEFAULT 0, "
+          + "location_name VARCHAR(255), "
+          + "street VARCHAR(100), "
+          + "address_line_2 VARCHAR(100), "
+          + "address_line_3 VARCHAR(100), "
+          + "city VARCHAR(100), "
+          + "state VARCHAR(100), "
+          + "country VARCHAR(100), "
+          + "postal_code VARCHAR(100), "
+          + "county VARCHAR(100), "
+          + "tsv TSVECTOR, "
+          + "image_url VARCHAR(255), "
+          + "video_url VARCHAR(255), "
+          + "video_embed VARCHAR(512), "
+          + "script_embed VARCHAR(512), "
+          + "tags_list VARCHAR(255))");
+      statement.execute("CREATE UNIQUE INDEX cal_events_unique_idx ON calendar_events(calendar_id, event_unique_id)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the calendar schema", se);
+    }
+  }
+
+  private static Calendar addCalendar(String uniqueId) {
+    Calendar calendar = new Calendar();
+    calendar.setUniqueId(uniqueId);
+    calendar.setName(uniqueId);
+    calendar.setCreatedBy(1L);
+    calendar.setModifiedBy(1L);
+    calendar.setEnabled(true);
+    return CalendarRepository.add(calendar);
+  }
+
+  private static CalendarEvent addEvent(long calendarId, String uniqueId, Timestamp published, Timestamp archived) {
+    CalendarEvent event = new CalendarEvent();
+    event.setCalendarId(calendarId);
+    event.setUniqueId(uniqueId);
+    event.setTitle(uniqueId);
+    event.setCreatedBy(1L);
+    event.setModifiedBy(1L);
+    event.setStartDate(Timestamp.valueOf("2026-08-01 09:00:00"));
+    event.setEndDate(Timestamp.valueOf("2026-08-01 10:00:00"));
+    event.setPublished(published);
+    event.setArchived(archived);
+    return CalendarEventRepository.add(event);
+  }
+
+  private static List<String> uniqueIdsFor(CalendarEventSpecification specification) {
+    List<CalendarEvent> results = CalendarEventRepository.findAll(specification, new DataConstraints());
+    return results == null ? List.of() : results.stream().map(CalendarEvent::getUniqueId).toList();
+  }
+
+  // --- archived filter (issue #882) ---
+
+  @Test
+  void archivedOnlyTrueReturnsOnlyArchivedEvents() {
+    Calendar calendar = addCalendar("cal-archived-only-true");
+    addEvent(calendar.getId(), "live-event", Timestamp.valueOf("2026-01-01 00:00:00"), null);
+    addEvent(calendar.getId(), "archived-event", Timestamp.valueOf("2026-01-01 00:00:00"),
+        Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setArchivedOnly(true);
+
+    assertEquals(List.of("archived-event"), uniqueIdsFor(specification));
+  }
+
+  @Test
+  void archivedOnlyFalseExcludesArchivedEvents() {
+    Calendar calendar = addCalendar("cal-archived-only-false");
+    addEvent(calendar.getId(), "live-event", null, null);
+    addEvent(calendar.getId(), "archived-event", null, Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setArchivedOnly(false);
+
+    assertEquals(List.of("live-event"), uniqueIdsFor(specification));
+  }
+
+  @Test
+  void undefinedArchivedOnlyReturnsEveryEventRegardlessOfArchivedState() {
+    // Proves the new filter is purely additive: any caller that never touches archivedOnly (every
+    // pre-#882 caller) keeps seeing archived rows exactly as before.
+    Calendar calendar = addCalendar("cal-archived-undefined");
+    addEvent(calendar.getId(), "live-event", null, null);
+    addEvent(calendar.getId(), "archived-event", null, Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    List<String> uniqueIds = uniqueIdsFor(new CalendarEventSpecification());
+
+    assertTrue(uniqueIds.contains("live-event"));
+    assertTrue(uniqueIds.contains("archived-event"));
+  }
+
+  @Test
+  void archivedFilterCombinesWithPublishedOnlyAsAnd() {
+    // A publicly-visible query (publishedOnly=true) must still exclude an archived-but-published
+    // event -- the two filters are independent dimensions, both applied.
+    Calendar calendar = addCalendar("cal-archived-and-published");
+    addEvent(calendar.getId(), "published-live", Timestamp.valueOf("2026-01-01 00:00:00"), null);
+    addEvent(calendar.getId(), "published-archived", Timestamp.valueOf("2026-01-01 00:00:00"),
+        Timestamp.valueOf("2026-06-01 00:00:00"));
+    addEvent(calendar.getId(), "draft-live", null, null);
+
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setPublishedOnly(true);
+    specification.setArchivedOnly(false);
+
+    assertEquals(List.of("published-live"), uniqueIdsFor(specification));
+  }
+
+  @Test
+  void findCountHonorsTheArchivedFilter() {
+    Calendar calendar = addCalendar("cal-archived-count");
+    addEvent(calendar.getId(), "live-1", null, null);
+    addEvent(calendar.getId(), "live-2", null, null);
+    addEvent(calendar.getId(), "archived-1", null, Timestamp.valueOf("2026-06-01 00:00:00"));
+
+    CalendarEventSpecification archivedOnly = new CalendarEventSpecification();
+    archivedOnly.setArchivedOnly(true);
+    CalendarEventSpecification nonArchivedOnly = new CalendarEventSpecification();
+    nonArchivedOnly.setArchivedOnly(false);
+
+    assertEquals(1, CalendarEventRepository.findCount(archivedOnly));
+    assertEquals(2, CalendarEventRepository.findCount(nonArchivedOnly));
+  }
+
+  // --- update()/remove() paths the bulk actions drive ---
+
+  @Test
+  void updateCanSetTheArchivedTimestamp() {
+    // Exercises CalendarEventListWidget#bulkArchiveAction's write path directly against a real row.
+    Calendar calendar = addCalendar("cal-update-archive");
+    CalendarEvent event = addEvent(calendar.getId(), "to-archive", null, null);
+    assertNull(event.getArchived());
+
+    Timestamp archivedAt = Timestamp.valueOf("2026-07-01 12:00:00");
+    event.setArchived(archivedAt);
+    CalendarEvent result = CalendarEventRepository.update(event);
+
+    assertNotNull(result);
+    CalendarEvent reloaded = CalendarEventRepository.findById(event.getId());
+    assertEquals(archivedAt, reloaded.getArchived());
+  }
+
+  @Test
+  void updateCanMoveAnEventToAnotherCalendar() {
+    // Exercises CalendarEventListWidget#bulkMoveAction's write path directly against real rows.
+    Calendar source = addCalendar("cal-move-source");
+    Calendar destination = addCalendar("cal-move-destination");
+    CalendarEvent event = addEvent(source.getId(), "to-move", null, null);
+
+    event.setCalendarId(destination.getId());
+    CalendarEvent result = CalendarEventRepository.update(event);
+
+    assertNotNull(result);
+    CalendarEvent reloaded = CalendarEventRepository.findById(event.getId());
+    assertEquals(destination.getId(), reloaded.getCalendarId());
+
+    CalendarEventSpecification destinationOnly = new CalendarEventSpecification();
+    destinationOnly.setCalendarId(destination.getId());
+    assertEquals(List.of("to-move"), uniqueIdsFor(destinationOnly));
+  }
+
+  @Test
+  void removeDeletesOnlyTheTargetedEvent() {
+    // Exercises CalendarEventListWidget#bulkDeleteAction's write path directly against real rows.
+    Calendar calendar = addCalendar("cal-remove");
+    CalendarEvent keep = addEvent(calendar.getId(), "keep-me", null, null);
+    CalendarEvent remove = addEvent(calendar.getId(), "remove-me", null, null);
+
+    boolean removed = CalendarEventRepository.remove(remove);
+
+    assertTrue(removed);
+    assertNull(CalendarEventRepository.findById(remove.getId()));
+    assertNotNull(CalendarEventRepository.findById(keep.getId()));
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryWhereClauseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import com.simisinc.platform.infrastructure.database.SqlValue;
+
+/**
+ * Pure unit tests (no database) on {@link CalendarEventRepository#createWhereStatement}'s built
+ * {@link SqlUtils} output for the archived filter issue #882 adds -- mirrors the shape of
+ * {@code ItemRepositoryWhereClauseTest}. These always run, unlike {@link CalendarEventRepositoryTest}
+ * (which needs a real PostgreSQL instance and is skipped without Docker).
+ *
+ * @author SimIS Inc.
+ */
+class CalendarEventRepositoryWhereClauseTest {
+
+  private static boolean whereContains(SqlUtils where, String fragment) {
+    for (SqlValue value : where.getValues()) {
+      if (value.getFieldOrClause() != null && value.getFieldOrClause().contains(fragment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  void archivedOnlyTrueAddsAnArchivedIsNotNullClause() {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setArchivedOnly(true);
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "archived IS NOT NULL"));
+    assertFalse(whereContains(where, "archived IS NULL"));
+  }
+
+  @Test
+  void archivedOnlyFalseAddsAnArchivedIsNullClause() {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setArchivedOnly(false);
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void archivedOnlyUndefinedByDefaultAddsNoArchivedClauseAtAll() {
+    // The default for every pre-#882 caller (and every caller that never touches this field) --
+    // proves the new filter is purely additive and does not change existing query behavior.
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertFalse(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void archivedFilterCombinesWithPublishedFilterAsAnd() {
+    // "Archived" is orthogonal to published/draft (an archived event may have been published or
+    // still a draft), so both clauses must be present together, not one replacing the other.
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setPublishedOnly(true);
+    specification.setArchivedOnly(true);
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "published IS NOT NULL"));
+    assertTrue(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void aNullSpecificationProducesNoArchivedClause() {
+    SqlUtils where = CalendarEventRepository.createWhereStatement(null);
+
+    assertFalse(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetBulkActionsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetBulkActionsTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.domain.model.cms.Calendar;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Covers the 3 bulk actions on /admin/calendars (issue #882, mirroring PR #731's
+ * UsersListWidgetBulkActionsTest for /admin/users): a batch over MAX_BULK_SELECTION is rejected
+ * outright rather than truncated, an empty selection is rejected, one id that no longer resolves
+ * never aborts the rest of the batch, bulkDelete triggers the same CalendarEventRemovedEvent
+ * workflow the single-event public delete path (CalendarWidget#delete) already triggers, and only
+ * admin/content-manager (the same pairing CalendarWidget's own post()/delete() already require) can
+ * reach any of this.
+ *
+ * @author SimIS Inc.
+ */
+class CalendarEventListWidgetBulkActionsTest extends WidgetBase {
+
+  private static CalendarEvent eventWithId(long id) {
+    CalendarEvent event = new CalendarEvent();
+    event.setId(id);
+    event.setTitle("Event " + id);
+    event.setCalendarId(1L);
+    return event;
+  }
+
+  private static Calendar calendarWithId(long id) {
+    Calendar calendar = new Calendar();
+    calendar.setId(id);
+    calendar.setName("Calendar " + id);
+    return calendar;
+  }
+
+  private void multiValue(String name, String... values) {
+    widgetContext.getParameterMap().put(name, values);
+  }
+
+  // --- Permission gate ---
+
+  @Test
+  void nonAdminNonContentManagerCannotReachBulkActionsAtAll() {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    multiValue("eventId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class)) {
+      new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.findById(any()), never());
+      repo.verify(() -> CalendarEventRepository.remove(any()), never());
+    }
+  }
+
+  @Test
+  void contentManagerCanReachBulkActions() {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    multiValue("eventId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    CalendarEvent event = eventWithId(5L);
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(event);
+      repo.when(() -> CalendarEventRepository.update(event)).thenReturn(event);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.update(event), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  // --- Selection bounds (shared shape across all 3 commands; exercised once each) ---
+
+  @Test
+  void bulkArchiveOverCapIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    String[] tooMany = new String[CalendarEventListWidget.MAX_BULK_SELECTION + 1];
+    for (int i = 0; i < tooMany.length; i++) {
+      tooMany[i] = String.valueOf(i + 100);
+    }
+    multiValue("eventId", tooMany);
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class)) {
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.findById(any()), never());
+      assertTrue(result.getErrorMessage().contains("Too many events"));
+    }
+  }
+
+  @Test
+  void emptySelectionIsRejectedForBulkDelete() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    // No eventId parameters at all
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class)) {
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.findById(any()), never());
+      assertEquals("No events were selected", result.getErrorMessage());
+    }
+  }
+
+  // --- bulkArchive ---
+
+  @Test
+  void bulkArchiveSetsTheArchivedTimestampOnEachResolvedEvent() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    CalendarEvent first = eventWithId(5L);
+    CalendarEvent second = eventWithId(6L);
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> CalendarEventRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> CalendarEventRepository.update(first)).thenReturn(first);
+      repo.when(() -> CalendarEventRepository.update(second)).thenReturn(second);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      assertNull(first.getPublished(), "archiving must not touch published");
+      assertNotNull(first.getArchived());
+      assertNotNull(second.getArchived());
+      repo.verify(() -> CalendarEventRepository.update(first), times(1));
+      repo.verify(() -> CalendarEventRepository.update(second), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("calendarEvent.archive"),
+          eq("success"), anyLong(), any(), any(), any(), eq("calendarEvent"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  @Test
+  void bulkArchiveSkipsAnIdThatNoLongerResolvesButContinues() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    CalendarEvent found = eventWithId(5L);
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(found);
+      repo.when(() -> CalendarEventRepository.findById(6L)).thenReturn(null); // deleted concurrently / tampered id
+      repo.when(() -> CalendarEventRepository.update(found)).thenReturn(found);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.update(any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Not found: 1"));
+    }
+  }
+
+  // --- bulkMove ---
+
+  @Test
+  void bulkMoveWithoutAResolvableDestinationCalendarIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "calendarId", "999");
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calRepo = mockStatic(CalendarRepository.class)) {
+      calRepo.when(() -> CalendarRepository.findById(999L)).thenReturn(null);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      // Rejected before any event is even loaded -- the destination is resolved first
+      repo.verify(() -> CalendarEventRepository.findById(any()), never());
+      assertEquals("The destination calendar was not found", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void bulkMoveUpdatesTheCalendarIdOnEachResolvedEvent() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "calendarId", "42");
+
+    Calendar destination = calendarWithId(42L);
+    CalendarEvent first = eventWithId(5L);
+    CalendarEvent second = eventWithId(6L);
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calRepo = mockStatic(CalendarRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      calRepo.when(() -> CalendarRepository.findById(42L)).thenReturn(destination);
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> CalendarEventRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> CalendarEventRepository.update(first)).thenReturn(first);
+      repo.when(() -> CalendarEventRepository.update(second)).thenReturn(second);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      assertEquals(42L, first.getCalendarId());
+      assertEquals(42L, second.getCalendarId());
+      repo.verify(() -> CalendarEventRepository.update(first), times(1));
+      repo.verify(() -> CalendarEventRepository.update(second), times(1));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+      assertTrue(result.getSuccessMessage().contains("Calendar 42"));
+    }
+  }
+
+  // --- bulkDelete ---
+
+  @Test
+  void bulkDeleteRemovesEachResolvedEventAndTriggersTheRemovedWorkflow() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    CalendarEvent first = eventWithId(5L);
+    CalendarEvent second = eventWithId(6L);
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> CalendarEventRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> CalendarEventRepository.remove(first)).thenReturn(true);
+      repo.when(() -> CalendarEventRepository.remove(second)).thenReturn(true);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      repo.verify(() -> CalendarEventRepository.remove(first), times(1));
+      repo.verify(() -> CalendarEventRepository.remove(second), times(1));
+      // Matches CalendarWidget#delete's single-event path: one workflow trigger per removed event
+      workflow.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), times(2));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("calendarEvent.delete"),
+          eq("success"), anyLong(), any(), any(), any(), eq("calendarEvent"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  @Test
+  void bulkDeleteDoesNotTriggerTheWorkflowForAFailedRemoval() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("eventId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    CalendarEvent event = eventWithId(5L);
+
+    try (MockedStatic<CalendarEventRepository> repo = mockStatic(CalendarEventRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> CalendarEventRepository.findById(5L)).thenReturn(event);
+      repo.when(() -> CalendarEventRepository.remove(event)).thenReturn(false);
+
+      WidgetContext result = new CalendarEventListWidget().post(widgetContext);
+
+      workflow.verifyNoInteractions();
+      assertEquals("0 of 1 selected event deleted. Failed: 1.", result.getErrorMessage());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/CalendarEventListWidgetTest.java
@@ -97,6 +97,7 @@ class CalendarEventListWidgetTest extends WidgetBase {
       assertEquals("town hall", spec.getSearchTerm());
       assertEquals(7L, spec.getCalendarId());
       assertEquals(1, spec.getPublishedOnly()); // DataConstants.TRUE
+      assertEquals(0, spec.getArchivedOnly()); // DataConstants.FALSE -- excluded whenever status isn't "archived"
       assertEquals(Timestamp.valueOf(LocalDate.parse("2026-08-01").atStartOfDay()), spec.getStartingDateRange());
       // The "to" bound is half-open: the start of the day AFTER the picked date, so that whole day is included
       assertEquals(Timestamp.valueOf(LocalDate.parse("2026-08-21").atStartOfDay()), spec.getEndingDateRange());
@@ -126,11 +127,36 @@ class CalendarEventListWidgetTest extends WidgetBase {
       ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
       repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
       assertEquals(0, captor.getValue().getPublishedOnly()); // DataConstants.FALSE
+      assertEquals(0, captor.getValue().getArchivedOnly()); // DataConstants.FALSE
     }
   }
 
   @Test
-  void blankFiltersLeaveTheSpecificationUnset() {
+  void archivedStatusMapsToArchivedOnlyTrueAndIgnoresPublishedOnly() {
+    // issue #882: "Archived" is its own status option, orthogonal to published/draft -- selecting
+    // it must not also constrain publishedOnly, since an archived event may have been published or
+    // still a draft before it was archived.
+    addQueryParameter(widgetContext, "status", "archived");
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
+          .thenReturn(new ArrayList<>());
+      calendarRepository.when(CalendarRepository::findAll).thenReturn(new ArrayList<>());
+
+      new CalendarEventListWidget().execute(widgetContext);
+
+      ArgumentCaptor<CalendarEventSpecification> captor = ArgumentCaptor.forClass(CalendarEventSpecification.class);
+      repository.verify(() -> CalendarEventRepository.findAll(captor.capture(), any(DataConstraints.class)));
+      CalendarEventSpecification spec = captor.getValue();
+
+      assertEquals(1, spec.getArchivedOnly()); // DataConstants.TRUE
+      assertEquals(-1, spec.getPublishedOnly()); // DataConstants.UNDEFINED -- left alone
+    }
+  }
+
+  @Test
+  void blankFiltersLeaveTheSpecificationUnsetExceptArchivedOnlyWhichDefaultsToExcluded() {
     try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
         MockedStatic<CalendarRepository> calendarRepository = mockStatic(CalendarRepository.class)) {
       repository.when(() -> CalendarEventRepository.findAll(any(CalendarEventSpecification.class), any(DataConstraints.class)))
@@ -146,6 +172,9 @@ class CalendarEventListWidgetTest extends WidgetBase {
       assertNull(spec.getSearchTerm());
       assertEquals(-1L, spec.getCalendarId());
       assertEquals(-1, spec.getPublishedOnly()); // DataConstants.UNDEFINED
+      // issue #882: archived events are hidden from the admin list by default, unlike every other
+      // filter above which stays UNDEFINED (no-op) when nothing was requested.
+      assertEquals(0, spec.getArchivedOnly()); // DataConstants.FALSE
       assertNull(spec.getStartingDateRange());
       assertNull(spec.getEndingDateRange());
     }


### PR DESCRIPTION
Closes #882.

Issue #882 (split from #501) described this as a near-mirror of PR #731's users-list bulk-actions pattern with the needed primitives already in place -- only partly true:

- **`archived` was a completely inert field.** `CalendarEvent.getArchived()`/`setArchived()` was referenced only in `CalendarEventRepository`'s own SQL mapping, never read or filtered anywhere. Added real filtering: `CalendarEventSpecification.archivedOnly` (mirroring `MedicineSpecification`'s existing shape) + a WHERE-clause branch in `CalendarEventRepository.createWhereStatement`, defaulting to `UNDEFINED` (purely additive, no behavior change for any existing caller). Archived events are now explicitly excluded from every public-facing calendar surface (`CalendarAjaxEvents`, `CalendarEventAjax`, `CalendarSearchResultsWidget`, `UpcomingCalendarEventsWidget`).
- **There was no delete flow to extend.** `calendar-event-form.jsp`/`CalendarEventFormWidget` have no delete button or confirmation, and `CalendarEventRepository.remove()` had zero callers in `src/main`. Built the confirmation UX from scratch, adapted from `image-browser.jsp`'s shipped `bulkDelete` pattern (PR #834) rather than inventing a new shape.

## What's new
Checkbox column + bulk action bar on `calendar-event-list.jsp` (mirroring `users-list.jsp`/PR #731), three `post()` handlers in `CalendarEventListWidget` (`bulkArchive`/`bulkMove`/`bulkDelete`), each: capped at `MAX_BULK_SELECTION=100` (rejects rather than silently truncates), audit-logs every item individually, and reports honest partial-failure counts (never claims full success for a partial batch).

## Test plan
- `CalendarEventRepositoryTest` (+8), `CalendarEventRepositoryWhereClauseTest` (new, 5 tests) -- archived filtering at the WHERE-clause and repository level
- `CalendarEventListWidgetBulkActionsTest` (new, 10 tests) -- all three bulk actions, permission gate, selection cap, partial-failure reporting
- Full `ant ci-test` -- BUILD SUCCESSFUL, 0 failures