### PR TITLE
Fix InaccessibleObjectException serializing java.sql.Timestamp in REST responses

### DIFF
--- a/src/main/java/com/simisinc/platform/rest/controller/RestServlet.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/RestServlet.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbConfig;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.MultipartConfig;
@@ -55,6 +56,13 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 public class RestServlet extends HttpServlet {
 
   private static Log LOG = LogFactory.getLog(RestServlet.class);
+
+  // Shared binding context for response serialization -- building one per request (as this used
+  // to) re-runs JSON-B's reflection scan on every call, and the default reflection strategy alone
+  // can't reach java.sql.Timestamp's private fields under the JDK module system, so a Timestamp
+  // adapter is required here too (see TimestampJsonbAdapter). Package-private so tests can verify
+  // the actual configured instance rather than a duplicate.
+  static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig().withAdapters(new TimestampJsonbAdapter()));
 
   // Services Cache
   private Map<String, Object> serviceInstances = new HashMap<String, Object>();
@@ -91,7 +99,11 @@ public class RestServlet extends HttpServlet {
 
   @Override
   public void destroy() {
-
+    try {
+      JSONB.close();
+    } catch (Exception e) {
+      LOG.warn("Error closing Jsonb: " + e.getMessage());
+    }
   }
 
   @Override
@@ -214,57 +226,55 @@ public class RestServlet extends HttpServlet {
       // Aspire to, but not quite there:
       // https://google.github.io/styleguide/jsoncstyleguide.xml
       LOG.debug("Returning JSON...");
-      try (Jsonb jsonb = JsonbBuilder.create()) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{");
-        boolean hasValues = false;
-        if (!result.getMeta().isEmpty()) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("{");
+      boolean hasValues = false;
+      if (!result.getMeta().isEmpty()) {
+        hasValues = true;
+        String meta = JSONB.toJson(result.getMeta());
+        sb.append("\"meta\": ").append(meta);
+      }
+      if (!result.getError().isEmpty()) {
+        if (hasValues) {
+          sb.append(",");
+        } else {
           hasValues = true;
-          String meta = jsonb.toJson(result.getMeta());
-          sb.append("\"meta\": ").append(meta);
         }
-        if (!result.getError().isEmpty()) {
-          if (hasValues) {
-            sb.append(",");
-          } else {
-            hasValues = true;
-          }
-          sb.append("\"error\": ")
-              .append("{")
-              .append("\"code\": ").append(result.getStatus()).append(",")
-              .append("\"message\": \"").append(JsonCommand.toJson(result.getError().get("title"))).append("\"")
-              .append("}");
+        sb.append("\"error\": ")
+            .append("{")
+            .append("\"code\": ").append(result.getStatus()).append(",")
+            .append("\"message\": \"").append(JsonCommand.toJson(result.getError().get("title"))).append("\"")
+            .append("}");
+      }
+      if (result.getData() != null) {
+        if (hasValues) {
+          sb.append(",");
+        } else {
+          hasValues = true;
         }
-        if (result.getData() != null) {
-          if (hasValues) {
-            sb.append(",");
-          } else {
-            hasValues = true;
-          }
-          String data = jsonb.toJson(result.getData());
-          sb.append("\"data\": ").append(data);
+        String data = JSONB.toJson(result.getData());
+        sb.append("\"data\": ").append(data);
+      }
+      if (!result.getLinks().isEmpty()) {
+        if (hasValues) {
+          sb.append(",");
         }
-        if (!result.getLinks().isEmpty()) {
-          if (hasValues) {
-            sb.append(",");
-          }
-          String links = jsonb.toJson(result.getLinks());
-          sb.append("\"links\": ").append(links);
-        }
-        sb.append("}");
-        String json = sb.toString();
+        String links = JSONB.toJson(result.getLinks());
+        sb.append("\"links\": ").append(links);
+      }
+      sb.append("}");
+      String json = sb.toString();
 
-        long endRequestTime = System.currentTimeMillis();
-        long totalTime = endRequestTime - startRequestTime;
-        LOG.debug("REST total time: " + totalTime + "ms");
+      long endRequestTime = System.currentTimeMillis();
+      long totalTime = endRequestTime - startRequestTime;
+      LOG.debug("REST total time: " + totalTime + "ms");
 
-        response.setContentLength(json.length());
-        PrintWriter out = response.getWriter();
-        out.print(json);
-        out.flush();
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Response sent: " + json);
-        }
+      response.setContentLength(json.length());
+      PrintWriter out = response.getWriter();
+      out.print(json);
+      out.flush();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Response sent: " + json);
       }
     } catch (Exception e) {
       LOG.error("Could not render: " + e.getMessage());

--- a/src/main/java/com/simisinc/platform/rest/controller/TimestampJsonbAdapter.java
+++ b/src/main/java/com/simisinc/platform/rest/controller/TimestampJsonbAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.controller;
+
+import javax.json.bind.adapter.JsonbAdapter;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * Unlike java.util.Date/java.time.*, java.sql.Timestamp has no built-in JSON-B handling, so the
+ * default reflection-based mapper tries to introspect its fields directly -- including the
+ * private `nanos` field -- which the JDK module system blocks (java.sql doesn't open itself to
+ * unnamed modules), throwing InaccessibleObjectException. This adapter handles the conversion
+ * explicitly so response DTOs can expose a Timestamp field without hitting that reflection wall.
+ *
+ * @author SimIS Inc.
+ */
+public class TimestampJsonbAdapter implements JsonbAdapter<Timestamp, String> {
+
+  @Override
+  public String adaptToJson(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant().toString();
+  }
+
+  @Override
+  public Timestamp adaptFromJson(String value) {
+    return value == null ? null : Timestamp.from(Instant.parse(value));
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/controller/RestServletTest.java
+++ b/src/test/java/com/simisinc/platform/rest/controller/RestServletTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.rest.services.cms.WebPageResponse;
+
+/**
+ * Regression test for the shared {@link RestServlet#JSONB} instance: before {@link
+ * TimestampJsonbAdapter} was registered, serializing any response DTO carrying a raw
+ * java.sql.Timestamp field (e.g. {@link WebPageResponse}, populated by real rows from
+ * PagesListService/PageService) threw InaccessibleObjectException at request time, turning a
+ * successful lookup into an HTTP 500 -- see RestServlet.service()'s catch-all "Could not render".
+ */
+class RestServletTest {
+
+  @Test
+  void serializesWebPageResponseWithTimestampFields() {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/about");
+    webPage.setTitle("About");
+    webPage.setPublishAt(Timestamp.from(Instant.parse("2026-01-01T00:00:00Z")));
+    webPage.setExpiresAt(null);
+    webPage.setModified(Timestamp.from(Instant.parse("2026-08-04T12:34:56.789Z")));
+
+    String json = assertDoesNotThrow(() -> RestServlet.JSONB.toJson(new WebPageResponse(webPage)));
+
+    assertTrue(json.contains("\"publishAt\":\"2026-01-01T00:00:00Z\""));
+    assertTrue(json.contains("\"modified\":\"2026-08-04T12:34:56.789Z\""));
+  }
+
+  @Test
+  void stillSerializesPlainMapValues() {
+    Map<String, Object> meta = new HashMap<>();
+    meta.put("total", 3);
+    assertDoesNotThrow(() -> RestServlet.JSONB.toJson(meta));
+  }
+}

--- a/src/test/java/com/simisinc/platform/rest/controller/TimestampJsonbAdapterTest.java
+++ b/src/test/java/com/simisinc/platform/rest/controller/TimestampJsonbAdapterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.rest.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link TimestampJsonbAdapter}'s conversion directly, and null handling on both sides.
+ */
+class TimestampJsonbAdapterTest {
+
+  private final TimestampJsonbAdapter adapter = new TimestampJsonbAdapter();
+
+  @Test
+  void adaptToJsonFormatsAsIsoInstant() {
+    Timestamp timestamp = Timestamp.from(Instant.parse("2026-08-04T12:34:56.789Z"));
+    assertEquals("2026-08-04T12:34:56.789Z", adapter.adaptToJson(timestamp));
+  }
+
+  @Test
+  void adaptToJsonHandlesNull() {
+    assertNull(adapter.adaptToJson(null));
+  }
+
+  @Test
+  void adaptFromJsonParsesIsoInstant() {
+    Timestamp timestamp = adapter.adaptFromJson("2026-08-04T12:34:56.789Z");
+    assertEquals(Instant.parse("2026-08-04T12:34:56.789Z"), timestamp.toInstant());
+  }
+
+  @Test
+  void adaptFromJsonHandlesNull() {
+    assertNull(adapter.adaptFromJson(null));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #940. `GET /api/pages` (and the other new REST read endpoints from #929/#412) returned HTTP 500 once the response actually contained rows with a `java.sql.Timestamp` field, instead of the expected JSON.

`RestServlet.service()` built a fresh `Jsonb jsonb = JsonbBuilder.create()` per request with no `JsonbConfig`. `java.sql.Timestamp` isn't one of JSON-B's built-in date/time types (unlike `java.util.Date`/`java.time.*`), so the default reflection-based mapper (this repo vendors Apache Johnzon 1.3.0 as its JSON-B impl) tried to introspect `Timestamp`'s private `nanos` field directly, which the JDK module system blocks:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private int java.sql.Timestamp.nanos accessible: module java.sql does not "opens java.sql" to unnamed module @...
```

## Fix

Registers a `TimestampJsonbAdapter` on a single `Jsonb` instance, built once at class-init in `RestServlet` and reused across requests (closed in `destroy()`) instead of rebuilt per request — the old per-request `JsonbBuilder.create()` was also re-running JSON-B's reflection scan on every call.

## Scope

Grepped every response DTO under `com.simisinc.platform.rest.services.*`. Exactly 3 files carry a raw `Timestamp` field, all added in #929: `WebPageResponse`, `BlogPostResponse`, `FileResponse`. Every other DTO already avoids this (medicine module converts to epoch-millis `Long`, `AuditLogEntryResponse` converts to an ISO string) — see #940 for the full writeup.

## Verification

- `ant -lib lib/war -lib lib/tests clean ci-test`: full suite green, including 6 new tests (`TimestampJsonbAdapterTest`, `RestServletTest`).
- Live Docker rehearsal: reproduced the exact `InaccessibleObjectException` hitting `GET /api/pages` on the pre-fix build, then confirmed a real 200 with correctly-formatted ISO-8601 timestamps after rebuilding with this fix — no other code changes in between.
