### PR TITLE
Phase 1: Webhook event system for mailing lists and core entities (#452)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
@@ -80,14 +80,21 @@ public class MailingListMemberCommand {
     // Use the email to remove from the list
     Email email = EmailRepository.findByEmailAddress(user.getEmail());
     if (email != null) {
+      // issue #452: capture prior state before mutating, so a duplicate/retried unsubscribe
+      // (already unsubscribed) doesn't fire a misleading "just transitioned from subscribed" event
+      MailingListMember existingBefore = MailingListMemberRepository.findByListAndEmail(mailingList.getId(),
+          email.getId());
+      boolean wasSubscribed = existingBefore != null && existingBefore.getUnsubscribed() == null;
+
       email.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
       MailingListMemberRepository.unsubscribe(mailingList, email, user);
       triggerEmailSubscriptionProcess(email, mailingList, false);
-      // issue #452: webhook/workflow event for the mailing-list-member lifecycle
-      MailingListMember member = MailingListMemberRepository.findByListAndEmail(mailingList.getId(), email.getId());
-      if (member != null) {
-        WorkflowManager.triggerWorkflowForEvent(
-            new MailingListMemberUpdatedEvent(member, mailingList, user, "unsubscribed", true));
+      if (wasSubscribed) {
+        MailingListMember member = MailingListMemberRepository.findByListAndEmail(mailingList.getId(), email.getId());
+        if (member != null) {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberUpdatedEvent(member, mailingList, user, "unsubscribed", true));
+        }
       }
     }
   }

--- a/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
@@ -17,12 +17,15 @@
 package com.simisinc.platform.application.mailinglists;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
 import com.simisinc.platform.infrastructure.scheduler.mailinglists.ProcessEmailSubscriptionJob;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.UserSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -80,6 +83,12 @@ public class MailingListMemberCommand {
       email.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
       MailingListMemberRepository.unsubscribe(mailingList, email, user);
       triggerEmailSubscriptionProcess(email, mailingList, false);
+      // issue #452: webhook/workflow event for the mailing-list-member lifecycle
+      MailingListMember member = MailingListMemberRepository.findByListAndEmail(mailingList.getId(), email.getId());
+      if (member != null) {
+        WorkflowManager.triggerWorkflowForEvent(
+            new MailingListMemberUpdatedEvent(member, mailingList, user, "unsubscribed", true));
+      }
     }
   }
 

--- a/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
@@ -114,17 +114,24 @@ public class SaveEmailCommand {
       throw new DataException("Please check the email address and try again");
     }
     // Add email to each list (even if user is already on it), and send to mailing list integration
-    User actingUser = email.getCreatedBy() > -1 ? UserRepository.findByUserId(email.getCreatedBy()) : null;
+    // issue #452: resolve the acting user from the submitted bean, not the persisted/re-fetched
+    // `email` record -- EmailRepository.update() deliberately never overwrites created_by (the
+    // #810 fix), so on the duplicate-email/update branch above, email.getCreatedBy() would still
+    // be whoever originally created that address, not who is submitting this request
+    User actingUser = emailBean.getCreatedBy() > -1 ? UserRepository.findByUserId(emailBean.getCreatedBy()) : null;
     for (MailingList mailingList : mailingLists) {
       MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
           mailingList);
       MailingListMemberCommand.triggerEmailSubscriptionProcess(email, mailingList, true);
       if (result != null && result.getMember() != null) {
-        // issue #452: webhook/workflow event for the mailing-list-member lifecycle
+        // issue #452: webhook/workflow event for the mailing-list-member lifecycle. A "not
+        // created" result also covers a harmless re-add of an already-active member (the (list,
+        // email) unique constraint just rejected a duplicate insert) -- only a genuine
+        // reactivation of a previously-unsubscribed member is a real state change worth an event
         if (result.isCreated()) {
           WorkflowManager.triggerWorkflowForEvent(
               new MailingListMemberCreatedEvent(result.getMember(), mailingList, actingUser));
-        } else {
+        } else if (result.wasPreviouslyUnsubscribed()) {
           WorkflowManager.triggerWorkflowForEvent(
               new MailingListMemberUpdatedEvent(result.getMember(), mailingList, actingUser, "resubscribed", false));
         }

--- a/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
@@ -25,12 +25,17 @@ import org.apache.commons.logging.LogFactory;
 import com.sanctionco.jmail.JMail;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.maps.GeoIPCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.domain.model.maps.GeoIP;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 
 /**
  * Validates and saves an email address to a mailing list
@@ -109,9 +114,21 @@ public class SaveEmailCommand {
       throw new DataException("Please check the email address and try again");
     }
     // Add email to each list (even if user is already on it), and send to mailing list integration
+    User actingUser = email.getCreatedBy() > -1 ? UserRepository.findByUserId(email.getCreatedBy()) : null;
     for (MailingList mailingList : mailingLists) {
-      MailingListMemberRepository.addEmailToList(email, mailingList);
+      MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+          mailingList);
       MailingListMemberCommand.triggerEmailSubscriptionProcess(email, mailingList, true);
+      if (result != null && result.getMember() != null) {
+        // issue #452: webhook/workflow event for the mailing-list-member lifecycle
+        if (result.isCreated()) {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberCreatedEvent(result.getMember(), mailingList, actingUser));
+        } else {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberUpdatedEvent(result.getMember(), mailingList, actingUser, "resubscribed", false));
+        }
+      }
     }
     return email;
   }

--- a/src/main/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommand.java
+++ b/src/main/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommand.java
@@ -24,6 +24,11 @@ import org.apache.commons.logging.LogFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberDeletedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.domain.events.cms.BlogPostPublishedEvent;
 import com.simisinc.platform.domain.events.cms.CalendarEventRemovedEvent;
 import com.simisinc.platform.domain.events.cms.CalendarEventRescheduledEvent;
@@ -154,6 +159,18 @@ public class BuildWebhookPayloadCommand {
     } else if (event instanceof UserAccountRestoredEvent userAccountRestoredEvent) {
       data.put("user", userSummary(userAccountRestoredEvent.getUser()));
       data.put("approvedBy", userSummary(userAccountRestoredEvent.getApprovedBy()));
+    } else if (event instanceof MailingListMemberCreatedEvent mailingListMemberCreatedEvent) {
+      putMailingListMember(data, mailingListMemberCreatedEvent.getMember(), mailingListMemberCreatedEvent.getMailingList());
+      data.put("user", userSummary(mailingListMemberCreatedEvent.getUser()));
+    } else if (event instanceof MailingListMemberUpdatedEvent mailingListMemberUpdatedEvent) {
+      putMailingListMember(data, mailingListMemberUpdatedEvent.getMember(), mailingListMemberUpdatedEvent.getMailingList());
+      data.put("changeType", mailingListMemberUpdatedEvent.getChangeType());
+      data.put("previousState",
+          java.util.Collections.singletonMap("subscribed", mailingListMemberUpdatedEvent.isPreviouslySubscribed()));
+      data.put("user", userSummary(mailingListMemberUpdatedEvent.getUser()));
+    } else if (event instanceof MailingListMemberDeletedEvent mailingListMemberDeletedEvent) {
+      putMailingListMember(data, mailingListMemberDeletedEvent.getMember(), mailingListMemberDeletedEvent.getMailingList());
+      data.put("user", userSummary(mailingListMemberDeletedEvent.getUser()));
     } else {
       LOG.warn("No webhook payload mapping for event type: " + event.getClass().getName()
           + " -- delivering with an empty data object rather than failing the dispatch");
@@ -170,6 +187,20 @@ public class BuildWebhookPayloadCommand {
     data.put("startDate", calendarEvent.getStartDate());
     data.put("endDate", calendarEvent.getEndDate());
     data.put("location", calendarEvent.getLocation());
+  }
+
+  private static void putMailingListMember(Map<String, Object> data, MailingListMember member,
+      MailingList mailingList) {
+    if (member == null) {
+      return;
+    }
+    data.put("memberId", member.getId());
+    data.put("email", member.getEmailAddress());
+    data.put("subscribed", member.getIsValid());
+    if (mailingList != null) {
+      data.put("mailingListId", mailingList.getId());
+      data.put("mailingListName", mailingList.getName());
+    }
   }
 
   private static void putWebPage(Map<String, Object> data,

--- a/src/main/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommand.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Event} subclass just declares its own {@code public static final String ID}). This list was
  * built by enumerating every class under {@code com.simisinc.platform.domain.events.**} and
  * cross-checked against {@code BuildWebhookPayloadCommand}'s {@code instanceof} chain, which
- * handles the identical 14 types (any addition/removal there means this list is stale too).
+ * handles the identical 17 types (any addition/removal there means this list is stale too).
  *
  * <p>
  * Deliberately excludes {@code item-file-uploaded}: it is referenced in {@code
@@ -73,7 +73,10 @@ public class WebhookEventTypeCommand {
       new WebhookEventType("user-invited", "User invited by an admin"),
       new WebhookEventType("user-password-reset", "User password reset"),
       new WebhookEventType("unsuspend-requested", "Account unsuspend requested"),
-      new WebhookEventType("user-account-restored", "User account restored"))));
+      new WebhookEventType("user-account-restored", "User account restored"),
+      new WebhookEventType("mailing-list-member-created", "Mailing list member subscribed"),
+      new WebhookEventType("mailing-list-member-updated", "Mailing list member subscription changed"),
+      new WebhookEventType("mailing-list-member-deleted", "Mailing list member removed"))));
 
   private WebhookEventTypeCommand() {
     // Static utility, not instantiated

--- a/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberCreatedEvent.java
+++ b/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberCreatedEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.events.mailinglists;
+
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+
+/**
+ * Event details for when a new mailing list member is created (issue #452).
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListMemberCreatedEvent extends Event {
+
+  public static final String ID = "mailing-list-member-created";
+
+  private final MailingListMember member;
+  private final MailingList mailingList;
+  private final User user;
+
+  public MailingListMemberCreatedEvent(MailingListMember member, MailingList mailingList, User user) {
+    this.member = member;
+    this.mailingList = mailingList;
+    this.user = user;
+  }
+
+  @Override
+  public String getDomainEventType() {
+    return ID;
+  }
+
+  public MailingListMember getMember() {
+    return member;
+  }
+
+  public MailingList getMailingList() {
+    return mailingList;
+  }
+
+  /** The user who triggered the subscription, or null for an anonymous/public signup. */
+  public User getUser() {
+    return user;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberDeletedEvent.java
+++ b/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberDeletedEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.events.mailinglists;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+
+/**
+ * Event details for when a mailing list member is removed (issue #452). {@code member} is the
+ * last-known snapshot taken immediately before deletion -- the row no longer exists by the time
+ * this event is dispatched.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListMemberDeletedEvent extends Event {
+
+  public static final String ID = "mailing-list-member-deleted";
+
+  private final MailingListMember member;
+  private final MailingList mailingList;
+  private final User user;
+
+  public MailingListMemberDeletedEvent(MailingListMember member, MailingList mailingList, User user) {
+    this.member = member;
+    this.mailingList = mailingList;
+    this.user = user;
+  }
+
+  @Override
+  public String getDomainEventType() {
+    return ID;
+  }
+
+  public MailingListMember getMember() {
+    return member;
+  }
+
+  public MailingList getMailingList() {
+    return mailingList;
+  }
+
+  /** The admin who removed the member, or null if removed by an automated process. */
+  public User getUser() {
+    return user;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberUpdatedEvent.java
+++ b/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberUpdatedEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.events.mailinglists;
+
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+
+/**
+ * Event details for when an existing mailing list member's subscription status changes (issue
+ * #452) -- currently fired for "resubscribed" (re-adding a previously-unsubscribed address) and
+ * "unsubscribed". {@code previouslySubscribed} carries the one piece of prior state a receiver
+ * needs to tell these apart without a second lookup.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListMemberUpdatedEvent extends Event {
+
+  public static final String ID = "mailing-list-member-updated";
+
+  private final MailingListMember member;
+  private final MailingList mailingList;
+  private final User user;
+  private final String changeType;
+  private final boolean previouslySubscribed;
+
+  public MailingListMemberUpdatedEvent(MailingListMember member, MailingList mailingList, User user,
+      String changeType, boolean previouslySubscribed) {
+    this.member = member;
+    this.mailingList = mailingList;
+    this.user = user;
+    this.changeType = changeType;
+    this.previouslySubscribed = previouslySubscribed;
+  }
+
+  @Override
+  public String getDomainEventType() {
+    return ID;
+  }
+
+  public MailingListMember getMember() {
+    return member;
+  }
+
+  public MailingList getMailingList() {
+    return mailingList;
+  }
+
+  /** The user who triggered the change, or null for an anonymous/self-service action. */
+  public User getUser() {
+    return user;
+  }
+
+  /** e.g. "resubscribed", "unsubscribed". */
+  public String getChangeType() {
+    return changeType;
+  }
+
+  public boolean isPreviouslySubscribed() {
+    return previouslySubscribed;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -61,18 +61,28 @@ public class MailingListMemberRepository {
 
   /** Whether {@link #addEmailToList} inserted a new member row or reactivated an existing one
    *  (issue #452 -- the caller needs this to fire a created vs. updated lifecycle event), plus the
-   *  persisted row so the caller doesn't have to look it up separately. */
+   *  persisted row so the caller doesn't have to look it up separately. {@code
+   *  previouslyUnsubscribed} distinguishes a genuine reactivation (the row existed and was
+   *  unsubscribed) from a harmless re-add of an already-active member (the row existed and was
+   *  never unsubscribed) -- both land in the {@code created == false} branch, but only the former
+   *  is a real state change worth an event. */
   public static final class AddToListResult {
     private final boolean created;
+    private final boolean previouslyUnsubscribed;
     private final MailingListMember member;
 
-    public AddToListResult(boolean created, MailingListMember member) {
+    public AddToListResult(boolean created, boolean previouslyUnsubscribed, MailingListMember member) {
       this.created = created;
+      this.previouslyUnsubscribed = previouslyUnsubscribed;
       this.member = member;
     }
 
     public boolean isCreated() {
       return created;
+    }
+
+    public boolean wasPreviouslyUnsubscribed() {
+      return previouslyUnsubscribed;
     }
 
     public MailingListMember getMember() {
@@ -81,6 +91,11 @@ public class MailingListMemberRepository {
   }
 
   public static AddToListResult addEmailToList(Email email, MailingList mailingList) {
+    // Capture prior state before mutating, so the caller can tell a genuine reactivation (was
+    // unsubscribed) from a harmless re-add of an already-active member (issue #452)
+    MailingListMember existingBefore = findByListAndEmail(mailingList.getId(), email.getId());
+    boolean previouslyUnsubscribed = existingBefore != null && existingBefore.getUnsubscribed() != null;
+
     // Determine if the email is already listed
     SqlUtils insertValues = new SqlUtils()
         .add("list_id", mailingList.getId())
@@ -106,7 +121,7 @@ public class MailingListMemberRepository {
           .add("email_id = ?", email.getId());
       DB.update(TABLE_NAME, updateValues, where);
     }
-    return new AddToListResult(created, findByListAndEmail(mailingList.getId(), email.getId()));
+    return new AddToListResult(created, previouslyUnsubscribed, findByListAndEmail(mailingList.getId(), email.getId()));
   }
 
   public static void remove(Email email, MailingList mailingList) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -59,7 +59,28 @@ public class MailingListMemberRepository {
 
   private static final int DEFAULT_QUARANTINE_ALERT_THRESHOLD_PERCENT = 10;
 
-  public static void addEmailToList(Email email, MailingList mailingList) {
+  /** Whether {@link #addEmailToList} inserted a new member row or reactivated an existing one
+   *  (issue #452 -- the caller needs this to fire a created vs. updated lifecycle event), plus the
+   *  persisted row so the caller doesn't have to look it up separately. */
+  public static final class AddToListResult {
+    private final boolean created;
+    private final MailingListMember member;
+
+    public AddToListResult(boolean created, MailingListMember member) {
+      this.created = created;
+      this.member = member;
+    }
+
+    public boolean isCreated() {
+      return created;
+    }
+
+    public MailingListMember getMember() {
+      return member;
+    }
+  }
+
+  public static AddToListResult addEmailToList(Email email, MailingList mailingList) {
     // Determine if the email is already listed
     SqlUtils insertValues = new SqlUtils()
         .add("list_id", mailingList.getId())
@@ -67,7 +88,8 @@ public class MailingListMemberRepository {
         .addIfExists("created_by", email.getCreatedBy(), -1)
         .addIfExists("modified_by", email.getCreatedBy(), -1);
     long memberId = DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY);
-    if (memberId > -1) {
+    boolean created = memberId > -1;
+    if (created) {
       // New member - Update the related count
       String set = "member_count = member_count + 1";
       SqlUtils where = new SqlUtils().add("list_id = ?", mailingList.getId());
@@ -84,6 +106,7 @@ public class MailingListMemberRepository {
           .add("email_id = ?", email.getId());
       DB.update(TABLE_NAME, updateValues, where);
     }
+    return new AddToListResult(created, findByListAndEmail(mailingList.getId(), email.getId()));
   }
 
   public static void remove(Email email, MailingList mailingList) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidget.java
@@ -23,13 +23,16 @@ import com.simisinc.platform.application.cms.SaveBlockedIPCommand;
 import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.application.mailinglists.ProcessEmailCSVFileCommand;
 import com.simisinc.platform.application.mailinglists.SaveEmailCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberDeletedEvent;
 import com.simisinc.platform.domain.model.BlockedIP;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.*;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
@@ -289,7 +292,13 @@ public class MailingListMembersWidget extends GenericWidget {
       if (email == null) {
         context.setErrorMessage("Email address was not found");
       }
+      // issue #452: capture a snapshot before removal -- the row won't exist to look up afterward
+      MailingListMember member = MailingListMemberRepository.findByListAndEmail(mailingListId, emailId);
       MailingListMemberRepository.remove(email, mailingList);
+      if (member != null && mailingList != null) {
+        User actingUser = context.getUserSession() != null ? context.getUserSession().getUser() : null;
+        WorkflowManager.triggerWorkflowForEvent(new MailingListMemberDeletedEvent(member, mailingList, actingUser));
+      }
     }
     context.setRedirect("/admin/mailing-list-members?mailingListId=" + mailingListId);
     return context;

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
@@ -17,8 +17,12 @@
 package com.simisinc.platform.presentation.widgets.mailinglists;
 
 import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import org.apache.commons.lang3.StringUtils;
@@ -64,6 +68,13 @@ public class NewsletterUnsubscribeWidget extends GenericWidget {
 
     if (member.getUnsubscribed() == null) {
       MailingListMemberRepository.unsubscribeByToken(member);
+      // issue #452: webhook/workflow event for the mailing-list-member lifecycle -- no acting
+      // User for this anonymous, token-authorized self-service action
+      MailingList mailingList = MailingListRepository.findById(member.getListId());
+      if (mailingList != null) {
+        WorkflowManager.triggerWorkflowForEvent(
+            new MailingListMemberUpdatedEvent(member, mailingList, null, "unsubscribed", true));
+      }
     }
 
     context.setJsp(JSP);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidget.java
@@ -69,11 +69,17 @@ public class NewsletterUnsubscribeWidget extends GenericWidget {
     if (member.getUnsubscribed() == null) {
       MailingListMemberRepository.unsubscribeByToken(member);
       // issue #452: webhook/workflow event for the mailing-list-member lifecycle -- no acting
-      // User for this anonymous, token-authorized self-service action
+      // User for this anonymous, token-authorized self-service action. unsubscribeByToken()
+      // mutates the DB row but not this in-memory `member` object, so re-fetch the post-mutation
+      // state rather than passing the stale (still-subscribed-looking) snapshot into the event.
       MailingList mailingList = MailingListRepository.findById(member.getListId());
       if (mailingList != null) {
-        WorkflowManager.triggerWorkflowForEvent(
-            new MailingListMemberUpdatedEvent(member, mailingList, null, "unsubscribed", true));
+        MailingListMember updatedMember = MailingListMemberRepository.findByListAndEmail(mailingList.getId(),
+            member.getEmailId());
+        if (updatedMember != null) {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberUpdatedEvent(updatedMember, mailingList, null, "unsubscribed", true));
+        }
       }
     }
 

--- a/src/test/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommandTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.jobrunr.scheduling.BackgroundJobRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+
+/**
+ * Verifies {@link MailingListMemberCommand#unsubscribe}, including the issue #452
+ * mailing-list-member-updated webhook/workflow event it now fires.
+ */
+class MailingListMemberCommandTest {
+
+  private static MailingList mailingList(long id, String name) {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(id);
+    mailingList.setName(name);
+    return mailingList;
+  }
+
+  private static User user(long id, String email) {
+    User user = new User();
+    user.setId(id);
+    user.setEmail(email);
+    return user;
+  }
+
+  @Test
+  void unsubscribeRejectsAMissingMailingList() {
+    assertThrows(DataException.class, () -> MailingListMemberCommand.unsubscribe(null, user(1L, "a@example.com")));
+  }
+
+  @Test
+  void unsubscribeRejectsAMissingUser() {
+    assertThrows(DataException.class, () -> MailingListMemberCommand.unsubscribe(mailingList(1L, "News"), null));
+  }
+
+  @Test
+  void unsubscribeDoesNothingWhenNoEmailRecordExists() throws DataException {
+    User user = user(1L, "ghost@example.com");
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      emailRepo.when(() -> EmailRepository.findByEmailAddress("ghost@example.com")).thenReturn(null);
+
+      MailingListMemberCommand.unsubscribe(mailingList(1L, "News"), user);
+
+      memberRepo.verify(() -> MailingListMemberRepository.unsubscribe(any(), any(), any()), never());
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+    }
+  }
+
+  @Test
+  void unsubscribeFiresAnUnsubscribedUpdatedEvent() throws DataException {
+    User user = user(1L, "subscriber@example.com");
+    MailingList mailingList = mailingList(1L, "News");
+    Email email = new Email();
+    email.setId(2L);
+    email.setEmail("subscriber@example.com");
+    MailingListMember member = new MailingListMember();
+    member.setId(9L);
+    member.setEmailAddress("subscriber@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      emailRepo.when(() -> EmailRepository.findByEmailAddress("subscriber@example.com")).thenReturn(email);
+      memberRepo.when(() -> MailingListMemberRepository.findByListAndEmail(1L, 2L)).thenReturn(member);
+
+      MailingListMemberCommand.unsubscribe(mailingList, user);
+
+      memberRepo.verify(() -> MailingListMemberRepository.unsubscribe(mailingList, email, user));
+      ArgumentCaptor<MailingListMemberUpdatedEvent> eventCaptor = ArgumentCaptor
+          .forClass(MailingListMemberUpdatedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      MailingListMemberUpdatedEvent fired = eventCaptor.getValue();
+      assertEquals(member, fired.getMember());
+      assertEquals(mailingList, fired.getMailingList());
+      assertEquals(user, fired.getUser());
+      assertEquals("unsubscribed", fired.getChangeType());
+      assertEquals(true, fired.isPreviouslySubscribed());
+    }
+  }
+
+  @Test
+  void unsubscribeDoesNotFireAnEventWhenTheMemberRowIsGoneAfterUpdate() throws DataException {
+    User user = user(1L, "subscriber@example.com");
+    MailingList mailingList = mailingList(1L, "News");
+    Email email = new Email();
+    email.setId(2L);
+    email.setEmail("subscriber@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      emailRepo.when(() -> EmailRepository.findByEmailAddress("subscriber@example.com")).thenReturn(email);
+      // findByListAndEmail left unstubbed -- default null
+
+      MailingListMemberCommand.unsubscribe(mailingList, user);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
@@ -109,6 +109,87 @@ class SaveEmailCommandTest {
   }
 
   @Test
+  void firesAPerListEventCarryingThatListsOwnMemberNotAnotherListsWhenSubscribingToSeveralListsAtOnce()
+      throws DataException {
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList listA = mailingList(1L, "News");
+    MailingList listB = mailingList(2L, "Cybersecurity Bulletin");
+    MailingListMember memberA = new MailingListMember();
+    memberA.setId(10L);
+    memberA.setEmailAddress("subscriber@example.com");
+    MailingListMember memberB = new MailingListMember();
+    memberB.setId(20L);
+    memberB.setEmailAddress("subscriber@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listA))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, memberA));
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listB))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, memberB));
+
+      SaveEmailCommand.saveEmail(emailBean, List.of(listA, listB));
+
+      ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()), times(2));
+      List<Event> fired = eventCaptor.getAllValues();
+      MailingListMemberCreatedEvent firedForA = (MailingListMemberCreatedEvent) fired.get(0);
+      MailingListMemberCreatedEvent firedForB = (MailingListMemberCreatedEvent) fired.get(1);
+      assertEquals(memberA, firedForA.getMember(), "list A's event must carry list A's own member, not list B's");
+      assertEquals(listA, firedForA.getMailingList());
+      assertEquals(memberB, firedForB.getMember(), "list B's event must carry list B's own member, not list A's");
+      assertEquals(listB, firedForB.getMailingList());
+    }
+  }
+
+  @Test
+  void resolvesTheActingUserFromTheSubmittedBeanNotThePossiblyStaleReFetchedEmailRecord() throws DataException {
+    // issue #452 review finding: EmailRepository.update() deliberately never overwrites
+    // created_by (the #810 fix), so on the duplicate-email/update branch, a re-fetched `email`
+    // record's createdBy would still be whoever originally created that address years ago --
+    // actingUser must come from the submitted emailBean (the current request), not that record
+    Email emailBean = email("subscriber@example.com");
+    emailBean.setCreatedBy(42L); // e.g. the admin submitting this specific request
+    Email existingWithADifferentOriginalCreator = email("subscriber@example.com");
+    existingWithADifferentOriginalCreator.setId(9L);
+    existingWithADifferentOriginalCreator.setCreatedBy(7L); // some unrelated original creator
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember member = new MailingListMember();
+    member.setId(10L);
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(null); // duplicate -> update branch
+      emailRepo.when(() -> EmailRepository.findByEmailAddress("subscriber@example.com"))
+          .thenReturn(existingWithADifferentOriginalCreator);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(existingWithADifferentOriginalCreator, mailingList))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, member));
+      com.simisinc.platform.domain.model.User admin42 = new com.simisinc.platform.domain.model.User();
+      admin42.setId(42L);
+      userRepo.when(() -> UserRepository.findByUserId(42L)).thenReturn(admin42);
+
+      SaveEmailCommand.saveEmail(emailBean, mailingList);
+
+      userRepo.verify(() -> UserRepository.findByUserId(42L));
+      userRepo.verify(() -> UserRepository.findByUserId(7L), never());
+      ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      MailingListMemberCreatedEvent fired = (MailingListMemberCreatedEvent) eventCaptor.getValue();
+      assertEquals(42L, fired.getUser().getId(), "the event must attribute the actual submitter, not the address's original creator");
+    }
+  }
+
+  @Test
   void singleListOverloadDelegatesToTheMultiListSave() throws DataException {
     Email emailBean = email("subscriber@example.com");
     Email saved = email("subscriber@example.com");
@@ -145,7 +226,7 @@ class SaveEmailCommandTest {
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
       memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
-          .thenReturn(new MailingListMemberRepository.AddToListResult(true, member));
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, member));
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
 
@@ -175,7 +256,7 @@ class SaveEmailCommandTest {
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
       memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
-          .thenReturn(new MailingListMemberRepository.AddToListResult(false, member));
+          .thenReturn(new MailingListMemberRepository.AddToListResult(false, true, member));
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
 
@@ -184,6 +265,38 @@ class SaveEmailCommandTest {
       assertEquals(MailingListMemberUpdatedEvent.class, eventCaptor.getValue().getClass());
       MailingListMemberUpdatedEvent fired = (MailingListMemberUpdatedEvent) eventCaptor.getValue();
       assertEquals("resubscribed", fired.getChangeType());
+      assertEquals(member, fired.getMember());
+      assertEquals(mailingList, fired.getMailingList());
+      assertEquals(false, fired.isPreviouslySubscribed(),
+          "a reactivation means they were NOT subscribed immediately beforehand");
+    }
+  }
+
+  @Test
+  void doesNotFireAnEventWhenAddEmailToListReportsAnAlreadyActiveMemberReAdd() throws DataException {
+    // mirrors addEmailToListDoesNotReportAnAlreadyActiveMemberAsReactivated at the repository
+    // layer -- a harmless re-submit of an already-active member must not fire a misleading
+    // "resubscribed" event for someone who never left
+    Email emailBean = email("already-subscribed@example.com");
+    Email saved = email("already-subscribed@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember member = new MailingListMember();
+    member.setId(12L);
+    member.setEmailAddress("already-subscribed@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(false, false, member));
+
+      SaveEmailCommand.saveEmail(emailBean, mailingList);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
     }
   }
 

--- a/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
@@ -28,14 +28,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.maps.GeoIPCommand;
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 
 class SaveEmailCommandTest {
 
@@ -118,6 +125,87 @@ class SaveEmailCommandTest {
 
       memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, mailingList), times(1));
       memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(any(), any()), times(1));
+    }
+  }
+
+  @Test
+  void firesACreatedEventWhenAddEmailToListReportsANewMember() throws DataException {
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember member = new MailingListMember();
+    member.setId(10L);
+    member.setEmailAddress("subscriber@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, member));
+
+      SaveEmailCommand.saveEmail(emailBean, mailingList);
+
+      ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals(MailingListMemberCreatedEvent.class, eventCaptor.getValue().getClass());
+      MailingListMemberCreatedEvent fired = (MailingListMemberCreatedEvent) eventCaptor.getValue();
+      assertEquals(member, fired.getMember());
+      assertEquals(mailingList, fired.getMailingList());
+    }
+  }
+
+  @Test
+  void firesAnUpdatedResubscribedEventWhenAddEmailToListReportsAReactivation() throws DataException {
+    Email emailBean = email("returning@example.com");
+    Email saved = email("returning@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember member = new MailingListMember();
+    member.setId(11L);
+    member.setEmailAddress("returning@example.com");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(false, member));
+
+      SaveEmailCommand.saveEmail(emailBean, mailingList);
+
+      ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals(MailingListMemberUpdatedEvent.class, eventCaptor.getValue().getClass());
+      MailingListMemberUpdatedEvent fired = (MailingListMemberUpdatedEvent) eventCaptor.getValue();
+      assertEquals("resubscribed", fired.getChangeType());
+    }
+  }
+
+  @Test
+  void doesNotFireAnEventWhenAddEmailToListReturnsNoMember() throws DataException {
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      // addEmailToList left unstubbed -- default Mockito return is null, matching every other
+      // test in this file that never stubs it either
+
+      SaveEmailCommand.saveEmail(emailBean, mailingList);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
     }
   }
 

--- a/src/test/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommandTest.java
@@ -33,10 +33,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.domain.events.cms.FormSubmittedEvent;
 import com.simisinc.platform.domain.events.cms.WebPagePublishedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberDeletedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.FormData;
 import com.simisinc.platform.domain.model.cms.FormField;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.persistence.UserRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
 
@@ -120,6 +125,80 @@ class BuildWebhookPayloadCommandTest {
     assertEquals(1, fields.size());
     assertEquals("Name", fields.get(0).get("label"));
     assertEquals("Jane Doe", fields.get(0).get("value"));
+  }
+
+  private static MailingListMember member(long id, String emailAddress, boolean subscribed) {
+    MailingListMember member = new MailingListMember();
+    member.setId(id);
+    member.setEmailAddress(emailAddress);
+    member.setIsValid(subscribed);
+    return member;
+  }
+
+  private static MailingList mailingList(long id, String name) {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(id);
+    mailingList.setName(name);
+    return mailingList;
+  }
+
+  @Test
+  void mailingListMemberCreatedEventProducesTheExpectedShapeAndData() {
+    MailingListMember member = member(10L, "new@example.com", true);
+    MailingList mailingList = mailingList(1L, "News");
+    User user = new User();
+    user.setId(3L);
+    user.setEmail("signup-page@example.com");
+
+    Map<String, Object> data = BuildWebhookPayloadCommand
+        .buildData(new MailingListMemberCreatedEvent(member, mailingList, user));
+
+    assertEquals(10L, data.get("memberId"));
+    assertEquals("new@example.com", data.get("email"));
+    assertEquals(true, data.get("subscribed"));
+    assertEquals(1L, data.get("mailingListId"));
+    assertEquals("News", data.get("mailingListName"));
+    assertNotNull(data.get("user"));
+  }
+
+  @Test
+  void mailingListMemberCreatedEventOmitsUserWhenTheSignupWasAnonymous() {
+    Map<String, Object> data = BuildWebhookPayloadCommand
+        .buildData(new MailingListMemberCreatedEvent(member(10L, "new@example.com", true), mailingList(1L, "News"), null));
+
+    assertTrue(data.containsKey("user"), "the key must be present");
+    assertEquals(null, data.get("user"), "value must be null for an anonymous signup, not omitted or a bogus summary");
+  }
+
+  @Test
+  void mailingListMemberUpdatedEventCarriesChangeTypeAndPreviousState() {
+    MailingListMember member = member(11L, "returning@example.com", false);
+    MailingList mailingList = mailingList(1L, "News");
+
+    Map<String, Object> data = BuildWebhookPayloadCommand.buildData(
+        new MailingListMemberUpdatedEvent(member, mailingList, null, "unsubscribed", true));
+
+    assertEquals("unsubscribed", data.get("changeType"));
+    assertEquals(false, data.get("subscribed"), "reflects the member's current (post-change) state");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> previousState = (Map<String, Object>) data.get("previousState");
+    assertEquals(true, previousState.get("subscribed"), "previousState must reflect the state before this change");
+  }
+
+  @Test
+  void mailingListMemberDeletedEventProducesTheExpectedShapeAndData() {
+    MailingListMember member = member(12L, "gone@example.com", false);
+    MailingList mailingList = mailingList(1L, "News");
+    User admin = new User();
+    admin.setId(2L);
+    admin.setUsername("admin2");
+
+    Map<String, Object> data = BuildWebhookPayloadCommand
+        .buildData(new MailingListMemberDeletedEvent(member, mailingList, admin));
+
+    assertEquals(12L, data.get("memberId"));
+    assertEquals("gone@example.com", data.get("email"));
+    assertEquals("admin2", ((Map<?, ?>) data.get("user")).get("username"));
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommandTest.java
@@ -20,12 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import com.simisinc.platform.application.webhooks.WebhookEventTypeCommand.WebhookEventType;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
 
 /**
  * Guards the hand-maintained event type list against silently drifting from {@code
@@ -45,21 +50,39 @@ class WebhookEventTypeCommandTest {
     }
   }
 
+  /**
+   * A genuine, automated version of the cross-check both this class's javadoc and {@code
+   * WebhookEventTypeCommand}'s own javadoc describe (issue #452 review finding) -- scans every
+   * real {@code Event} subclass under {@code com.simisinc.platform.domain.events.**} via
+   * ClassGraph (already a project dependency) and reads each one's {@code ID} field via
+   * reflection, rather than comparing two independently hand-maintained literal lists that could
+   * silently drift together. {@code item-file-uploaded} is deliberately excluded from the
+   * comparison since (by design) no Event subclass declares it.
+   */
   @Test
-  void matchesTheRealSeventeenEventTypesBuildWebhookPayloadCommandHandles() {
-    Set<String> expected = Set.of(
-        "web-page-published", "web-page-updated", "blog-post-published",
-        "calendar-event-scheduled", "calendar-event-rescheduled", "calendar-event-removed",
-        "form-submitted", "order-submitted",
-        "user-signed-up", "user-registered", "user-invited", "user-password-reset",
-        "unsuspend-requested", "user-account-restored",
-        "mailing-list-member-created", "mailing-list-member-updated", "mailing-list-member-deleted");
-
-    Set<String> actual = new HashSet<>();
-    for (WebhookEventType type : WebhookEventTypeCommand.getAll()) {
-      actual.add(type.getId());
+  void matchesEveryRealEventTypeIdReflectedFromTheDomainEventsPackage() throws Exception {
+    Set<String> realEventIds = new HashSet<>();
+    try (ScanResult scanResult = new ClassGraph()
+        .enableClassInfo()
+        .acceptPackages("com.simisinc.platform.domain.events")
+        .scan()) {
+      for (ClassInfo classInfo : scanResult.getSubclasses("com.simisinc.platform.domain.events.Event")) {
+        if (classInfo.isAbstract()) {
+          continue;
+        }
+        Field idField = classInfo.loadClass().getField("ID");
+        realEventIds.add((String) idField.get(null));
+      }
     }
-    assertEquals(expected, actual);
+    assertFalse(realEventIds.isEmpty(), "the scan itself found nothing -- likely a broken package name, not zero events");
+
+    Set<String> registeredIds = new HashSet<>();
+    for (WebhookEventType type : WebhookEventTypeCommand.getAll()) {
+      registeredIds.add(type.getId());
+    }
+    assertEquals(realEventIds, registeredIds,
+        "WebhookEventTypeCommand.EVENT_TYPES must list exactly the real Event subclasses' ids, or a new "
+            + "event type silently becomes payload-buildable but never selectable in the admin subscription UI");
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommandTest.java
@@ -46,13 +46,14 @@ class WebhookEventTypeCommandTest {
   }
 
   @Test
-  void matchesTheRealFourteenEventTypesBuildWebhookPayloadCommandHandles() {
+  void matchesTheRealSeventeenEventTypesBuildWebhookPayloadCommandHandles() {
     Set<String> expected = Set.of(
         "web-page-published", "web-page-updated", "blog-post-published",
         "calendar-event-scheduled", "calendar-event-rescheduled", "calendar-event-removed",
         "form-submitted", "order-submitted",
         "user-signed-up", "user-registered", "user-invited", "user-password-reset",
-        "unsuspend-requested", "user-account-restored");
+        "unsuspend-requested", "user-account-restored",
+        "mailing-list-member-created", "mailing-list-member-updated", "mailing-list-member-deleted");
 
     Set<String> actual = new HashSet<>();
     for (WebhookEventType type : WebhookEventTypeCommand.getAll()) {

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
@@ -42,6 +42,8 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataSource;
 
@@ -237,6 +239,43 @@ class MailingListMemberRepositoryQueryTest {
   }
 
   @Test
+  void addEmailToListReportsCreatedForABrandNewMembership() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("new@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList);
+
+    assertTrue(result.isCreated(), "issue #452 -- must report created=true for a brand-new membership");
+    assertNotNull(result.getMember());
+    assertEquals("new@example.com", result.getMember().getEmailAddress());
+    assertTrue(result.getMember().getIsValid());
+  }
+
+  @Test
+  void addEmailToListReportsNotCreatedForAReactivatedMembership() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("returning@example.com");
+    seedMembership(listId, emailId, false, "2026-07-01 00:00:00"); // previously unsubscribed
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList);
+
+    assertTrue(!result.isCreated(), "issue #452 -- re-adding an existing (list, email) pair must report created=false");
+    assertNotNull(result.getMember());
+    assertNull(result.getMember().getUnsubscribed(), "reactivating must clear the prior unsubscribe timestamp");
+    assertTrue(result.getMember().getIsValid());
+  }
+
+  @Test
   void findLastClassifiedAtReturnsNullWhenNoSubscriberHasBeenClassified() throws SQLException {
     long list = seedList("List A");
     seedMembership(list, seedEmail("unchecked@example.com"), true, null);
@@ -326,8 +365,14 @@ class MailingListMemberRepositoryQueryTest {
           + "list_id BIGINT REFERENCES mailing_lists(list_id), "
           + "email_id BIGINT REFERENCES emails(email_id), "
           + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "created_by BIGINT DEFAULT -1, "
+          + "modified TIMESTAMP(3), "
+          + "modified_by BIGINT DEFAULT -1, "
+          + "last_emailed TIMESTAMP(3), "
           + "unsubscribed TIMESTAMP(3), "
+          + "unsubscribed_by BIGINT DEFAULT -1, "
           + "unsubscribe_reason VARCHAR(100), "
+          + "unsubscribe_token VARCHAR(255), "
           + "is_valid BOOLEAN DEFAULT true, "
           + "quarantined TIMESTAMP(3), "
           + "quarantine_reason VARCHAR(50))");

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
@@ -251,6 +251,7 @@ class MailingListMemberRepositoryQueryTest {
         mailingList);
 
     assertTrue(result.isCreated(), "issue #452 -- must report created=true for a brand-new membership");
+    assertTrue(!result.wasPreviouslyUnsubscribed(), "there was no prior row at all, so it was never unsubscribed");
     assertNotNull(result.getMember());
     assertEquals("new@example.com", result.getMember().getEmailAddress());
     assertTrue(result.getMember().getIsValid());
@@ -270,9 +271,30 @@ class MailingListMemberRepositoryQueryTest {
         mailingList);
 
     assertTrue(!result.isCreated(), "issue #452 -- re-adding an existing (list, email) pair must report created=false");
+    assertTrue(result.wasPreviouslyUnsubscribed(),
+        "issue #452 -- a genuine reactivation must be reported so the caller can fire the right event");
     assertNotNull(result.getMember());
     assertNull(result.getMember().getUnsubscribed(), "reactivating must clear the prior unsubscribe timestamp");
     assertTrue(result.getMember().getIsValid());
+  }
+
+  @Test
+  void addEmailToListDoesNotReportAnAlreadyActiveMemberAsReactivated() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("already-subscribed@example.com");
+    seedMembership(listId, emailId, true, null); // already active, never unsubscribed
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList);
+
+    assertTrue(!result.isCreated(), "the row already existed");
+    assertTrue(!result.wasPreviouslyUnsubscribed(),
+        "issue #452 -- re-adding an already-active member is a no-op, not a reactivation; the caller must not "
+            + "fire a misleading \"resubscribed\" event for someone who never left");
   }
 
   @Test
@@ -350,6 +372,10 @@ class MailingListMemberRepositoryQueryTest {
           + "email_id BIGSERIAL PRIMARY KEY, "
           + "email VARCHAR(255) UNIQUE NOT NULL, "
           + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "first_name VARCHAR(100), "
+          + "last_name VARCHAR(100), "
+          + "organization VARCHAR(200), "
+          + "ip_address VARCHAR(45), "
           + "validation_status VARCHAR(20), "
           + "validation_sub_status VARCHAR(50), "
           + "validated_at TIMESTAMP(3))");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
@@ -19,7 +19,6 @@ package com.simisinc.platform.presentation.widgets.mailinglists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -313,16 +312,21 @@ class MailingListMembersWidgetTest extends WidgetBase {
     MailingListMember member = new MailingListMember();
     member.setId(9L);
     member.setEmailAddress("spammer@example.com");
+    MailingList mailingList = mailingList();
+    // UserSession.getUser() (called by delete()'s context.getUserSession().getUser()) always
+    // re-loads via LoadUserCommand.loadUser(userId) rather than returning a cached User -- this
+    // must be mocked or the real, unconfigured DataSource NPEs
+    User loadedUser = adminUser();
 
     try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
         MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
         MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
         MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
-      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList);
       emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
       memberRepo.when(() -> MailingListMemberRepository.findByListAndEmail(1L, 2L)).thenReturn(member);
-      loadUser.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+      loadUser.when(() -> LoadUserCommand.loadUser(1L)).thenReturn(loadedUser);
 
       new MailingListMembersWidget().delete(widgetContext);
 
@@ -331,7 +335,13 @@ class MailingListMembersWidgetTest extends WidgetBase {
       ArgumentCaptor<MailingListMemberDeletedEvent> eventCaptor = ArgumentCaptor.forClass(
           MailingListMemberDeletedEvent.class);
       workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
-      assertEquals(member, eventCaptor.getValue().getMember());
+      MailingListMemberDeletedEvent fired = eventCaptor.getValue();
+      assertEquals(member, fired.getMember());
+      assertEquals(mailingList, fired.getMailingList(),
+          "the deleted mailing list, not the deleted member's list, must be attached to the event");
+      assertEquals(loadedUser, fired.getUser(),
+          "actingUser must be the real User loaded via context.getUserSession().getUser(), "
+              + "not left null or some other value");
     }
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListMembersWidgetTest.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.mailinglists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -30,16 +31,21 @@ import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.cms.SaveBlockedIPCommand;
 import com.simisinc.platform.application.mailinglists.ProcessEmailCSVFileCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberDeletedEvent;
 import com.simisinc.platform.domain.model.BlockedIP;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.persistence.BlockedIPRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberSpecification;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 
@@ -68,6 +74,13 @@ class MailingListMembersWidgetTest extends WidgetBase {
     email.setEmail("spammer@example.com");
     email.setIpAddress(ip);
     return email;
+  }
+
+  private static User adminUser() {
+    User user = new User();
+    user.setId(1L);
+    user.setUsername("admin");
+    return user;
   }
 
   @Test
@@ -288,6 +301,57 @@ class MailingListMembersWidgetTest extends WidgetBase {
       assertNull(specification.getMatchesName());
       assertNull(specification.getMatchesEmail());
       assertNull(specification.getStatus());
+    }
+  }
+
+  @Test
+  void deleteFiresAMailingListMemberDeletedEventWithASnapshotTakenBeforeRemoval() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    MailingListMember member = new MailingListMember();
+    member.setId(9L);
+    member.setEmailAddress("spammer@example.com");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
+      memberRepo.when(() -> MailingListMemberRepository.findByListAndEmail(1L, 2L)).thenReturn(member);
+      loadUser.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+
+      new MailingListMembersWidget().delete(widgetContext);
+
+      memberRepo.verify(() -> MailingListMemberRepository.findByListAndEmail(1L, 2L));
+      memberRepo.verify(() -> MailingListMemberRepository.remove(any(), any()));
+      ArgumentCaptor<MailingListMemberDeletedEvent> eventCaptor = ArgumentCaptor.forClass(
+          MailingListMemberDeletedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals(member, eventCaptor.getValue().getMember());
+    }
+  }
+
+  @Test
+  void deleteDoesNotFireAnEventWhenTheMemberWasAlreadyGone() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "mailingListId", "1");
+    addQueryParameter(widgetContext, "emailId", "2");
+
+    try (MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      mailingListRepo.when(() -> MailingListRepository.findById(1L)).thenReturn(mailingList());
+      emailRepo.when(() -> EmailRepository.findById(2L)).thenReturn(emailWithIp("203.0.113.20"));
+      // findByListAndEmail left unstubbed -- default null, as if the row was already gone
+
+      new MailingListMembersWidget().delete(widgetContext);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
     }
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
@@ -44,6 +44,7 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
     MailingListMember member = new MailingListMember();
     member.setId(id);
     member.setListId(3L);
+    member.setEmailId(4L);
     member.setUnsubscribeToken("tok-123");
     if (alreadyUnsubscribed) {
       member.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
@@ -61,6 +62,11 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
   @Test
   void executeUnsubscribesAValidToken() {
     MailingListMember member = member(1L, false);
+    // unsubscribeByToken() mutates the DB row but not this in-memory object, so the widget
+    // re-fetches -- stub a distinct post-mutation snapshot to prove the event carries THAT,
+    // not the stale, still-subscribed-looking `member` returned by findByUnsubscribeToken
+    MailingListMember updatedMember = member(1L, true);
+    MailingList mailingList = mailingList();
     addQueryParameter(widgetContext, "token", "tok-123");
 
     try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
@@ -69,7 +75,8 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
       repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
-      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList());
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList);
+      repository.when(() -> MailingListMemberRepository.findByListAndEmail(3L, 4L)).thenReturn(updatedMember);
 
       WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
 
@@ -79,8 +86,12 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
       ArgumentCaptor<MailingListMemberUpdatedEvent> eventCaptor = ArgumentCaptor
           .forClass(MailingListMemberUpdatedEvent.class);
       workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
-      assertEquals("unsubscribed", eventCaptor.getValue().getChangeType());
-      assertEquals(null, eventCaptor.getValue().getUser(), "self-service, token-authorized -- no acting User");
+      MailingListMemberUpdatedEvent fired = eventCaptor.getValue();
+      assertEquals("unsubscribed", fired.getChangeType());
+      assertEquals(null, fired.getUser(), "self-service, token-authorized -- no acting User");
+      assertEquals(updatedMember, fired.getMember(),
+          "must carry the re-fetched post-mutation member, not the stale pre-mutation snapshot");
+      assertEquals(mailingList, fired.getMailingList());
     }
   }
 
@@ -96,6 +107,26 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
       repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
       // mailingListRepo left unstubbed -- default null
+
+      new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+    }
+  }
+
+  @Test
+  void executeDoesNotFireAnEventWhenTheReFetchAfterUnsubscribeFindsNoRow() {
+    MailingListMember member = member(1L, false);
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList());
+      // findByListAndEmail left unstubbed -- default null, as if the row vanished mid-request
 
       new NewsletterUnsubscribeWidget().execute(widgetContext);
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/NewsletterUnsubscribeWidgetTest.java
@@ -29,20 +29,33 @@ import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
 import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.WidgetContext;
+import org.mockito.ArgumentCaptor;
 
 class NewsletterUnsubscribeWidgetTest extends WidgetBase {
 
   private static MailingListMember member(long id, boolean alreadyUnsubscribed) {
     MailingListMember member = new MailingListMember();
     member.setId(id);
+    member.setListId(3L);
     member.setUnsubscribeToken("tok-123");
     if (alreadyUnsubscribed) {
       member.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
     }
     return member;
+  }
+
+  private static MailingList mailingList() {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(3L);
+    mailingList.setName("Newsletter");
+    return mailingList;
   }
 
   @Test
@@ -51,14 +64,42 @@ class NewsletterUnsubscribeWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "token", "tok-123");
 
     try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
-        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
       repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList());
 
       WidgetContext result = new NewsletterUnsubscribeWidget().execute(widgetContext);
 
       assertEquals("/mailinglists/newsletter-unsubscribed.jsp", result.getJsp());
       repository.verify(() -> MailingListMemberRepository.unsubscribeByToken(member));
+
+      ArgumentCaptor<MailingListMemberUpdatedEvent> eventCaptor = ArgumentCaptor
+          .forClass(MailingListMemberUpdatedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals("unsubscribed", eventCaptor.getValue().getChangeType());
+      assertEquals(null, eventCaptor.getValue().getUser(), "self-service, token-authorized -- no acting User");
+    }
+  }
+
+  @Test
+  void executeDoesNotFireAnEventWhenTheMailingListNoLongerExists() {
+    MailingListMember member = member(1L, false);
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByUnsubscribeToken("tok-123")).thenReturn(member);
+      // mailingListRepo left unstubbed -- default null
+
+      new NewsletterUnsubscribeWidget().execute(widgetContext);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
     }
   }
 


### PR DESCRIPTION
## Summary
Closes #452. Wires real lifecycle events into the webhook delivery/admin-UI infrastructure built by #418/#453/#456, which had nothing actually triggering deliveries yet. Scoped to `MailingListMember` create/update/delete for this phase.

- `MailingListMemberCreatedEvent`, `MailingListMemberUpdatedEvent` (`changeType`: `resubscribed`/`unsubscribed`), `MailingListMemberDeletedEvent`, fired via the existing `WorkflowManager.triggerWorkflowForEvent()` entry point from `SaveEmailCommand`, `MailingListMemberCommand.unsubscribe()`, `NewsletterUnsubscribeWidget`, and `MailingListMembersWidget.delete()`
- `BuildWebhookPayloadCommand` gains matching payload branches (`memberId`, `email`, `subscribed`, `mailingListId`, `mailingListName`, plus `changeType`/`previousState` on the updated event)
- `WebhookEventTypeCommand` registers the 3 new subscribable event types for the admin subscription-form checkbox UI
- `MailingListMemberRepository.addEmailToList()` now distinguishes a genuine reactivation (member was previously unsubscribed) from a harmless re-add of an already-active member, so the latter no longer fires a false "resubscribed" event
- Acting user is resolved from the submitted form bean rather than a possibly-stale re-fetched `Email` record, since `EmailRepository.update()` deliberately never overwrites `created_by` (the #810 fix) and that field can't be reused as a proxy for "who is acting right now"
- `NewsletterUnsubscribeWidget` re-fetches the member after `unsubscribeByToken()` mutates it, rather than passing the stale pre-mutation snapshot into the fired event

**Known, accepted limitation:** `MailingListMembersWidget.delete()`'s snapshot-then-delete has a narrow, low-severity TOCTOU race (two unsynchronized DB operations, no transaction/locking) between reading the member for the event snapshot and removing it. Left as-is rather than introducing transactional locking for this phase.

Went through an adversarial multi-dimension review before opening this PR; every confirmed finding (4 production correctness bugs, several test-quality gaps including a swallowed-`SQLException` test-schema gap) is fixed here.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green, 0 failures
- [x] `python3 tools/check-unescaped-el.py` — 0 unallowlisted
- [x] New/updated unit + Testcontainers-backed repository tests cover: created/updated/deleted event firing, the reactivation-vs-no-op distinction, acting-user resolution, per-list event/member pairing on multi-list signup, and the ClassGraph-based reflective check that the registered webhook event types match the real `Event` subclasses