### PR TITLE
Add REST API read endpoints for pages, blog posts, and folder files (#412 PR1/4)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ValidateApiAccessToWebPageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ValidateApiAccessToWebPageCommand.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+/**
+ * Determines whether a REST API caller may see a given web page (issue #412), mirroring
+ * {@code PageServlet.service()}'s combined gate for a live, non-editor site visitor:
+ * {@link ValidateUserAccessToWebPageCommand#hasAccess} (draft/blank-pageXml + widget/section/
+ * column role, group, and capability gating) plus the {@code publishAt}/{@code expiresAt}
+ * scheduling window PageServlet enforces separately for non-admin/content-manager users.
+ * <p>
+ * {@code WebPage.enabled} is deliberately NOT checked here -- {@code PageServlet} never checks it
+ * either; it is not part of the live-serving gate.
+ * </p>
+ * <p>
+ * Bridges the REST layer's plain {@link User} (set by {@code RestRequestFilter}, either a real
+ * authenticated user loaded via {@code LoadUserCommand.loadUser} or a bare guest user) into the
+ * {@link UserSession} that the shared access-check commands require, via
+ * {@code UserSession.login(User)} -- the same role/group/capability lists a JSP-session login
+ * would populate.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class ValidateApiAccessToWebPageCommand {
+
+  private ValidateApiAccessToWebPageCommand() {
+    // Static utility, not instantiated
+  }
+
+  public static boolean hasAccess(WebPage webPage, User user) {
+    if (webPage == null) {
+      return false;
+    }
+    UserSession userSession = new UserSession();
+    if (user != null) {
+      userSession.login(user);
+    }
+    if (!ValidateUserAccessToWebPageCommand.hasAccess(webPage.getLink(), userSession)) {
+      return false;
+    }
+    if (!userSession.hasRole("admin") && !userSession.hasRole("content-manager")) {
+      Timestamp now = new Timestamp(System.currentTimeMillis());
+      if (webPage.getPublishAt() != null && webPage.getPublishAt().after(now)) {
+        return false;
+      }
+      if (webPage.getExpiresAt() != null && webPage.getExpiresAt().before(now)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostListService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostListService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a paginated list of a blog's published posts (issue #412).
+ * <p>
+ * Registered as {@code blog-posts/{blogUniqueId}}, not {@code blog/{blogUniqueId}/posts} as
+ * originally specced -- {@link com.simisinc.platform.rest.controller.RestServlet}'s router treats
+ * everything after the first path segment as up to 2 raw path params with no support for a
+ * literal segment in between them, so a trailing literal "/posts" isn't representable. This
+ * mirrors the existing {@code item-blog}/{@code item-list} naming convention already used for the
+ * same routing constraint (see the commented-out block in rest-services.xml).
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class BlogPostListService {
+
+  private static Log LOG = LogFactory.getLog(BlogPostListService.class);
+
+  // GET /blog-posts/{blogUniqueId}?page={pageNumber}&size={pageSize}
+  public ServiceResponse get(ServiceContext context) {
+
+    String blogUniqueId = context.getPathParam();
+    Blog blog = BlogRepository.findByUniqueId(blogUniqueId);
+    if (blog == null || !blog.getEnabled()) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Blog was not found");
+      return response;
+    }
+
+    int pageNumber = context.getParameterAsInt("page", 1);
+    int pageSize = context.getParameterAsInt("size", 20);
+    DataConstraints constraints = new DataConstraints(pageNumber, pageSize);
+
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setBlogId(blog.getId());
+    specification.setPublishedOnly(true);
+    specification.setStartDateIsBeforeNow(true);
+    specification.setIsWithinEndDate(true);
+
+    List<BlogPost> blogPostList = BlogPostRepository.findAll(specification, constraints);
+
+    List<BlogPostResponse> recordList = new ArrayList<>();
+    for (BlogPost blogPost : blogPostList) {
+      recordList.add(new BlogPostResponse(blogPost));
+    }
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "post", recordList, constraints);
+    response.setData(recordList);
+    return response;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostResponse.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostResponse.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.cms.BlogPost;
+
+/**
+ * Public fields for a published blog post (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+public class BlogPostResponse {
+
+  private String uniqueId;
+  private String title;
+  private String body;
+  private String summary;
+  private String keywords;
+  private String imageUrl;
+  private String videoUrl;
+  private Timestamp published;
+  private Timestamp startDate;
+  private Timestamp endDate;
+  private Timestamp modified;
+
+  public BlogPostResponse(BlogPost blogPost) {
+    uniqueId = blogPost.getUniqueId();
+    title = blogPost.getTitle();
+    body = blogPost.getBody();
+    summary = blogPost.getSummary();
+    keywords = blogPost.getKeywords();
+    imageUrl = blogPost.getImageUrl();
+    videoUrl = blogPost.getVideoUrl();
+    published = blogPost.getPublished();
+    startDate = blogPost.getStartDate();
+    endDate = blogPost.getEndDate();
+    modified = blogPost.getModified();
+  }
+
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  public void setUniqueId(String uniqueId) {
+    this.uniqueId = uniqueId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+
+  public String getKeywords() {
+    return keywords;
+  }
+
+  public void setKeywords(String keywords) {
+    this.keywords = keywords;
+  }
+
+  public String getImageUrl() {
+    return imageUrl;
+  }
+
+  public void setImageUrl(String imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+
+  public String getVideoUrl() {
+    return videoUrl;
+  }
+
+  public void setVideoUrl(String videoUrl) {
+    this.videoUrl = videoUrl;
+  }
+
+  public Timestamp getPublished() {
+    return published;
+  }
+
+  public void setPublished(Timestamp published) {
+    this.published = published;
+  }
+
+  public Timestamp getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(Timestamp startDate) {
+    this.startDate = startDate;
+  }
+
+  public Timestamp getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(Timestamp endDate) {
+    this.endDate = endDate;
+  }
+
+  public Timestamp getModified() {
+    return modified;
+  }
+
+  public void setModified(Timestamp modified) {
+    this.modified = modified;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/BlogPostService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a single published blog post (issue #412).
+ * <p>
+ * Registered as {@code post/{blogUniqueId}/{postUniqueId}}, not {@code post/{postUniqueId}} as
+ * originally specced -- {@link BlogPostRepository#findByUniqueId} is keyed by
+ * {@code (blogId, postUniqueId)}, not a globally-unique post identifier, so the blog must be
+ * resolved first regardless.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class BlogPostService {
+
+  private static Log LOG = LogFactory.getLog(BlogPostService.class);
+
+  // GET /post/{blogUniqueId}/{postUniqueId}
+  public ServiceResponse get(ServiceContext context) {
+
+    String blogUniqueId = context.getPathParam();
+    String postUniqueId = context.getPathParam2();
+
+    Blog blog = BlogRepository.findByUniqueId(blogUniqueId);
+    if (blog == null || !blog.getEnabled()) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Blog was not found");
+      return response;
+    }
+
+    BlogPost blogPost = BlogPostRepository.findByUniqueId(blog.getId(), postUniqueId);
+    if (blogPost == null || !isVisible(blogPost, context)) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Post was not found");
+      return response;
+    }
+
+    BlogPostResponse blogPostResponse = new BlogPostResponse(blogPost);
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "post");
+    response.setData(blogPostResponse);
+    return response;
+  }
+
+  // Mirrors BlogPostWidget.retrieveValidatedBlogPostFromUrl exactly -- the real single-post live
+  // page only checks `published != null` (with an admin/content-manager bypass for unpublished
+  // drafts); it does NOT enforce startDate/endDate the way the list-page widgets do. An earlier
+  // version of this method incorrectly borrowed the list-page's stricter date-window filter,
+  // which 404'd posts the live site actually serves (e.g. a live post whose endDate has passed --
+  // a common way to pull it out of list/recent-posts widgets while keeping the permalink live).
+  private static boolean isVisible(BlogPost blogPost, ServiceContext context) {
+    if (blogPost.getPublished() != null) {
+      return true;
+    }
+    return context.hasRole("admin") || context.hasRole("content-manager");
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/FileResponse.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/FileResponse.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.cms.FileItem;
+
+/**
+ * Public fields for a file in a folder (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+public class FileResponse {
+
+  private long id;
+  private String filename;
+  private String title;
+  private String summary;
+  private String mimeType;
+  private long fileLength;
+  private int width;
+  private int height;
+  private Timestamp modified;
+
+  public FileResponse(FileItem fileItem) {
+    id = fileItem.getId();
+    filename = fileItem.getFilename();
+    title = fileItem.getTitle();
+    summary = fileItem.getSummary();
+    mimeType = fileItem.getMimeType();
+    fileLength = fileItem.getFileLength();
+    width = fileItem.getWidth();
+    height = fileItem.getHeight();
+    modified = fileItem.getModified();
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public void setSummary(String summary) {
+    this.summary = summary;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType) {
+    this.mimeType = mimeType;
+  }
+
+  public long getFileLength() {
+    return fileLength;
+  }
+
+  public void setFileLength(long fileLength) {
+    this.fileLength = fileLength;
+  }
+
+  public int getWidth() {
+    return width;
+  }
+
+  public void setWidth(int width) {
+    this.width = width;
+  }
+
+  public int getHeight() {
+    return height;
+  }
+
+  public void setHeight(int height) {
+    this.height = height;
+  }
+
+  public Timestamp getModified() {
+    return modified;
+  }
+
+  public void setModified(Timestamp modified) {
+    this.modified = modified;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/FileService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/FileService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.cms.LoadFileCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a single file's public metadata, if the caller has access to its folder (issue #412).
+ * <p>
+ * Registered as {@code file/{fileId}}, keyed by the numeric id rather than {@code fileUniqueId}
+ * as originally specced -- {@link FileItem} has no {@code uniqueId} field the way
+ * {@link Folder}/{@code Blog}/{@code WebPage} do (it has {@code barcode} instead, which serves a
+ * different purpose). Revisit if a durable public file identifier is actually needed.
+ * </p>
+ * <p>
+ * Uses {@link LoadFileCommand#loadFileByIdForAuthorizedUser}, which applies the same guest/group
+ * folder ACL as {@code DownloadFileWidget}'s non-admin path -- a prior version of this class
+ * incorrectly claimed no such ACL was enforced anywhere and only checked {@code Folder.enabled}.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class FileService {
+
+  private static Log LOG = LogFactory.getLog(FileService.class);
+
+  // GET /file/{fileId}
+  public ServiceResponse get(ServiceContext context) {
+
+    long fileId = context.getPathParam() != null && StringUtils.isNumeric(context.getPathParam())
+        ? Long.parseLong(context.getPathParam())
+        : -1L;
+    FileItem fileItem = LoadFileCommand.loadFileByIdForAuthorizedUser(fileId, context.getUserId());
+    if (fileItem == null) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "File was not found");
+      return response;
+    }
+
+    FileResponse fileResponse = new FileResponse(fileItem);
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "file");
+    response.setData(fileResponse);
+    return response;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/FolderFilesListService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/FolderFilesListService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.cms.LoadFolderCommand;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a paginated list of files in a folder the caller has access to (issue #412).
+ * <p>
+ * Uses {@link LoadFolderCommand#loadFolderByUniqueIdForAuthorizedUser} and
+ * {@link FileSpecification#setForUserId} -- the same guest/group ACL
+ * ({@code Folder.allowsGuests} + {@code folder_groups}/{@code user_groups} membership) that
+ * {@code FileListByFolderWidget} applies on the live site, embedded directly in
+ * {@code FileItemRepository}'s WHERE-clause construction. A prior version of this class
+ * incorrectly claimed no such ACL was enforced anywhere -- it is, and this endpoint now respects
+ * it rather than exposing every enabled folder's contents to an anonymous/guest API caller.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class FolderFilesListService {
+
+  private static Log LOG = LogFactory.getLog(FolderFilesListService.class);
+
+  // GET /files/{folderUniqueId}?page={pageNumber}&size={pageSize}
+  public ServiceResponse get(ServiceContext context) {
+
+    String folderUniqueId = context.getPathParam();
+    Folder folder = LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser(folderUniqueId, context.getUserId());
+    if (folder == null) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Folder was not found");
+      return response;
+    }
+
+    int pageNumber = context.getParameterAsInt("page", 1);
+    int pageSize = context.getParameterAsInt("size", 20);
+    DataConstraints constraints = new DataConstraints(pageNumber, pageSize);
+
+    FileSpecification specification = new FileSpecification();
+    specification.setFolderId(folder.getId());
+    specification.setForUserId(context.getUserId());
+
+    List<FileItem> fileItemList = FileItemRepository.findAll(specification, constraints);
+
+    List<FileResponse> recordList = new ArrayList<>();
+    for (FileItem fileItem : fileItemList) {
+      recordList.add(new FileResponse(fileItem));
+    }
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "file", recordList, constraints);
+    response.setData(recordList);
+    return response;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/PageService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/PageService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.cms.ValidateApiAccessToWebPageCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a single web page's public metadata by its link (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+public class PageService {
+
+  private static Log LOG = LogFactory.getLog(PageService.class);
+
+  // GET /page/{pagePath} -- pagePath may itself contain "/" (e.g. "/about/team"). RestServlet's
+  // 2-path-param router preserves this: pathParam2 holds everything after the second "/" verbatim
+  // (it is not further split), so pathParam + "/" + pathParam2 always reconstructs the original
+  // suffix exactly, regardless of how many segments it has. A trailing slash (e.g.
+  // "/page/about/") yields pathParam2 == "" (not null) per RestServlet's substring logic, so an
+  // empty pathParam2 is treated the same as "not present" rather than appended literally.
+  public ServiceResponse get(ServiceContext context) {
+
+    String pathParam = context.getPathParam();
+    if (StringUtils.isBlank(pathParam)) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Page was not found");
+      return response;
+    }
+    String pagePath = pathParam;
+    if (StringUtils.isNotEmpty(context.getPathParam2())) {
+      pagePath = pagePath + "/" + context.getPathParam2();
+    }
+    String link = "/" + pagePath;
+
+    WebPage webPage = WebPageRepository.findByLink(link);
+    if (webPage == null || !ValidateApiAccessToWebPageCommand.hasAccess(webPage, context.getUser())) {
+      ServiceResponse response = new ServiceResponse(404);
+      response.getError().put("title", "Page was not found");
+      return response;
+    }
+
+    WebPageResponse webPageResponse = new WebPageResponse(webPage);
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "page");
+    response.setData(webPageResponse);
+    return response;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/PagesListService.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/PagesListService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.cms.ValidateApiAccessToWebPageCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+import com.simisinc.platform.rest.controller.ServiceResponseCommand;
+
+/**
+ * Returns a paginated list of web pages visible to the caller (issue #412), using the same
+ * {@link ValidateApiAccessToWebPageCommand} gate as {@link PageService} -- draft/blank-pageXml,
+ * publish schedule, and widget/section/column role/group/capability access. {@code enabled}/
+ * {@code draft} are NOT used as a SQL pre-filter here since neither one alone matches the real
+ * gate (see {@link ValidateApiAccessToWebPageCommand}'s javadoc).
+ * <p>
+ * Known limitation: the per-page visibility check runs in Java, after the DB-level
+ * page/size pagination, so a returned page can legitimately contain fewer than {@code size}
+ * entries when some pages within that DB window aren't visible to the caller -- this trades an
+ * exactly-full page for not leaking access-check logic into SQL. Revisit if that's an issue.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class PagesListService {
+
+  private static Log LOG = LogFactory.getLog(PagesListService.class);
+
+  // GET /pages?page={pageNumber}&size={pageSize}
+  public ServiceResponse get(ServiceContext context) {
+
+    int pageNumber = context.getParameterAsInt("page", 1);
+    int pageSize = context.getParameterAsInt("size", 20);
+    DataConstraints constraints = new DataConstraints(pageNumber, pageSize);
+
+    WebPageSpecification specification = new WebPageSpecification();
+
+    List<WebPage> webPageList = WebPageRepository.findAll(specification, constraints);
+
+    List<WebPageResponse> recordList = new ArrayList<>();
+    for (WebPage webPage : webPageList) {
+      if (ValidateApiAccessToWebPageCommand.hasAccess(webPage, context.getUser())) {
+        recordList.add(new WebPageResponse(webPage));
+      }
+    }
+
+    ServiceResponse response = new ServiceResponse(200);
+    ServiceResponseCommand.addMeta(response, "page", recordList, constraints);
+    response.setData(recordList);
+    return response;
+  }
+}

--- a/src/main/java/com/simisinc/platform/rest/services/cms/WebPageResponse.java
+++ b/src/main/java/com/simisinc/platform/rest/services/cms/WebPageResponse.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.cms.WebPage;
+
+/**
+ * Public metadata for a web page (issue #412) -- not the rendered widget content, which would
+ * require the same section/column/widget role-gating {@code PageServlet} applies and is out of
+ * scope for this read endpoint.
+ *
+ * @author SimIS Inc.
+ */
+public class WebPageResponse {
+
+  private String link;
+  private String title;
+  private String description;
+  private String keywords;
+  private String imageUrl;
+  private String redirectUrl;
+  private Timestamp publishAt;
+  private Timestamp expiresAt;
+  private Timestamp modified;
+
+  public WebPageResponse(WebPage webPage) {
+    link = webPage.getLink();
+    title = webPage.getTitle();
+    description = webPage.getDescription();
+    keywords = webPage.getKeywords();
+    imageUrl = webPage.getImageUrl();
+    redirectUrl = webPage.getRedirectUrl();
+    publishAt = webPage.getPublishAt();
+    expiresAt = webPage.getExpiresAt();
+    modified = webPage.getModified();
+  }
+
+  public String getLink() {
+    return link;
+  }
+
+  public void setLink(String link) {
+    this.link = link;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getKeywords() {
+    return keywords;
+  }
+
+  public void setKeywords(String keywords) {
+    this.keywords = keywords;
+  }
+
+  public String getImageUrl() {
+    return imageUrl;
+  }
+
+  public void setImageUrl(String imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+
+  public String getRedirectUrl() {
+    return redirectUrl;
+  }
+
+  public void setRedirectUrl(String redirectUrl) {
+    this.redirectUrl = redirectUrl;
+  }
+
+  public Timestamp getPublishAt() {
+    return publishAt;
+  }
+
+  public void setPublishAt(Timestamp publishAt) {
+    this.publishAt = publishAt;
+  }
+
+  public Timestamp getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(Timestamp expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public Timestamp getModified() {
+    return modified;
+  }
+
+  public void setModified(Timestamp modified) {
+    this.modified = modified;
+  }
+}

--- a/src/main/webapp/WEB-INF/rest-services/rest-services.xml
+++ b/src/main/webapp/WEB-INF/rest-services/rest-services.xml
@@ -34,6 +34,19 @@
   -->
   <service method="get" endpoint="audit-log" class="com.simisinc.platform.rest.services.audit.AuditLogListService" />
   <!--
+  Issue #412: read endpoints for web pages, blog posts, and folder files. "blog-posts/{id}" and
+  "post/{blogId}/{postId}" deviate from the issue's originally-specced "blog/{id}/posts" and
+  "post/{postId}" -- RestServlet's router only supports up to 2 raw path params with no literal
+  segment between them, and BlogPostRepository.findByUniqueId is keyed by (blogId, postUniqueId),
+  not a globally-unique post id. See each service class's javadoc for the full rationale.
+  -->
+  <service method="get" endpoint="pages" class="com.simisinc.platform.rest.services.cms.PagesListService" />
+  <service method="get" endpoint="page/{pagePath}" class="com.simisinc.platform.rest.services.cms.PageService" />
+  <service method="get" endpoint="blog-posts/{blogUniqueId}" class="com.simisinc.platform.rest.services.cms.BlogPostListService" />
+  <service method="get" endpoint="post/{blogUniqueId}/{postUniqueId}" class="com.simisinc.platform.rest.services.cms.BlogPostService" />
+  <service method="get" endpoint="files/{folderUniqueId}" class="com.simisinc.platform.rest.services.cms.FolderFilesListService" />
+  <service method="get" endpoint="file/{fileId}" class="com.simisinc.platform.rest.services.cms.FileService" />
+  <!--
   /item-blog/unique-id
   /item-blog-post/unique-id/post-id
   /item-gallery/unique-id

--- a/src/test/java/com/simisinc/platform/application/cms/ValidateApiAccessToWebPageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ValidateApiAccessToWebPageCommandTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.presentation.controller.UserSession;
+
+/**
+ * Verifies {@link ValidateApiAccessToWebPageCommand}: the User-to-UserSession bridge and the
+ * publishAt/expiresAt scheduling check it layers on top of
+ * {@link ValidateUserAccessToWebPageCommand#hasAccess} (issue #412). The underlying
+ * draft/role/group/capability logic itself is covered by ValidateUserAccessToWebPageCommandTest;
+ * these tests mock that boundary to isolate what this class adds.
+ *
+ * @author SimIS Inc.
+ */
+class ValidateApiAccessToWebPageCommandTest {
+
+  private WebPage webPageWithLink(String link) {
+    WebPage webPage = new WebPage();
+    webPage.setLink(link);
+    return webPage;
+  }
+
+  private User userWithRoles(String... roleCodes) {
+    List<Role> roles = new ArrayList<>();
+    for (String code : roleCodes) {
+      roles.add(new Role(code, code));
+    }
+    User user = new User();
+    user.setId(1L);
+    user.setRoleList(roles);
+    return user;
+  }
+
+  @Test
+  void returnsFalseForANullWebPage() {
+    assertFalse(ValidateApiAccessToWebPageCommand.hasAccess(null, null));
+  }
+
+  @Test
+  void delegatesToTheSharedAccessCheckAndDeniesWhenItDenies() {
+    WebPage webPage = webPageWithLink("/gated");
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/gated"), any(UserSession.class)))
+          .thenReturn(false);
+
+      assertFalse(ValidateApiAccessToWebPageCommand.hasAccess(webPage, null));
+    }
+  }
+
+  @Test
+  void aGuestNullUserStillProducesAWorkingUserSession() {
+    // A null User (never logged in / no bearer token resolved) must not NPE the UserSession
+    // bridge -- it should behave like the guest UserSession the JSP path uses.
+    WebPage webPage = webPageWithLink("/public-page");
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/public-page"), any(UserSession.class)))
+          .thenReturn(true);
+
+      assertTrue(ValidateApiAccessToWebPageCommand.hasAccess(webPage, null));
+    }
+  }
+
+  @Test
+  void returnsFalseForAPageScheduledToPublishInTheFuture() {
+    WebPage webPage = webPageWithLink("/upcoming");
+    webPage.setPublishAt(new Timestamp(System.currentTimeMillis() + 3_600_000));
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/upcoming"), any(UserSession.class)))
+          .thenReturn(true);
+
+      assertFalse(ValidateApiAccessToWebPageCommand.hasAccess(webPage, null));
+    }
+  }
+
+  @Test
+  void returnsFalseForAPageThatHasAlreadyExpired() {
+    WebPage webPage = webPageWithLink("/expired");
+    webPage.setExpiresAt(new Timestamp(System.currentTimeMillis() - 3_600_000));
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/expired"), any(UserSession.class)))
+          .thenReturn(true);
+
+      assertFalse(ValidateApiAccessToWebPageCommand.hasAccess(webPage, null));
+    }
+  }
+
+  @Test
+  void anAdminSeesAScheduledPageDespiteThePublishAtWindow() {
+    // Mirrors PageServlet.service(): the publishAt/expiresAt check is skipped entirely for
+    // admin/content-manager, same as it is for a real logged-in editor browsing the live site.
+    WebPage webPage = webPageWithLink("/upcoming");
+    webPage.setPublishAt(new Timestamp(System.currentTimeMillis() + 3_600_000));
+    User admin = userWithRoles("admin");
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/upcoming"), any(UserSession.class)))
+          .thenReturn(true);
+
+      assertTrue(ValidateApiAccessToWebPageCommand.hasAccess(webPage, admin));
+    }
+  }
+
+  @Test
+  void returnsTrueForALivePageWithNoScheduleRestriction() {
+    WebPage webPage = webPageWithLink("/about");
+    try (MockedStatic<ValidateUserAccessToWebPageCommand> shared = mockStatic(ValidateUserAccessToWebPageCommand.class)) {
+      shared.when(() -> ValidateUserAccessToWebPageCommand.hasAccess(eq("/about"), any(UserSession.class)))
+          .thenReturn(true);
+
+      assertTrue(ValidateApiAccessToWebPageCommand.hasAccess(webPage, null));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/BlogPostListServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/BlogPostListServiceTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link BlogPostListService} (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class BlogPostListServiceTest {
+
+  private ServiceContext contextFor(String blogUniqueId) {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam(blogUniqueId);
+    context.setParameterMap(new HashMap<>());
+    return context;
+  }
+
+  private ServiceContext contextFor(String blogUniqueId, String page, String size) {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam(blogUniqueId);
+    HashMap<String, String[]> params = new HashMap<>();
+    params.put("page", new String[] { page });
+    params.put("size", new String[] { size });
+    context.setParameterMap(params);
+    return context;
+  }
+
+  private Blog enabledBlog(long id) {
+    Blog blog = new Blog();
+    blog.setId(id);
+    blog.setEnabled(true);
+    return blog;
+  }
+
+  @Test
+  void getReturns404WhenTheBlogDoesNotExist() {
+    ServiceContext context = contextFor("missing-blog");
+
+    try (MockedStatic<BlogRepository> repo = mockStatic(BlogRepository.class)) {
+      repo.when(() -> BlogRepository.findByUniqueId("missing-blog")).thenReturn(null);
+
+      ServiceResponse response = new BlogPostListService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns404WhenTheBlogIsDisabled() {
+    ServiceContext context = contextFor("disabled-blog");
+    Blog disabledBlog = enabledBlog(9L);
+    disabledBlog.setEnabled(false);
+
+    try (MockedStatic<BlogRepository> repo = mockStatic(BlogRepository.class)) {
+      repo.when(() -> BlogRepository.findByUniqueId("disabled-blog")).thenReturn(disabledBlog);
+
+      ServiceResponse response = new BlogPostListService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getOnlyRequestsPublishedPostsWithinTheDateWindow() {
+    ServiceContext context = contextFor("news");
+    Blog blog = enabledBlog(9L);
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findAll(any(BlogPostSpecification.class), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      new BlogPostListService().get(context);
+
+      ArgumentCaptor<BlogPostSpecification> specCaptor = ArgumentCaptor.forClass(BlogPostSpecification.class);
+      postRepo.verify(() -> BlogPostRepository.findAll(specCaptor.capture(), any(DataConstraints.class)));
+      BlogPostSpecification spec = specCaptor.getValue();
+      assertEquals(9L, spec.getBlogId());
+      assertEquals(1, spec.getPublishedOnly());
+      assertEquals(1, spec.getStartDateIsBeforeNow());
+      assertEquals(1, spec.getIsWithinEndDate());
+    }
+  }
+
+  @Test
+  void getPassesTheRequestedPageAndSizeToDataConstraints() {
+    ServiceContext context = contextFor("news", "2", "10");
+    Blog blog = enabledBlog(9L);
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findAll(any(BlogPostSpecification.class), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      new BlogPostListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      postRepo.verify(() -> BlogPostRepository.findAll(any(BlogPostSpecification.class), constraintsCaptor.capture()));
+      assertEquals(2, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(10, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void getReturns200WithMappedPosts() {
+    ServiceContext context = contextFor("news");
+    Blog blog = enabledBlog(9L);
+    BlogPost post = new BlogPost();
+    post.setUniqueId("hello-world");
+    post.setTitle("Hello World");
+    post.setSummary("A summary");
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findAll(any(BlogPostSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of(post));
+
+      ServiceResponse response = new BlogPostListService().get(context);
+
+      assertEquals(200, response.getStatus());
+      @SuppressWarnings("unchecked")
+      List<BlogPostResponse> data = (List<BlogPostResponse>) response.getData();
+      assertEquals(1, data.size());
+      assertEquals("hello-world", data.get(0).getUniqueId());
+      assertEquals("Hello World", data.get(0).getTitle());
+      assertEquals("A summary", data.get(0).getSummary());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/BlogPostServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/BlogPostServiceTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link BlogPostService} matches {@code BlogPostWidget.retrieveValidatedBlogPostFromUrl}
+ * exactly -- only {@code published != null} (with an admin/content-manager bypass), NOT the
+ * list-page's stricter startDate/endDate window (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class BlogPostServiceTest {
+
+  private ServiceContext contextFor(String blogUniqueId, String postUniqueId) {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam(blogUniqueId);
+    context.setPathParam2(postUniqueId);
+    return context;
+  }
+
+  private ServiceContext adminContextFor(String blogUniqueId, String postUniqueId) {
+    ServiceContext context = contextFor(blogUniqueId, postUniqueId);
+    User admin = new User();
+    admin.setId(1L);
+    List<Role> roles = new ArrayList<>();
+    roles.add(new Role("admin", "admin"));
+    admin.setRoleList(roles);
+    context.setUser(admin);
+    return context;
+  }
+
+  private Blog enabledBlog(long id) {
+    Blog blog = new Blog();
+    blog.setId(id);
+    blog.setEnabled(true);
+    return blog;
+  }
+
+  private BlogPost publishedPost(String uniqueId) {
+    BlogPost post = new BlogPost();
+    post.setUniqueId(uniqueId);
+    post.setTitle("A Post");
+    post.setPublished(new Timestamp(System.currentTimeMillis() - 100_000));
+    return post;
+  }
+
+  @Test
+  void getReturns404WhenTheBlogDoesNotExist() {
+    ServiceContext context = contextFor("missing-blog", "some-post");
+
+    try (MockedStatic<BlogRepository> repo = mockStatic(BlogRepository.class)) {
+      repo.when(() -> BlogRepository.findByUniqueId("missing-blog")).thenReturn(null);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns404WhenTheBlogIsDisabled() {
+    ServiceContext context = contextFor("disabled-blog", "some-post");
+    Blog disabled = enabledBlog(9L);
+    disabled.setEnabled(false);
+
+    try (MockedStatic<BlogRepository> repo = mockStatic(BlogRepository.class)) {
+      repo.when(() -> BlogRepository.findByUniqueId("disabled-blog")).thenReturn(disabled);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns404WhenThePostDoesNotExistWithinThatBlog() {
+    ServiceContext context = contextFor("news", "missing-post");
+    Blog blog = enabledBlog(9L);
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findByUniqueId(9L, "missing-post")).thenReturn(null);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns404ForAnUnpublishedPost() {
+    ServiceContext context = contextFor("news", "draft-post");
+    Blog blog = enabledBlog(9L);
+    BlogPost unpublished = new BlogPost();
+    unpublished.setUniqueId("draft-post");
+    unpublished.setPublished(null);
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findByUniqueId(9L, "draft-post")).thenReturn(unpublished);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns200ForAnUnpublishedPostWhenCallerIsAnAdmin() {
+    // Mirrors BlogPostWidget.retrieveValidatedBlogPostFromUrl's admin/content-manager bypass.
+    ServiceContext context = adminContextFor("news", "draft-post");
+    Blog blog = enabledBlog(9L);
+    BlogPost unpublished = new BlogPost();
+    unpublished.setUniqueId("draft-post");
+    unpublished.setPublished(null);
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findByUniqueId(9L, "draft-post")).thenReturn(unpublished);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(200, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns200ForAPublishedPostWhoseEndDateHasPassed() {
+    // The real single-post live page (BlogPostWidget) never enforces endDate -- only the list
+    // widgets do. A published post pulled out of listings via a past endDate must still resolve.
+    ServiceContext context = contextFor("news", "expired-from-listings");
+    Blog blog = enabledBlog(9L);
+    BlogPost post = publishedPost("expired-from-listings");
+    post.setEndDate(new Timestamp(System.currentTimeMillis() - 1000));
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findByUniqueId(9L, "expired-from-listings")).thenReturn(post);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(200, response.getStatus());
+      BlogPostResponse data = (BlogPostResponse) response.getData();
+      assertEquals("expired-from-listings", data.getUniqueId());
+    }
+  }
+
+  @Test
+  void getReturns200ForAPublishedCurrentPost() {
+    ServiceContext context = contextFor("news", "hello-world");
+    Blog blog = enabledBlog(9L);
+    BlogPost post = publishedPost("hello-world");
+
+    try (MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<BlogPostRepository> postRepo = mockStatic(BlogPostRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findByUniqueId("news")).thenReturn(blog);
+      postRepo.when(() -> BlogPostRepository.findByUniqueId(9L, "hello-world")).thenReturn(post);
+
+      ServiceResponse response = new BlogPostService().get(context);
+
+      assertEquals(200, response.getStatus());
+      BlogPostResponse data = (BlogPostResponse) response.getData();
+      assertEquals("hello-world", data.getUniqueId());
+      assertEquals("A Post", data.getTitle());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/FileServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/FileServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.cms.LoadFileCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link FileService} uses {@link LoadFileCommand#loadFileByIdForAuthorizedUser}, which
+ * applies the same guest/group folder ACL as {@code DownloadFileWidget}'s non-admin path, rather
+ * than only checking {@code Folder.enabled} (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class FileServiceTest {
+
+  private ServiceContext contextFor(String pathParam) {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam(pathParam);
+    return context;
+  }
+
+  private ServiceContext contextFor(String pathParam, long userId) {
+    ServiceContext context = contextFor(pathParam);
+    User user = new User();
+    user.setId(userId);
+    context.setUser(user);
+    return context;
+  }
+
+  @Test
+  void getReturns404ForANonNumericPathParam() {
+    ServiceContext context = contextFor("not-a-number");
+
+    ServiceResponse response = new FileService().get(context);
+
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  void getReturns404WhenTheCallerHasNoAccessToTheFile() {
+    // loadFileByIdForAuthorizedUser returns null both when the file doesn't exist AND when it
+    // exists but the caller isn't authorized for its folder -- must not distinguish the two.
+    ServiceContext context = contextFor("101", 7L);
+
+    try (MockedStatic<LoadFileCommand> load = mockStatic(LoadFileCommand.class)) {
+      load.when(() -> LoadFileCommand.loadFileByIdForAuthorizedUser(101L, 7L)).thenReturn(null);
+
+      ServiceResponse response = new FileService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getPassesTheParsedFileIdAndTheCallersUserId() {
+    ServiceContext context = contextFor("101", 42L);
+    FileItem fileItem = new FileItem();
+    fileItem.setId(101L);
+    fileItem.setFilename("report.pdf");
+
+    try (MockedStatic<LoadFileCommand> load = mockStatic(LoadFileCommand.class)) {
+      load.when(() -> LoadFileCommand.loadFileByIdForAuthorizedUser(101L, 42L)).thenReturn(fileItem);
+
+      ServiceResponse response = new FileService().get(context);
+
+      assertEquals(200, response.getStatus());
+      load.verify(() -> LoadFileCommand.loadFileByIdForAuthorizedUser(101L, 42L));
+    }
+  }
+
+  @Test
+  void getReturns200ForAFileTheCallerHasAccessTo() {
+    ServiceContext context = contextFor("101", 42L);
+    FileItem fileItem = new FileItem();
+    fileItem.setId(101L);
+    fileItem.setFilename("report.pdf");
+    fileItem.setTitle("Annual Report");
+
+    try (MockedStatic<LoadFileCommand> load = mockStatic(LoadFileCommand.class)) {
+      load.when(() -> LoadFileCommand.loadFileByIdForAuthorizedUser(101L, 42L)).thenReturn(fileItem);
+
+      ServiceResponse response = new FileService().get(context);
+
+      assertEquals(200, response.getStatus());
+      FileResponse data = (FileResponse) response.getData();
+      assertEquals("report.pdf", data.getFilename());
+      assertEquals("Annual Report", data.getTitle());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/FolderFilesListServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/FolderFilesListServiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.cms.LoadFolderCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.domain.model.cms.Folder;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.FileItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FileSpecification;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link FolderFilesListService} uses the same guest/group folder ACL
+ * ({@link LoadFolderCommand#loadFolderByUniqueIdForAuthorizedUser} +
+ * {@link FileSpecification#setForUserId}) as {@code FileListByFolderWidget} on the live site,
+ * rather than only checking {@code Folder.enabled} (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class FolderFilesListServiceTest {
+
+  private ServiceContext contextFor(String folderUniqueId) {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam(folderUniqueId);
+    context.setParameterMap(new HashMap<>());
+    return context;
+  }
+
+  private Folder folder(long id) {
+    Folder folder = new Folder();
+    folder.setId(id);
+    folder.setEnabled(true);
+    return folder;
+  }
+
+  @Test
+  void getReturns404WhenTheCallerHasNoAccessToTheFolder() {
+    // loadFolderByUniqueIdForAuthorizedUser returns null both when the folder doesn't exist AND
+    // when it exists but the caller (e.g. a guest against a non-guest-accessible folder) isn't
+    // authorized -- this endpoint must not distinguish the two in its response.
+    ServiceContext context = contextFor("private-folder");
+
+    try (MockedStatic<LoadFolderCommand> load = mockStatic(LoadFolderCommand.class)) {
+      load.when(() -> LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser(eq("private-folder"), anyLong()))
+          .thenReturn(null);
+
+      ServiceResponse response = new FolderFilesListService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getScopesTheFileQueryToTheResolvedFolderIdAndTheCallersUserId() {
+    ServiceContext context = contextFor("documents");
+    User user = new User();
+    user.setId(42L);
+    context.setUser(user);
+    Folder folder = folder(4L);
+
+    try (MockedStatic<LoadFolderCommand> load = mockStatic(LoadFolderCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class)) {
+      load.when(() -> LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser("documents", 42L)).thenReturn(folder);
+      fileRepo.when(() -> FileItemRepository.findAll(any(FileSpecification.class), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      new FolderFilesListService().get(context);
+
+      ArgumentCaptor<FileSpecification> specCaptor = ArgumentCaptor.forClass(FileSpecification.class);
+      fileRepo.verify(() -> FileItemRepository.findAll(specCaptor.capture(), any(DataConstraints.class)));
+      assertEquals(4L, specCaptor.getValue().getFolderId());
+      assertEquals(42L, specCaptor.getValue().getForUserId());
+    }
+  }
+
+  @Test
+  void getPassesTheRequestedPageAndSizeToDataConstraints() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("documents");
+    HashMap<String, String[]> params = new HashMap<>();
+    params.put("page", new String[] { "2" });
+    params.put("size", new String[] { "10" });
+    context.setParameterMap(params);
+    Folder folder = folder(4L);
+
+    try (MockedStatic<LoadFolderCommand> load = mockStatic(LoadFolderCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class)) {
+      load.when(() -> LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser(eq("documents"), anyLong()))
+          .thenReturn(folder);
+      fileRepo.when(() -> FileItemRepository.findAll(any(FileSpecification.class), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      new FolderFilesListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      fileRepo.verify(() -> FileItemRepository.findAll(any(FileSpecification.class), constraintsCaptor.capture()));
+      assertEquals(2, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(10, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void getReturns200WithMappedFiles() {
+    ServiceContext context = contextFor("documents");
+    Folder folder = folder(4L);
+    FileItem fileItem = new FileItem();
+    fileItem.setId(101L);
+    fileItem.setFilename("report.pdf");
+    fileItem.setTitle("Annual Report");
+
+    try (MockedStatic<LoadFolderCommand> load = mockStatic(LoadFolderCommand.class);
+        MockedStatic<FileItemRepository> fileRepo = mockStatic(FileItemRepository.class)) {
+      load.when(() -> LoadFolderCommand.loadFolderByUniqueIdForAuthorizedUser(eq("documents"), anyLong()))
+          .thenReturn(folder);
+      fileRepo.when(() -> FileItemRepository.findAll(any(FileSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of(fileItem));
+
+      ServiceResponse response = new FolderFilesListService().get(context);
+
+      assertEquals(200, response.getStatus());
+      @SuppressWarnings("unchecked")
+      List<FileResponse> data = (List<FileResponse>) response.getData();
+      assertEquals(1, data.size());
+      assertEquals("report.pdf", data.get(0).getFilename());
+      assertEquals("Annual Report", data.get(0).getTitle());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/PageServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/PageServiceTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.cms.ValidateApiAccessToWebPageCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link PageService}, including that a multi-segment page path (pathParam + pathParam2)
+ * is reconstructed correctly back into a single {@code WebPage.link} value, and that visibility
+ * is delegated to {@link ValidateApiAccessToWebPageCommand} rather than a raw enabled/draft check
+ * (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class PageServiceTest {
+
+  private WebPage webPageWithLink(String link) {
+    WebPage webPage = new WebPage();
+    webPage.setLink(link);
+    webPage.setTitle("Title for " + link);
+    return webPage;
+  }
+
+  @Test
+  void getReconstructsATwoSegmentPagePathIntoTheFullLinkWithLeadingSlash() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("about");
+    context.setPathParam2("team");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      WebPage webPage = webPageWithLink("/about/team");
+      repo.when(() -> WebPageRepository.findByLink("/about/team")).thenReturn(webPage);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(webPage, null)).thenReturn(true);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(200, response.getStatus());
+      repo.verify(() -> WebPageRepository.findByLink("/about/team"));
+    }
+  }
+
+  @Test
+  void getReconstructsAThreeSegmentPagePath() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("about");
+    context.setPathParam2("team/leadership");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      WebPage webPage = webPageWithLink("/about/team/leadership");
+      repo.when(() -> WebPageRepository.findByLink("/about/team/leadership")).thenReturn(webPage);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(webPage, null)).thenReturn(true);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(200, response.getStatus());
+      WebPageResponse data = (WebPageResponse) response.getData();
+      assertEquals("/about/team/leadership", data.getLink());
+    }
+  }
+
+  @Test
+  void getTreatsAnEmptyPathParam2FromATrailingSlashAsAbsent() {
+    // RestServlet's split yields "" (not null) for pathParam2 on a request like
+    // GET /api/page/about/ -- must reconstruct to "/about", not "/about/".
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("about");
+    context.setPathParam2("");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      WebPage webPage = webPageWithLink("/about");
+      repo.when(() -> WebPageRepository.findByLink("/about")).thenReturn(webPage);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(webPage, null)).thenReturn(true);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(200, response.getStatus());
+      repo.verify(() -> WebPageRepository.findByLink("/about"));
+    }
+  }
+
+  @Test
+  void getUsesJustThePathParamWhenThereIsOnlyOneSegment() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("about");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      WebPage webPage = webPageWithLink("/about");
+      repo.when(() -> WebPageRepository.findByLink("/about")).thenReturn(webPage);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(webPage, null)).thenReturn(true);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(200, response.getStatus());
+      WebPageResponse data = (WebPageResponse) response.getData();
+      assertEquals("/about", data.getLink());
+    }
+  }
+
+  @Test
+  void getReturns404WhenThereIsNoPathParamAtAll() {
+    // GET /api/page with no further segment -- RestServlet's direct-key lookup means pathParam
+    // never gets populated. Must not become the literal string "/null".
+    ServiceContext context = new ServiceContext();
+
+    ServiceResponse response = new PageService().get(context);
+
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  void getReturns404WhenThePageDoesNotExist() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("nowhere");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
+      repo.when(() -> WebPageRepository.findByLink("/nowhere")).thenReturn(null);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+
+  @Test
+  void getReturns404WhenAccessIsDenied() {
+    ServiceContext context = new ServiceContext();
+    context.setPathParam("gated-page");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      WebPage webPage = webPageWithLink("/gated-page");
+      repo.when(() -> WebPageRepository.findByLink("/gated-page")).thenReturn(webPage);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(any(WebPage.class), any())).thenReturn(false);
+
+      ServiceResponse response = new PageService().get(context);
+
+      assertEquals(404, response.getStatus());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/services/cms/PagesListServiceTest.java
+++ b/src/test/java/com/simisinc/platform/rest/services/cms/PagesListServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.services.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.cms.ValidateApiAccessToWebPageCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
+import com.simisinc.platform.rest.controller.ServiceContext;
+import com.simisinc.platform.rest.controller.ServiceResponse;
+
+/**
+ * Verifies {@link PagesListService} filters each page through
+ * {@link ValidateApiAccessToWebPageCommand}, the same gate {@link PageService} uses for a single
+ * page (issue #412).
+ *
+ * @author SimIS Inc.
+ */
+class PagesListServiceTest {
+
+  private ServiceContext contextWithParams(String page, String size) {
+    ServiceContext context = new ServiceContext();
+    HashMap<String, String[]> params = new HashMap<>();
+    if (page != null) {
+      params.put("page", new String[] { page });
+    }
+    if (size != null) {
+      params.put("size", new String[] { size });
+    }
+    context.setParameterMap(params);
+    return context;
+  }
+
+  private WebPage webPageWithLink(String link) {
+    WebPage webPage = new WebPage();
+    webPage.setLink(link);
+    return webPage;
+  }
+
+  @Test
+  void getPassesTheRequestedPageAndSizeToDataConstraints() {
+    ServiceContext context = contextWithParams("3", "5");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
+      repo.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of());
+
+      new PagesListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      repo.verify(() -> WebPageRepository.findAll(any(WebPageSpecification.class), constraintsCaptor.capture()));
+      assertEquals(3, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(5, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void getDefaultsToPageOneSizeTwentyWhenParamsAreMissing() {
+    ServiceContext context = contextWithParams(null, null);
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class)) {
+      repo.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of());
+
+      new PagesListService().get(context);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      repo.verify(() -> WebPageRepository.findAll(any(WebPageSpecification.class), constraintsCaptor.capture()));
+      assertEquals(1, constraintsCaptor.getValue().getPageNumber());
+      assertEquals(20, constraintsCaptor.getValue().getPageSize());
+    }
+  }
+
+  @Test
+  void getOmitsPagesThatFailTheAccessCheck() {
+    ServiceContext context = contextWithParams(null, null);
+    WebPage visible = webPageWithLink("/about");
+    WebPage gated = webPageWithLink("/internal-only");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      repo.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of(visible, gated));
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(visible, null)).thenReturn(true);
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(gated, null)).thenReturn(false);
+
+      ServiceResponse response = new PagesListService().get(context);
+
+      assertEquals(200, response.getStatus());
+      @SuppressWarnings("unchecked")
+      List<WebPageResponse> data = (List<WebPageResponse>) response.getData();
+      assertEquals(1, data.size());
+      assertEquals("/about", data.get(0).getLink());
+    }
+  }
+
+  @Test
+  void getReturns200WithAllVisiblePagesMapped() {
+    ServiceContext context = contextWithParams(null, null);
+    WebPage page = webPageWithLink("/about");
+    page.setTitle("About");
+
+    try (MockedStatic<WebPageRepository> repo = mockStatic(WebPageRepository.class);
+        MockedStatic<ValidateApiAccessToWebPageCommand> access = mockStatic(ValidateApiAccessToWebPageCommand.class)) {
+      repo.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any(DataConstraints.class)))
+          .thenReturn(List.of(page));
+      access.when(() -> ValidateApiAccessToWebPageCommand.hasAccess(page, null)).thenReturn(true);
+
+      ServiceResponse response = new PagesListService().get(context);
+
+      assertEquals(200, response.getStatus());
+      @SuppressWarnings("unchecked")
+      List<WebPageResponse> data = (List<WebPageResponse>) response.getData();
+      assertEquals(1, data.size());
+      assertEquals("/about", data.get(0).getLink());
+      assertEquals("About", data.get(0).getTitle());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of a 4-PR split for #412 (expanding the REST API). This PR is read-only GET endpoints for three content types the API doesn't currently expose. Write endpoints (content blocks, mailing list members) and an OpenAPI spec are separate follow-up PRs.

- `GET /api/pages`, `GET /api/page/{pagePath}` — web page metadata (title, description, keywords, link, imageUrl, redirectUrl, publish schedule)
- `GET /api/blog-posts/{blogUniqueId}`, `GET /api/post/{blogUniqueId}/{postUniqueId}` — blog posts
- `GET /api/files/{folderUniqueId}`, `GET /api/file/{fileId}` — files in a folder

Two URL shapes deviate from the issue's original spec, for reasons documented in each service class's javadoc:
- `RestServlet`'s router only supports up to 2 raw path segments with no literal segment between them, so `blog/{id}/posts` isn't representable — registered as `blog-posts/{id}` instead (matches the `item-blog`/`item-list` naming convention already used elsewhere in `rest-services.xml` for the same constraint).
- `BlogPostRepository.findByUniqueId` is keyed by `(blogId, postUniqueId)`, not a globally-unique post id, so `post/{postUniqueId}` becomes `post/{blogUniqueId}/{postUniqueId}`.

## Visibility — matches the live site, not a simplified reconstruction

Each endpoint's "is this visible to the caller" check reuses or mirrors the app's real live-serving logic, not an ad hoc enabled/draft check:

- **Pages**: new `ValidateApiAccessToWebPageCommand` bridges the REST layer's plain `User` into a `UserSession` (via `UserSession.login()`, the same role/group/capability lists a real login populates) so it can call the existing `ValidateUserAccessToWebPageCommand` — the same draft/pageXml/widget-role-gating check `PageServlet` applies — plus the `publishAt`/`expiresAt` scheduling window `PageServlet` enforces separately for non-editors.
- **Blog posts**: matches `BlogPostWidget`'s real single-post gate (`published != null`, with an admin/content-manager bypass) rather than the stricter `startDate`/`endDate` window the list-page widgets use — that window doesn't apply to the single-post permalink on the live site.
- **Folder files**: uses `LoadFolderCommand`/`LoadFileCommand`'s `*ForAuthorizedUser` methods, applying the same guest/group ACL (`Folder.allowsGuests` + `folder_groups`/`user_groups` membership) that `FileListByFolderWidget` and `DownloadFileWidget`'s non-admin path already enforce.

## How this got here

An adversarial multi-agent review (correctness/security/test-coverage dimensions, each finding independently re-verified by 3 more agents) caught real gaps in an earlier version of this PR before it shipped:
- The folder/file endpoints originally bypassed the folder ACL entirely — my own code comment claimed no such ACL existed anywhere in the app, which was wrong; the review agents found and verified the real enforcement mechanism I'd missed.
- The page/blog-post endpoints originally used simplified visibility checks that diverged from the live site in both directions — hiding some pages/posts a real visitor can see, and exposing some that aren't actually live yet (scheduled, role-gated, or expired).
- Two smaller routing edge cases (`GET /api/page` with no path segment, a trailing slash on a page path).

All confirmed findings are fixed in this PR, each with a test.

## Verification

- Full `ci-test` suite green.
- Unescaped-EL gate: 0 unallowlisted (no JSPs touched).
- 45 new/updated unit tests across the 6 new services, the response DTOs, and the new `ValidateApiAccessToWebPageCommand`.