### PR TITLE
Add geographic-anomaly alert to the admin dashboard (#569 slice 2)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/SessionRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/SessionRepository.java
@@ -380,6 +380,70 @@ public class SessionRepository {
     return days;
   }
 
+  /**
+   * Top {@code recordLimit} countries by non-bot session count within the given window -- backs the
+   * geographic-anomaly alert (issue #569 slice 2): a country appearing in a short recent window's
+   * top list that was not in a longer baseline window's top list. Sessions with no resolved country
+   * (country IS NULL) are excluded, since they can't be attributed to any country's count.
+   *
+   * <p>Deliberately does NOT filter on is_anonymous, unlike {@link #findDailyUniqueLocations(int)}:
+   * SaveSessionCommand populates country/continent for every session, anonymous or not -- only
+   * city/postal/lat/long are anonymous-restricted. Filtering on is_anonymous here would silently
+   * undercount and could hide a real anomaly made up mostly of anonymous traffic.
+   */
+  public static List<StatisticsData> findTopCountriesByCount(Timestamp startDate, Timestamp endDate, int recordLimit) {
+    SqlUtils where = new SqlUtils()
+        .add("created >= ?", startDate)
+        .add("created < ?", endDate)
+        .add("is_bot = ?", false)
+        .add("country IS NOT NULL");
+    SqlUtils orderBy = new SqlUtils().add("country_count DESC");
+    return DB.selectGroupedFrom(TABLE_NAME, "country", "country_count", where, orderBy, recordLimit);
+  }
+
+  private static final int DEFAULT_GEO_ANOMALY_BASELINE_DAYS = 30;
+  private static final int DEFAULT_GEO_ANOMALY_RECENT_HOURS = 24;
+
+  /** Parses the configured geo-anomaly baseline window (days), defaulting to 30, matching resolveRetentionDays's precedent. */
+  public static int resolveGeoAnomalyBaselineDays(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_GEO_ANOMALY_BASELINE_DAYS;
+    }
+    int days;
+    try {
+      days = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_GEO_ANOMALY_BASELINE_DAYS;
+    }
+    if (days < 1) {
+      return 1;
+    }
+    if (days > 365) {
+      return 365;
+    }
+    return days;
+  }
+
+  /** Parses the configured geo-anomaly recent window (hours), defaulting to 24, capped at one week. */
+  public static int resolveGeoAnomalyRecentHours(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_GEO_ANOMALY_RECENT_HOURS;
+    }
+    int hours;
+    try {
+      hours = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_GEO_ANOMALY_RECENT_HOURS;
+    }
+    if (hours < 1) {
+      return 1;
+    }
+    if (hours > 168) {
+      return 168;
+    }
+    return hours;
+  }
+
   private static Session buildRecord(ResultSet rs) {
     try {
       Session record = new Session();

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidget.java
@@ -52,9 +52,11 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.simisinc.platform.presentation.widgets.dashboard.StatisticCardWidget.valueForColor;
 
@@ -537,6 +539,33 @@ public class SiteStatsWidget extends GenericWidget {
           LoadSitePropertyCommand.loadByName("security.ipRequestRateAlertThreshold"));
       context.getRequest().setAttribute("numberValue", String.valueOf(peakHitsPerIp));
       context.getRequest().setAttribute("severity", peakHitsPerIp > threshold ? "warning" : "ok");
+      return ALERT_CARD_JSP;
+    } else if ("geo-anomaly-alert".equalsIgnoreCase(report)) {
+      // Issue #569 slice 2: a geographic-anomaly signal -- a country appearing in the top 5 by
+      // session count during a short recent window that was NOT in the top 5 during a longer
+      // baseline window immediately preceding it. The baseline is non-overlapping with the recent
+      // window on purpose: if it were the same "last N days including today" window, a real recent
+      // spike would already be counted in its own baseline and could never look anomalous. Windows
+      // are configurable via security.geoAnomalyBaselineDays/security.geoAnomalyRecentHours.
+      int baselineDays = SessionRepository.resolveGeoAnomalyBaselineDays(
+          LoadSitePropertyCommand.loadByName("security.geoAnomalyBaselineDays"));
+      int recentHours = SessionRepository.resolveGeoAnomalyRecentHours(
+          LoadSitePropertyCommand.loadByName("security.geoAnomalyRecentHours"));
+      java.time.Instant nowInstant = java.time.Instant.now();
+      Timestamp recentStart = Timestamp.from(nowInstant.minus(Duration.ofHours(recentHours)));
+      Timestamp baselineStart = Timestamp.from(
+          nowInstant.minus(Duration.ofHours(recentHours)).minus(Duration.ofDays(baselineDays)));
+      List<StatisticsData> recentTopCountries = SessionRepository.findTopCountriesByCount(recentStart, Timestamp.from(nowInstant), 5);
+      List<StatisticsData> baselineTopCountries = SessionRepository.findTopCountriesByCount(baselineStart, recentStart, 5);
+      Set<String> baselineCountryNames = new HashSet<>();
+      for (StatisticsData data : baselineTopCountries) {
+        baselineCountryNames.add(data.getLabel());
+      }
+      long newCountryCount = recentTopCountries.stream()
+          .filter(data -> !baselineCountryNames.contains(data.getLabel()))
+          .count();
+      context.getRequest().setAttribute("numberValue", String.valueOf(newCountryCount));
+      context.getRequest().setAttribute("severity", newCountryCount > 0 ? "warning" : "ok");
       return ALERT_CARD_JSP;
     } else if ("recent-admin-actions".equalsIgnoreCase(report)) {
       context.getRequest().setAttribute("recentActionsList", findRecentAdminActions(5));

--- a/src/main/resources/database/install/NEW_10140__new_security_properties.sql
+++ b/src/main/resources/database/install/NEW_10140__new_security_properties.sql
@@ -13,3 +13,9 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 -- so it surfaces on this same Security Settings page and requires step-up auth to change, like the
 -- rate-limit properties above.
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (30, 'IP Request Rate Alert Threshold (hits/hour)', 'security.ipRequestRateAlertThreshold', '300', 'text');
+
+-- Issue #569 slice 2: configurable windows for the geographic-anomaly dashboard tile (a country
+-- newly appearing in the top 5 by session count). Same "security" prefix / step-up-auth placement
+-- as the properties above.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (40, 'Geo Anomaly Baseline Window (days)', 'security.geoAnomalyBaselineDays', '30', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (41, 'Geo Anomaly Recent Window (hours)', 'security.geoAnomalyRecentHours', '24', 'text');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1900__geo_anomaly_alert_properties.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1900__geo_anomaly_alert_properties.sql
@@ -1,0 +1,11 @@
+-- Issue #569 slice 2: configurable windows for the geographic-anomaly dashboard tile (a country
+-- newly appearing in the top 5 by session count in a short recent window that wasn't in the top 5
+-- during a longer baseline window). Placed under the "security" prefix so it surfaces on the
+-- existing /admin/security-properties settings page and requires step-up auth to change, matching
+-- security.ipRequestRateAlertThreshold's precedent (see UPGRADE_20260802.1005).
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (40, 'Geo Anomaly Baseline Window (days)', 'security.geoAnomalyBaselineDays', '30', 'text')
+ON CONFLICT (property_name) DO NOTHING;
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (41, 'Geo Anomaly Recent Window (hours)', 'security.geoAnomalyRecentHours', '24', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -41,6 +41,14 @@
       </column>
       <column class="small-6 medium-4 large-3 cell">
         <widget name="siteStats">
+          <icon>fa-map-marker-alt</icon>
+          <title>New Countries in Top 5</title>
+          <report>geo-anomaly-alert</report>
+          <link>/admin/community/analytics</link>
+        </widget>
+      </column>
+      <column class="small-6 medium-4 large-3 cell">
+        <widget name="siteStats">
           <icon>fa-exclamation-triangle</icon>
           <title>Failed Logins (24h)</title>
           <report>failed-logins-24h</report>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/SessionRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/SessionRepositoryTest.java
@@ -155,7 +155,11 @@ class SessionRepositoryTest {
     seedSession("Canada", false, false, now);
     seedSession("Mexico", false, false, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+    // Use a comfortably-future upper bound, not a freshly-computed now() -- otherwise this is flaky:
+    // findTopCountriesByCount's upper bound is exclusive (created < endDate), so if a second
+    // System.currentTimeMillis() call happens to land in the same millisecond as the seeded rows'
+    // "now" (or earlier, under scheduling jitter), they'd be excluded by their own query's boundary.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 5);
 
     assertEquals(3, results.size());
     assertEquals("Brazil", results.get(0).getLabel());
@@ -172,7 +176,8 @@ class SessionRepositoryTest {
     seedSession("Brazil", true, false, now);
     seedSession("Canada", false, false, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+    // Use a comfortably-future upper bound -- see findTopCountriesByCountOrdersByDescendingSessionCount for why.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 5);
 
     assertEquals(1, results.size(), "Brazil's bot sessions must not count at all: " + results);
     assertEquals("Canada", results.get(0).getLabel());
@@ -185,7 +190,8 @@ class SessionRepositoryTest {
     seedSession(null, false, false, now);
     seedSession("Canada", false, false, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+    // Use a comfortably-future upper bound -- see findTopCountriesByCountOrdersByDescendingSessionCount for why.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 5);
 
     assertEquals(1, results.size(), "sessions with no resolved country can't be attributed to any country: " + results);
     assertEquals("Canada", results.get(0).getLabel());
@@ -199,7 +205,8 @@ class SessionRepositoryTest {
     Timestamp now = new Timestamp(System.currentTimeMillis());
     seedSession("Brazil", false, true, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+    // Use a comfortably-future upper bound -- see findTopCountriesByCountOrdersByDescendingSessionCount for why.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 5);
 
     assertEquals(1, results.size(), "an anonymous session's country must still count: " + results);
     assertEquals("Brazil", results.get(0).getLabel());
@@ -212,7 +219,8 @@ class SessionRepositoryTest {
     seedSession("Brazil", false, false, twoHoursAgo);
     seedSession("Canada", false, false, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+    // Use a comfortably-future upper bound -- see findTopCountriesByCountOrdersByDescendingSessionCount for why.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 5);
 
     assertEquals(1, results.size(), "the session outside the 1-hour window must not count: " + results);
     assertEquals("Canada", results.get(0).getLabel());
@@ -232,7 +240,8 @@ class SessionRepositoryTest {
     seedSession("Canada", false, false, now);
     seedSession("Mexico", false, false, now);
 
-    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 2);
+    // Use a comfortably-future upper bound -- see findTopCountriesByCountOrdersByDescendingSessionCount for why.
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), future(), 2);
 
     assertEquals(2, results.size());
   }
@@ -243,6 +252,17 @@ class SessionRepositoryTest {
 
   private static Timestamp now() {
     return new Timestamp(System.currentTimeMillis());
+  }
+
+  /**
+   * A query upper bound guaranteed to be strictly after anything seeded with {@code now()} in this
+   * test class, without relying on two separate {@code System.currentTimeMillis()} calls landing in
+   * different milliseconds. findTopCountriesByCount's upper bound is exclusive, so an upper bound
+   * that isn't comfortably ahead of the seeded data is a real source of flakiness, not just a
+   * theoretical one.
+   */
+  private static Timestamp future() {
+    return Timestamp.from(Instant.now().plusSeconds(60));
   }
 
   private static void seedSession(String country, boolean isBot, boolean isAnonymous, Timestamp created) {

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/SessionRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/SessionRepositoryTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.dashboard.StatisticsData;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Tests parsing of the geo-anomaly alert's configurable windows, plus (for
+ * {@link #findTopCountriesByCount}) a real-Postgres integration test -- the geographic-anomaly
+ * dashboard tile added for issue #569 slice 2.
+ *
+ * @author elizabeth houser
+ */
+class SessionRepositoryTest {
+
+  @Test
+  void resolveGeoAnomalyBaselineDaysFallsBackToDefaultWhenBlankOrUnparseable() {
+    assertEquals(30, SessionRepository.resolveGeoAnomalyBaselineDays(null));
+    assertEquals(30, SessionRepository.resolveGeoAnomalyBaselineDays(""));
+    assertEquals(30, SessionRepository.resolveGeoAnomalyBaselineDays("not-a-number"));
+    assertEquals(30, SessionRepository.resolveGeoAnomalyBaselineDays("30; DROP TABLE sessions"));
+  }
+
+  @Test
+  void resolveGeoAnomalyBaselineDaysUsesConfiguredValueAndBounds() {
+    assertEquals(90, SessionRepository.resolveGeoAnomalyBaselineDays("90"));
+    assertEquals(1, SessionRepository.resolveGeoAnomalyBaselineDays("0"));
+    assertEquals(1, SessionRepository.resolveGeoAnomalyBaselineDays("-5"));
+    assertEquals(365, SessionRepository.resolveGeoAnomalyBaselineDays("999999"));
+  }
+
+  @Test
+  void resolveGeoAnomalyRecentHoursFallsBackToDefaultWhenBlankOrUnparseable() {
+    assertEquals(24, SessionRepository.resolveGeoAnomalyRecentHours(null));
+    assertEquals(24, SessionRepository.resolveGeoAnomalyRecentHours(""));
+    assertEquals(24, SessionRepository.resolveGeoAnomalyRecentHours("not-a-number"));
+  }
+
+  @Test
+  void resolveGeoAnomalyRecentHoursUsesConfiguredValueAndBounds() {
+    assertEquals(6, SessionRepository.resolveGeoAnomalyRecentHours("6"));
+    assertEquals(1, SessionRepository.resolveGeoAnomalyRecentHours("0"));
+    assertEquals(168, SessionRepository.resolveGeoAnomalyRecentHours("999999"));
+  }
+
+  // --- findTopCountriesByCount() integration coverage (issue #569 slice 2) ---
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping SessionRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE sessions RESTART IDENTITY");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset sessions table", se);
+    }
+  }
+
+  @Test
+  void findTopCountriesByCountOrdersByDescendingSessionCount() {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession("Brazil", false, false, now);
+    seedSession("Brazil", false, false, now);
+    seedSession("Brazil", false, false, now);
+    seedSession("Canada", false, false, now);
+    seedSession("Canada", false, false, now);
+    seedSession("Mexico", false, false, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertEquals(3, results.size());
+    assertEquals("Brazil", results.get(0).getLabel());
+    assertEquals("3", results.get(0).getValue());
+    assertEquals("Canada", results.get(1).getLabel());
+    assertEquals("Mexico", results.get(2).getLabel());
+  }
+
+  @Test
+  void findTopCountriesByCountExcludesBotSessions() {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession("Brazil", true, false, now);
+    seedSession("Brazil", true, false, now);
+    seedSession("Brazil", true, false, now);
+    seedSession("Canada", false, false, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertEquals(1, results.size(), "Brazil's bot sessions must not count at all: " + results);
+    assertEquals("Canada", results.get(0).getLabel());
+  }
+
+  @Test
+  void findTopCountriesByCountExcludesSessionsWithNoResolvedCountry() {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession(null, false, false, now);
+    seedSession(null, false, false, now);
+    seedSession("Canada", false, false, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertEquals(1, results.size(), "sessions with no resolved country can't be attributed to any country: " + results);
+    assertEquals("Canada", results.get(0).getLabel());
+  }
+
+  @Test
+  void findTopCountriesByCountIncludesAnonymousSessions() {
+    // GeoIPCommand/SaveSessionCommand populate country for every session, anonymous or not --
+    // only city/postal/lat/long are anonymous-restricted. Filtering on is_anonymous here would
+    // silently undercount and could hide a real anomaly made up mostly of anonymous traffic.
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession("Brazil", false, true, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertEquals(1, results.size(), "an anonymous session's country must still count: " + results);
+    assertEquals("Brazil", results.get(0).getLabel());
+  }
+
+  @Test
+  void findTopCountriesByCountExcludesSessionsOutsideTheWindow() {
+    Timestamp twoHoursAgo = Timestamp.from(Instant.now().minus(Duration.ofHours(2)));
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession("Brazil", false, false, twoHoursAgo);
+    seedSession("Canada", false, false, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertEquals(1, results.size(), "the session outside the 1-hour window must not count: " + results);
+    assertEquals("Canada", results.get(0).getLabel());
+  }
+
+  @Test
+  void findTopCountriesByCountReturnsEmptyListWhenThereIsNoData() {
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 5);
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void findTopCountriesByCountRespectsTheRecordLimit() {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    seedSession("Brazil", false, false, now);
+    seedSession("Canada", false, false, now);
+    seedSession("Mexico", false, false, now);
+
+    List<StatisticsData> results = SessionRepository.findTopCountriesByCount(hoursAgo(1), now(), 2);
+
+    assertEquals(2, results.size());
+  }
+
+  private static Timestamp hoursAgo(int hours) {
+    return Timestamp.from(Instant.now().minus(Duration.ofHours(hours)));
+  }
+
+  private static Timestamp now() {
+    return new Timestamp(System.currentTimeMillis());
+  }
+
+  private static void seedSession(String country, boolean isBot, boolean isAnonymous, Timestamp created) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      String countryValue = country == null ? "NULL" : "'" + country + "'";
+      statement.execute("INSERT INTO sessions (country, is_bot, is_anonymous, created) VALUES ("
+          + countryValue + ", " + isBot + ", " + isAnonymous + ", '" + created + "')");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not seed session", se);
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real sessions schema -- enough for findTopCountriesByCount's
+    // window/bot/country filtering. FK constraints to unrelated tables are omitted.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS sessions CASCADE");
+      statement.execute("CREATE TABLE sessions ("
+          + "id BIGSERIAL PRIMARY KEY, "
+          + "session_id VARCHAR(255), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "country VARCHAR(100), "
+          + "is_bot BOOLEAN DEFAULT false, "
+          + "is_anonymous BOOLEAN NOT NULL DEFAULT false)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the sessions schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SiteStatsWidgetTest.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.presentation.widgets.admin;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.List;
 
 import com.simisinc.platform.WidgetBase;
@@ -26,6 +27,7 @@ import com.simisinc.platform.infrastructure.persistence.SessionRepository;
 import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
 import java.sql.Timestamp;
@@ -850,6 +852,92 @@ class SiteStatsWidgetTest extends WidgetBase {
 
     Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
     Assertions.assertEquals("450", request.getAttribute("numberValue"));
+    Assertions.assertEquals("warning", request.getAttribute("severity"));
+  }
+
+  /** The recent window's startDate is always much closer to "now" than the baseline window's. */
+  private static boolean isRecentWindowStart(Timestamp startDate) {
+    return startDate.after(new Timestamp(System.currentTimeMillis() - Duration.ofDays(2).toMillis()));
+  }
+
+  @Test
+  void executeGeoAnomalyAlertIsOkWhenNoNewCountryAppears() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>New Countries in Top 5</title>\n" +
+            "  <report>geo-anomaly-alert</report>\n" +
+            "</widget>");
+
+    StatisticsData canada = new StatisticsData();
+    canada.setLabel("Canada");
+    canada.setValue("10");
+    StatisticsData mexico = new StatisticsData();
+    mexico.setLabel("Mexico");
+    mexico.setValue("5");
+
+    try (MockedStatic<SessionRepository> sessionRepository = mockStatic(SessionRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.geoAnomalyBaselineDays")).thenReturn("30");
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.geoAnomalyRecentHours")).thenReturn("24");
+      sessionRepository.when(() -> SessionRepository.resolveGeoAnomalyBaselineDays("30")).thenReturn(30);
+      sessionRepository.when(() -> SessionRepository.resolveGeoAnomalyRecentHours("24")).thenReturn(24);
+      // The recent window's top 5 (Canada) is a subset of the baseline's (Canada, Mexico) -- no new country.
+      sessionRepository.when(() -> SessionRepository.findTopCountriesByCount(
+          argThat(SiteStatsWidgetTest::isRecentWindowStart), any(Timestamp.class), eq(5)))
+          .thenReturn(List.of(canada));
+      sessionRepository.when(() -> SessionRepository.findTopCountriesByCount(
+          argThat(startDate -> !isRecentWindowStart(startDate)), any(Timestamp.class), eq(5)))
+          .thenReturn(List.of(canada, mexico));
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("0", request.getAttribute("numberValue"));
+    Assertions.assertEquals("ok", request.getAttribute("severity"));
+  }
+
+  @Test
+  void executeGeoAnomalyAlertIsWarningWhenANewCountryAppearsInTheTop5() {
+    addPreferencesFromWidgetXml(widgetContext,
+        "<widget name=\"siteStats\" class=\"stats card\">\n" +
+            "  <title>New Countries in Top 5</title>\n" +
+            "  <report>geo-anomaly-alert</report>\n" +
+            "</widget>");
+
+    StatisticsData canada = new StatisticsData();
+    canada.setLabel("Canada");
+    canada.setValue("10");
+    StatisticsData newCountry = new StatisticsData();
+    newCountry.setLabel("Elbonia");
+    newCountry.setValue("8");
+    StatisticsData mexico = new StatisticsData();
+    mexico.setLabel("Mexico");
+    mexico.setValue("5");
+
+    try (MockedStatic<SessionRepository> sessionRepository = mockStatic(SessionRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.geoAnomalyBaselineDays")).thenReturn("30");
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.geoAnomalyRecentHours")).thenReturn("24");
+      sessionRepository.when(() -> SessionRepository.resolveGeoAnomalyBaselineDays("30")).thenReturn(30);
+      sessionRepository.when(() -> SessionRepository.resolveGeoAnomalyRecentHours("24")).thenReturn(24);
+      // Elbonia is in the recent top 5 but never appeared in the baseline top 5 -- one new country.
+      sessionRepository.when(() -> SessionRepository.findTopCountriesByCount(
+          argThat(SiteStatsWidgetTest::isRecentWindowStart), any(Timestamp.class), eq(5)))
+          .thenReturn(List.of(canada, newCountry));
+      sessionRepository.when(() -> SessionRepository.findTopCountriesByCount(
+          argThat(startDate -> !isRecentWindowStart(startDate)), any(Timestamp.class), eq(5)))
+          .thenReturn(List.of(canada, mexico));
+
+      setRoles(widgetContext, ADMIN);
+      SiteStatsWidget widget = new SiteStatsWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(SiteStatsWidget.ALERT_CARD_JSP, widgetContext.getJsp());
+    Assertions.assertEquals("1", request.getAttribute("numberValue"));
     Assertions.assertEquals("warning", request.getAttribute("severity"));
   }
 


### PR DESCRIPTION
Follow-on to #569 slice 1 (#891).

## Problem

Issue #569 asks for traffic-quality/anomaly detection across several signal types. It was deliberately scoped slice-by-slice rather than built all at once (see the issue's own comments). Slice 1 shipped the alert-delivery mechanism itself, demonstrated with a request-rate-per-IP spike signal. This PR adds slice 2: a geographic anomaly signal, the next-most-buildable item per the issue's own investigation notes ("GeoIP is fully built... nothing currently alerts on a geographic distribution shift").

## What counts as an anomaly

A country appears in the top 5 (by non-bot session count) during a short recent window, but was **not** in the top 5 during a longer baseline window immediately preceding it. The two windows are non-overlapping on purpose — a baseline that included "today" would already contain any real spike and could never look anomalous against itself.

Both windows are configurable: `security.geoAnomalyBaselineDays` (default 30) and `security.geoAnomalyRecentHours` (default 24) — same `security.` prefix and step-up-auth gate as the existing rate-limit and IP-alert properties, so they surface automatically on the existing Security Settings page with no new admin UI.

## Implementation

Reuses the alert-card mechanism from slice 1 rather than building anything new:
- `SessionRepository.findTopCountriesByCount(startDate, endDate, limit)` — a `DB.selectGroupedFrom`-based top-N query, excluding bot sessions. Deliberately does **not** filter on `is_anonymous`: `SaveSessionCommand` populates `country`/`continent` for every session regardless of anonymity (only city/postal/lat/long are anonymous-restricted), so filtering on it here would silently undercount.
- `SessionRepository.resolveGeoAnomalyBaselineDays`/`resolveGeoAnomalyRecentHours` — bounds-checked property resolvers, mirroring `resolveIpRequestRateAlertThreshold`'s precedent.
- A new `geo-anomaly-alert` report branch in `SiteStatsWidget`, diffing the two country lists and reporting the count of newly-appearing countries as the tile's number (0 = "ok", severity "warning" if the count is over 0) — the alert-card JSP requires a numeric value, so the tile shows a count rather than country names; clicking through (`/admin/community/analytics`) shows the actual breakdown.
- A new dashboard tile in `admin-layout.xml`, placed next to the existing "Peak Requests / IP" tile.

## Testing

- `ant -lib lib/war compile-jsp` — passes
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green
- New `SessionRepositoryTest` (Testcontainers, real Postgres): ordering, bot exclusion, NULL-country exclusion, anonymous-sessions-still-count, window-boundary exclusion, empty-data, record-limit, plus the resolver bounds-checks
- Extended `SiteStatsWidgetTest` with both severity branches
- Live docker rehearsal: seeded real session rows across both windows and confirmed the rendered tile end-to-end —
  - Baseline {Canada, Mexico}, recent {Canada, Elbonia} → tile shows **1**, warning styling
  - Baseline/recent both {Canada} only → tile shows **0**, no warning styling
  - Also confirmed both new site properties appear correctly on `/admin/security-properties` with their default values
