### PR TITLE
Fix RobotsServlet caching 500 error responses for 24 hours

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/RobotsServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/RobotsServlet.java
@@ -38,7 +38,6 @@ public class RobotsServlet extends HttpServlet {
       throws ServletException, IOException {
 
     response.setContentType("text/plain;charset=UTF-8");
-    response.setHeader("Cache-Control", "public, max-age=86400");
 
     try {
       String robotsContent = loadRobotsTxt();
@@ -46,6 +45,10 @@ public class RobotsServlet extends HttpServlet {
         robotsContent = generateDefaultRobotsTxt();
       }
 
+      // Only a successfully generated (or statically overridden) body is cacheable -- a 500 error
+      // response must not be cached, or a transient failure gets replayed to every visitor/CDN for
+      // up to a day (matches LlmsTxtServlet's identical fix, issue #417 / PR #935).
+      response.setHeader("Cache-Control", "public, max-age=86400");
       response.setStatus(HttpServletResponse.SC_OK);
       response.getWriter().print(robotsContent);
     } catch (Exception e) {

--- a/src/test/java/com/simisinc/platform/presentation/controller/RobotsServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/RobotsServletTest.java
@@ -19,8 +19,12 @@ package com.simisinc.platform.presentation.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -175,5 +179,8 @@ class RobotsServletTest {
     }
 
     org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    // A 500 error response must not be cached -- a transient failure would otherwise get replayed
+    // to every visitor/CDN for up to a day instead of retried on the next request.
+    verify(response, never()).setHeader(eq("Cache-Control"), any());
   }
 }


### PR DESCRIPTION
## Problem

Fixes #936.

`RobotsServlet.doGet()` set `Cache-Control: public, max-age=86400` unconditionally before the try/catch block. When `LoadSitePropertyCommand` (or anything else in the request path) throws, the servlet falls into its catch block and returns a 500 with body `# Error generating robots.txt` -- but that error response carried the same 24-hour cache header as a successful response. Any browser or CDN in front of the site would then keep serving the cached error for up to a day, even after the underlying failure cleared.

## Fix

This is the exact same bug shape as the one just fixed in the sibling `LlmsTxtServlet` (issue #417 / PR #935): move `response.setHeader("Cache-Control", "public, max-age=86400")` from the unconditional top-of-method position to right before the `SC_OK` write in the try block, so only a successfully generated (or statically overridden) body is cacheable.

## Testing

- `ant -lib lib/war clean compile` -- clean
- `ant -lib lib/war -lib lib/tests clean ci-test` -- full suite green, run twice
- Added `RobotsServletTest.doGetReturns500AndDoesNotThrowWhenSitePropertiesFail` assertion: `verify(response, never()).setHeader(eq("Cache-Control"), any())`, matching the analogous assertions in `LlmsTxtServletTest`