### PR TITLE
HTTP retry-with-backoff for the shared outbound transport (#455)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpGetCommand.java
@@ -168,7 +168,7 @@ public class HttpGetCommand {
 
       // Send the request and handle the response
       HttpClient client = HttpClient.newHttpClient();
-      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      var response = HttpRetryCommand.send(client, request, HttpResponse.BodyHandlers.ofString());
       if (response == null) {
         LOG.debug("No response");
         return null;

--- a/src/main/java/com/simisinc/platform/application/http/HttpPostCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpPostCommand.java
@@ -260,7 +260,7 @@ public class HttpPostCommand {
 
       // Create the HTTP client
       HttpClient client = HttpClient.newBuilder().build();
-      return client.send(request, HttpResponse.BodyHandlers.ofString());
+      return HttpRetryCommand.send(client, request, HttpResponse.BodyHandlers.ofString());
     } catch (Exception e) {
       LOG.error("Http client exception", e);
       return null;

--- a/src/main/java/com/simisinc/platform/application/http/HttpRetryCommand.java
+++ b/src/main/java/com/simisinc/platform/application/http/HttpRetryCommand.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Shared retry-with-backoff wrapper around {@link HttpClient#send}, used by
+ * {@link HttpGetCommand} and {@link HttpPostCommand} -- and, through them,
+ * {@link HttpDeleteCommand}/{@link HttpPutCommand}/{@link HttpPatchCommand}, which delegate into
+ * those two -- for calls to fixed, operator-configured third-party API endpoints (issue #455's
+ * audit found this as the broadest gap: a single transient blip or rate-limit response from a
+ * vendor currently fails the call outright with no retry at all).
+ *
+ * <p>Only retries {@link #RETRYABLE_METHODS idempotent methods} (GET/HEAD/PUT/DELETE): a 5xx or
+ * timeout can arrive after a vendor has already accepted and acted on a POST/PATCH (e.g. sending
+ * a campaign), so blindly resending one risks a duplicate, externally-visible side effect. A
+ * non-idempotent request is sent exactly once, unchanged from pre-retry behavior.
+ *
+ * <p>For a retryable method, retries a connection failure or a 429/5xx response up to
+ * {@link #MAX_ATTEMPTS} times. A {@link HttpTimeoutException} (the per-attempt request timeout
+ * itself elapsing -- i.e. the vendor is hanging, not failing fast) is NOT retried: another
+ * attempt would just cost another full timeout on this request-handling thread for little chance
+ * of success. Other {@link IOException}s (connection refused/reset, which typically fail in
+ * milliseconds) are retried. A retryable response's {@code Retry-After} header is honored when
+ * present and within {@link #MAX_DELAY_MS}; otherwise backoff is exponential with jitter. A
+ * non-retryable status (2xx, or a 4xx other than 429) is returned immediately on the first
+ * attempt -- retrying an invalid API key or a bad request would waste time and, for some
+ * vendors, risks tripping their own abuse detection.
+ */
+class HttpRetryCommand {
+
+  private static final Log LOG = LogFactory.getLog(HttpRetryCommand.class);
+
+  static final int MAX_ATTEMPTS = 3;
+  private static final long BASE_DELAY_MS = 300;
+  private static final long MAX_DELAY_MS = 2000;
+  private static final long JITTER_MS = 100;
+
+  /** RFC 7231-idempotent methods: repeating the same request is safe, so retry-on-failure is safe. */
+  private static final Set<String> RETRYABLE_METHODS = Set.of("GET", "HEAD", "PUT", "DELETE");
+
+  private HttpRetryCommand() {
+  }
+
+  static <T> HttpResponse<T> send(HttpClient client, HttpRequest request, HttpResponse.BodyHandler<T> bodyHandler)
+      throws IOException {
+    if (!RETRYABLE_METHODS.contains(request.method())) {
+      return sendOnce(client, request, bodyHandler);
+    }
+
+    IOException lastException = null;
+    HttpResponse<T> lastResponse = null;
+    for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        HttpResponse<T> response = sendOnce(client, request, bodyHandler);
+        lastException = null;
+        if (!isRetryableStatus(response.statusCode())) {
+          return response;
+        }
+        lastResponse = response;
+        LOG.debug("Retryable status " + response.statusCode() + " from " + loggableUri(request.uri()) + " (attempt "
+            + attempt + "/" + MAX_ATTEMPTS + ")");
+      } catch (HttpTimeoutException e) {
+        // The vendor is hanging rather than failing fast -- give up now rather than spend
+        // another full per-attempt timeout on this thread for little chance of success.
+        throw e;
+      } catch (IOException e) {
+        lastException = e;
+        lastResponse = null;
+        LOG.debug("Retryable exception from " + loggableUri(request.uri()) + " (attempt " + attempt + "/"
+            + MAX_ATTEMPTS + "): " + e);
+      }
+
+      if (attempt == MAX_ATTEMPTS) {
+        break;
+      }
+      Long retryAfterMs = lastResponse != null ? retryAfterMs(lastResponse) : null;
+      if (retryAfterMs != null && retryAfterMs > MAX_DELAY_MS) {
+        // The vendor asked for a wait longer than this synchronous call can reasonably honor --
+        // stop rather than hammer it again after only a fraction of the requested delay.
+        break;
+      }
+      if (!sleepBeforeRetry(retryAfterMs != null ? retryAfterMs : backoffMs(attempt))) {
+        break;
+      }
+    }
+    if (lastException != null) {
+      throw lastException;
+    }
+    return lastResponse;
+  }
+
+  private static <T> HttpResponse<T> sendOnce(HttpClient client, HttpRequest request,
+      HttpResponse.BodyHandler<T> bodyHandler) throws IOException {
+    try {
+      return client.send(request, bodyHandler);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while sending request to " + loggableUri(request.uri()), e);
+    }
+  }
+
+  private static boolean isRetryableStatus(int statusCode) {
+    return statusCode == 429 || (statusCode >= 500 && statusCode < 600);
+  }
+
+  /** The Retry-After header's delay in milliseconds, or null if absent/unparsable. */
+  private static Long retryAfterMs(HttpResponse<?> response) {
+    List<String> values = response.headers().allValues("Retry-After");
+    if (values.isEmpty()) {
+      return null;
+    }
+    String value = values.get(0).trim();
+    try {
+      long seconds = Long.parseLong(value);
+      return seconds < 0 ? null : seconds * 1000;
+    } catch (NumberFormatException e) {
+      // Fall through to the HTTP-date form.
+    }
+    try {
+      ZonedDateTime target = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME);
+      long millis = Duration.between(ZonedDateTime.now(target.getZone()), target).toMillis();
+      return Math.max(millis, 0);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+  }
+
+  private static long backoffMs(int attempt) {
+    long backoff = (long) (BASE_DELAY_MS * Math.pow(2, attempt - 1));
+    return Math.min(backoff + ThreadLocalRandom.current().nextLong(JITTER_MS), MAX_DELAY_MS);
+  }
+
+  /** Returns false (and restores the interrupt flag) if interrupted mid-sleep, so the caller stops retrying. */
+  private static boolean sleepBeforeRetry(long delayMs) {
+    try {
+      Thread.sleep(delayMs);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  /** The URI without its query string, so a retry log line never repeats a credential passed as a query param. */
+  private static String loggableUri(URI uri) {
+    String authority = uri.getAuthority();
+    String path = uri.getPath();
+    return uri.getScheme() + "://" + (authority != null ? authority : "") + (path != null ? path : "");
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/HttpGetCommandRetryTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpGetCommandRetryTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves {@link HttpGetCommand#execute(String)} actually retries through {@link HttpRetryCommand}
+ * on a real call path, not just that the two are theoretically wired together. See
+ * {@link HttpPostCommandTest}'s header comment for why this is a hand-rolled ServerSocket
+ * responder rather than com.sun.net.httpserver.HttpServer (JaCoCo cannot instrument it under
+ * "ant ci-test"). {@link HttpRetryCommandTest} covers the retry/backoff mechanics themselves.
+ */
+class HttpGetCommandRetryTest {
+
+  /** Starts a listener that responds to successive connections with each (status, body) pair in order. */
+  private static int startServer(List<Integer> statuses, List<String> bodies) throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+    int port = serverSocket.getLocalPort();
+    Deque<Integer> statusQueue = new ArrayDeque<>(statuses);
+    Deque<String> bodyQueue = new ArrayDeque<>(bodies);
+    Thread thread = new Thread(() -> {
+      try (ServerSocket ss = serverSocket) {
+        while (!statusQueue.isEmpty()) {
+          try (Socket socket = ss.accept()) {
+            int status = statusQueue.poll();
+            String body = bodyQueue.poll();
+
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            // Consume the request line + headers so the client sees a clean response.
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+              // no-op
+            }
+
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            StringBuilder response = new StringBuilder();
+            response.append("HTTP/1.1 ").append(status).append(" STATUS\r\n");
+            response.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
+            response.append("Connection: close\r\n\r\n");
+
+            OutputStream out = socket.getOutputStream();
+            out.write(response.toString().getBytes(StandardCharsets.UTF_8));
+            out.write(bodyBytes);
+            out.flush();
+          }
+        }
+      } catch (IOException e) {
+        // Surfaces to the test as a connection failure on the client side
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+    return port;
+  }
+
+  private static String url(int port) {
+    // 127.0.0.1, not localhost: HttpGetCommand's own UrlValidator rejects a bare "localhost"
+    // host as having no valid TLD, which would fail every request here before any connection.
+    return "http://127.0.0.1:" + port + "/";
+  }
+
+  @Test
+  void executeRetriesA503AndReturnsTheBodyOnceTheServerRecovers() throws IOException {
+    int port = startServer(List.of(503, 200), List.of("", "recovered"));
+
+    String result = HttpGetCommand.execute(url(port));
+
+    assertEquals("recovered", result);
+  }
+
+  @Test
+  void executeReturnsNullWithoutRetryingOnA404() throws IOException {
+    int port = startServer(List.of(404), List.of("not found"));
+
+    String result = HttpGetCommand.execute(url(port));
+
+    assertNull(result);
+  }
+
+  @Test
+  void httpDeleteCommandRetriesA503ThroughItsDelegationIntoHttpGetCommand() throws IOException {
+    // DELETE is idempotent, so it's retried too -- proven here through the real
+    // HttpDeleteCommand.execute(...) -> HttpGetCommand.execute(..., DELETE) delegation, not just
+    // by reading the source.
+    int port = startServer(List.of(503, 200), List.of("", "recovered"));
+
+    String result = HttpDeleteCommand.execute(url(port));
+
+    assertEquals("recovered", result);
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/http/HttpPostCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpPostCommandTest.java
@@ -27,7 +27,10 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -52,35 +55,55 @@ class HttpPostCommandTest {
 
   /** Starts a one-shot listener that responds to the first connection with the given status/body. */
   private static int startServer(int status, String body, AtomicReference<ReceivedRequest> captured) throws IOException {
+    return startServer(List.of(status), List.of(body), captured);
+  }
+
+  /**
+   * Starts a listener that responds to successive connections with each (status, body) pair in
+   * order -- used to prove that {@link HttpPostCommand} actually retries through
+   * {@link HttpRetryCommand} rather than just being wired to a mechanism no real call path uses.
+   */
+  private static int startServer(List<Integer> statuses, List<String> bodies, AtomicReference<ReceivedRequest> captured)
+      throws IOException {
     ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
     int port = serverSocket.getLocalPort();
+    Deque<Integer> statusQueue = new ArrayDeque<>(statuses);
+    Deque<String> bodyQueue = new ArrayDeque<>(bodies);
     Thread thread = new Thread(() -> {
-      try (ServerSocket ss = serverSocket; Socket socket = ss.accept()) {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
-        String requestLine = reader.readLine();
-        String method = requestLine == null ? null : requestLine.split(" ")[0];
-        Map<String, String> headers = new HashMap<>();
-        String line;
-        while ((line = reader.readLine()) != null && !line.isEmpty()) {
-          int colon = line.indexOf(':');
-          if (colon > 0) {
-            headers.put(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
+      try (ServerSocket ss = serverSocket) {
+        while (!statusQueue.isEmpty()) {
+          try (Socket socket = ss.accept()) {
+            int status = statusQueue.poll();
+            String body = bodyQueue.poll();
+
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            String requestLine = reader.readLine();
+            String method = requestLine == null ? null : requestLine.split(" ")[0];
+            Map<String, String> headers = new HashMap<>();
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+              int colon = line.indexOf(':');
+              if (colon > 0) {
+                headers.put(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
+              }
+            }
+            if (captured != null) {
+              captured.set(new ReceivedRequest(method, headers));
+            }
+
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            StringBuilder response = new StringBuilder();
+            response.append("HTTP/1.1 ").append(status).append(" STATUS\r\n");
+            response.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
+            response.append("Connection: close\r\n\r\n");
+
+            OutputStream out = socket.getOutputStream();
+            out.write(response.toString().getBytes(StandardCharsets.UTF_8));
+            out.write(bodyBytes);
+            out.flush();
           }
         }
-        if (captured != null) {
-          captured.set(new ReceivedRequest(method, headers));
-        }
-
-        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
-        StringBuilder response = new StringBuilder();
-        response.append("HTTP/1.1 ").append(status).append(" STATUS\r\n");
-        response.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
-        response.append("Connection: close\r\n\r\n");
-
-        OutputStream out = socket.getOutputStream();
-        out.write(response.toString().getBytes(StandardCharsets.UTF_8));
-        out.write(bodyBytes);
-        out.flush();
       } catch (IOException e) {
         // Surfaces to the test as a connection failure on the client side
       }
@@ -197,6 +220,30 @@ class HttpPostCommandTest {
 
     assertEquals(200, status);
     assertEquals("PATCH", captured.get().method());
+  }
+
+  @Test
+  void executeDoesNotRetryA503OnAPostSincePostIsNotIdempotent() throws IOException {
+    // A 5xx can arrive after a vendor already accepted and acted on a POST (e.g. sent a
+    // campaign) -- HttpRetryCommand deliberately never retries POST/PATCH, so this must behave
+    // exactly as it did before retry/backoff existed: one attempt, null on failure.
+    AtomicReference<ReceivedRequest> captured = new AtomicReference<>();
+    int port = startServer(List.of(503), List.of(""), captured);
+
+    String result = HttpPostCommand.execute(url(port), null, "payload");
+
+    assertNull(result);
+    assertEquals("POST", captured.get().method());
+  }
+
+  @Test
+  void executeForStatusCodeRetriesA503AndReturnsTheStatusOnceAPutRecovers() throws IOException {
+    // PUT is idempotent, unlike POST/PATCH, so it IS retried.
+    int port = startServer(List.of(503, 200), List.of("", "recovered"), null);
+
+    int status = HttpPostCommand.executeForStatusCode(url(port), null, "payload", HttpPostCommand.PUT);
+
+    assertEquals(200, status);
   }
 
   @Test

--- a/src/test/java/com/simisinc/platform/application/http/HttpRetryCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/http/HttpRetryCommandTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link HttpRetryCommand} against a real local listener that can serve a different,
+ * pre-scripted response (or a malformed one) on each successive attempt -- see
+ * {@link HttpPostCommandTest}'s header comment for why this is a hand-rolled ServerSocket
+ * responder rather than com.sun.net.httpserver.HttpServer (JaCoCo cannot instrument it under
+ * "ant ci-test").
+ *
+ * <p>Uses a malformed (non-HTTP) response, not an early connection close, to simulate a transient
+ * I/O failure: the JDK's own {@code HttpClient} transparently retries a GET whose connection was
+ * closed before any response bytes arrived, entirely beneath {@link HttpRetryCommand}'s own
+ * try/catch -- a test built on that technique would pass even if this class's retry loop were
+ * deleted. A malformed response has already been partially received, so it is not eligible for
+ * that transparent retry and reliably surfaces as a real {@link IOException} to this class.
+ */
+class HttpRetryCommandTest {
+
+  private record ScriptedResponse(Integer statusCode, String body, String retryAfterHeader, boolean isMalformed) {
+    static ScriptedResponse status(int statusCode, String body) {
+      return new ScriptedResponse(statusCode, body, null, false);
+    }
+
+    static ScriptedResponse status(int statusCode, String body, String retryAfterHeader) {
+      return new ScriptedResponse(statusCode, body, retryAfterHeader, false);
+    }
+
+    /** Not a valid HTTP response -- the client sees a real parse failure, not a clean early close. */
+    static ScriptedResponse malformed() {
+      return new ScriptedResponse(null, null, null, true);
+    }
+  }
+
+  private static int startServer(List<ScriptedResponse> script, AtomicInteger connectionCount) throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+    int port = serverSocket.getLocalPort();
+    Deque<ScriptedResponse> queue = new ArrayDeque<>(script);
+    Thread thread = new Thread(() -> {
+      try (ServerSocket ss = serverSocket) {
+        while (!queue.isEmpty()) {
+          try (Socket socket = ss.accept()) {
+            connectionCount.incrementAndGet();
+            ScriptedResponse next = queue.poll();
+            OutputStream out = socket.getOutputStream();
+            if (next.isMalformed()) {
+              out.write("NOT AN HTTP RESPONSE AT ALL\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+              out.flush();
+              continue;
+            }
+            byte[] bodyBytes = next.body().getBytes(StandardCharsets.UTF_8);
+            StringBuilder response = new StringBuilder();
+            response.append("HTTP/1.1 ").append(next.statusCode()).append(" STATUS\r\n");
+            response.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
+            if (next.retryAfterHeader() != null) {
+              response.append("Retry-After: ").append(next.retryAfterHeader()).append("\r\n");
+            }
+            response.append("Connection: close\r\n\r\n");
+            out.write(response.toString().getBytes(StandardCharsets.UTF_8));
+            out.write(bodyBytes);
+            out.flush();
+          }
+        }
+        // Queue exhausted: closing the socket (the try-with-resources above) means any further
+        // connection attempt is refused, not silently accepted -- used by the "last exception"
+        // test below to get a distinguishable failure on the final attempt.
+      } catch (IOException e) {
+        // Surfaces to the test as a connection failure on the client side
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+    return port;
+  }
+
+  private static HttpRequest requestFor(int port, String method) {
+    // 127.0.0.1, not localhost: consistent with HttpPostCommandTest's rationale, and avoids any
+    // dependency on this JVM's hosts-file/DNS resolution for a bare "localhost".
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://127.0.0.1:" + port + "/"));
+    switch (method) {
+      case "POST" -> builder.POST(HttpRequest.BodyPublishers.noBody());
+      case "PUT" -> builder.PUT(HttpRequest.BodyPublishers.noBody());
+      case "PATCH" -> builder.method("PATCH", HttpRequest.BodyPublishers.noBody());
+      case "DELETE" -> builder.DELETE();
+      default -> builder.GET();
+    }
+    return builder.build();
+  }
+
+  @Test
+  void succeedsOnTheFirstAttemptWithoutRetrying() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(200, "ok")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals("ok", response.body());
+    assertEquals(1, connections.get());
+  }
+
+  @Test
+  void retriesA503AndSucceedsOnceTheServerRecovers() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(503, ""), ScriptedResponse.status(200, "recovered")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals("recovered", response.body());
+    assertEquals(2, connections.get());
+  }
+
+  @Test
+  void retriesA429AndSucceedsOnceTheServerRecovers() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(429, ""), ScriptedResponse.status(200, "recovered")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals(2, connections.get());
+  }
+
+  @Test
+  void doesNotRetryA404() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(404, "not found")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(404, response.statusCode());
+    assertEquals(1, connections.get());
+  }
+
+  @Test
+  void givesUpAfterMaxAttemptsOnAPersistentFailure() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(
+        List.of(ScriptedResponse.status(503, ""), ScriptedResponse.status(503, ""), ScriptedResponse.status(503, "")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(503, response.statusCode());
+    assertEquals(HttpRetryCommand.MAX_ATTEMPTS, connections.get());
+  }
+
+  @Test
+  void retriesAMalformedResponseAndSucceedsOnceTheServerRecovers() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.malformed(), ScriptedResponse.status(200, "recovered")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals("recovered", response.body());
+    assertEquals(2, connections.get());
+  }
+
+  @Test
+  void throwsAfterExhaustingRetriesOnAPersistentConnectionFailure() {
+    // Nothing is listening on this port, so every attempt fails to connect at all.
+    HttpRequest request = requestFor(1, "GET");
+    long start = System.nanoTime();
+
+    assertThrows(IOException.class, () -> HttpRetryCommand.send(HttpClient.newHttpClient(), request,
+        HttpResponse.BodyHandlers.ofString()));
+
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    // 2 backoff sleeps happen between the 3 attempts (300ms then ~600ms minimum) -- a regression
+    // that collapsed the loop to a single attempt would finish in a few milliseconds instead.
+    assertTrue(elapsedMs >= 800,
+        "expected at least 2 backoff sleeps across " + HttpRetryCommand.MAX_ATTEMPTS + " attempts, took " + elapsedMs
+            + "ms");
+  }
+
+  @Test
+  void theExceptionThatSurfacesIsFromTheLastAttemptNotAnEarlierOne() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    // Only one scripted response: the server closes after serving it, so attempts 2+ get
+    // connection-refused -- a different exception flavor than attempt 1's malformed-response
+    // parse failure, proving the LAST attempt's exception is what surfaces, not the first.
+    int port = startServer(List.of(ScriptedResponse.malformed()), connections);
+    HttpRequest request = requestFor(port, "GET");
+
+    IOException thrown = assertThrows(IOException.class, () -> HttpRetryCommand.send(HttpClient.newHttpClient(),
+        request, HttpResponse.BodyHandlers.ofString()));
+
+    assertTrue(thrown instanceof ConnectException,
+        "expected the LAST attempt's connection-refused exception to surface, not attempt 1's malformed-response "
+            + "exception; got " + thrown.getClass() + ": " + thrown.getMessage());
+  }
+
+  @Test
+  void returnsTheFinalStatusRatherThanAnEarlierAttemptsStaleExceptionWhenAttemptsMixFailureModes() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.malformed(), ScriptedResponse.status(503, "still down"),
+        ScriptedResponse.status(503, "still down")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    // The final (3rd) attempt produced a real HTTP response, so that must be what's returned --
+    // not attempt 1's exception, which a real caller would otherwise see thrown instead of a
+    // normal "received a bad status" outcome.
+    assertEquals(503, response.statusCode());
+    assertEquals(3, connections.get());
+  }
+
+  @Test
+  void doesNotRetryOnAPerAttemptTimeoutSinceTheVendorIsHangingNotFailingFast() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startHangingServer(connections);
+    HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://127.0.0.1:" + port + "/"))
+        .timeout(Duration.ofMillis(200)).GET().build();
+
+    assertThrows(HttpTimeoutException.class, () -> HttpRetryCommand.send(HttpClient.newHttpClient(), request,
+        HttpResponse.BodyHandlers.ofString()));
+
+    assertEquals(1, connections.get(), "a per-attempt timeout means the vendor is hanging -- retrying would just "
+        + "cost another full timeout for little chance of success");
+  }
+
+  private static int startHangingServer(AtomicInteger connectionCount) throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+    int port = serverSocket.getLocalPort();
+    Thread thread = new Thread(() -> {
+      try (ServerSocket ss = serverSocket; Socket socket = ss.accept()) {
+        connectionCount.incrementAndGet();
+        Thread.sleep(5000);
+      } catch (IOException | InterruptedException e) {
+        // Test teardown races (client already gave up and closed) are expected here.
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+    return port;
+  }
+
+  @Test
+  void honorsARetryAfterHeaderInsteadOfExponentialBackoffOnA429() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(
+        List.of(ScriptedResponse.status(429, "", "1"), ScriptedResponse.status(200, "recovered")), connections);
+    long start = System.nanoTime();
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertEquals(200, response.statusCode());
+    assertEquals("recovered", response.body());
+    assertTrue(elapsedMs >= 900,
+        "expected the 1-second Retry-After to be honored instead of the ~300-700ms default backoff, took "
+            + elapsedMs + "ms");
+  }
+
+  @Test
+  void givesUpWithoutRetryingWhenRetryAfterExceedsTheDelayCap() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(429, "slow down", "999")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "GET"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(429, response.statusCode());
+    assertEquals(1, connections.get(),
+        "a Retry-After longer than this synchronous call can honor should stop retrying, not under-wait");
+  }
+
+  @Test
+  void doesNotRetryPostSincePostIsNotIdempotent() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(503, "")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "POST"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(503, response.statusCode());
+    assertEquals(1, connections.get());
+  }
+
+  @Test
+  void doesNotRetryPatchSincePatchIsNotIdempotent() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(503, "")), connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "PATCH"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(503, response.statusCode());
+    assertEquals(1, connections.get());
+  }
+
+  @Test
+  void retriesPutSincePutIsIdempotent() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(503, ""), ScriptedResponse.status(200, "recovered")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "PUT"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals(2, connections.get());
+  }
+
+  @Test
+  void retriesDeleteSinceDeleteIsIdempotent() throws IOException {
+    AtomicInteger connections = new AtomicInteger();
+    int port = startServer(List.of(ScriptedResponse.status(503, ""), ScriptedResponse.status(200, "recovered")),
+        connections);
+
+    HttpResponse<String> response = HttpRetryCommand.send(HttpClient.newHttpClient(), requestFor(port, "DELETE"),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals(2, connections.get());
+  }
+}


### PR DESCRIPTION
## Summary

Scoped-down build of #455 ("Phase 2: Third-party integration registry and UI discovery"). Per the audit comment on the issue, most of the original ask (marketplace UI, one-click install, ZeroBounce/Slack registry) either already exists (ZeroBounce shipped as #574) or isn't warranted yet. The one broad, confirmed gap — no retry/backoff on any fixed-endpoint outbound HTTP call — is what this PR builds. The allowlist-automation gap the same audit flagged is already closed by #454's `SecretSitePropertiesCommandTest` guardrail.

- Adds `HttpRetryCommand`, a shared retry-with-backoff wrapper used by `HttpGetCommand`/`HttpPostCommand` (and, through them, `HttpDeleteCommand`/`HttpPutCommand`/`HttpPatchCommand`).
- Retries idempotent methods only (GET/HEAD/PUT/DELETE) up to 3 attempts on a connection failure or a 429/5xx response, exponential backoff + jitter, honoring a `Retry-After` header when present.
- POST/PATCH are **never** retried automatically — a 5xx can arrive after a vendor already accepted and acted on the request (e.g. sent a MailChimp campaign), so resending risks a duplicate side effect. This is unchanged from pre-PR behavior for those methods.
- A per-attempt timeout (`HttpTimeoutException` — the vendor hanging, not failing fast) is not retried, so a stalled vendor can't tie up a request-handling thread for multiples of the original 20s timeout.
- Retry log lines strip the query string from the logged URL, so a retried call to a vendor that puts its API key in a query param doesn't write the secret to logs multiple times.

## Review

Went through an adversarial-review pass (multiple independent reviewers across correctness/concurrency, security/abuse-potential, and test-coverage, each finding adversarially re-verified) before this PR. It caught two real bugs and several coverage gaps, all fixed here:
- A stale-exception bug where, if an early attempt threw an exception but a later attempt returned a real (still-failing) HTTP response, the stale exception from the early attempt was thrown instead of the real response being returned.
- The original draft retried POST/PATCH unconditionally — fixed by restricting retry to idempotent methods only, as described above.
- A test that looked like it exercised this class's own retry logic but actually passed due to the JDK HttpClient's own transparent one-shot retry on a GET whose connection closed before any bytes arrived — replaced with a technique (a malformed, partially-received response) that reliably reaches this class's own retry path.

## Test plan
- [x] `HttpRetryCommandTest` — retry/backoff mechanics: retryable status/exception, non-retryable status short-circuits, method-based idempotency restriction, per-attempt-timeout no-retry, `Retry-After` honored (and given up on when it exceeds what a synchronous call can wait), mixed-failure-mode sequences, exhaustion behavior.
- [x] `HttpGetCommandRetryTest` / `HttpPostCommandTest` — wiring-proof tests against a real local listener confirming `HttpGetCommand.execute()`/`HttpPostCommand.execute()`/`HttpDeleteCommand.execute()` actually retry through this class on the real call path, not just in isolation.
- [x] Full `ant ci-test` (336 test classes) — all passing.
- [x] `tools/check-unescaped-el.py` — clean (no JSP changes in this PR).