### PR TITLE
Clear a web page's review workflow when its draft is published

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -274,7 +274,14 @@ public class WebPageRepository {
 
       int updated;
       try (PreparedStatement pst = connection.prepareStatement(
-          "UPDATE " + TABLE_NAME + " SET page_xml = draft_page_xml, draft_page_xml = null, draft = false "
+          "UPDATE " + TABLE_NAME + " SET page_xml = draft_page_xml, draft_page_xml = null, draft = false, "
+              // The draft is consumed, so clear its review workflow -- otherwise a stale
+              // draft_status="submitted"/approved_by from this cycle would let the *next* draft
+              // staged on this page (via SaveDraftLayoutCommand or a widget mutation) publish
+              // without ever being resubmitted or re-approved. Mirrors ContentRepository.publish()'s
+              // identical reset exactly; the durable record of who submitted and approved lives in
+              // the append-only audit trail, not here.
+              + "draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null "
               + "WHERE draft_page_xml IS NOT NULL AND web_page_id = ?")) {
         pst.setLong(1, record.getId());
         updated = pst.executeUpdate();

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -39,6 +39,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.cms.WebPageVersion;
@@ -336,6 +337,45 @@ class WebPageRepositoryTest {
 
     List<WebPageVersion> versions = WebPageVersionRepository.findByWebPageId(saved.getId(), null);
     assertEquals(3, versions.size(), "only the configured limit of prior versions should be retained");
+  }
+
+  // --- publish() clears the review workflow (#948) ---
+
+  @Test
+  void publishClearsTheReviewWorkflowSoAFreshDraftMustBeReapproved() throws DataException {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/governed");
+    webPage.setTitle("Governed Page");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setDraftPageXml("<xml>v1</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+
+    // Cycle 1: an ordinary submit -> approve -> publish.
+    ContentReviewCommand.submitForReview(saved, 10L);
+    WebPageRepository.save(saved);
+    ContentReviewCommand.approve(saved, 20L, "CAB-123");
+    WebPageRepository.publish(saved, 20L, 20);
+
+    WebPage afterFirstPublish = WebPageRepository.findById(saved.getId());
+    assertNull(afterFirstPublish.getDraftStatus(),
+        "the consumed draft's review workflow must be cleared, not left \"submitted\"");
+    assertEquals(-1L, afterFirstPublish.getSubmittedBy());
+    assertEquals(-1L, afterFirstPublish.getApprovedBy());
+    assertNull(afterFirstPublish.getReleaseReference());
+
+    // Cycle 2: an entirely new, never-reviewed draft is staged on the same page (e.g. via the
+    // layout builder's SaveDraftLayoutCommand) -- the exact scenario reported in #948.
+    afterFirstPublish.setDraftPageXml("<xml>v2 -- never reviewed</xml>");
+    afterFirstPublish.setDraft(true);
+    afterFirstPublish.setModifiedBy(10L);
+    WebPageRepository.save(afterFirstPublish);
+
+    WebPage beforeSecondPublish = WebPageRepository.findById(saved.getId());
+    assertFalse(ContentReviewCommand.mayPublish(beforeSecondPublish, true),
+        "a fresh draft must not inherit the prior cycle's approval -- it has to be resubmitted and reapproved");
   }
 
   @Test


### PR DESCRIPTION
Fixes #948.

## Root cause

`WebPageRepository.publish()` promotes `draft_page_xml` to `page_xml` but never resets `draft_status`/`submitted_by`/`approved_by`/`release_reference`. `ContentReviewCommand.isApproved()` derives "approved" purely from the record's *current* state (`draft_status == "submitted" && approved_by > 0`) — it has no way to correlate that state with *which* draft content was actually reviewed.

So after one full submit → approve → publish cycle, those four columns are left exactly as they were at approval time. If the page is edited again later (e.g. via the layout builder's `SaveDraftLayoutCommand`, or any other path that stages a new `draft_page_xml`), the brand-new, never-reviewed draft inherits the prior cycle's stale `draft_status`/`approved_by` — `mayPublish()` reads that stale state and returns true, and the new content can be published directly with no re-review, defeating the control this workflow exists to enforce (CMMC AC.L1-b.1.iv / NIST 800-171 3.1.22).

`ContentRepository.publish()` (the original, working precedent this workflow was generalized from — see `ContentReviewCommand`'s own javadoc) already clears the same four columns as part of publishing, with this rationale in its own comment: "The draft is consumed, so clear its review workflow. The durable record of who submitted and approved... lives in the append-only audit trail, not here." `WebPageRepository.publish()` never got the equivalent reset when the workflow was extended to web pages (#898).

## Fix

Add the identical reset (`draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null`) to `WebPageRepository.publish()`'s `UPDATE`, mirroring `ContentRepository.publish()` exactly. All three call sites (`PageServlet`'s `publishDraft` action, and `WebPageReviewWidget`'s direct-publish and approve-and-publish paths) go through this one method, so a single fix closes the gap everywhere. No other file needed a change — once `draft_status` is null after publish, any subsequently staged draft naturally requires a fresh submit → approve before `mayPublish()` allows it, without needing a separate reset at draft-staging time.

## A note on the issue's reference to a blog-post fix

I couldn't corroborate the issue's claim that this shape was "just found and fixed for blog posts (#407 phase 2)" — I found no Flyway migration adding `draft_status`/`approved_by`/etc. to `blog_posts` on `main`, and no merged or open PR implementing a blog-post review workflow. #407's own tracking comment says phase 2 (blog posts) is "a deliberate follow-up... not attempted" in the phase-1 PR. I verified the root cause and fix independently against `ContentRepository.publish()` (the actual working precedent for both web pages and, eventually, blog posts) rather than relying on that reference.

## Testing

- New regression test `WebPageRepositoryTest#publishClearsTheReviewWorkflowSoAFreshDraftMustBeReapproved` reproduces the exact scenario from #948 end-to-end at the repository layer: submit → approve → publish, assert all four columns are cleared, then stage a second never-reviewed draft and assert `mayPublish()` now correctly returns `false`. Ran in isolation (18/18 tests in `WebPageRepositoryTest`, 0 failures) and as part of the full suite.
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green.
