### PR TITLE
Fix WebP uploads rejected despite being wired into the variant pipeline (#931)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommand.java
@@ -20,16 +20,10 @@ import java.awt.Dimension;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.FileImageInputStream;
-import javax.imageio.stream.ImageInputStream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
@@ -195,21 +189,7 @@ public class GenerateImageVariantsCommand {
     return ImageVariantRepository.save(record);
   }
 
-  /** Mirrors {@code ValidateImageCommand.getImageDimension} -- a streaming, no-decode read. */
   private static Dimension readDimension(File imageFile) throws IOException {
-    String suffix = FilenameUtils.getExtension(imageFile.getName());
-    Iterator<ImageReader> readers = ImageIO.getImageReadersBySuffix(suffix);
-    while (readers.hasNext()) {
-      ImageReader reader = readers.next();
-      try (ImageInputStream stream = new FileImageInputStream(imageFile)) {
-        reader.setInput(stream);
-        return new Dimension(reader.getWidth(reader.getMinIndex()), reader.getHeight(reader.getMinIndex()));
-      } catch (IOException e) {
-        LOG.warn("Error reading generated variant dimensions: " + imageFile.getAbsolutePath(), e);
-      } finally {
-        reader.dispose();
-      }
-    }
-    throw new IOException("Not a known image file: " + imageFile.getAbsolutePath());
+    return ImageDimensionCommand.readDimension(imageFile);
   }
 }

--- a/src/main/java/com/simisinc/platform/application/cms/ImageDimensionCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ImageDimensionCommand.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.awt.Dimension;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.FileImageInputStream;
+import javax.imageio.stream.ImageInputStream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.im4java.core.IMOperation;
+import org.im4java.core.IdentifyCmd;
+import org.im4java.process.ArrayListOutputConsumer;
+
+/**
+ * Reads an image file's pixel dimensions without fully decoding it into memory.
+ *
+ * <p>
+ * Tries {@code javax.imageio.ImageIO} first -- an in-process, no-subprocess read that covers
+ * jpeg/png/gif/bmp. The JDK ships no WebP (or AVIF) decoder, so a WebP file falls through to
+ * ImageMagick's {@code identify} instead, via the {@code im4java} dependency this app already
+ * uses for variant generation ({@link GenerateImageVariantsCommand}). This reuses the same
+ * hardened, resource-bounded ImageMagick invocation path already in place (see
+ * {@code docker/app/imagemagick-policy.xml}, which permits exactly the coders
+ * GenerateImageVariantsCommand resizes: jpeg/png/gif/webp) rather than adding a new third-party
+ * ImageIO codec dependency. Issue #931.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public class ImageDimensionCommand {
+
+  private static final Log LOG = LogFactory.getLog(ImageDimensionCommand.class);
+
+  private ImageDimensionCommand() {
+    // Static utility, not instantiated
+  }
+
+  public static Dimension readDimension(File imageFile) throws IOException {
+    String suffix = FilenameUtils.getExtension(imageFile.getName());
+    Iterator<ImageReader> readers = ImageIO.getImageReadersBySuffix(suffix);
+    while (readers.hasNext()) {
+      ImageReader reader = readers.next();
+      try (ImageInputStream stream = new FileImageInputStream(imageFile)) {
+        reader.setInput(stream);
+        return new Dimension(reader.getWidth(reader.getMinIndex()), reader.getHeight(reader.getMinIndex()));
+      } catch (IOException e) {
+        LOG.warn("Error reading image dimensions: " + imageFile.getAbsolutePath(), e);
+      } finally {
+        reader.dispose();
+      }
+    }
+    return readDimensionViaImageMagick(imageFile);
+  }
+
+  private static Dimension readDimensionViaImageMagick(File imageFile) throws IOException {
+    try {
+      IdentifyCmd identify = new IdentifyCmd();
+      ArrayListOutputConsumer output = new ArrayListOutputConsumer();
+      identify.setOutputConsumer(output);
+      IMOperation op = new IMOperation();
+      op.format("%w %h");
+      op.addImage(imageFile.getAbsolutePath());
+      identify.run(op);
+
+      ArrayList<String> lines = output.getOutput();
+      if (lines.isEmpty()) {
+        throw new IOException("identify returned no output for: " + imageFile.getAbsolutePath());
+      }
+      String[] parts = lines.get(0).trim().split("\\s+");
+      if (parts.length < 2) {
+        throw new IOException("identify did not return width/height for: " + imageFile.getAbsolutePath());
+      }
+      return new Dimension(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      // im4java throws checked InterruptedException/IM4JavaException for a failed invocation
+      // (e.g. a format the policy.xml denies, or a corrupt file) -- normalize to IOException so
+      // callers have one exception type to handle, matching the ImageIO path above.
+      throw new IOException("Not a known image file: " + imageFile.getAbsolutePath(), e);
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/cms/ValidateImageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ValidateImageCommand.java
@@ -22,16 +22,9 @@ import com.simisinc.platform.domain.model.cms.Image;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.FileImageInputStream;
-import javax.imageio.stream.ImageInputStream;
 import java.awt.*;
-import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Iterator;
 
 /**
  * Validates image objects
@@ -66,52 +59,17 @@ public class ValidateImageCommand {
     LOG.debug("MimeType: " + mimeType);
     imageBean.setFileType(mimeType);
 
-    // Use a streaming method to get the dimensions
+    // Use a streaming method to get the dimensions -- falls back to ImageMagick's `identify` for
+    // formats the JDK's own ImageIO cannot decode (e.g. WebP), see ImageDimensionCommand.
     try {
-      Dimension dimension = getImageDimension(imageFile);
+      Dimension dimension = ImageDimensionCommand.readDimension(imageFile);
       imageBean.setWidth(dimension.width);
       imageBean.setHeight(dimension.height);
-      LOG.debug("Width: " + imageBean.getWidth());
-      LOG.debug("Height: " + imageBean.getHeight());
-      return;
-    } catch (Exception e) {
-      LOG.warn("Image could not be read for dimensions", e);
-    }
-
-    // Not found? Use an expensive image buffer
-    try {
-      BufferedImage image = ImageIO.read(imageFile);
-      imageBean.setWidth(image.getWidth());
-      imageBean.setHeight(image.getHeight());
       LOG.debug("Width: " + imageBean.getWidth());
       LOG.debug("Height: " + imageBean.getHeight());
     } catch (Exception e) {
       LOG.warn("Image could not be read", e);
       throw new DataException("Image could not be read");
     }
-  }
-
-  private static Dimension getImageDimension(File imgFile) throws IOException {
-    int pos = imgFile.getName().lastIndexOf(".");
-    if (pos == -1)
-      throw new IOException("No extension for file: " + imgFile.getAbsolutePath());
-    String suffix = imgFile.getName().substring(pos + 1);
-    Iterator<ImageReader> iter = ImageIO.getImageReadersBySuffix(suffix);
-    while (iter.hasNext()) {
-      ImageReader reader = iter.next();
-      try {
-        ImageInputStream stream = new FileImageInputStream(imgFile);
-        reader.setInput(stream);
-        int width = reader.getWidth(reader.getMinIndex());
-        int height = reader.getHeight(reader.getMinIndex());
-        return new Dimension(width, height);
-      } catch (IOException e) {
-        LOG.warn("Error reading: " + imgFile.getAbsolutePath(), e);
-      } finally {
-        reader.dispose();
-      }
-    }
-
-    throw new IOException("Not a known image file: " + imgFile.getAbsolutePath());
   }
 }

--- a/src/test/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommandTest.java
@@ -286,6 +286,56 @@ class GenerateImageVariantsCommandTest {
         "resizing an animated GIF must not drop frames -- coalesce before resize, layers optimize after");
   }
 
+  @Test
+  void generateVariantsReadsTheResizedVariantsDimensionsForAWebpOriginal(@TempDir Path tempDir) throws Exception {
+    // Issue #931: readDimension() (used to record each generated variant's width/height) had the
+    // same JDK-ImageIO-only limitation as ValidateImageCommand's upload-time check -- it could
+    // resize a WebP original but then fail to read the resized variant's own dimensions. This
+    // exercises that exact second call site via the shared ImageDimensionCommand fix.
+    Assumptions.assumeTrue(isImageMagickAvailable(), "ImageMagick is not on PATH - skipping WebP variant test");
+
+    Image image = insertImageWithRealWebpFile(tempDir, "large-original.webp", 2000, 1500);
+
+    List<ImageVariant> variants = withStubbedRoot(tempDir, () -> GenerateImageVariantsCommand.generateVariants(image));
+
+    Map<String, ImageVariant> byType = variants.stream()
+        .collect(Collectors.toMap(ImageVariant::getVariantType, v -> v));
+    assertEquals(3, variants.size(), "a 2000x1500 WebP original is larger than all three variant targets");
+    assertEquals(800, byType.get("medium").getWidth(), "the medium variant's own dimensions must be readable");
+    assertEquals(600, byType.get("medium").getHeight());
+  }
+
+  private static Image insertImageWithRealWebpFile(Path tempDir, String filename, int width, int height)
+      throws Exception {
+    String relativePath = "images/2026/08/" + filename;
+    File file = tempDir.resolve(relativePath).toFile();
+    file.getParentFile().mkdirs();
+    File pngSource = File.createTempFile("webp-source", ".png");
+    try {
+      ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB), "png", pngSource);
+      Process process = new ProcessBuilder("convert", pngSource.getAbsolutePath(), file.getAbsolutePath())
+          .redirectErrorStream(true).start();
+      String output = new String(process.getInputStream().readAllBytes());
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        throw new IllegalStateException("Could not build the WebP test fixture: " + output);
+      }
+    } finally {
+      pngSource.delete();
+    }
+
+    Image image = new Image();
+    image.setFilename(filename);
+    image.setFileServerPath(relativePath);
+    image.setCreatedBy(userId);
+    image.setFileLength(file.length());
+    image.setFileType("image/webp");
+    image.setWidth(width);
+    image.setHeight(height);
+    image.setWebPath("20260803120300");
+    return ImageRepository.save(image);
+  }
+
   /** Builds a 2-frame animated GIF whose second frame is a sub-rectangle at a nonzero offset. */
   private static void createAnimatedGifWithOffsetFrames(File outputGif, int canvasSize) throws Exception {
     File frame1 = File.createTempFile("frame1", ".png");

--- a/src/test/java/com/simisinc/platform/application/cms/ImageDimensionCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ImageDimensionCommandTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.Dimension;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies {@link ImageDimensionCommand} reads dimensions via the fast {@code javax.imageio}
+ * path for formats the JDK can decode, and falls back to ImageMagick's {@code identify} for
+ * formats it can't (WebP) -- issue #931. The WebP-specific tests require a real ImageMagick
+ * binary on PATH and are skipped otherwise (this repo's ImageMagick-dependent tests all follow
+ * this pattern; see {@link GenerateImageVariantsCommandTest}).
+ *
+ * @author SimIS Inc.
+ */
+class ImageDimensionCommandTest {
+
+  @Test
+  void readDimensionUsesTheFastImageIoPathForPng(@TempDir Path tempDir) throws Exception {
+    File pngFile = tempDir.resolve("sample.png").toFile();
+    ImageIO.write(new BufferedImage(320, 240, BufferedImage.TYPE_INT_RGB), "png", pngFile);
+
+    Dimension dimension = ImageDimensionCommand.readDimension(pngFile);
+
+    assertEquals(320, dimension.width);
+    assertEquals(240, dimension.height);
+  }
+
+  @Test
+  void readDimensionFallsBackToImageMagickForAWebpFile(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(isImageMagickAvailable(), "ImageMagick is not on PATH - skipping WebP dimension test");
+
+    File webpFile = buildRealWebpFixture(tempDir, 320, 240);
+
+    Dimension dimension = ImageDimensionCommand.readDimension(webpFile);
+
+    assertEquals(320, dimension.width, "the JDK's own ImageIO cannot decode WebP -- this must come from the identify fallback");
+    assertEquals(240, dimension.height);
+  }
+
+  @Test
+  void readDimensionThrowsIoExceptionForAFileThatIsNotAnImage(@TempDir Path tempDir) throws Exception {
+    File notAnImage = tempDir.resolve("not-an-image.png").toFile();
+    Files.write(notAnImage.toPath(), "this is plain text, not a PNG".getBytes());
+
+    assertThrows(IOException.class, () -> ImageDimensionCommand.readDimension(notAnImage));
+  }
+
+  @Test
+  void readDimensionThrowsIoExceptionForAFileWithNoRecognizedExtension(@TempDir Path tempDir) throws Exception {
+    File noExtension = tempDir.resolve("mystery-file").toFile();
+    Files.write(noExtension.toPath(), "not an image at all".getBytes());
+
+    assertThrows(IOException.class, () -> ImageDimensionCommand.readDimension(noExtension));
+  }
+
+  /** Builds a real WebP file via a `convert`/`cwebp` subprocess -- the JDK cannot write WebP either. */
+  private static File buildRealWebpFixture(Path tempDir, int width, int height) throws Exception {
+    File pngSource = tempDir.resolve("source-for-webp.png").toFile();
+    ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB), "png", pngSource);
+    File webpFile = tempDir.resolve("sample.webp").toFile();
+
+    Process process = new ProcessBuilder("convert", pngSource.getAbsolutePath(), webpFile.getAbsolutePath())
+        .redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IllegalStateException("Could not build the WebP test fixture: " + output);
+    }
+    return webpFile;
+  }
+
+  private static boolean isImageMagickAvailable() {
+    try {
+      Process process = new ProcessBuilder("convert", "-version").redirectErrorStream(true).start();
+      return process.waitFor() == 0;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/ValidateImageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ValidateImageCommandTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.domain.model.cms.Image;
+
+/**
+ * Verifies {@link ValidateImageCommand#checkFile} correctly accepts a WebP upload (issue #931) --
+ * previously rejected with "Image could not be read" because the dimension read only tried the
+ * JDK's own {@code javax.imageio}, which cannot decode WebP. Also locks in the pre-existing
+ * behavior for a missing file and a non-image file, both unchanged by that fix.
+ *
+ * <p>
+ * The WebP test requires a real ImageMagick binary on PATH (the fallback {@link
+ * ImageDimensionCommand} uses) and is skipped otherwise, matching this repo's other
+ * ImageMagick-dependent tests (see {@link GenerateImageVariantsCommandTest}).
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+class ValidateImageCommandTest {
+
+  @Test
+  void checkFileAcceptsAJpegAndRecordsItsDimensions(@TempDir Path tempDir) throws Exception {
+    Image image = imageForRealFile(tempDir, "photo.jpg", 400, 300, "jpg");
+
+    withStubbedRoot(tempDir, () -> ValidateImageCommand.checkFile(image));
+
+    assertEquals(400, image.getWidth());
+    assertEquals(300, image.getHeight());
+    assertEquals("image/jpeg", image.getFileType());
+  }
+
+  @Test
+  void checkFileAcceptsAWebpAndRecordsItsDimensions(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(isImageMagickAvailable(), "ImageMagick is not on PATH - skipping WebP upload test");
+
+    String relativePath = "images/2026/08/photo.webp";
+    File webpFile = tempDir.resolve(relativePath).toFile();
+    webpFile.getParentFile().mkdirs();
+    buildRealWebpFixture(tempDir, webpFile, 400, 300);
+
+    Image image = new Image();
+    image.setFilename("photo.webp");
+    image.setFileServerPath(relativePath);
+
+    withStubbedRoot(tempDir, () -> ValidateImageCommand.checkFile(image));
+
+    assertEquals(400, image.getWidth(), "a WebP upload must not be rejected -- this is the bug being fixed");
+    assertEquals(300, image.getHeight());
+  }
+
+  @Test
+  void checkFileReturnsSilentlyWhenTheFileDoesNotExist(@TempDir Path tempDir) throws Exception {
+    Image image = new Image();
+    image.setFilename("gone.png");
+    image.setFileServerPath("images/2026/08/gone.png");
+
+    // Must not throw -- checkFile's contract for a missing file is a silent no-op, unchanged by
+    // the WebP fix.
+    withStubbedRoot(tempDir, () -> ValidateImageCommand.checkFile(image));
+  }
+
+  @Test
+  void checkFileThrowsDataExceptionForATextFileMasqueradingAsAnImage(@TempDir Path tempDir) throws Exception {
+    String relativePath = "images/2026/08/fake.png";
+    File fakeFile = tempDir.resolve(relativePath).toFile();
+    fakeFile.getParentFile().mkdirs();
+    Files.write(fakeFile.toPath(), "this is plain text, not a real PNG".getBytes());
+
+    Image image = new Image();
+    image.setFilename("fake.png");
+    image.setFileServerPath(relativePath);
+
+    assertThrows(DataException.class,
+        () -> withStubbedRoot(tempDir, () -> ValidateImageCommand.checkFile(image)));
+  }
+
+  private static Image imageForRealFile(Path tempDir, String filename, int width, int height, String format)
+      throws Exception {
+    String relativePath = "images/2026/08/" + filename;
+    File file = tempDir.resolve(relativePath).toFile();
+    file.getParentFile().mkdirs();
+    ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB), format, file);
+
+    Image image = new Image();
+    image.setFilename(filename);
+    image.setFileServerPath(relativePath);
+    return image;
+  }
+
+  /** Builds a real WebP file via a `convert` subprocess -- the JDK cannot write WebP either. */
+  private static void buildRealWebpFixture(Path tempDir, File webpFile, int width, int height) throws Exception {
+    File pngSource = tempDir.resolve("source-for-webp.png").toFile();
+    ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB), "png", pngSource);
+
+    Process process = new ProcessBuilder("convert", pngSource.getAbsolutePath(), webpFile.getAbsolutePath())
+        .redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IllegalStateException("Could not build the WebP test fixture: " + output);
+    }
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private static void withStubbedRoot(Path tempDir, ThrowingRunnable body) throws Exception {
+    try (MockedStatic<FileSystemCommand> fsc = mockStatic(FileSystemCommand.class, Answers.CALLS_REAL_METHODS)) {
+      fsc.when(FileSystemCommand::getFileServerRootPath).thenReturn(tempDir.toString() + "/");
+      body.run();
+    }
+  }
+
+  private static boolean isImageMagickAvailable() {
+    try {
+      Process process = new ProcessBuilder("convert", "-version").redirectErrorStream(true).start();
+      return process.waitFor() == 0;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `ValidateImageCommand.checkFile()` -- the gate every uploaded image must pass -- read dimensions via plain `javax.imageio.ImageIO`, which has no WebP decoder (confirmed empirically: `ImageIO.getImageReadersBySuffix("webp")` returns no readers on this repo's pinned JDK 21, and no third-party ImageIO plugin is in the dependency tree). Every WebP upload was therefore rejected with "Image could not be read" -- even though `GenerateImageVariantsCommand.SUPPORTED_MIME_TYPES` already includes `image/webp` and the `docker/app/imagemagick-policy.xml` added in #411 already allows the WEBP coder for `read|write`. WebP support was clearly intended but the upload gate blocked it before it could ever be exercised.
- Same bug, second call site: `GenerateImageVariantsCommand.readDimension()` (used to record each generated variant's own width/height) used the identical plain-ImageIO approach -- its own comment says it "Mirrors ValidateImageCommand.getImageDimension" -- so even a WebP original that got past the upload gate would fail to have its resized thumbnail/medium/large variants' dimensions read.
- Fix: extracted `ImageDimensionCommand`, a shared dimension-reader both call sites now use. It tries `ImageIO` first (fast, in-process, unchanged for jpeg/png/gif/bmp), then falls back to shelling out to ImageMagick's `identify` (via the `im4java` dependency this app already uses for variant generation) for anything ImageIO can't decode. This reuses the same hardened, resource-bounded ImageMagick invocation path already in place from #411, rather than adding a new third-party ImageIO codec dependency.
- AVIF is explicitly out of scope: the ImageMagick policy.xml denies every coder except `{JPEG,JPG,PNG,GIF,WEBP}`, so an AVIF file is still correctly rejected by both the upload gate and variant generation.

## Test plan
- [x] `ant ci-test` -- full suite green (0 failures)
- [x] New `ImageDimensionCommandTest`: fast ImageIO path for PNG, ImageMagick fallback for a real WebP fixture (built via a `convert` subprocess, matching this repo's existing ImageMagick-dependent test pattern), and IOException for non-image / unrecognized-extension input
- [x] New `ValidateImageCommandTest`: a real WebP upload now records correct width/height (the exact bug being fixed), a JPEG upload is unaffected, a missing file still no-ops silently, and a text file masquerading as `.png` still throws `DataException`
- [x] Extended `GenerateImageVariantsCommandTest` with a WebP-original variant-generation case, proving the second bug site (post-resize dimension read) is fixed too
- [x] All WebP-specific tests require and use a **real** ImageMagick binary + real WebP files (no mocking of the fix itself), matching this repo's existing convention (skipped only when ImageMagick is unavailable, e.g. GitHub Actions ubuntu-latest ships it)
- [x] **Live verification against the real Docker image**: built and ran the actual `docker/app/Dockerfile` container, authenticated as admin, and POSTed a real WebP file directly to the running `ImageUploadWidget` endpoint -- got back `HTTP 200 {"location": "/assets/img/.../verify-931.webp"}` (previously this would have failed with "Image could not be read"). Confirmed in `/admin/images`: the image is listed with the correct `320x240` dimensions and its thumbnail renders.