### PR TITLE
Add a 30-day view count column to /admin/web-pages (#497)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepository.java
@@ -29,7 +29,9 @@ import org.apache.commons.logging.LogFactory;
 import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Persists and retrieves web page hit objects
@@ -251,6 +253,51 @@ public class WebPageHitRepository {
       LOG.error("SQLException: " + se.getMessage());
     }
     return records;
+  }
+
+  /**
+   * View counts for a specific set of pages over a trailing window, excluding bot sessions (issue
+   * #497 -- the /admin/web-pages traffic column). findTopWebPages is the closest existing bulk
+   * query but is a ranked, LIMIT-capped "top N" report; this returns every requested page's count
+   * (including 0 for pages with no hits in range, by simply being absent from the map -- callers
+   * must treat a missing key as zero) in one query, keyed by web_page_id to avoid an N+1 query per
+   * table row. Returns an empty map for a null/empty input rather than querying with an empty
+   * IN () clause (invalid SQL).
+   */
+  public static Map<Long, Long> countViewsByWebPageId(List<Long> webPageIds, int daysToLimit) {
+    Map<Long, Long> countsByWebPageId = new HashMap<>();
+    if (webPageIds == null || webPageIds.isEmpty()) {
+      return countsByWebPageId;
+    }
+    StringBuilder placeholders = new StringBuilder();
+    for (int i = 0; i < webPageIds.size(); i++) {
+      if (i > 0) {
+        placeholders.append(",");
+      }
+      placeholders.append("?");
+    }
+    String SQL_QUERY =
+        "SELECT web_page_id, COUNT(*) AS hit_count " +
+            "FROM web_page_hits " +
+            "WHERE web_page_id IN (" + placeholders + ") " +
+            "AND hit_date > NOW() - INTERVAL '" + daysToLimit + " days' " +
+            "AND NOT EXISTS (SELECT 1 FROM sessions WHERE session_id = web_page_hits.session_id AND is_bot = TRUE) " +
+            "GROUP BY web_page_id";
+    try (Connection connection = DB.getConnection();
+         PreparedStatement pst = connection.prepareStatement(SQL_QUERY)) {
+      int parameterIndex = 1;
+      for (Long webPageId : webPageIds) {
+        pst.setLong(parameterIndex++, webPageId);
+      }
+      try (ResultSet rs = pst.executeQuery()) {
+        while (rs.next()) {
+          countsByWebPageId.put(rs.getLong("web_page_id"), rs.getLong("hit_count"));
+        }
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return countsByWebPageId;
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidget.java
@@ -20,6 +20,7 @@ import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.LoadMenuTabsCommand;
 import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageHitRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
 import com.simisinc.platform.presentation.controller.XMLPageLoader;
@@ -164,6 +165,20 @@ public class WebPageListWidget extends GenericWidget {
       }
     }
     context.getRequest().setAttribute("webPageReviewStatusMap", webPageReviewStatusMap);
+
+    // Trailing 30-day view count per page (#497), keyed by web_page_id -- one bulk query for the
+    // whole page set rather than a per-row lookup. This must cover every page in webPageList, not
+    // just filteredWebPageList: the "In Navigation Menu" section above always renders from the
+    // unfiltered webPageMap regardless of the active search/status filter, so scoping this query to
+    // the filtered subset would silently show 0 views for a nav-menu page excluded by the filter. A
+    // page absent from the map (no hits in the window, or a WebPage with a null/unset id) has zero
+    // views; the JSP must treat a missing key as zero rather than blank.
+    List<Long> webPageIdList = new ArrayList<>();
+    for (WebPage webPage : webPageList) {
+      webPageIdList.add(webPage.getId());
+    }
+    Map<Long, Long> webPageViewCountMap = WebPageHitRepository.countViewsByWebPageId(webPageIdList, 30);
+    context.getRequest().setAttribute("webPageViewCountMap", webPageViewCountMap);
 
     // Echo the filter values back so the form keeps its state
     context.getRequest().setAttribute("q", searchTerm);

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -264,6 +264,7 @@ CREATE TABLE web_page_hits (
 
 CREATE INDEX web_pg_hits_dt_idx ON web_page_hits(hit_date);
 CREATE INDEX web_pg_hits_ss_idx ON web_page_hits(session_id);
+CREATE INDEX web_pg_hits_wpid_idx ON web_page_hits(web_page_id);
 
 CREATE TABLE web_page_hit_snapshots (
   snapshot_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260803.1010__web_page_hits_id_index.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260803.1010__web_page_hits_id_index.sql
@@ -1,0 +1,7 @@
+-- Copyright 2026 SimIS Inc. (https://www.simiscms.com), Licensed under the Apache License, Version 2.0 (the "License").
+-- Issue #497: web_page_hits.web_page_id has never had its own index -- findTopWebPages/
+-- findTrafficBySolutionType/findEngagementBySolutionType already JOIN on it (unindexed), and the
+-- new countViewsByWebPageId bulk query (WHERE web_page_id IN (...) GROUP BY web_page_id) makes
+-- this a hot path for the /admin/web-pages traffic column. Mirrors NEW_10010__new_cms.sql, which
+-- carries this index directly in the table definition for fresh installs.
+CREATE INDEX IF NOT EXISTS web_pg_hits_wpid_idx ON web_page_hits(web_page_id);

--- a/src/main/webapp/WEB-INF/jsp/admin/web-page-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-page-list.jsp
@@ -30,7 +30,7 @@
 <table class="unstriped">
   <thead>
     <tr>
-      <th colspan="7"><strong>In Navigation Menu</strong></th>
+      <th colspan="8"><strong>In Navigation Menu</strong></th>
     </tr>
     <tr>
       <th width="45"></th>
@@ -40,6 +40,7 @@
       <th>Keywords, Description</th>
       <th>Modified</th>
       <th>Scheduled/Expires</th>
+      <th>Views (30d)</th>
     </tr>
   </thead>
   <tbody>
@@ -124,6 +125,11 @@
           <td></td>
         </c:otherwise>
       </c:choose>
+      <td>
+        <c:if test="${fn:contains(webPageMap, menuTab.link)}">
+          <fmt:formatNumber value="${empty webPageViewCountMap[webPageMap[menuTab.link].id] ? 0 : webPageViewCountMap[webPageMap[menuTab.link].id]}" />
+        </c:if>
+      </td>
     </tr>
     <c:forEach items="${menuTab.menuItemList}" var="menuItem">
       <tr>
@@ -205,11 +211,16 @@
             <td></td>
           </c:otherwise>
         </c:choose>
+        <td>
+          <c:if test="${fn:contains(webPageMap, menuItem.link)}">
+            <fmt:formatNumber value="${empty webPageViewCountMap[webPageMap[menuItem.link].id] ? 0 : webPageViewCountMap[webPageMap[menuItem.link].id]}" />
+          </c:if>
+        </td>
       </tr>
     </c:forEach>
   </c:forEach>
   <tr>
-    <td colspan="7">
+    <td colspan="8">
       <strong>All Web Pages</strong>
       <small class="subheader">Every page record in the system, including the ones already shown above in the navigation menu.</small>
       <br />
@@ -223,7 +234,7 @@
     </td>
   </tr>
   <tr>
-    <td colspan="7">
+    <td colspan="8">
       <form method="get" autocomplete="off" class="grid-x grid-margin-x align-bottom">
         <div class="cell medium-5">
           <label>Search
@@ -309,11 +320,14 @@
           <small>Expires: <fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${webPage.expiresAt}" /></small>
         </c:if>
       </td>
+      <td>
+        <fmt:formatNumber value="${empty webPageViewCountMap[webPage.id] ? 0 : webPageViewCountMap[webPage.id]}" />
+      </td>
     </tr>
   </c:forEach>
   <c:if test="${empty webPageList}">
       <tr>
-        <td colspan="7">No web pages were found</td>
+        <td colspan="8">No web pages were found</td>
       </tr>
   </c:if>
   </tbody>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageHitRepositoryTest.java
@@ -28,6 +28,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.AfterAll;
@@ -184,6 +185,78 @@ class WebPageHitRepositoryTest {
 
     assertNotNull(results);
     assertEquals(0, results.size());
+  }
+
+  // --- countViewsByWebPageId() integration coverage (issue #497) ---
+
+  @Test
+  void countViewsByWebPageIdCountsRealSessionHitsPerRequestedPage() {
+    seedSession("real-session", false);
+    seedSession("bot-session", true);
+    long pageA = seedPage("/a");
+    long pageB = seedPage("/b");
+    seedHit(pageA, "real-session");
+    seedHit(pageA, "real-session");
+    seedHit(pageA, "bot-session");
+    seedHit(pageB, "real-session");
+
+    Map<Long, Long> counts = WebPageHitRepository.countViewsByWebPageId(List.of(pageA, pageB), 30);
+
+    assertEquals(2L, counts.get(pageA), "only the two real-session hits should count, not the bot's");
+    assertEquals(1L, counts.get(pageB));
+  }
+
+  @Test
+  void countViewsByWebPageIdOmitsPagesWithNoHitsRatherThanReturningZero() {
+    long pageWithNoHits = seedPage("/never-viewed");
+
+    Map<Long, Long> counts = WebPageHitRepository.countViewsByWebPageId(List.of(pageWithNoHits), 30);
+
+    assertTrue(counts.isEmpty(), "a page with no hits in range must be absent from the map, not present with 0");
+  }
+
+  @Test
+  void countViewsByWebPageIdOnlyCountsRequestedPagesNotEveryPageInTheDatabase() {
+    seedSession("real-session", false);
+    long requestedPage = seedPage("/requested");
+    long otherPage = seedPage("/not-requested");
+    seedHit(requestedPage, "real-session");
+    seedHit(otherPage, "real-session");
+    seedHit(otherPage, "real-session");
+
+    Map<Long, Long> counts = WebPageHitRepository.countViewsByWebPageId(List.of(requestedPage), 30);
+
+    assertEquals(1, counts.size());
+    assertEquals(1L, counts.get(requestedPage));
+  }
+
+  @Test
+  void countViewsByWebPageIdReturnsEmptyMapForNullOrEmptyInputWithoutQuerying() {
+    assertTrue(WebPageHitRepository.countViewsByWebPageId(null, 30).isEmpty());
+    assertTrue(WebPageHitRepository.countViewsByWebPageId(List.of(), 30).isEmpty());
+  }
+
+  @Test
+  void countViewsByWebPageIdExcludesHitsOutsideTheWindow() {
+    seedSession("real-session", false);
+    long page = seedPage("/boundary");
+    Timestamp thirtyOneDaysAgo = Timestamp.from(java.time.Instant.now().minus(Duration.ofDays(31)));
+    seedHit(page, "real-session", thirtyOneDaysAgo);
+    seedHit(page, "real-session", new Timestamp(System.currentTimeMillis()));
+
+    Map<Long, Long> counts = WebPageHitRepository.countViewsByWebPageId(List.of(page), 30);
+
+    assertEquals(1L, counts.get(page), "the hit older than the 30-day window must not count");
+  }
+
+  private static void seedHit(long webPageId, String sessionId, Timestamp hitDate) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("INSERT INTO web_page_hits (web_page_id, session_id, hit_date) VALUES ("
+          + webPageId + ", '" + sessionId + "', '" + hitDate + "')");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not seed web page hit", se);
+    }
   }
 
   // --- findAvgPagesPerSession() integration coverage (issue #568) ---

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageListWidgetTest.java
@@ -18,10 +18,13 @@ package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -29,6 +32,7 @@ import org.mockito.MockedStatic;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.cms.LoadMenuTabsCommand;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPageHitRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
 
@@ -84,9 +88,11 @@ class WebPageListWidgetTest extends WidgetBase {
     webPageList.add(brokenPage());
 
     try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
-        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<WebPageHitRepository> hitRepository = mockStatic(WebPageHitRepository.class)) {
       repository.when(WebPageRepository::findAll).thenReturn(webPageList);
       menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+      hitRepository.when(() -> WebPageHitRepository.countViewsByWebPageId(any(), anyInt())).thenReturn(new HashMap<>());
 
       new WebPageListWidget().execute(widgetContext);
     }
@@ -109,10 +115,12 @@ class WebPageListWidgetTest extends WidgetBase {
     List<WebPage> draftOnly = new ArrayList<>(List.of(draftPage()));
 
     try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
-        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<WebPageHitRepository> hitRepository = mockStatic(WebPageHitRepository.class)) {
       repository.when(WebPageRepository::findAll).thenReturn(webPageList);
       repository.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any())).thenReturn(draftOnly);
       menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+      hitRepository.when(() -> WebPageHitRepository.countViewsByWebPageId(any(), anyInt())).thenReturn(new HashMap<>());
 
       new WebPageListWidget().execute(widgetContext);
 
@@ -132,9 +140,11 @@ class WebPageListWidgetTest extends WidgetBase {
   @Test
   void emptyPageListProducesAllZeroCounts() {
     try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
-        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class)) {
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<WebPageHitRepository> hitRepository = mockStatic(WebPageHitRepository.class)) {
       repository.when(WebPageRepository::findAll).thenReturn(new ArrayList<>());
       menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+      hitRepository.when(() -> WebPageHitRepository.countViewsByWebPageId(any(), anyInt())).thenReturn(new HashMap<>());
 
       new WebPageListWidget().execute(widgetContext);
     }
@@ -144,5 +154,67 @@ class WebPageListWidgetTest extends WidgetBase {
     assertEquals(0, request.getAttribute("webPageDraftCount"));
     assertEquals(0, request.getAttribute("webPageRedirectCount"));
     assertEquals(0, request.getAttribute("webPageBrokenCount"));
+  }
+
+  @Test
+  void viewCountMapIsPassedThroughFromTheRepositoryKeyedByWebPageId() {
+    WebPage webPage = livePage();
+    webPage.setId(42L);
+    List<WebPage> webPageList = new ArrayList<>(List.of(webPage));
+    Map<Long, Long> viewCounts = new HashMap<>();
+    viewCounts.put(42L, 17L);
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<WebPageHitRepository> hitRepository = mockStatic(WebPageHitRepository.class)) {
+      repository.when(WebPageRepository::findAll).thenReturn(webPageList);
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+      hitRepository.when(() -> WebPageHitRepository.countViewsByWebPageId(List.of(42L), 30)).thenReturn(viewCounts);
+
+      new WebPageListWidget().execute(widgetContext);
+    }
+
+    Map<Long, Long> viewCountMap = (Map<Long, Long>) request.getAttribute("webPageViewCountMap");
+    assertEquals(17L, viewCountMap.get(42L));
+  }
+
+  @Test
+  void viewCountMapCoversTheFullPageSetNotJustTheActiveFilterResults() {
+    // The "In Navigation Menu" section always renders from the unfiltered webPageMap, independent
+    // of the active search/status filter -- so a page excluded from the filtered "All Web Pages"
+    // list below must still get a real view count, not a silent 0. Regression test for a review
+    // finding: the count query was originally scoped to just the filtered list.
+    WebPage draftPage = draftPage();
+    draftPage.setId(1L);
+    WebPage livePageExcludedByFilter = livePage();
+    livePageExcludedByFilter.setId(2L);
+    List<WebPage> webPageList = new ArrayList<>(List.of(draftPage, livePageExcludedByFilter));
+
+    addQueryParameter(widgetContext, "status", "draft");
+    List<WebPage> draftOnly = new ArrayList<>(List.of(draftPage));
+
+    Map<Long, Long> viewCounts = new HashMap<>();
+    viewCounts.put(1L, 3L);
+    viewCounts.put(2L, 99L);
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadMenuTabsCommand> menuTabsCommand = mockStatic(LoadMenuTabsCommand.class);
+        MockedStatic<WebPageHitRepository> hitRepository = mockStatic(WebPageHitRepository.class)) {
+      repository.when(WebPageRepository::findAll).thenReturn(webPageList);
+      repository.when(() -> WebPageRepository.findAll(any(WebPageSpecification.class), any())).thenReturn(draftOnly);
+      menuTabsCommand.when(LoadMenuTabsCommand::findAllIncludeMenuItemList).thenReturn(new ArrayList<>());
+      hitRepository.when(() -> WebPageHitRepository.countViewsByWebPageId(List.of(1L, 2L), 30)).thenReturn(viewCounts);
+
+      new WebPageListWidget().execute(widgetContext);
+
+      // The "All Web Pages" list narrows to just the draft page...
+      List<WebPage> filtered = (List) request.getAttribute("webPageList");
+      assertEquals(1, filtered.size());
+    }
+
+    // ...but the view-count map must still carry the excluded page's real count, since the
+    // nav-menu section can still reference it via the unfiltered webPageMap
+    Map<Long, Long> viewCountMap = (Map<Long, Long>) request.getAttribute("webPageViewCountMap");
+    assertEquals(99L, viewCountMap.get(2L), "a page excluded by the active filter must not silently show 0 views");
   }
 }


### PR DESCRIPTION
## Summary
- Adds `WebPageHitRepository.countViewsByWebPageId(List<Long> webPageIds, int daysToLimit)`, a bulk trailing-window hit count query keyed by `web_page_id`, excluding bot sessions (same pattern as the existing `findTopWebPages`).
- Adds an index on `web_page_hits.web_page_id` (both the install baseline and a matching upgrade migration) — the column already backs several existing JOINs/queries but never had its own index.
- Surfaces the counts as a new "Views (30d)" column on `/admin/web-pages`, in all three places a page row can appear: the "In Navigation Menu" MenuTab rows, its nested MenuItem rows, and the "All Web Pages" list.

The view-count map is built from the *full* unfiltered page list, not just the active search/status-filtered subset — the "In Navigation Menu" section always renders from the unfiltered page set regardless of the filter, so scoping the query to the filtered list would silently show 0 views for a nav-menu page excluded by an unrelated filter. Caught by an adversarial review pass before opening this PR; a regression test (`viewCountMapCoversTheFullPageSetNotJustTheActiveFilterResults`) asserts the exact id list passed to the repository.

## Test plan
- [x] `ant ci-test` — full suite green (0 failures)
- [x] New `WebPageHitRepositoryTest` coverage: bot-session exclusion, empty-list/null input, exact scoping to requested ids, and the 30-day window boundary
- [x] New `WebPageListWidgetTest` coverage: view-count map pass-through, and the full-vs-filtered-list regression case
- [x] `tools/check-unescaped-el.py` — 0 unallowlisted sites
- [x] Live verification against a Docker rehearsal build: seeded real hit rows, confirmed correct counts render, confirmed filtering doesn't break the column or the "No web pages were found" row (colspan bumped 7→8 in all three sections)