### PR TITLE
Fix systemPropertyMap/etc invisible to widget JSPs during their own render

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -738,6 +738,19 @@ public class PageServlet extends HttpServlet {
       AnalyticsTrackingIdCommand.sanitize(analyticsPropertyMap);
       Map<String, String> ecommercePropertyMap = LoadSitePropertyCommand.loadAsMap("ecommerce");
 
+      // Publish these before any widget renders (below), not just for main.jsp/layout.jsp
+      // afterward -- a widget JSP (e.g. ActivityListWidget's activity-list.jsp) that reads
+      // systemPropertyMap/etc directly needs them during its own JSP turn, not just once the
+      // whole page/header/footer walk is done. WebContainerCommand.PAGE_LEVEL_ATTRIBUTE_NAMES
+      // must keep exempting these names from that walk's per-widget request attribute reset.
+      request.setAttribute("systemPropertyMap", systemPropertyMap);
+      request.setAttribute("sitePropertyMap", sitePropertyMap);
+      request.setAttribute("themePropertyMap", themePropertyMap);
+      request.setAttribute("socialPropertyMap", socialPropertyMap);
+      request.setAttribute("socialMediaLinkList", socialMediaLinkList);
+      request.setAttribute("analyticsPropertyMap", analyticsPropertyMap);
+      request.setAttribute("ecommercePropertyMap", ecommercePropertyMap);
+
       // Allow content admins to see a page
       if (pageRef == null &&
           (userSession.hasRole("admin") ||
@@ -999,15 +1012,6 @@ public class PageServlet extends HttpServlet {
         // site's admin-configured contact-form page
         FunnelEventCommand.recordContactFormPageView(pagePath, userSession != null ? userSession.getSessionId() : null);
       }
-
-      // Allow the layout to use the properties
-      request.setAttribute("systemPropertyMap", systemPropertyMap);
-      request.setAttribute("sitePropertyMap", sitePropertyMap);
-      request.setAttribute("themePropertyMap", themePropertyMap);
-      request.setAttribute("socialPropertyMap", socialPropertyMap);
-      request.setAttribute("socialMediaLinkList", socialMediaLinkList);
-      request.setAttribute("analyticsPropertyMap", analyticsPropertyMap);
-      request.setAttribute("ecommercePropertyMap", ecommercePropertyMap);
 
       // Determine global items
       if (userSession.isLoggedIn() || "true".equals(sitePropertyMap.getOrDefault("site.online", "false"))) {

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -71,7 +71,9 @@ public class WebContainerCommand implements Serializable {
   // leftovers can't bleed into the next widget's render. These names must be kept in sync with the
   // request.setAttribute(...) calls in PageServlet.java that set them.
   private static final Set<String> PAGE_LEVEL_ATTRIBUTE_NAMES = Set.of(
-      "pageEditMode", "pageLayoutMode", "hasDraft", "widgetLibraryJson", "cspNonce");
+      "pageEditMode", "pageLayoutMode", "hasDraft", "widgetLibraryJson", "cspNonce",
+      "systemPropertyMap", "sitePropertyMap", "themePropertyMap", "socialPropertyMap",
+      "socialMediaLinkList", "analyticsPropertyMap", "ecommercePropertyMap");
 
 
   public static boolean processWidgets(WebContainerContext webContainerContext, List<Section> sections,

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebContainerCommandTest.java
@@ -291,6 +291,24 @@ class WebContainerCommandTest {
   }
 
   @Test
+  void sitePropertyMapsSurviveThePerWidgetReset() {
+    // Regression test: PageServlet.java now publishes systemPropertyMap/sitePropertyMap/
+    // themePropertyMap/socialPropertyMap/socialMediaLinkList/analyticsPropertyMap/
+    // ecommercePropertyMap before the section/column/widget walk begins (moved there so a
+    // widget JSP like ActivityListWidget's activity-list.jsp -- which reads
+    // systemPropertyMap['system.www.context'] directly -- can see them during its own JSP turn,
+    // not just once main.jsp renders afterward). Without this exemption the very first widget's
+    // reset would wipe them right back out before any later widget, or even main.jsp, read them.
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("systemPropertyMap"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("sitePropertyMap"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("themePropertyMap"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("socialPropertyMap"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("socialMediaLinkList"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("analyticsPropertyMap"));
+    Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("ecommercePropertyMap"));
+  }
+
+  @Test
   void existingControllerMasterAndRequestPrefixedAttributesStillSurvive() {
     // Unchanged pre-existing behavior -- must not regress with the new exemption added alongside it.
     Assertions.assertTrue(WebContainerCommand.isPreservedAcrossWidgetReset("controllerShowMainMenu"));


### PR DESCRIPTION
## Summary
- `systemPropertyMap`/`sitePropertyMap`/`themePropertyMap`/`socialPropertyMap`/`socialMediaLinkList`/`analyticsPropertyMap`/`ecommercePropertyMap` were only published as request attributes *after* `WebContainerCommand.processWidgets()` had already rendered the page body, header, and footer -- so no widget's own JSP ever saw them, only the final `main.jsp`/`layout.jsp` forward did. `LogoWidget`/`SystemAlertWidget`/`ToggleMenuWidget` each work around this today by re-loading and re-setting these same maps themselves.
- Found live-verifying `ActivityListWidget`'s `activity-list.jsp` on an item-detail page: `${systemPropertyMap['system.www.context']}` resolved to empty there, producing `/images/apple-touch-icon.png` instead of the real `/web-content/images/apple-touch-icon.png`, while the identical expression in `main.jsp` on the same request resolved correctly.
- Same root cause as #944/#946 (`cspNonce` clobbered by `WebContainerCommand`'s per-widget request-attribute reset), just for a different, earlier-computed set of attributes that #946 didn't cover.
- Fix: move the `setAttribute` calls to right after the maps are loaded (before the page-body `processWidgets()` call), and add their names to `PAGE_LEVEL_ATTRIBUTE_NAMES` alongside `cspNonce`.

## Test plan
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` -- all green, including a new `WebContainerCommandTest#sitePropertyMapsSurviveThePerWidgetReset` regression test mirroring the existing `cspNonceSurvivesThePerWidgetReset` pattern from #946.
- [x] Live docker-compose rehearsal, authenticated as admin: fetched `/show/{uniqueId}/chat` before and after the fix. Before: `activity-list.jsp`'s rendered `apple-touch-icon` URL was `/images/apple-touch-icon.png` (missing the `/web-content` prefix); after: `/web-content/images/apple-touch-icon.png`, matching `main.jsp`'s own tag.
- [x] Spot-checked `/`, `/admin/site-properties-editor`, `/directory/{collection}`, `/show/{uniqueId}` after the fix -- all 200, no new exceptions in app logs.

Closes #953