### PR TITLE
Fix FolderFilesListWidget claiming success on a failed file delete

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidget.java
@@ -306,17 +306,18 @@ public class FolderFilesListWidget extends GenericWidget {
     String targetId = String.valueOf(record.getId());
     String targetLabel = record.getFilename();
     try {
-      // NOTE: the pre-existing "File deleted" success message/redirect below does not check
-      // DeleteFileCommand.deleteFile()'s boolean return value (a latent bug, out of scope here); the
-      // audit record below uses the real return value so it reflects what actually happened.
       boolean removed = DeleteFileCommand.deleteFile(record);
       AuditEventCommand.record(context, AuditEventCommand.CONTENT, "folder_file.delete",
           removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE, "folder_file", targetId, targetLabel, null);
-      context.setSuccessMessage("File deleted");
-      if (record.getSubFolderId() > -1) {
-        context.setRedirect("/admin/sub-folder-details?folderId=" + record.getFolderId() + "&subFolderId=" + record.getSubFolderId());
+      if (removed) {
+        context.setSuccessMessage("File deleted");
+        if (record.getSubFolderId() > -1) {
+          context.setRedirect("/admin/sub-folder-details?folderId=" + record.getFolderId() + "&subFolderId=" + record.getSubFolderId());
+        } else {
+          context.setRedirect("/admin/folder-details?folderId=" + record.getFolderId());
+        }
       } else {
-        context.setRedirect("/admin/folder-details?folderId=" + record.getFolderId());
+        context.setErrorMessage("Error. File could not be deleted.");
       }
       return context;
     } catch (Exception e) {

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FolderFilesListWidgetTest.java
@@ -18,6 +18,7 @@ package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.ArrayList;
@@ -30,6 +31,9 @@ import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.cms.CheckFolderPermissionCommand;
+import com.simisinc.platform.application.cms.DeleteFileCommand;
+import com.simisinc.platform.application.cms.LoadFileCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
 import com.simisinc.platform.domain.model.cms.Folder;
 import com.simisinc.platform.domain.model.cms.FolderCategory;
 import com.simisinc.platform.domain.model.cms.SubFolder;
@@ -39,6 +43,7 @@ import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderCategoryRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FolderRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.SubFolderRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 
 /**
  * Verifies the search-by-filename/title and sort-by-name/date/size/downloads behavior added to the
@@ -255,5 +260,34 @@ class FolderFilesListWidgetTest extends WidgetBase {
     // instead, since the explicit "size" sort survives alongside it.
     Assertions.assertEquals("report", specCaptor.getValue().getSearchTerm());
     Assertions.assertArrayEquals(new String[] { "file_length" }, constraintsCaptor.getValue().getColumnsToSortBy());
+  }
+
+  @Test
+  void deleteWhenTheRepositoryRemoveFailsDoesNotClaimSuccess() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "fileId", "7");
+
+    FileItem record = new FileItem();
+    record.setId(7L);
+    record.setFilename("policy.pdf");
+    record.setFolderId(5L);
+
+    try (MockedStatic<LoadFileCommand> loadFileCommand = mockStatic(LoadFileCommand.class);
+        MockedStatic<DeleteFileCommand> deleteFileCommand = mockStatic(DeleteFileCommand.class);
+        MockedStatic<AuditEventCommand> auditEventCommand = mockStatic(AuditEventCommand.class)) {
+      loadFileCommand.when(() -> LoadFileCommand.loadItemById(7L)).thenReturn(record);
+      // A false return (no exception) models a DB-level failure, e.g. FileItemRepository.remove()
+      // failing -- the widget must not tell the admin the file was deleted when it was not.
+      deleteFileCommand.when(() -> DeleteFileCommand.deleteFile(record)).thenReturn(false);
+
+      new FolderFilesListWidget().delete(widgetContext);
+
+      auditEventCommand.verify(() -> AuditEventCommand.record(any(), any(), any(),
+          eq(AuditEventCommand.FAILURE), any(), any(), any(), any()));
+    }
+
+    Assertions.assertNull(widgetContext.getSuccessMessage());
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+    Assertions.assertNull(widgetContext.getRedirect());
   }
 }


### PR DESCRIPTION
## Problem

`FolderFilesListWidget.delete(WidgetContext)` always set the "File deleted" success message and redirected to the folder view, regardless of `DeleteFileCommand.deleteFile()`'s return value. `deleteFile()` returns `false` (without throwing) when `FileItemRepository.remove(fileBean)` fails at the DB level -- in that case the admin was told the file was deleted when it was not.

Found while reviewing the audit trail added in #900, whose `folder_file.delete` audit event already correctly reflects the real `removed` boolean (SUCCESS vs FAILURE) -- but the pre-existing UI message logic was left alone there to keep that PR scoped to adding audit records.

## Fix

Branch on `removed` the same way `AdminImageBrowserWidget#deleteOne()` and `WikiListWidget#delete()` already do for their own repository-delete calls: only set the success message and redirect when the delete actually succeeded; otherwise set the existing "Error. File could not be deleted." message (previously only reachable from the `catch` block).

## Testing

- Added `deleteWhenTheRepositoryRemoveFailsDoesNotClaimSuccess` to `FolderFilesListWidgetTest`, mocking `DeleteFileCommand.deleteFile()` to return `false` and asserting no success message/redirect and a non-null error message. Confirmed it fails without the fix and passes with it.
- `ant -lib lib/tests -Dtest.includes='**/FolderFilesListWidgetTest.class' ci-test` -- 8/8 passing.
- `ant clean compile` -- clean.