### PR TITLE
Add accessible names to social-media icon links

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/social-media-links.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/social-media-links.jsp
@@ -22,5 +22,5 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <%-- issue #516: any admin-configured platform, not a fixed per-platform <c:if> chain --%>
 <c:forEach items="${socialMediaLinkList}" var="link" varStatus="linkStatus">
-  <a <c:if test="${!linkStatus.first}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" rel="noopener noreferrer" href="<c:out value="${link.url}"/>"><i class="fa fa-2x ${fn:escapeXml(link.iconClass)}"></i></a>
+  <a <c:if test="${!linkStatus.first}">class="<c:out value="${iconClass}"/>" </c:if>target="_blank" rel="noopener noreferrer" aria-label="<c:out value="${link.platformName}"/>" href="<c:out value="${link.url}"/>"><i class="fa fa-2x ${fn:escapeXml(link.iconClass)}" aria-hidden="true"></i></a>
 </c:forEach>


### PR DESCRIPTION
Fixes #947.

## Problem

`cms/social-media-links.jsp` (the widget JSP behind the `socialMediaLinks` widget) rendered every admin-configured social link as an icon-only anchor with no `aria-label`, no visually-hidden text, and nothing else a screen reader could announce — fails WCAG 2.1 SC 4.1.2 (Name, Role, Value).

One correction to the issue's own description: this template isn't referenced from `layout-header-standard.jspf`/`layout-footer-standard.jspf` (those two already render their own, separate, already-accessible social-links markup — see below). The actual live path is `footer-layout.xml`'s `socialMediaLinks` widget placement, and `theme.footer.style` defaults to `custom` on a fresh install, which is what makes this the *default* footer experience rather than a rare custom-layout case — confirmed live via a docker rehearsal.

## Why this regressed

`layout-footer-standard.jspf` already has the correct `aria-label`/`aria-hidden` treatment for its own inline social-links markup — added by #348 (WCAG 4.1.2), back when social links were a fixed per-platform `<c:if>` chain. #591 (3 days later) replaced that hardcoded approach everywhere with a dynamic, admin-editable link list (`SocialMediaLink`/`SocialMediaLinkRepository`) and rewrote `cms/social-media-links.jsp` from scratch as part of that refactor — but the new widget JSP never got the equivalent accessible-name treatment `layout-footer-standard.jspf`'s sibling implementation already had.

## Fix

Mirror the exact pattern already proven correct in `layout-footer-standard.jspf`: `aria-label="<c:out value="${link.platformName}"/>"` on the anchor (`SocialMediaLink.platformName` is `NOT NULL` at the DB level, so this can't render blank), `aria-hidden="true"` on the icon so assistive tech reads the label instead of the glyph.

## Testing

- `ant -lib lib/war compile-jsp` — passes
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green
- Live docker rehearsal: seeded a `social_media_links` row, confirmed the rendered footer markup on a fresh install: `<a target="_blank" rel="noopener noreferrer" aria-label="Instagram" href="..."><i class="fa fa-2x fa-instagram" aria-hidden="true"></i></a>`

## Not addressed here

The issue also flagged malformed ARIA roles injected at runtime by Zurb Foundation's dropdown-menu.js into the main nav — the issue itself says that needs its own investigation before a fix can be scoped, and I agree it's a separate piece of work (different root cause, different files, no fix to mirror). Left it out of this PR; happy to pick it up separately once scoped.
