### PR TITLE
Fall back to the bundled favicon when none is uploaded

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
@@ -19,6 +19,7 @@
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
 <jsp:useBean id="masterWebPage" class="com.simisinc.platform.domain.model.cms.WebPage" scope="request"/>
 <jsp:useBean id="pageRenderInfo" class="com.simisinc.platform.presentation.controller.PageRenderInfo" scope="request"/>
 <jsp:useBean id="systemPropertyMap" class="java.util.HashMap" scope="request"/>
@@ -40,7 +41,12 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="apple-touch-icon" type="image/png" href="${systemPropertyMap['system.www.context']}/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" href="${systemPropertyMap['system.www.context']}/images/favicon.png">
+  <link rel="icon" type="image/png" id="favicon-link" href="${ctx}/images/favicon.png">
+  <%-- Prefers an admin-uploaded favicon at system.www.context when one actually loads; otherwise
+       stays on the bundled default above, so a fresh install (nothing uploaded yet) never 404s
+       on this request. A <link rel="icon">'s own load/error events are not reliably dispatched
+       across browsers, so existence is probed with an Image() object instead, whose events are. --%>
+  <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/favicon.png';var i=new Image();i.onload=function(){document.getElementById('favicon-link').href=u;};i.src=u;})();</script>
   <c:choose>
     <c:when test="${!empty masterWebPage.title}"><title><c:out value="${masterWebPage.title}"/> | <c:out value="${sitePropertyMap['site.name']}"/><c:if test="${!empty sitePropertyMap['site.name.keyword']}"> - <c:out value="${sitePropertyMap['site.name.keyword']}"/></c:if></title></c:when>
     <c:when test="${!empty pageRenderInfo.title}"><title><c:out value="${pageRenderInfo.title}"/> | <c:out value="${sitePropertyMap['site.name']}"/><c:if test="${!empty sitePropertyMap['site.name.keyword']}"> - <c:out value="${sitePropertyMap['site.name.keyword']}"/></c:if></title></c:when>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -79,7 +79,12 @@
   </c:otherwise>
 </c:choose>
   <link rel="apple-touch-icon" type="image/png" href="${systemPropertyMap['system.www.context']}/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" href="${systemPropertyMap['system.www.context']}/images/favicon.png">
+  <link rel="icon" type="image/png" id="favicon-link" href="${ctx}/images/favicon.png">
+  <%-- Prefers an admin-uploaded favicon at system.www.context when one actually loads; otherwise
+       stays on the bundled default above, so a fresh install (nothing uploaded yet) never 404s
+       on this request. A <link rel="icon">'s own load/error events are not reliably dispatched
+       across browsers, so existence is probed with an Image() object instead, whose events are. --%>
+  <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/favicon.png';var i=new Image();i.onload=function(){document.getElementById('favicon-link').href=u;};i.src=u;})();</script>
   <c:choose>
     <c:when test="${!empty pageRenderInfo.title}"><title><c:out value="${pageRenderInfo.title}"/> | <c:out value="${sitePropertyMap['site.name']}"/><c:if test="${!empty sitePropertyMap['site.name.keyword']}"> - <c:out value="${sitePropertyMap['site.name.keyword']}"/></c:if></title></c:when>
     <c:when test="${!empty masterWebPage.title}"><title><c:out value="${masterWebPage.title}"/> | <c:out value="${sitePropertyMap['site.name']}"/><c:if test="${!empty sitePropertyMap['site.name.keyword']}"> - <c:out value="${sitePropertyMap['site.name.keyword']}"/></c:if></title></c:when>


### PR DESCRIPTION
## Problem

The favicon `<link>` in `main.jsp` and `embedded-layout.jsp` is hardcoded to `${systemPropertyMap['system.www.context']}/images/favicon.png` (`system.www.context` defaults to `/web-content`). Nothing in this deployment serves `/web-content/*` until an admin uploads a custom favicon there, so a fresh "New Site" install 404s on this request on every page load — confirmed via a live Docker rehearsal + Lighthouse's errors-in-console audit.

A bundled default favicon already ships at `src/main/webapp/images/favicon.png`, but it was never referenced as a fallback.

## Fix

The `<link>` now defaults to the bundled `images/favicon.png`. A small inline script probes the configured `system.www.context` path with an `Image()` object and swaps the `href` to it only if that request actually succeeds, so a site that *has* a working custom favicon configured still gets it.

Note: a `<link rel="icon">` element's own `load`/`error` events are **not** reliably dispatched by browsers (confirmed empirically against real Chrome — a control test showed neither event firing for either a 200 or a 404 favicon path), which is why the existence check goes through an `Image()` object instead, whose events fire reliably.

`embedded-layout.jsp` got the same fix for consistency, though note it currently appears unreachable from any request path in this codebase (nothing forwards/includes it — `PageServlet.isEmbedded()` renders `embedded.jsp`, not `embedded-layout.jsp`); flagging that in case it's slated for future use.

## Testing

- `ant -lib lib/war compile-jsp` — JSP syntax gate passes for both files
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green
- Live Docker rehearsal (`docker compose ... up --build`) against a fresh "New Site" install:
  - `curl http://localhost:8097/web-content/images/favicon.png` → 404 (unchanged, expected — nothing serves this path in the current deployment)
  - `curl http://localhost:8097/images/favicon.png` → 200, `image/png`
  - Real Chrome (not just the automated pane) against the rehearsal instance: page's `<link id="favicon-link">` renders with `href="/images/favicon.png"` on load and stays there (network panel shows the probe's request to `/web-content/images/favicon.png` returning 404, with no effect on the link), `fetch('/images/favicon.png')` confirms 200/`image/png`, no console errors from the new script