### PR TITLE
Add video widget for YouTube/Vimeo embeds with consent gate (#428)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/VideoWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/VideoWidget.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * Renders a click-to-play embed for a YouTube or Vimeo video whose URL is entered as a widget
+ * preference (issue #428). This is a purpose-built widget: unlike {@code ContentWidget}'s raw-HTML
+ * youtube.com/vimeo.com substring detection (which only toggled a since-abandoned, commented-out
+ * CSP header), it parses the URL into a provider + video id and renders a lightweight placeholder --
+ * never an unconditional iframe.
+ *
+ * <p>
+ * Two gates stand between a page visitor and the real embed, both enforced here and in video.jsp --
+ * neither is optional:
+ * <ol>
+ * <li><b>Consent</b>: the real embed markup (the youtube-nocookie.com/player.vimeo.com URL, and for
+ * YouTube its static thumbnail image) is only written into the response when the site's {@code
+ * analytics-consent} cookie is {@code "accepted"} -- the same cookie main.jsp's accept/decline
+ * banner sets (issue #366). Without it, video.jsp renders a plain placeholder with no
+ * video-identifying markup at all, so nothing about the page ever calls out to YouTube/Vimeo.</li>
+ * <li><b>Click</b>: even with consent, the iframe is never embedded directly. video.jsp renders a
+ * click-to-play button; its own inline script only inserts the &lt;iframe&gt; into the DOM after
+ * the visitor clicks it.</li>
+ * </ol>
+ * </p>
+ *
+ * <p>
+ * YouTube embeds use youtube-nocookie.com rather than youtube.com, which defers YouTube's own
+ * non-essential cookies until playback actually starts.
+ * </p>
+ *
+ * <p>
+ * Vimeo has no static thumbnail URL the way YouTube does (img.youtube.com/vi/{id}/hqdefault.jpg
+ * needs no API call) -- getting one requires calling Vimeo's oEmbed endpoint. That lookup is done
+ * client-side, by video.jsp's own script calling https://vimeo.com/api/oembed.json directly from
+ * the browser, specifically so this widget does not add another server-side outbound fetch to this
+ * codebase (see issues #784 and #760, both real SSRF findings fixed by routing/pinning existing
+ * server-side outbound fetches).
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class VideoWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908897L;
+
+  static String JSP = "/cms/video.jsp";
+
+  /** Mirrors the cookie name main.jsp's analytics-consent accept/decline banner sets (issue #366).
+   * There is no shared constant for it today -- main.jsp reads it directly via the JSTL cookie map
+   * (`cookie['analytics-consent']`) rather than through CookieConstants. */
+  private static final String ANALYTICS_CONSENT_COOKIE = "analytics-consent";
+  private static final String ANALYTICS_CONSENT_ACCEPTED = "accepted";
+
+  private static final Pattern YOUTUBE_ID_PATTERN = Pattern.compile(
+      "youtube(?:-nocookie)?\\.com/(?:watch\\?(?:\\S*&)?v=|embed/|shorts/)([A-Za-z0-9_-]{6,})|youtu\\.be/([A-Za-z0-9_-]{6,})");
+  private static final Pattern VIMEO_ID_PATTERN = Pattern.compile("vimeo\\.com/(?:video/)?(\\d+)");
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Neither privacy-sensitive nor dependent on consent -- just sizing/labeling, so these are
+    // always set, even for the "hidden until consent" placeholder.
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+    // aspectRatio is only ever used by video.jsp's c:choose to pick a known CSS ratio, defaulting
+    // to 16:9 for anything unrecognized -- so it never needs validating here (same convention as
+    // LogoWidget's "view" preference).
+    context.getRequest().setAttribute("aspectRatio", context.getPreferences().get("aspectRatio"));
+
+    boolean consentGiven = hasAnalyticsConsent(context);
+    context.getRequest().setAttribute("consentGiven", String.valueOf(consentGiven));
+    if (!consentGiven) {
+      // Gate 1 (issue #428 / #366): without consent, provider/embedUrl/thumbnailUrl/videoPageUrl
+      // are never populated -- not merely hidden by the JSP. video.jsp's placeholder branch is
+      // driven off embedUrl being empty, so there is nothing here that identifies the video or
+      // could cause a request to YouTube/Vimeo, even if the JSP were changed independently later.
+      context.setJsp(JSP);
+      return context;
+    }
+
+    String videoUrl = StringUtils.trimToNull(context.getPreferences().get("videoUrl"));
+    if (videoUrl != null) {
+      String youTubeId = extractYouTubeId(videoUrl);
+      if (youTubeId != null) {
+        context.getRequest().setAttribute("provider", "youtube");
+        context.getRequest().setAttribute("embedUrl", "https://www.youtube-nocookie.com/embed/" + youTubeId + "?rel=0");
+        context.getRequest().setAttribute("thumbnailUrl", "https://img.youtube.com/vi/" + youTubeId + "/hqdefault.jpg");
+      } else {
+        String vimeoId = extractId(VIMEO_ID_PATTERN, videoUrl, 1);
+        if (vimeoId != null) {
+          context.getRequest().setAttribute("provider", "vimeo");
+          context.getRequest().setAttribute("embedUrl", "https://player.vimeo.com/video/" + vimeoId);
+          // No static thumbnail URL for Vimeo -- video.jsp fetches one client-side via Vimeo's
+          // oEmbed endpoint, using this page URL. See the class Javadoc for why that call is made
+          // from the browser rather than from here.
+          context.getRequest().setAttribute("videoPageUrl", "https://vimeo.com/" + vimeoId);
+        }
+        // Neither pattern matched -- videoUrl isn't a recognized YouTube/Vimeo URL. embedUrl is
+        // left unset, so video.jsp renders its "no video configured" placeholder, same as if the
+        // preference were blank.
+      }
+    }
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  private static String extractYouTubeId(String url) {
+    Matcher matcher = YOUTUBE_ID_PATTERN.matcher(url);
+    if (!matcher.find()) {
+      return null;
+    }
+    return matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+  }
+
+  private static String extractId(Pattern pattern, String url, int group) {
+    Matcher matcher = pattern.matcher(url);
+    return matcher.find() ? matcher.group(group) : null;
+  }
+
+  /**
+   * @return true only when the analytics-consent cookie is present and its value is exactly
+   *     "accepted" -- missing, "declined", or any other value all mean no consent
+   */
+  private static boolean hasAnalyticsConsent(WidgetContext context) {
+    Cookie[] cookies = context.getRequest().getCookies();
+    if (cookies == null) {
+      return false;
+    }
+    for (Cookie cookie : cookies) {
+      if (ANALYTICS_CONSENT_COOKIE.equals(cookie.getName())) {
+        return ANALYTICS_CONSENT_ACCEPTED.equals(cookie.getValue());
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/cms/video.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/video.jsp
@@ -1,0 +1,140 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="title" class="java.lang.String" scope="request"/>
+<jsp:useBean id="aspectRatio" class="java.lang.String" scope="request"/>
+<jsp:useBean id="provider" class="java.lang.String" scope="request"/>
+<jsp:useBean id="embedUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="thumbnailUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="videoPageUrl" class="java.lang.String" scope="request"/>
+<jsp:useBean id="consentGiven" class="java.lang.String" scope="request"/>
+<c:set var="videoWidgetId" value="video-widget${widgetContext.uniqueId}"/>
+<%-- aspectRatio is free-form (see VideoWidget#execute); any value not recognized below simply
+     falls through to the 16:9 default, so it never needs sanitizing to be safe here. --%>
+<c:choose>
+  <c:when test="${aspectRatio eq '4:3'}"><c:set var="aspectRatioCss" value="4 / 3"/></c:when>
+  <c:when test="${aspectRatio eq '1:1'}"><c:set var="aspectRatioCss" value="1 / 1"/></c:when>
+  <c:when test="${aspectRatio eq '9:16'}"><c:set var="aspectRatioCss" value="9 / 16"/></c:when>
+  <c:otherwise><c:set var="aspectRatioCss" value="16 / 9"/></c:otherwise>
+</c:choose>
+<c:choose>
+  <%-- Gate 1: no analytics consent yet -- VideoWidget#execute never even populates embedUrl/
+       provider/thumbnailUrl without consent, so there is nothing here that identifies the video or
+       could cause a request to YouTube/Vimeo, only a static placeholder (issue #428 / #366) --%>
+  <c:when test="${consentGiven ne 'true'}">
+    <div class="platform-video-widget-consent-placeholder" role="note" style="aspect-ratio: <c:out value="${aspectRatioCss}"/>;">
+      <i class="fa fa-video" aria-hidden="true"></i>
+      <p>This video is hidden until analytics cookies are accepted.</p>
+    </div>
+  </c:when>
+  <%-- Consent is present, but no videoUrl preference was set, or it didn't match a recognized
+       YouTube/Vimeo URL --%>
+  <c:when test="${empty embedUrl}">
+    <div class="platform-video-widget-placeholder" role="img" style="aspect-ratio: <c:out value="${aspectRatioCss}"/>;"
+         aria-label="<c:out value="${empty title ? 'No video configured' : title}"/>">
+      <i class="fa fa-video" aria-hidden="true"></i>
+    </div>
+  </c:when>
+  <%-- Gate 2: consent is present and the video is recognized, but the iframe is still not embedded
+       until the visitor clicks --%>
+  <c:otherwise>
+    <div id="${videoWidgetId}" class="platform-video-widget" style="aspect-ratio: <c:out value="${aspectRatioCss}"/>;"
+         data-embed-url="<c:out value="${embedUrl}"/>" data-video-title="<c:out value="${title}"/>">
+      <button type="button" class="platform-video-play-button"
+              <c:if test="${provider eq 'youtube'}">style="background-image: url('<c:out value="${thumbnailUrl}"/>');"</c:if>
+              aria-label="Play video<c:if test="${!empty title}">: <c:out value="${title}"/></c:if>">
+        <i class="fa fa-play-circle" aria-hidden="true"></i>
+      </button>
+    </div>
+    <style nonce="${cspNonce}">
+      #${videoWidgetId} {
+        position: relative;
+        width: 100%;
+        overflow: hidden;
+        background: #000;
+      }
+      #${videoWidgetId} .platform-video-play-button {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        padding: 0;
+        margin: 0;
+        cursor: pointer;
+        background-color: #222;
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        color: #fff;
+        font-size: 3.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #${videoWidgetId} .platform-video-play-button:hover,
+      #${videoWidgetId} .platform-video-play-button:focus {
+        color: #fff;
+        opacity: 0.9;
+      }
+      #${videoWidgetId} iframe {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+    </style>
+    <script nonce="${cspNonce}">
+      (function () {
+        var container = document.getElementById('${videoWidgetId}');
+        if (!container) {
+          return;
+        }
+        var playButton = container.querySelector('.platform-video-play-button');
+        <c:if test="${provider eq 'vimeo'}">
+        // Vimeo has no static thumbnail URL the way YouTube does (img.youtube.com/vi/{id}/hqdefault.jpg
+        // needs no API call) -- fetch one from Vimeo's public, CORS-enabled oEmbed endpoint directly
+        // from the browser. This is intentionally NOT a server-side fetch -- see VideoWidget's class
+        // Javadoc and the PR description for why (issues #784, #760).
+        fetch('https://vimeo.com/api/oembed.json?url=' + encodeURIComponent('${js:escape(videoPageUrl)}'))
+          .then(function (response) { return response.ok ? response.json() : null; })
+          .then(function (data) {
+            if (data && data.thumbnail_url && playButton) {
+              playButton.style.backgroundImage = "url('" + data.thumbnail_url + "')";
+            }
+          })
+          .catch(function () {
+            // The thumbnail is a nice-to-have; the click-to-play button still works without it.
+          });
+        </c:if>
+        if (playButton) {
+          playButton.addEventListener('click', function () {
+            var iframe = document.createElement('iframe');
+            iframe.src = container.getAttribute('data-embed-url');
+            iframe.title = container.getAttribute('data-video-title') || 'Video';
+            iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share');
+            iframe.allowFullscreen = true;
+            container.innerHTML = '';
+            container.appendChild(iframe);
+          });
+        }
+      })();
+    </script>
+  </c:otherwise>
+</c:choose>

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -63,6 +63,7 @@
   <widget name="form" class="com.simisinc.platform.presentation.widgets.cms.FormWidget" />
   <widget name="albumGallery" class="com.simisinc.platform.presentation.widgets.cms.AlbumGalleryWidget" />
   <widget name="photoGallery" class="com.simisinc.platform.presentation.widgets.cms.PhotoGalleryWidget" />
+  <widget name="video" class="com.simisinc.platform.presentation.widgets.cms.VideoWidget" />
   <widget name="fileList" class="com.simisinc.platform.presentation.widgets.cms.FileListWidget" />
   <widget name="fileListByFolder" class="com.simisinc.platform.presentation.widgets.cms.FileListByFolderWidget" />
   <widget name="fileListByYear" class="com.simisinc.platform.presentation.widgets.cms.FileListByYearWidget" />

--- a/src/main/webapp/WEB-INF/widgets/widget-schema.json
+++ b/src/main/webapp/WEB-INF/widgets/widget-schema.json
@@ -251,6 +251,36 @@
       "preferences": []
     },
 
+    "video": {
+      "label": "Video",
+      "category": "Media",
+      "icon": "fa-video",
+      "preferences": [
+        {
+          "name": "videoUrl",
+          "label": "Video URL (YouTube or Vimeo)",
+          "type": "url"
+        },
+        {
+          "name": "title",
+          "label": "Title",
+          "type": "text"
+        },
+        {
+          "name": "aspectRatio",
+          "label": "Aspect Ratio",
+          "type": "select",
+          "options": [
+            "16:9",
+            "4:3",
+            "1:1",
+            "9:16"
+          ],
+          "default": "16:9"
+        }
+      ]
+    },
+
     "form": {
       "label": "Form",
       "category": "Forms",

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/VideoWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/VideoWidgetTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.WidgetBase;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * Covers issue #428: YouTube and Vimeo url parsing, the youtube-nocookie.com domain, and the
+ * consent gate -- VideoWidget#execute must not populate provider/embedUrl/thumbnailUrl (the "real
+ * embed markup" video.jsp renders into the click-to-play button) unless the analytics-consent
+ * cookie is present and "accepted"; without it, only the placeholder-driving attributes are set.
+ *
+ * @author SimIS Inc.
+ */
+class VideoWidgetTest extends WidgetBase {
+
+  private static final Cookie ACCEPTED = new Cookie("analytics-consent", "accepted");
+  private static final Cookie DECLINED = new Cookie("analytics-consent", "declined");
+
+  private static final String YOUTUBE_XML = "<widget name=\"video\">\n" +
+      "  <videoUrl>https://www.youtube.com/watch?v=dQw4w9WgXcQ</videoUrl>\n" +
+      "  <title>Sample Video</title>\n" +
+      "</widget>";
+
+  private static final String VIMEO_XML = "<widget name=\"video\">\n" +
+      "  <videoUrl>https://vimeo.com/76979871</videoUrl>\n" +
+      "  <title>Sample Vimeo Video</title>\n" +
+      "</widget>";
+
+  @Test
+  void executeWithYouTubeUrlAndConsentRendersNoCookieEmbedAndThumbnail() {
+    when(request.getCookies()).thenReturn(new Cookie[] { ACCEPTED });
+    addPreferencesFromWidgetXml(widgetContext, YOUTUBE_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("true", request.getAttribute("consentGiven"));
+    Assertions.assertEquals("youtube", request.getAttribute("provider"));
+    Assertions.assertEquals("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0", request.getAttribute("embedUrl"));
+    Assertions.assertEquals("https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg", request.getAttribute("thumbnailUrl"));
+    Assertions.assertEquals(VideoWidget.JSP, widgetContext.getJsp());
+
+    // Never youtube.com itself -- youtube-nocookie.com only
+    Assertions.assertFalse(((String) request.getAttribute("embedUrl")).contains("//www.youtube.com"));
+  }
+
+  @Test
+  void executeParsesYouTubeShortUrlAndEmbedUrlVariants() {
+    when(request.getCookies()).thenReturn(new Cookie[] { ACCEPTED });
+
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"video\">\n" +
+            "  <videoUrl>https://youtu.be/dQw4w9WgXcQ</videoUrl>\n" +
+            "</widget>");
+    new VideoWidget().execute(widgetContext);
+    Assertions.assertEquals("youtube", request.getAttribute("provider"));
+    Assertions.assertEquals("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0", request.getAttribute("embedUrl"));
+
+    preferences.clear();
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"video\">\n" +
+            "  <videoUrl>https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ</videoUrl>\n" +
+            "</widget>");
+    new VideoWidget().execute(widgetContext);
+    Assertions.assertEquals("youtube", request.getAttribute("provider"));
+    Assertions.assertEquals("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0", request.getAttribute("embedUrl"));
+  }
+
+  @Test
+  void executeWithVimeoUrlAndConsentRendersPlayerEmbedAndPageUrlForClientSideOembed() {
+    when(request.getCookies()).thenReturn(new Cookie[] { ACCEPTED });
+    addPreferencesFromWidgetXml(widgetContext, VIMEO_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("true", request.getAttribute("consentGiven"));
+    Assertions.assertEquals("vimeo", request.getAttribute("provider"));
+    Assertions.assertEquals("https://player.vimeo.com/video/76979871", request.getAttribute("embedUrl"));
+    // No server-side thumbnail lookup -- video.jsp does the oEmbed call client-side using this url
+    Assertions.assertEquals("https://vimeo.com/76979871", request.getAttribute("videoPageUrl"));
+    Assertions.assertNull(request.getAttribute("thumbnailUrl"));
+    Assertions.assertEquals(VideoWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeWithNoConsentCookieWithholdsRealEmbedMarkupEvenForAValidYouTubeUrl() {
+    // No cookies at all on the request (the common case for a first-time visitor)
+    when(request.getCookies()).thenReturn(null);
+    addPreferencesFromWidgetXml(widgetContext, YOUTUBE_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("false", request.getAttribute("consentGiven"));
+    // The real embed markup must never be populated without consent -- video.jsp's placeholder
+    // branch is driven entirely off these being absent, not a JSP-side re-check of the cookie.
+    Assertions.assertNull(request.getAttribute("provider"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+    Assertions.assertNull(request.getAttribute("thumbnailUrl"));
+    Assertions.assertEquals(VideoWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeWithNoConsentCookieWithholdsRealEmbedMarkupForAValidVimeoUrl() {
+    when(request.getCookies()).thenReturn(null);
+    addPreferencesFromWidgetXml(widgetContext, VIMEO_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("false", request.getAttribute("consentGiven"));
+    Assertions.assertNull(request.getAttribute("provider"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+    Assertions.assertNull(request.getAttribute("videoPageUrl"));
+  }
+
+  @Test
+  void executeWithDeclinedConsentCookieWithholdsRealEmbedMarkup() {
+    when(request.getCookies()).thenReturn(new Cookie[] { DECLINED });
+    addPreferencesFromWidgetXml(widgetContext, YOUTUBE_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("false", request.getAttribute("consentGiven"));
+    Assertions.assertNull(request.getAttribute("provider"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+  }
+
+  @Test
+  void executeWithUnrelatedCookiesWithholdsRealEmbedMarkup() {
+    when(request.getCookies()).thenReturn(new Cookie[] { new Cookie("some-other-cookie", "accepted") });
+    addPreferencesFromWidgetXml(widgetContext, YOUTUBE_XML);
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("false", request.getAttribute("consentGiven"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+  }
+
+  @Test
+  void executeWithNoVideoUrlLeavesEmbedUrlUnset() {
+    when(request.getCookies()).thenReturn(new Cookie[] { ACCEPTED });
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertEquals("true", request.getAttribute("consentGiven"));
+    Assertions.assertNull(request.getAttribute("provider"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+    Assertions.assertEquals(VideoWidget.JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeWithUnrecognizedUrlLeavesEmbedUrlUnset() {
+    when(request.getCookies()).thenReturn(new Cookie[] { ACCEPTED });
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"video\">\n" +
+            "  <videoUrl>https://example.com/not-a-video-site</videoUrl>\n" +
+            "</widget>");
+
+    VideoWidget widget = new VideoWidget();
+    widget.execute(widgetContext);
+
+    Assertions.assertNull(request.getAttribute("provider"));
+    Assertions.assertNull(request.getAttribute("embedUrl"));
+  }
+}


### PR DESCRIPTION
Closes #428.

No first-class video-embed widget existed -- `VideoBrowserWidget` is an unrelated admin file browser, and `ContentWidget`'s only video handling was a raw youtube.com/vimeo.com substring check feeding a large commented-out CSP block, with no consent gating, no youtube-nocookie, no click-to-play.

New `VideoWidget` + `video.jsp`, following the existing widget-schema.json/widget-library.xml pattern:
- Consent gate: the real embed URL/thumbnail are never written into the response unless the site's `analytics-consent` cookie (the mechanism issue #366 shipped) is accepted -- not just visually hidden, genuinely absent from the markup.
- Click gate: even with consent, a click-to-play placeholder renders first; the iframe is only inserted after the visitor clicks.
- YouTube via youtube-nocookie.com, static thumbnail (no API call needed).
- Vimeo has no static thumbnail URL, so the oEmbed lookup happens client-side (a browser-side fetch to Vimeo's oEmbed endpoint) rather than adding a new server-side outbound fetch, given this codebase's SSRF history (#784, #760).

## Test plan
- `VideoWidgetTest` (9 cases): both providers' URL formats, consent-gate on/off, malformed/unrecognized URL, aspect-ratio preference
- Full `ant ci-test` -- BUILD SUCCESSFUL, 0 failures
- `compile-jsp` + unescaped-EL gate -- clean