### PR TITLE
Add admin cache management dashboard (#463)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/cache/CacheManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/cache/CacheManager.java
@@ -32,8 +32,11 @@ import com.simisinc.platform.infrastructure.persistence.cms.StylesheetRepository
 import com.simisinc.platform.infrastructure.persistence.cms.TableOfContentsRepository;
 import com.simisinc.platform.infrastructure.persistence.items.CollectionRepository;
 
+import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -67,6 +70,11 @@ public class CacheManager {
 
   private static final Map<String, Cache> cacheManager = new ConcurrentHashMap<>();
 
+  // Tracks the last time each cache was explicitly cleared via #invalidateAll/#invalidateAllCaches,
+  // for the admin cache management dashboard's "last cleared" column (issue #463). Intentionally
+  // in-memory only and not persisted -- it resets on restart, same as the caches themselves.
+  private static final Map<String, Instant> lastClearedAt = new ConcurrentHashMap<>();
+
   private CacheManager() {
   }
 
@@ -85,6 +93,7 @@ public class CacheManager {
     // System Property Cache (prefix = map)
     LoadingCache<String, List<SiteProperty>> sitePropertyListCache = Caffeine.newBuilder()
         .maximumSize(10_000)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(SitePropertyRepository::findAllByPrefix);
@@ -93,6 +102,7 @@ public class CacheManager {
     // App Cache (publicKey = app)
     LoadingCache<String, App> appCache = Caffeine.newBuilder()
         .maximumSize(1_000)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(AppRepository::findByPublicKey);
@@ -102,12 +112,14 @@ public class CacheManager {
     Cache<Long, String> userCredentialsCache = Caffeine.newBuilder()
         .maximumSize(1_000_000)
         .expireAfterAccess(20, TimeUnit.HOURS)
+        .recordStats()
         .build();
     cacheManager.put(USER_CREDENTIALS_CACHE, userCredentialsCache);
 
     // Stylesheet Cache (webPageId = stylesheet)
     LoadingCache<Long, Stylesheet> stylesheetCache = Caffeine.newBuilder()
         .maximumSize(100)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(StylesheetRepository::findByWebPageId);
@@ -116,6 +128,7 @@ public class CacheManager {
     // Content Cache (contentUniqueId = content)
     LoadingCache<String, Content> contentCache = Caffeine.newBuilder()
         .maximumSize(10_000)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(ContentRepository::findByUniqueId);
@@ -125,12 +138,14 @@ public class CacheManager {
     Cache<String, Content> remoteContentCache = Caffeine.newBuilder()
         .maximumSize(100)
         .expireAfterAccess(5, TimeUnit.MINUTES)
+        .recordStats()
         .build();
     cacheManager.put(CONTENT_REMOTE_URL_CACHE, remoteContentCache);
 
     // Collection Unique Id Cache (collectionUniqueId = collection)
     LoadingCache<String, Collection> collectionCache = Caffeine.newBuilder()
         .maximumSize(100)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(CollectionRepository::findByUniqueId);
@@ -139,6 +154,7 @@ public class CacheManager {
     // Collection Unique Id Cache (collectionUniqueId = collection)
     LoadingCache<String, TableOfContents> tableOfContentsCache = Caffeine.newBuilder()
         .maximumSize(100)
+        .recordStats()
 //        .expireAfterWrite(5, TimeUnit.MINUTES)
 //        .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(TableOfContentsRepository::findByUniqueId);
@@ -148,6 +164,7 @@ public class CacheManager {
     Cache<String, Object> loginAttemptByUsernameCache = Caffeine.newBuilder()
         .maximumSize(100_000)
         .expireAfterAccess(30, TimeUnit.MINUTES)
+        .recordStats()
         .build();
     cacheManager.put(RATE_LIMIT_LOGIN_ATTEMPT_BY_USERNAME_CACHE, loginAttemptByUsernameCache);
 
@@ -155,12 +172,14 @@ public class CacheManager {
     Cache<String, Object> accessAttemptByIpCache = Caffeine.newBuilder()
         .maximumSize(1_000_000)
         .expireAfterAccess(30, TimeUnit.MINUTES)
+        .recordStats()
         .build();
     cacheManager.put(RATE_LIMIT_ATTEMPT_BY_IP_CACHE, accessAttemptByIpCache);
 
     // Rate limit by app cache
     Cache<String, Object> rateLimitByAppCache = Caffeine.newBuilder()
         .expireAfterAccess(15, TimeUnit.MINUTES)
+        .recordStats()
         .build();
     cacheManager.put(RATE_LIMIT_BY_APP_CACHE, rateLimitByAppCache);
 
@@ -168,6 +187,7 @@ public class CacheManager {
     Cache<String, Object> rateLimitByAppUserCache = Caffeine.newBuilder()
         .maximumSize(1_000_000)
         .expireAfterAccess(15, TimeUnit.MINUTES)
+        .recordStats()
         .build();
     cacheManager.put(RATE_LIMIT_BY_APP_USER_CACHE, rateLimitByAppUserCache);
 
@@ -175,6 +195,7 @@ public class CacheManager {
     Cache<String, Object> objectCache = Caffeine.newBuilder()
         .maximumSize(100)
         .expireAfterAccess(24, TimeUnit.HOURS)
+        .recordStats()
         .build();
     cacheManager.put(OBJECT_CACHE, objectCache);
   }
@@ -206,6 +227,49 @@ public class CacheManager {
     if (cache != null) {
       cache.invalidate(key);
     }
+  }
+
+  /**
+   * Returns the registry's cache names (issue #463 admin dashboard's inventory). Callers -- notably
+   * a mutating admin action -- should validate any user-supplied cache name against this set before
+   * acting on it, the same way {@code DatabaseMaintenanceWidget} validates a table name against
+   * {@code DatabaseMaintenanceRepository.findTableNames()} before it reaches raw SQL.
+   */
+  public static Set<String> getCacheNames() {
+    ensureStarted();
+    return Collections.unmodifiableSet(cacheManager.keySet());
+  }
+
+  /**
+   * Clears every entry in the named cache without an application restart (issue #463). A no-op if
+   * the name isn't registered. Records the clear time for the dashboard's "last cleared" column.
+   */
+  public static void invalidateAll(String cacheName) {
+    Cache cache = getCache(cacheName);
+    if (cache == null) {
+      return;
+    }
+    cache.invalidateAll();
+    lastClearedAt.put(cacheName, Instant.now());
+  }
+
+  /**
+   * Clears every entry in every registered cache without an application restart (issue #463).
+   */
+  public static void invalidateAllCaches() {
+    ensureStarted();
+    for (String cacheName : cacheManager.keySet()) {
+      invalidateAll(cacheName);
+    }
+  }
+
+  /**
+   * The last time {@link #invalidateAll(String)} (directly, or via {@link #invalidateAllCaches()})
+   * cleared this cache, or {@code null} if it hasn't been explicitly cleared since this JVM started.
+   * In-memory only -- resets on restart along with the caches themselves.
+   */
+  public static Instant getLastClearedAt(String cacheName) {
+    return lastClearedAt.get(cacheName);
   }
 
   public static void addToObjectCache(String key, Object value) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidget.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Admin-only cache management dashboard (issue #463): lists the application's in-memory Caffeine
+ * caches with entry counts and hit/miss/eviction stats, and lets an admin clear one cache or all of
+ * them without an application restart.
+ *
+ * <p>
+ * Deliberately scoped to inventory + clear-all/clear-one, mirroring {@link DatabaseMaintenanceWidget}
+ * (issue #469). TTL/max-size/eviction-policy configuration, clear-by-pattern, and byte-level memory
+ * usage are left for a follow-up -- see the issue for why each is out of scope for this slice.
+ * </p>
+ *
+ * @author SimIS
+ * @created 8/3/2026
+ */
+public class CacheManagementWidget extends GenericWidget {
+
+  static final long serialVersionUID = 4361509049183624381L;
+
+  static String JSP = "/admin/cache-management.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    loadDashboardData(context);
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) {
+
+    if (!context.hasRole("admin")) {
+      return context;
+    }
+
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("clearAll".equals(command)) {
+      CacheManager.invalidateAllCaches();
+      AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "cache.clear_all",
+          AuditEventCommand.SUCCESS, "cache", null, null, "All caches were cleared");
+      context.setSuccessMessage("All caches were cleared");
+    } else if ("clearCache".equals(command)) {
+      String cacheName = context.getParameter("cache");
+      // The requested name is validated against the live registry before it's used anywhere,
+      // including in the audit log entry below -- so only a known, fixed cache name is ever
+      // recorded, the same guard DatabaseMaintenanceWidget uses for a VACUUM table target.
+      Set<String> knownCaches = CacheManager.getCacheNames();
+      if (cacheName == null || !knownCaches.contains(cacheName)) {
+        context.setErrorMessage("Unknown cache");
+      } else {
+        CacheManager.invalidateAll(cacheName);
+        AuditEventCommand.record(context, AuditEventCommand.CONFIGURATION, "cache.clear",
+            AuditEventCommand.SUCCESS, "cache", cacheName, cacheName, "Cache cleared: " + cacheName);
+        context.setSuccessMessage("Cache cleared: " + cacheName);
+      }
+    }
+
+    context.setRedirect("/admin/cache-management");
+    return context;
+  }
+
+  private void loadDashboardData(WidgetContext context) {
+    context.getRequest().setAttribute("cacheSummaryList", buildCacheSummaryList());
+
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+  }
+
+  /** Alphabetical by cache name, so the dashboard's row order doesn't shift between page loads. */
+  private List<CacheSummary> buildCacheSummaryList() {
+    List<String> cacheNames = new ArrayList<>(CacheManager.getCacheNames());
+    Collections.sort(cacheNames);
+
+    List<CacheSummary> results = new ArrayList<>();
+    for (String cacheName : cacheNames) {
+      Cache cache = CacheManager.getCache(cacheName);
+      if (cache == null) {
+        continue;
+      }
+      CacheStats stats = cache.stats();
+      Instant lastClearedAt = CacheManager.getLastClearedAt(cacheName);
+      results.add(new CacheSummary(
+          cacheName,
+          cache.estimatedSize(),
+          stats.hitCount(),
+          stats.missCount(),
+          stats.hitRate(),
+          stats.missRate(),
+          stats.evictionCount(),
+          lastClearedAt == null ? null : Timestamp.from(lastClearedAt)));
+    }
+    return results;
+  }
+
+  public static class CacheSummary {
+    private final String name;
+    private final long estimatedSize;
+    private final long hitCount;
+    private final long missCount;
+    private final double hitRate;
+    private final double missRate;
+    private final long evictionCount;
+    private final Timestamp lastClearedAt;
+
+    public CacheSummary(String name, long estimatedSize, long hitCount, long missCount, double hitRate,
+        double missRate, long evictionCount, Timestamp lastClearedAt) {
+      this.name = name;
+      this.estimatedSize = estimatedSize;
+      this.hitCount = hitCount;
+      this.missCount = missCount;
+      this.hitRate = hitRate;
+      this.missRate = missRate;
+      this.evictionCount = evictionCount;
+      this.lastClearedAt = lastClearedAt;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public long getEstimatedSize() {
+      return estimatedSize;
+    }
+
+    public long getHitCount() {
+      return hitCount;
+    }
+
+    public long getMissCount() {
+      return missCount;
+    }
+
+    public double getHitRate() {
+      return hitRate;
+    }
+
+    public double getMissRate() {
+      return missRate;
+    }
+
+    public long getEvictionCount() {
+      return evictionCount;
+    }
+
+    public Timestamp getLastClearedAt() {
+      return lastClearedAt;
+    }
+
+    public boolean isNeverCleared() {
+      return lastClearedAt == null;
+    }
+  }
+}

--- a/src/main/webapp/WEB-INF/jsp/admin/cache-management.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/cache-management.jsp
@@ -1,0 +1,83 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="date" uri="/WEB-INF/tlds/date-functions.tld" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="cacheSummaryList" class="java.util.ArrayList" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="small">
+  In-memory application caches (Caffeine) -- clearing a cache is immediate and does not require a
+  restart, and the next request simply reloads what it needs. Hit/miss/eviction counts accumulate
+  from the moment the application started, so they will read low right after a deploy.
+</p>
+
+<p>
+  <a href="#" onclick="return confirmPostAction('Clear ALL caches? This cannot be undone.', '${widgetContext.uri}?command=clearAll&widget=${widgetContext.uniqueId}&token=${userSession.formToken}');" class="button alert">Clear All Caches</a>
+</p>
+
+<div style="overflow-x: auto">
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Cache</th>
+      <th>Entries</th>
+      <th>Hits</th>
+      <th>Misses</th>
+      <th>Hit Rate</th>
+      <th>Evictions</th>
+      <th>Last Cleared</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${cacheSummaryList}" var="cacheSummary">
+      <tr>
+        <td><c:out value="${cacheSummary.name}" /></td>
+        <td><fmt:formatNumber value="${cacheSummary.estimatedSize}" /></td>
+        <td><fmt:formatNumber value="${cacheSummary.hitCount}" /></td>
+        <td><fmt:formatNumber value="${cacheSummary.missCount}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${cacheSummary.hitCount + cacheSummary.missCount == 0}">&#8212;</c:when>
+            <c:otherwise><fmt:formatNumber value="${cacheSummary.hitRate * 100}" maxFractionDigits="1" />%</c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:choose>
+            <c:when test="${cacheSummary.evictionCount > 0}"><span class="label warning radius"><fmt:formatNumber value="${cacheSummary.evictionCount}" /></span></c:when>
+            <c:otherwise>0</c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:choose>
+            <c:when test="${cacheSummary.neverCleared}">&#8212;</c:when>
+            <c:otherwise><span title="<fmt:formatDate pattern='yyyy-MM-dd HH:mm:ss z' value='${cacheSummary.lastClearedAt}' />"><c:out value="${date:relative(cacheSummary.lastClearedAt)}" /></span></c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <a href="#" onclick="return confirmPostAction('Clear the ${fn:escapeXml(cacheSummary.name)} cache?', '${widgetContext.uri}?command=clearCache&cache=${fn:escapeXml(cacheSummary.name)}&widget=${widgetContext.uniqueId}&token=${userSession.formToken}');" class="button tiny secondary">Clear</a>
+        </td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -430,6 +430,7 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/health-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/health-dashboard"><i class="${font:far()} fa-heart-pulse fa-fw"></i> <span>System Health</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/job-queue-dashboard')}"> class="is-active"</c:if>><a href="${ctx}/admin/job-queue-dashboard"><i class="${font:far()} fa-list-check fa-fw"></i> <span>Job Queue</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/database-maintenance')}"> class="is-active"</c:if>><a href="${ctx}/admin/database-maintenance"><i class="${font:far()} fa-database fa-fw"></i> <span>Database Maintenance</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/cache-management')}"> class="is-active"</c:if>><a href="${ctx}/admin/cache-management"><i class="${font:far()} fa-bolt fa-fw"></i> <span>Cache Management</span></a></li>
             </c:if>
           </ul>
           <%-- Community menu --%>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -2038,6 +2038,17 @@
     </section>
   </page>
 
+  <page name="/admin/cache-management" role="admin" title="Cache Management">
+    <section>
+      <column class="small-12 cell">
+        <widget name="cacheManagement">
+          <icon>fa-bolt</icon>
+          <title>Cache Management</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/job-queue-dashboard" role="admin" title="Job Queue Dashboard">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -283,6 +283,7 @@
   <widget name="auditLogList" class="com.simisinc.platform.presentation.widgets.admin.audit.AuditLogListWidget" />
   <widget name="healthDashboard" class="com.simisinc.platform.presentation.widgets.admin.HealthDashboardWidget" />
   <widget name="databaseMaintenance" class="com.simisinc.platform.presentation.widgets.admin.DatabaseMaintenanceWidget" />
+  <widget name="cacheManagement" class="com.simisinc.platform.presentation.widgets.admin.CacheManagementWidget" />
   <widget name="jobQueueDashboard" class="com.simisinc.platform.presentation.widgets.admin.JobQueueDashboardWidget" />
   <!-- Not implemented -->
   <widget name="profilePhoto" class="com.simisinc.platform.presentation.widgets.GenericWidget" />

--- a/src/test/java/com/simisinc/platform/infrastructure/cache/CacheManagerTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/cache/CacheManagerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.cache;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+/**
+ * Covers the CacheManager additions made for issue #463 (admin cache management dashboard):
+ * inventory listing, clear-one, clear-all, and "last cleared" tracking.
+ *
+ * <p>
+ * CacheManager is a real, JVM-wide static registry shared by every test that runs in this build
+ * (test classes are launched inside a single forked JVM, see build.xml's junitlauncher). These
+ * tests therefore avoid asserting "pristine"/"never touched" state up front -- some other test
+ * class may have already caused a cache to be loaded or cleared before this class runs -- and
+ * instead assert the effect each call under test has relative to its own setup.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class CacheManagerTest {
+
+  @Test
+  void getCacheNamesReturnsAllThirteenRegisteredCaches() {
+    Set<String> names = CacheManager.getCacheNames();
+    assertEquals(13, names.size());
+    assertTrue(names.contains(CacheManager.SYSTEM_PROPERTY_PREFIX_CACHE));
+    assertTrue(names.contains(CacheManager.APP_CACHE));
+    assertTrue(names.contains(CacheManager.USER_CREDENTIALS_CACHE));
+    assertTrue(names.contains(CacheManager.STYLESHEET_WEB_PAGE_ID_CACHE));
+    assertTrue(names.contains(CacheManager.CONTENT_UNIQUE_ID_CACHE));
+    assertTrue(names.contains(CacheManager.CONTENT_REMOTE_URL_CACHE));
+    assertTrue(names.contains(CacheManager.COLLECTION_UNIQUE_ID_CACHE));
+    assertTrue(names.contains(CacheManager.TABLE_OF_CONTENTS_UNIQUE_ID_CACHE));
+    assertTrue(names.contains(CacheManager.RATE_LIMIT_LOGIN_ATTEMPT_BY_USERNAME_CACHE));
+    assertTrue(names.contains(CacheManager.RATE_LIMIT_ATTEMPT_BY_IP_CACHE));
+    assertTrue(names.contains(CacheManager.RATE_LIMIT_BY_APP_CACHE));
+    assertTrue(names.contains(CacheManager.RATE_LIMIT_BY_APP_USER_CACHE));
+    assertTrue(names.contains(CacheManager.OBJECT_CACHE));
+  }
+
+  @Test
+  void getCacheNamesReturnsAnUnmodifiableView() {
+    Set<String> names = CacheManager.getCacheNames();
+    assertThrows(UnsupportedOperationException.class, () -> names.add("SomeNewCache"));
+  }
+
+  @Test
+  void invalidateAllClearsAllEntriesInTheNamedCacheAndRecordsWhenItHappened() {
+    @SuppressWarnings("unchecked")
+    Cache<String, Object> objectCache = CacheManager.getCache(CacheManager.OBJECT_CACHE);
+    objectCache.put("cache-manager-test-key", "value");
+    assertNotNull(objectCache.getIfPresent("cache-manager-test-key"));
+
+    Instant before = Instant.now();
+    CacheManager.invalidateAll(CacheManager.OBJECT_CACHE);
+    Instant after = Instant.now();
+
+    assertNull(objectCache.getIfPresent("cache-manager-test-key"));
+    Instant lastCleared = CacheManager.getLastClearedAt(CacheManager.OBJECT_CACHE);
+    assertNotNull(lastCleared);
+    assertFalse(lastCleared.isBefore(before));
+    assertFalse(lastCleared.isAfter(after));
+  }
+
+  @Test
+  void invalidateAllIsANoOpForAnUnregisteredCacheName() {
+    assertDoesNotThrow(() -> CacheManager.invalidateAll("NotARealCache"));
+    assertNull(CacheManager.getLastClearedAt("NotARealCache"));
+  }
+
+  @Test
+  void invalidateAllCachesClearsEveryRegisteredCacheAndRecordsWhenEachWasCleared() {
+    @SuppressWarnings("unchecked")
+    Cache<String, Object> objectCache = CacheManager.getCache(CacheManager.OBJECT_CACHE);
+    objectCache.put("cache-manager-test-key-2", "value");
+    @SuppressWarnings("unchecked")
+    Cache<Long, String> userCredentialsCache = CacheManager.getCache(CacheManager.USER_CREDENTIALS_CACHE);
+    userCredentialsCache.put(999_999L, "some-hash");
+
+    CacheManager.invalidateAllCaches();
+
+    assertNull(objectCache.getIfPresent("cache-manager-test-key-2"));
+    assertNull(userCredentialsCache.getIfPresent(999_999L));
+    for (String cacheName : CacheManager.getCacheNames()) {
+      assertNotNull(CacheManager.getLastClearedAt(cacheName), "Expected " + cacheName + " to have a last-cleared time");
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/cache/CacheManagerTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/cache/CacheManagerTest.java
@@ -97,6 +97,31 @@ class CacheManagerTest {
   }
 
   @Test
+  void recordStatsIsActuallyEnabledSoHitAndMissCountsMoveOffZero() {
+    // The core of issue #463's CacheManager change is adding .recordStats() to every Caffeine
+    // builder in startup() -- without it, Cache.stats() always returns CacheStats.empty() (all
+    // zeros) regardless of how many times a cache is actually used. This drives a real
+    // miss-then-hit cycle and asserts both counters move, rather than trusting that the
+    // .recordStats() call site was wired up correctly. Uses deltas, not absolute counts, since
+    // OBJECT_CACHE is real JVM-wide static state other test classes may also be touching (see the
+    // class-level note above).
+    @SuppressWarnings("unchecked")
+    Cache<String, Object> objectCache = CacheManager.getCache(CacheManager.OBJECT_CACHE);
+    long hitsBefore = objectCache.stats().hitCount();
+    long missesBefore = objectCache.stats().missCount();
+
+    String key = "cache-manager-test-recordstats-key";
+    assertNull(objectCache.getIfPresent(key), "test setup: this key must not already be cached");
+    objectCache.put(key, "value");
+    assertNotNull(objectCache.getIfPresent(key));
+
+    assertTrue(objectCache.stats().missCount() > missesBefore,
+        "the first getIfPresent (a miss) must be recorded now that .recordStats() is enabled");
+    assertTrue(objectCache.stats().hitCount() > hitsBefore,
+        "the second getIfPresent (a hit) must be recorded now that .recordStats() is enabled");
+  }
+
+  @Test
   void invalidateAllCachesClearsEveryRegisteredCacheAndRecordsWhenEachWasCleared() {
     @SuppressWarnings("unchecked")
     Cache<String, Object> objectCache = CacheManager.getCache(CacheManager.OBJECT_CACHE);

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidgetTest.java
@@ -95,7 +95,56 @@ class CacheManagementWidgetTest extends WidgetBase {
       assertEquals(5, objectCacheSummary.getEstimatedSize());
       assertEquals(10, objectCacheSummary.getHitCount());
       assertEquals(2, objectCacheSummary.getMissCount());
+      // 10 hits / 12 requests = 0.8333..., 2 misses / 12 requests = 0.1666...; asserted with a
+      // tolerance since CacheStats computes these as doubles. A transposed constructor argument
+      // (e.g. hitRate/missRate swapped, or evictionCount fed from the wrong stat) would otherwise
+      // ship undetected -- the earlier version of this test never checked these three fields at all.
+      assertEquals(10.0 / 12.0, objectCacheSummary.getHitRate(), 0.0001);
+      assertEquals(2.0 / 12.0, objectCacheSummary.getMissRate(), 0.0001);
+      assertEquals(0, objectCacheSummary.getEvictionCount());
       assertFalse(objectCacheSummary.isNeverCleared());
+
+      // appCacheMock was built with 0 evictions and mockCache(3, 0, 0, 0) -- assert the
+      // eviction-count wiring on a second, differently-shaped cache too.
+      assertEquals(0, appCacheSummary.getEvictionCount());
+    }
+  }
+
+  @Test
+  void executeReportsAnEmptyListWhenNoCachesAreRegistered() {
+    setRoles(widgetContext, ADMIN);
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      cacheManager.when(CacheManager::getCacheNames).thenReturn(Set.of());
+
+      WidgetContext result = new CacheManagementWidget().execute(widgetContext);
+
+      @SuppressWarnings("unchecked")
+      List<CacheManagementWidget.CacheSummary> cacheSummaryList =
+          (List<CacheManagementWidget.CacheSummary>) result.getRequest().getAttribute("cacheSummaryList");
+      assertTrue(cacheSummaryList.isEmpty());
+    }
+  }
+
+  @Test
+  void executeSkipsARegisteredNameWhoseCacheHasGoneMissing() {
+    // getCacheNames() and getCache(name) are two separate reads of the same underlying
+    // ConcurrentHashMap -- a name present in one snapshot could be absent by the time the other is
+    // read. buildCacheSummaryList()'s `if (cache == null) { continue; }` guard exists for exactly
+    // this race; this asserts it skips the row rather than throwing a NullPointerException trying
+    // to call .stats() on a null Cache.
+    setRoles(widgetContext, ADMIN);
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      cacheManager.when(CacheManager::getCacheNames).thenReturn(Set.of(CacheManager.OBJECT_CACHE));
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.OBJECT_CACHE)).thenReturn(null);
+
+      WidgetContext result = new CacheManagementWidget().execute(widgetContext);
+
+      @SuppressWarnings("unchecked")
+      List<CacheManagementWidget.CacheSummary> cacheSummaryList =
+          (List<CacheManagementWidget.CacheSummary>) result.getRequest().getAttribute("cacheSummaryList");
+      assertTrue(cacheSummaryList.isEmpty());
     }
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/CacheManagementWidgetTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.infrastructure.cache.CacheManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author elizabeth houser
+ */
+class CacheManagementWidgetTest extends WidgetBase {
+
+  private static Cache<?, ?> mockCache(long estimatedSize, long hits, long misses, long evictions) {
+    @SuppressWarnings("unchecked")
+    Cache<Object, Object> cache = Mockito.mock(Cache.class);
+    when(cache.estimatedSize()).thenReturn(estimatedSize);
+    when(cache.stats()).thenReturn(CacheStats.of(hits, misses, 0, 0, 0, evictions, 0));
+    return cache;
+  }
+
+  @Test
+  void executeLoadsTheCacheSummaryListForAnAdmin() {
+    setRoles(widgetContext, ADMIN);
+
+    // Built before any MockedStatic#when() call is opened below -- mockCache() itself calls
+    // Mockito's when(), and nesting that inside an unfinished cacheManager.when(...).thenReturn(...)
+    // throws UnfinishedStubbingException (Mockito can't tell which when() the next thenReturn()
+    // belongs to).
+    Cache<?, ?> objectCacheMock = mockCache(5, 10, 2, 0);
+    Cache<?, ?> appCacheMock = mockCache(3, 0, 0, 0);
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      cacheManager.when(CacheManager::getCacheNames)
+          .thenReturn(Set.of(CacheManager.OBJECT_CACHE, CacheManager.APP_CACHE));
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.OBJECT_CACHE)).thenReturn(objectCacheMock);
+      cacheManager.when(() -> CacheManager.getCache(CacheManager.APP_CACHE)).thenReturn(appCacheMock);
+      cacheManager.when(() -> CacheManager.getLastClearedAt(CacheManager.OBJECT_CACHE))
+          .thenReturn(Instant.now());
+      cacheManager.when(() -> CacheManager.getLastClearedAt(CacheManager.APP_CACHE)).thenReturn(null);
+
+      WidgetContext result = new CacheManagementWidget().execute(widgetContext);
+
+      assertEquals("/admin/cache-management.jsp", result.getJsp());
+      @SuppressWarnings("unchecked")
+      List<CacheManagementWidget.CacheSummary> cacheSummaryList =
+          (List<CacheManagementWidget.CacheSummary>) result.getRequest().getAttribute("cacheSummaryList");
+      assertEquals(2, cacheSummaryList.size());
+
+      // Alphabetical: AppCache before ObjectCache
+      CacheManagementWidget.CacheSummary appCacheSummary = cacheSummaryList.get(0);
+      assertEquals(CacheManager.APP_CACHE, appCacheSummary.getName());
+      assertEquals(3, appCacheSummary.getEstimatedSize());
+      assertTrue(appCacheSummary.isNeverCleared());
+
+      CacheManagementWidget.CacheSummary objectCacheSummary = cacheSummaryList.get(1);
+      assertEquals(CacheManager.OBJECT_CACHE, objectCacheSummary.getName());
+      assertEquals(5, objectCacheSummary.getEstimatedSize());
+      assertEquals(10, objectCacheSummary.getHitCount());
+      assertEquals(2, objectCacheSummary.getMissCount());
+      assertFalse(objectCacheSummary.isNeverCleared());
+    }
+  }
+
+  @Test
+  void executeDoesNothingForAUserWithoutAdmin() {
+    // WidgetBase's default logged-in test user has no roles at all
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class)) {
+      WidgetContext result = new CacheManagementWidget().execute(widgetContext);
+
+      assertNull(result.getJsp());
+      cacheManager.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postClearAllInvalidatesEveryCacheRecordsAnAuditEventAndRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "clearAll");
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+
+      WidgetContext result = new CacheManagementWidget().post(widgetContext);
+
+      cacheManager.verify(CacheManager::invalidateAllCaches);
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.CONFIGURATION),
+          eq("cache.clear_all"), eq(AuditEventCommand.SUCCESS), eq("cache"), isNull(), isNull(), anyString()));
+      assertEquals("/admin/cache-management", result.getRedirect());
+      assertEquals("All caches were cleared", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postClearCacheClearsAKnownCacheRecordsAnAuditEventAndRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "clearCache");
+    addQueryParameter(widgetContext, "cache", CacheManager.OBJECT_CACHE);
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      cacheManager.when(CacheManager::getCacheNames).thenReturn(Set.of(CacheManager.OBJECT_CACHE));
+
+      WidgetContext result = new CacheManagementWidget().post(widgetContext);
+
+      cacheManager.verify(() -> CacheManager.invalidateAll(CacheManager.OBJECT_CACHE));
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.CONFIGURATION), eq("cache.clear"),
+          eq(AuditEventCommand.SUCCESS), eq("cache"), eq(CacheManager.OBJECT_CACHE), eq(CacheManager.OBJECT_CACHE),
+          anyString()));
+      assertEquals("/admin/cache-management", result.getRedirect());
+      assertEquals("Cache cleared: " + CacheManager.OBJECT_CACHE, result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postClearCacheRejectsACacheNameNotInTheLiveRegistry() {
+    // Guards both correctness (only a real cache can be cleared) and audit-log integrity: a
+    // rejected name is never handed to invalidateAll or to the audit event, so untrusted input
+    // can never reach the log format as anything other than a plain, allow-listed cache name.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "clearCache");
+    addQueryParameter(widgetContext, "cache", "NotARealCache\nuser=admin forged-entry");
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      cacheManager.when(CacheManager::getCacheNames).thenReturn(Set.of(CacheManager.OBJECT_CACHE));
+
+      WidgetContext result = new CacheManagementWidget().post(widgetContext);
+
+      cacheManager.verify(() -> CacheManager.invalidateAll(anyString()), never());
+      audit.verifyNoInteractions();
+      assertEquals("Unknown cache", result.getErrorMessage());
+      assertEquals("/admin/cache-management", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postDoesNothingForAUserWithoutAdmin() {
+    addQueryParameter(widgetContext, "command", "clearAll");
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      WidgetContext result = new CacheManagementWidget().post(widgetContext);
+
+      assertNull(result.getRedirect());
+      cacheManager.verifyNoInteractions();
+      audit.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postIgnoresAnUnrecognizedCommandButStillRedirects() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "somethingElse");
+
+    try (MockedStatic<CacheManager> cacheManager = mockStatic(CacheManager.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      WidgetContext result = new CacheManagementWidget().post(widgetContext);
+
+      cacheManager.verify(CacheManager::invalidateAllCaches, never());
+      cacheManager.verify(() -> CacheManager.invalidateAll(anyString()), never());
+      audit.verifyNoInteractions();
+      assertEquals("/admin/cache-management", result.getRedirect());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a Cache Management admin page (`/admin/cache-management`), mirroring the `DatabaseMaintenanceWidget` pattern from #469: lists every registered Caffeine cache with entry count and hit/miss/eviction stats, and lets an admin clear one cache or all of them without a restart, with a full audit trail.

**Scope note -- this issue's original wishlist was larger than what Caffeine (the actual caching library in use) can support.** Before building, I investigated the real `CacheManager` implementation rather than assuming the issue's example caches ("pages, content, users, sessions") were accurate -- they aren't; the real inventory is 13 named Caffeine caches, and several of the ask's items aren't feasible with this library at all:

| Requirement | Status |
|---|---|
| Cache inventory + entry counts | ✅ Built |
| Clear all / clear one | ✅ Built |
| Hit/miss/eviction stats | ✅ Built -- `.recordStats()` was never called before this PR, so these numbers read as zero immediately after deploy and become meaningful as traffic accrues |
| Audit trail (who cleared what, when) | ✅ Built -- reuses the existing generic `audit_log` infrastructure, no new table needed |
| Clear by pattern | ❌ Deferred -- Caffeine has no key-pattern API; would need a per-cache `O(n)` key scan (up to 1M entries on the largest caches) and its own glob/regex design |
| TTL / max-size configuration from the UI | ❌ Deferred -- Caffeine cache parameters are baked in at `Caffeine.newBuilder()` time and are immutable on a live `Cache`; real support needs persisted config (e.g. new `SiteProperty` rows) plus a rebuild-on-change operation, a materially larger change |
| Selectable eviction policy (LRU, FIFO, etc.) | ❌ Not buildable at all -- Caffeine always uses its own fixed W-TinyLFU algorithm with no policy-swap API on any version |
| Byte-level memory usage | ❌ Not available -- none of the 13 caches configure a `Weigher` (all use entry-count `maximumSize`, not `maximumWeight`); real support means writing a size-estimating `Weigher` per distinct cached value type |
| "Warming up" status | ❌ Dropped -- no such lifecycle exists in this caching layer (caches are either populated ad hoc or lazily load-on-miss; there's no background preload phase to report on) |

## Changes
- `CacheManager`: expose the cache-name registry (`getCacheNames()`), add `invalidateAll(name)`/`invalidateAllCaches()`, track per-cache last-cleared time, and turn on `.recordStats()` on all 13 builders.
- `CacheManagementWidget` + `cache-management.jsp`: admin-only dashboard with a POST-only, CSRF-protected clear action (mirrors the CSRF pattern already used site-wide via `PageServlet`'s central token check). The requested cache name is validated against the live registry before it's used anywhere, including the audit log entry, so untrusted input can never reach the log as anything but a known cache name.
- Wired into `widget-library.xml`, `admin-layout.xml`, and the admin nav in `main.jsp`.

## Test plan
- [x] `ant ci-test` -- full suite green (0 failures), run independently twice against the actual committed code (not just trusting a self-report)
- [x] `CacheManagerTest`: registry listing/immutability, clear-one, clear-all, "last cleared" tracking, and a real Caffeine get-miss/get-hit cycle proving `.recordStats()` actually collects stats
- [x] `CacheManagementWidgetTest`: admin-gating on both `execute()`/`post()`, clear-all/clear-one dispatch + audit-event recording, a name not in the live registry is rejected before it ever reaches `invalidateAll` or the audit log (log-injection guard), hit-rate/miss-rate/eviction-count are asserted (not just entry count), plus empty-registry and cache-went-missing branch coverage
- [x] `python3 tools/check-unescaped-el.py` -- 0 unallowlisted sites
- [x] **Live verification against the real Docker image**: logged in as admin, viewed the dashboard (already showing real accumulated hit/miss stats from normal app traffic -- e.g. ObjectCache at 60% hit rate), cleared one cache (confirmed entries dropped and "Last Cleared" updated to "just now"), cleared all caches (confirmed every row updated), and confirmed both actions appear in the Security Audit Log with the correct actor, source IP, timestamp, and target. Also confirmed the CSRF protection is real: replaying a stale form token after the first POST returned 404 (token had rotated via `renewFormToken()`), and a fresh token succeeded.

This was built via a research → build → adversarial-review workflow; I independently re-verified the build (read the actual diffs, re-ran ci-test myself, did the live Docker verification above) and applied the 3 confirmed test-coverage findings from the review before opening this PR.