### PR TITLE
Fix malformed ARIA roles Foundation injects into nested dropdown menus

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/embedded-layout.jsp
@@ -237,6 +237,12 @@
     <script src="${ctx}/javascript/foundation-6.8.1/foundation.min.js"></script>
     <script nonce="${cspNonce}">
       $(document).foundation();
+      <%-- Foundation's Nest.Feather (foundation.util.nest.js) unconditionally tags every
+           dropdown-menu/drilldown submenu <ul> with role="menubar" -- the same role as the
+           top-level menu bar. role="menubar" is not an allowed owned element of role="menubar",
+           so nested submenus fail WAI-ARIA's required-owned-elements check for their parent
+           menubar. There is no Foundation option to change this; correct it after init. --%>
+      $('[data-submenu]').attr('role', 'menu');
       <%--
       $('.card-profile-stats-more-link').click(function(e){
         e.preventDefault();

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -664,6 +664,12 @@
     <script src="${ctx}/javascript/foundation-6.8.1/foundation.min.js"></script>
     <script nonce="${cspNonce}">
       $(document).foundation();
+      <%-- Foundation's Nest.Feather (foundation.util.nest.js) unconditionally tags every
+           dropdown-menu/drilldown submenu <ul> with role="menubar" -- the same role as the
+           top-level menu bar. role="menubar" is not an allowed owned element of role="menubar",
+           so nested submenus fail WAI-ARIA's required-owned-elements check for their parent
+           menubar. There is no Foundation option to change this; correct it after init. --%>
+      $('[data-submenu]').attr('role', 'menu');
       <%--
       $('.card-profile-stats-more-link').click(function(e){
         e.preventDefault();


### PR DESCRIPTION
Addresses the second, previously-uninvestigated finding from #947 (the icon-only social link labels were already fixed in #952).

## What's happening

The automated audit's finding was that the main nav dropdown menu has malformed ARIA relationships. These roles aren't in the JSP source — `cms/main-menu.jsp`/`layout-header-standard.jspf` render plain `<ul>`/`<li>`/`<a>` with no `role`/`aria-*` attributes at all. They're injected at runtime by Zurb Foundation 6.8.1's `Nest.Feather` (`javascript/foundation-6.8.1/foundation.js`, vendored, called from `DropdownMenu._init()` and `Drilldown._init()`).

Reading `Nest.Feather` and reproducing it live (real vendored `foundation.js` + real `jquery-3.7.1` + byte-for-byte `main-menu.jsp` output captured from a docker rehearsal, `$(document).foundation()` run for real, checked with axe-core 4.10.2) found the actual defect:

`Nest.Feather` unconditionally does `menu.attr('role', 'menubar')` on the top-level list **and** `$sub.attr({role: 'menubar'})` on every nested submenu `<ul>` it finds — the same role at every level, for both the `dropdown` and `drilldown` plugin types. Per WAI-ARIA's required-owned-elements rules, `role="menubar"` is not an allowed child of `role="menubar"`, so axe-core flags a **critical `aria-required-children` violation** wherever a submenu exists — not just the main nav, but every Foundation dropdown-menu on the page (e.g. the account/admin gear menu).

The `aria-haspopup`/`aria-label`-on-a-`role="none"`-`<li>` part of the issue's description didn't reproduce: `Nest.Feather` places those two attributes on the submenu-parent `<a>`, not on its `<li>` — confirmed against the live rendered DOM. The `<li role="none">` itself carries no attributes that conflict with being presentational.

## Why the fix is a JS patch, not a Foundation option or a markup change

`DropdownMenu._init()`/`Drilldown._init()` call `Nest.Feather(this.$element, 'dropdown'|'drilldown')` with no options plumbed through, and `Nest.Feather` hardcodes `role="menubar"` for every nested `<ul>` regardless of `type` — there's no init option or `data-*` attribute that changes it. Restructuring the JSP markup doesn't help either: as long as a submenu is a nested `<ul>` under an `<li>` in the `[data-dropdown-menu]`/`[data-drilldown]` container (required for Foundation's own show/hide/keyboard logic to find it), `Nest.Feather` will keep re-stamping it `role="menubar"` on every init, regardless of how the surrounding HTML is shaped.

So the fix runs a one-line correction right after `$(document).foundation()`, in the two JSPs that call it (`main.jsp`, `embedded-layout.jsp`):

```js
$('[data-submenu]').attr('role', 'menu');
```

`[data-submenu]` is itself a Foundation-applied marker (`Nest.Feather` sets `data-submenu=""` on the exact same elements it wrongly tags `role="menubar"`), so this targets precisely the nested submenus and nothing else, on every Foundation dropdown-menu/drilldown on the page — global, not scoped to just the main nav.

Confirmed safe: Foundation's own code never reads `role="menubar"`/`role="menu"` for behavior (only `[role="none"]` for menu-item traversal and `[role="tab"]`, unrelated to Tabs) — grepped the whole vendored bundle to check. Confirmed working: after rebuilding and redeploying to a docker rehearsal, the live nav's submenu shows `role="menu"`, the dropdown still opens correctly on hover, and no console errors.

## Testing

- `ant -lib lib/war compile-jsp` — passes
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green
- Live docker rehearsal, before/after, checked with axe-core 4.10.2 against the real vendored `foundation.js` + real JSP-rendered markup:
  - Before: `aria-required-children` (critical) — "Element has children which are not allowed: [role=menubar]" on the outer `<ul role="menubar">`
  - After: violation cleared
  - Confirmed the deployed app (not just the isolated test) actually emits `role="menu"` on its nested submenus post-fix, for both the seeded main-nav submenu and the pre-existing account/admin gear submenu
  - Confirmed hover-to-open still works and no new console errors