### PR TITLE
Close governed-review bypass in legacy web page editors

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidget.java
@@ -108,10 +108,19 @@ public class WebPageFormWidget extends GenericWidget {
     // here, before BeanUtils.populate() below walks the entire raw parameter map: without this, a
     // crafted POST (e.g. approvedBy=<any user id>) would bypass separation-of-duties and step-up
     // re-authentication entirely, the same class of mass-assignment gap fixed for #492/#730.
+    //
+    // pageXml/draftPageXml (#957) are captured and restored the same way, for the same reason: this
+    // form has no content field of its own (web-page-form.jsp is metadata only -- title, keywords,
+    // sitemap settings, publish/expire dates), but BeanUtils.populate() walks the *raw* HTTP parameter
+    // map rather than the JSP's actual field set, so a crafted "pageXml" POST parameter would otherwise
+    // write straight to the live page through this widget's unconditional SaveWebPageCommand.saveWebPage()
+    // call below -- the exact bypass #957 closes in WebPageDesignerWidget, reachable here too.
     String existingDraftStatus = webPageBean.getDraftStatus();
     long existingSubmittedBy = webPageBean.getSubmittedBy();
     long existingApprovedBy = webPageBean.getApprovedBy();
     String existingReleaseReference = webPageBean.getReleaseReference();
+    String existingPageXml = webPageBean.getPageXml();
+    String existingDraftPageXml = webPageBean.getDraftPageXml();
 
     // Populate the form fields
     BeanUtils.populate(webPageBean, context.getParameterMap());
@@ -121,6 +130,8 @@ public class WebPageFormWidget extends GenericWidget {
     webPageBean.setSubmittedBy(existingSubmittedBy);
     webPageBean.setApprovedBy(existingApprovedBy);
     webPageBean.setReleaseReference(existingReleaseReference);
+    webPageBean.setPageXml(existingPageXml);
+    webPageBean.setDraftPageXml(existingDraftPageXml);
 
     // Handle publish/draft choice
     String publish = context.getParameter("publish");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidget.java
@@ -18,6 +18,8 @@ package com.simisinc.platform.presentation.widgets.cms;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.FeatureFlagCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.MakeContentUniqueIdCommand;
 import com.simisinc.platform.application.cms.SaveWebPageCommand;
 import com.simisinc.platform.application.cms.UrlCommand;
@@ -101,7 +103,13 @@ public class WebPageDesignerWidget extends GenericWidget {
       // Determine the reason...
       webPage = (WebPage) context.getRequestObject();
       context.getRequest().setAttribute("webPage", webPage);
-      if (webPage.getPageXml().contains("editor=\"designer\"") && FeatureFlagCommand.isEnabled(LAYOUT_EDITOR_FLAG)) {
+      // #957: post() left the just-submitted content in whichever field the governed-review gate
+      // routed it to -- pageXml when it published directly, draftPageXml when review diverted it.
+      // Reading getPageXml() unconditionally here would NPE for a brand-new page saved entirely as a
+      // draft (pageXml is still null), and would redisplay stale live content instead of the draft
+      // the user just typed and needs to correct, once a page does have prior live content.
+      String content = effectiveContent(webPage, mayPublishDirectly());
+      if (content != null && content.contains("editor=\"designer\"") && FeatureFlagCommand.isEnabled(LAYOUT_EDITOR_FLAG)) {
         // An editor was specified, so use it
         context.setJsp(DESIGNER_JSP);
       } else {
@@ -128,12 +136,20 @@ public class WebPageDesignerWidget extends GenericWidget {
       webPage.setLink(webPageLinkValue);
     }
     // Show some templates
-    if (StringUtils.isBlank(webPage.getPageXml())) {
+    // #957: "is this page blank" must check BOTH fields, not just whichever one a save would write
+    // to -- an existing live page (pageXml set, no pending draftPageXml) is not blank just because
+    // governed review means a save right now would target draftPageXml. Checking only that field
+    // would show the template picker for an existing page instead of the raw XML editor with its
+    // real content. A brand-new page whose only content is a just-redisplayed gated draft (pageXml
+    // still null, draftPageXml set) is correctly NOT blank here either, so it isn't clobbered by the
+    // generic default scaffold below.
+    boolean mayPublishDirectly = mayPublishDirectly();
+    if (StringUtils.isBlank(webPage.getPageXml()) && StringUtils.isBlank(webPage.getDraftPageXml())) {
 
       if (useDesigner) {
         // @todo use WebPageDesignerCommand.convertFromPageLayoutToBootstrap();
         // Default to a single column template
-        webPage.setPageXml("<page>\n" +
+        applyNewPageContent(webPage, "<page>\n" +
             "  <section>\n" +
             "    <column class=\"small-12 cell\">\n" +
             "      <widget name=\"content\">\n" +
@@ -141,7 +157,7 @@ public class WebPageDesignerWidget extends GenericWidget {
             "      </widget>\n" +
             "    </column>\n" +
             "  </section>\n" +
-            "</page>");
+            "</page>", mayPublishDirectly);
         // Which will be... MakeContentUniqueIdCommand.getId(webPageLinkValue.substring(1)) + "-hello
         // <div class="row">
         //    <div class="column col-sm-12" data-unique-id="">
@@ -190,6 +206,43 @@ public class WebPageDesignerWidget extends GenericWidget {
     return context;
   }
 
+  /**
+   * Whether a save from this widget may write straight to the live {@code pageXml} column right now
+   * (#957): the same {@code webPage.review.required} gate {@code PageServlet}'s {@code publishDraft}
+   * action enforces for the P4 layout builder.
+   */
+  private static boolean mayPublishDirectly() {
+    boolean webPageReviewRequired = LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required");
+    return ContentReviewCommand.mayPublishDirectly(webPageReviewRequired);
+  }
+
+  /**
+   * Applies newly-authored page content to the correct field per the governed publish gate (#957):
+   * straight to the live {@code pageXml} when direct publishing is allowed, or into
+   * {@code draftPageXml} (leaving whatever is currently live untouched) when it is not. A null
+   * {@code newContent} clears whichever field it would have landed in.
+   */
+  private static void applyNewPageContent(WebPage webPage, String newContent, boolean mayPublishDirectly) {
+    if (mayPublishDirectly) {
+      webPage.setPageXml(newContent);
+    } else {
+      webPage.setDraftPageXml(newContent);
+    }
+  }
+
+  /**
+   * The page content this widget is currently authoritative over, per the same gate (#957): the live
+   * {@code pageXml} when direct publishing is allowed, or the pending {@code draftPageXml} when
+   * governed review diverted new content there. Used everywhere this widget needs to inspect or
+   * redisplay "what the user is looking at" -- both the fresh save in {@code post()} and a
+   * previously-rejected save redisplayed by {@code execute()} -- so a rejected draft's own content
+   * (not stale live content, and not a null pageXml on a brand-new page) is what gets validated,
+   * checked for the designer-canvas marker, and shown back to the user.
+   */
+  private static String effectiveContent(WebPage webPage, boolean mayPublishDirectly) {
+    return mayPublishDirectly ? webPage.getPageXml() : webPage.getDraftPageXml();
+  }
+
   private static synchronized String loadWidgetSchemaJson(ServletContext servletContext) {
     if (widgetSchemaJson == null) {
       try (InputStream is = servletContext.getResourceAsStream(WIDGET_SCHEMA_RESOURCE)) {
@@ -225,6 +278,15 @@ public class WebPageDesignerWidget extends GenericWidget {
     webPage.setCreatedBy(context.getUserId());
     webPage.setModifiedBy(context.getUserId());
 
+    // Governed publish workflow (#957): this legacy editor writes page content directly, with none
+    // of the draftPageXml/submit/approve machinery the P4 layout builder (PageServlet) uses. When
+    // webPage.review.required is on, it must not be a way to skip review -- so new content is routed
+    // into draftPageXml (leaving whatever is already live untouched) instead of straight to pageXml,
+    // exactly as ContentReviewCommand.mayPublishDirectly() already governs for Content and blog
+    // posts. When review is not required this is a no-op and behavior is unchanged.
+    boolean webPageReviewRequired = LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required");
+    boolean mayPublishDirectly = ContentReviewCommand.mayPublishDirectly(webPageReviewRequired);
+
     // Determine the source of the page content
     // Database Template
     String templateIdValue = context.getRequest().getParameter("templateId");
@@ -257,7 +319,7 @@ public class WebPageDesignerWidget extends GenericWidget {
         webPageName = "home";
       }
       template = StringUtils.replace(template, "${webPageName}", webPageName);
-      webPage.setPageXml(template);
+      applyNewPageContent(webPage, template, mayPublishDirectly);
       webPage.setTemplate(webPageTemplate.getName());
     } else if (pageDesignHtml != null) {
       // Page designer
@@ -268,8 +330,12 @@ public class WebPageDesignerWidget extends GenericWidget {
       try {
         String pageXml = WebPageDesignerToXmlCommand.convertFromBootstrapHtml(webPage, pageDesignHtml);
         LOG.debug("Converted to: " + pageXml);
-        webPage.setPageXml(pageXml);
-        SaveWebPageCommand.saveWebPage(webPage);
+        applyNewPageContent(webPage, pageXml, mayPublishDirectly);
+        if (mayPublishDirectly) {
+          SaveWebPageCommand.saveWebPage(webPage);
+        } else {
+          WebPageRepository.save(webPage);
+        }
         context.setJson("[{\"status\":\"0\"}]");
       } catch (Exception e) {
         context.setJson("[{\"message\":\"The web page could not be saved: " + e.getMessage() + "\"}]");
@@ -279,17 +345,22 @@ public class WebPageDesignerWidget extends GenericWidget {
       // Check for raw content
       if (StringUtils.isEmpty(pageXmlValue)) {
         // Content is being removed
-        webPage.setPageXml(null);
+        applyNewPageContent(webPage, null, mayPublishDirectly);
       } else {
         // Content is being updated
         String webPageName = MakeContentUniqueIdCommand.parseToValidValue(contentUniqueIdValue);
         pageXmlValue = StringUtils.replace(pageXmlValue, "${webPageName}", webPageName);
-        webPage.setPageXml(pageXmlValue);
+        applyNewPageContent(webPage, pageXmlValue, mayPublishDirectly);
       }
     }
 
+    // The new content just applied above -- in pageXml when it can go live directly, or in
+    // draftPageXml when governed review diverted it there. Validation and the designer-canvas
+    // redirect check must look at wherever it actually landed.
+    String newPageContent = mayPublishDirectly ? webPage.getPageXml() : webPage.getDraftPageXml();
+
     // Validate the XML before saving and alert the user
-    if (!StringUtils.isEmpty(webPage.getPageXml())) {
+    if (!StringUtils.isEmpty(newPageContent)) {
       try {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
@@ -298,7 +369,7 @@ public class WebPageDesignerWidget extends GenericWidget {
 
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = null;
-        try (InputStream is = IOUtils.toInputStream(webPage.getPageXml(), "UTF-8")) {
+        try (InputStream is = IOUtils.toInputStream(newPageContent, "UTF-8")) {
           document = builder.parse(is);
         }
         NodeList pageTags = document.getElementsByTagName("page");
@@ -318,7 +389,7 @@ public class WebPageDesignerWidget extends GenericWidget {
       // which case fall through to the normal save below instead of bouncing to the canvas -- the
       // editor="designer" text in the XML is preserved verbatim either way, this only decides
       // whether the redirect opens the canvas or the page just saves and returns normally.
-      if (webPage.getPageXml().contains("editor=\"designer\"") && FeatureFlagCommand.isEnabled(LAYOUT_EDITOR_FLAG)) {
+      if (newPageContent.contains("editor=\"designer\"") && FeatureFlagCommand.isEnabled(LAYOUT_EDITOR_FLAG)) {
         context.setRequestObject(webPage);
         context.setRedirect("/admin/web-page-designer?editor=designer&webPage=" + webPage.getLink());
         return context;
@@ -328,7 +399,11 @@ public class WebPageDesignerWidget extends GenericWidget {
     // Save the page
     webPage.setSearchable(true);
     try {
-      webPage = SaveWebPageCommand.saveWebPage(webPage);
+      if (mayPublishDirectly) {
+        webPage = SaveWebPageCommand.saveWebPage(webPage);
+      } else {
+        webPage = WebPageRepository.save(webPage);
+      }
     } catch (DataException de) {
       LOG.warn("Web page record was not saved!");
       context.setErrorMessage("An error occurred");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/WebPageFormWidgetTest.java
@@ -152,4 +152,48 @@ class WebPageFormWidgetTest extends WidgetBase {
               && bean.getReleaseReference() == null)));
     }
   }
+
+  /**
+   * Issue #957: this widget has no content field of its own (web-page-form.jsp is metadata only --
+   * title, keywords, sitemap settings, publish/expire dates), but BeanUtils.populate() walks the
+   * *raw* HTTP parameter map, not the JSP's actual field set. Without capturing/restoring
+   * pageXml/draftPageXml the same way the four governed-workflow fields above are guarded, a crafted
+   * "pageXml" POST parameter would write straight to the live page through this widget's
+   * unconditional SaveWebPageCommand.saveWebPage() call -- the same review bypass #957 closes in
+   * WebPageDesignerWidget, reachable here too since this widget never even checks
+   * webPage.review.required. This proves the guard: a save that tries to inject new content for both
+   * fields leaves an existing page's real content completely untouched.
+   */
+  @Test
+  void postCannotInjectPageContentViaFormSave() throws Exception {
+    setRoles(widgetContext, ADMIN);
+
+    WebPage existing = new WebPage();
+    existing.setId(7L);
+    existing.setLink("/about");
+    existing.setTitle("About Us");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+    existing.setDraftPageXml(null);
+
+    addQueryParameter(widgetContext, "id", "7");
+    addQueryParameter(widgetContext, "link", "/about");
+    addQueryParameter(widgetContext, "title", "About Us");
+    // The attack: forge the content fields directly, bypassing WebPageDesignerWidget entirely.
+    addQueryParameter(widgetContext, "pageXml", "<page><section><column><widget name=\"content\"><uniqueId>injected</uniqueId></widget></column></section></page>");
+    addQueryParameter(widgetContext, "draftPageXml", "<page><section><column><widget name=\"content\"><uniqueId>injected-draft</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findById(7L)).thenReturn(existing);
+      saveCommand.when(() -> SaveWebPageCommand.saveWebPage(any(WebPage.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      new WebPageFormWidget().post(widgetContext);
+
+      saveCommand.verify(() -> SaveWebPageCommand.saveWebPage(argThat(bean ->
+          bean.getPageXml().contains("reviewed-and-live")
+              && bean.getDraftPageXml() == null)));
+    }
+  }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/WebPageDesignerWidgetTest.java
@@ -29,6 +29,7 @@ import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.controller.XMLWebPageTemplateLoader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
@@ -52,7 +53,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "webPage", "web-page");
 
     // Shows the editor
-    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class)) {
+    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepositoryMockedStatic.when(() -> WebPageRepository.findByLink("web-page")).thenReturn(null);
 
       List<WebPageTemplate> webPageTemplateList = new ArrayList<>();
@@ -102,10 +104,12 @@ class WebPageDesignerWidgetTest extends WidgetBase {
     widgetContext.setRequestObject(webPage);
 
     // Show a form Error
-    WebPageDesignerWidget widget = new WebPageDesignerWidget();
-    widget.execute(widgetContext);
-    Assertions.assertEquals(WebPageDesignerWidget.ACE_XML_EDITOR_JSP, widgetContext.getJsp());
-    Assertions.assertNotNull(request.getAttribute("webPage"));
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.execute(widgetContext);
+      Assertions.assertEquals(WebPageDesignerWidget.ACE_XML_EDITOR_JSP, widgetContext.getJsp());
+      Assertions.assertNotNull(request.getAttribute("webPage"));
+    }
   }
 
   @Test
@@ -118,7 +122,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "pageXmlValue", "<page><section><column><widget name=\"content\" /></column></section></page>");
 
     // Execute the widget
-    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class)) {
+    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepositoryMockedStatic.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
 
       try (MockedStatic<SaveWebPageCommand> saveWebPageCommandMockedStatic = mockStatic(SaveWebPageCommand.class)) {
@@ -147,7 +152,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "pageXmlValue", "<page><section><column><widget name=\"content\" /></column></section></page>");
 
     // Execute the widget
-    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class)) {
+    try (MockedStatic<WebPageRepository> webPageRepositoryMockedStatic = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepositoryMockedStatic.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
 
       try (MockedStatic<SaveWebPageCommand> saveWebPageCommandMockedStatic = mockStatic(SaveWebPageCommand.class)) {
@@ -188,7 +194,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
 
     try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
         MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
-        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class)) {
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepository.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
       saveWebPageCommand.when(() -> SaveWebPageCommand.saveWebPage(any())).thenReturn(new WebPage());
       widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
@@ -213,7 +220,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
 
     try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
         MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
-        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class)) {
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepository.when(() -> WebPageRepository.findByLink("/web-page")).thenReturn(null);
       widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
 
@@ -331,10 +339,8 @@ class WebPageDesignerWidgetTest extends WidgetBase {
     existing.setPageXml("<page editor=\"designer\"><section><column class=\"small-12 cell\">"
         + "<widget name=\"content\"><uniqueId>hello</uniqueId></widget></column></section></page>");
 
-    // Deliberately not mocking LoadSitePropertyCommand -- this path never consults the flag at all
-    // (no "editor" param means the designer branch short-circuits before any flag lookup), so this
-    // also proves that by construction rather than by stubbing a particular return value.
-    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class)) {
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       webPageRepository.when(() -> WebPageRepository.findByLink("/existing-designer-page")).thenReturn(existing);
 
       WebPageDesignerWidget widget = new WebPageDesignerWidget();
@@ -393,6 +399,341 @@ class WebPageDesignerWidgetTest extends WidgetBase {
 
       Assertions.assertNotNull(result);
       Assertions.assertEquals("/admin/web-page-designer?editor=designer&webPage=/new-designer-page", widgetContext.getRedirect());
+    }
+  }
+
+  // Issue #957: this legacy editor writes page content directly via SaveWebPageCommand, with none of
+  // the draftPageXml/submit/approve machinery the P4 layout builder (PageServlet) goes through --
+  // completely bypassing governed review. These prove that when webPage.review.required is on, new
+  // content lands in draftPageXml (leaving whatever is already live untouched) instead of publishing
+  // straight to pageXml, and that legacy behavior is unchanged when review is not required.
+
+  @Test
+  void postRawXmlSaveRoutesToDraftPageXmlWhenReviewIsRequiredInsteadOfPublishingDirectly() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "returnPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "pageXml",
+        "<page><section><column><widget name=\"content\"><uniqueId>injected</uniqueId></widget></column></section></page>");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+      webPageRepository.when(() -> WebPageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      WidgetContext result = widget.post(widgetContext);
+
+      Assertions.assertNotNull(result);
+      Assertions.assertNull(widgetContext.getErrorMessage());
+      Assertions.assertNull(widgetContext.getWarningMessage());
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      webPageRepository.verify(() -> WebPageRepository.save(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("reviewed-and-live"),
+          "the live page content must not change until the new content is reviewed and approved");
+      Assertions.assertTrue(saved.getValue().getDraftPageXml().contains("injected"),
+          "the new content must land in draftPageXml pending review");
+
+      // The single save chokepoint that would publish straight to live must never be reached
+      saveWebPageCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postRawXmlSavePublishesDirectlyWhenReviewIsNotRequired() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "returnPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "pageXml",
+        "<page><section><column><widget name=\"content\"><uniqueId>new-content</uniqueId></widget></column></section></page>");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>old-content</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(false);
+      saveWebPageCommand.when(() -> SaveWebPageCommand.saveWebPage(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      WidgetContext result = widget.post(widgetContext);
+
+      Assertions.assertNotNull(result);
+      Assertions.assertNull(widgetContext.getErrorMessage());
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      saveWebPageCommand.verify(() -> SaveWebPageCommand.saveWebPage(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("new-content"),
+          "legacy behavior: publishes straight to live when review is not required");
+
+      webPageRepository.verify(() -> WebPageRepository.save(any()), org.mockito.Mockito.never());
+    }
+  }
+
+  @Test
+  void postDesignerCanvasSaveRoutesToDraftPageXmlWhenReviewIsRequired() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "content",
+        "<div class=\"row\"><div class=\"column col-sm-12 col-md-12 col-xs-12\">"
+            + "<!--gm-editable-region--><h3 data-widget=\"map\">Map</h3><p>Write a description</p><!--/gm-editable-region-->"
+            + "</div></div>");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+      widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
+      webPageRepository.when(() -> WebPageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      Assertions.assertEquals("[{\"status\":\"0\"}]", widgetContext.getJson());
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      webPageRepository.verify(() -> WebPageRepository.save(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("reviewed-and-live"),
+          "the live page content must not change until the new content is reviewed and approved");
+      Assertions.assertNotNull(saved.getValue().getDraftPageXml(),
+          "the designer-canvas save must land in draftPageXml pending review");
+      saveWebPageCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postDesignerCanvasSavePublishesDirectlyToPageXmlWhenReviewIsNotRequired() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "content",
+        "<div class=\"row\"><div class=\"column col-sm-12 col-md-12 col-xs-12\">"
+            + "<!--gm-editable-region--><h3 data-widget=\"map\">Map</h3><p>Write a description</p><!--/gm-editable-region-->"
+            + "</div></div>");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>old-content</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<WebPageXmlLayoutCommand> widgetLibrary = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(false);
+      widgetLibrary.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(REGISTERED_WIDGETS);
+      saveWebPageCommand.when(() -> SaveWebPageCommand.saveWebPage(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      Assertions.assertEquals("[{\"status\":\"0\"}]", widgetContext.getJson());
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      saveWebPageCommand.verify(() -> SaveWebPageCommand.saveWebPage(saved.capture()));
+      Assertions.assertFalse(saved.getValue().getPageXml().contains("old-content"),
+          "legacy behavior: the designer-canvas save publishes straight to pageXml when review is not required");
+      Assertions.assertNull(saved.getValue().getDraftPageXml());
+      webPageRepository.verify(() -> WebPageRepository.save(any()), org.mockito.Mockito.never());
+    }
+  }
+
+  @Test
+  void postRemovingContentRoutesToDraftPageXmlWhenReviewIsRequiredLeavingLivePageUntouched() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "returnPage", "/existing-live-page");
+    // No "pageXml" parameter at all -- the widget's own "content is being removed" branch.
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+    existing.setDraftPageXml("<page><section><column><widget name=\"content\"><uniqueId>stale-pending-draft</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+      webPageRepository.when(() -> WebPageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      webPageRepository.verify(() -> WebPageRepository.save(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("reviewed-and-live"),
+          "removing draft content must never touch the live page");
+      Assertions.assertNull(saved.getValue().getDraftPageXml(),
+          "the pending draft is cleared, not silently republished");
+      saveWebPageCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postDatabaseTemplateRoutesToDraftPageXmlWhenReviewIsRequired() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "returnPage", "/existing-live-page");
+    // templateId is read via context.getRequest().getParameter(...), not context.getParameter(...) --
+    // the test harness's mock backs the former with setAttribute(), not the query-parameter map.
+    request.setAttribute("templateId", "5");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+
+    WebPageTemplate dbTemplate = new WebPageTemplate();
+    dbTemplate.setId(5L);
+    dbTemplate.setName("From The Database");
+    dbTemplate.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>${webPageName}-from-template</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<WebPageTemplateRepository> templateRepository = mockStatic(WebPageTemplateRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      templateRepository.when(() -> WebPageTemplateRepository.findById(5L)).thenReturn(dbTemplate);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+      webPageRepository.when(() -> WebPageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      webPageRepository.verify(() -> WebPageRepository.save(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("reviewed-and-live"),
+          "picking a template for an existing page must not change what's live until reviewed");
+      Assertions.assertTrue(saved.getValue().getDraftPageXml().contains("from-template"),
+          "the selected template's content must land in draftPageXml pending review");
+      saveWebPageCommand.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void postDatabaseTemplatePublishesDirectlyWhenReviewIsNotRequired() {
+    addQueryParameter(widgetContext, "widget", widgetContext.getUniqueId());
+    addQueryParameter(widgetContext, "token", "12345");
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+    addQueryParameter(widgetContext, "returnPage", "/existing-live-page");
+    // templateId is read via context.getRequest().getParameter(...), not context.getParameter(...) --
+    // the test harness's mock backs the former with setAttribute(), not the query-parameter map.
+    request.setAttribute("templateId", "5");
+
+    WebPage existing = new WebPage();
+    existing.setId(42);
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>old-content</uniqueId></widget></column></section></page>");
+
+    WebPageTemplate dbTemplate = new WebPageTemplate();
+    dbTemplate.setId(5L);
+    dbTemplate.setName("From The Database");
+    dbTemplate.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>${webPageName}-from-template</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<WebPageTemplateRepository> templateRepository = mockStatic(WebPageTemplateRepository.class);
+        MockedStatic<SaveWebPageCommand> saveWebPageCommand = mockStatic(SaveWebPageCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      templateRepository.when(() -> WebPageTemplateRepository.findById(5L)).thenReturn(dbTemplate);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(false);
+      saveWebPageCommand.when(() -> SaveWebPageCommand.saveWebPage(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      widget.post(widgetContext);
+
+      ArgumentCaptor<WebPage> saved = ArgumentCaptor.forClass(WebPage.class);
+      saveWebPageCommand.verify(() -> SaveWebPageCommand.saveWebPage(saved.capture()));
+      Assertions.assertTrue(saved.getValue().getPageXml().contains("from-template"),
+          "legacy behavior: a template pick publishes straight to pageXml when review is not required");
+      Assertions.assertNull(saved.getValue().getDraftPageXml());
+      webPageRepository.verify(() -> WebPageRepository.save(any()), org.mockito.Mockito.never());
+    }
+  }
+
+  // Issue #957 review follow-up: execute()'s redisplay of a just-submitted save must not crash or
+  // discard real (gated) content -- see effectiveContent()/mayPublishDirectly() in the production code.
+
+  @Test
+  void executeRedisplayingAGatedBrandNewDesignerPageDoesNotThrowAndKeepsTheRealDraftContent() {
+    addQueryParameter(widgetContext, "webPage", "/brand-new-page");
+
+    WebPage justSaved = new WebPage();
+    justSaved.setLink("/brand-new-page");
+    // Simulates exactly what post() leaves behind for a brand-new page created from a
+    // designer-tagged template while governed review is required: pageXml is still null, the real
+    // selected template's content is in draftPageXml.
+    justSaved.setDraftPageXml("<page editor=\"designer\"><section><column class=\"small-12 cell\">"
+        + "<widget name=\"content\"><uniqueId>hello</uniqueId></widget></column></section></page>");
+    widgetContext.setRequestObject(justSaved);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("features.layout-editor")).thenReturn(true);
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      WidgetContext result = Assertions.assertDoesNotThrow(() -> widget.execute(widgetContext),
+          "must not NPE reading pageXml on a page whose real content is gated into draftPageXml");
+
+      Assertions.assertEquals(WebPageDesignerWidget.DESIGNER_JSP, result.getJsp());
+      WebPage shown = (WebPage) request.getAttribute("webPage");
+      Assertions.assertTrue(shown.getDraftPageXml().contains("hello"),
+          "the real selected-template content must survive redisplay, not get overwritten by the generic blank scaffold");
+    }
+  }
+
+  @Test
+  void executeShowsTheRawXmlEditorForAnExistingLivePageWhenReviewIsRequiredInsteadOfTheTemplatePicker() {
+    // Live-verification catch: an existing page with real live content, no pending draft, opened
+    // normally (not a post-redisplay) while webPage.review.required is on. The blank-page check must
+    // look at both pageXml and draftPageXml -- checking only whichever field a save would target
+    // (draftPageXml, since review is required) would misread this page as blank and show the
+    // template picker instead of the editor with its real content.
+    addQueryParameter(widgetContext, "webPage", "/existing-live-page");
+
+    WebPage existing = new WebPage();
+    existing.setLink("/existing-live-page");
+    existing.setPageXml("<page><section><column><widget name=\"content\"><uniqueId>reviewed-and-live</uniqueId></widget></column></section></page>");
+
+    try (MockedStatic<WebPageRepository> webPageRepository = mockStatic(WebPageRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      webPageRepository.when(() -> WebPageRepository.findByLink("/existing-live-page")).thenReturn(existing);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("webPage.review.required")).thenReturn(true);
+
+      WebPageDesignerWidget widget = new WebPageDesignerWidget();
+      WidgetContext result = widget.execute(widgetContext);
+
+      Assertions.assertEquals(WebPageDesignerWidget.ACE_XML_EDITOR_JSP, result.getJsp(),
+          "an existing page with real content must show the editor, not the blank-page template picker");
+      WebPage shown = (WebPage) request.getAttribute("webPage");
+      Assertions.assertTrue(shown.getPageXml().contains("reviewed-and-live"), "the live content must be untouched");
     }
   }
 }


### PR DESCRIPTION
## Summary
- `WebPageDesignerWidget` (the legacy raw-XML/designer-canvas editor) writes new content straight to the live `pageXml` column, with no awareness of the `draftPageXml` → submit → approve → publish workflow the P4 layout builder enforces via `ContentReviewCommand`. When `webPage.review.required` is on, this is a complete bypass — reachable for any existing page from the normal Web Pages admin list.
- `WebPageFormWidget` already guards the four governed-review fields (`draftStatus`/`submittedBy`/`approvedBy`/`releaseReference`) against mass assignment from `BeanUtils.populate(webPageBean, context.getParameterMap())`'s raw parameter walk (the #492/#730 pattern), but `pageXml`/`draftPageXml` were never added to that same guard — a forged `pageXml` POST parameter reaches the live page through this second widget too, even though its own JSP has no content field at all.

## Fix
- `WebPageDesignerWidget`: new content from all three sources (template picker, designer-canvas AJAX save, raw XML textbox) now routes through `draftPageXml` instead of `pageXml` whenever direct publishing isn't allowed (`ContentReviewCommand.mayPublishDirectly`), leaving whatever is already live untouched. Validation and the `editor="designer"` redirect check follow the same routing. Behavior is unchanged when review is not required (the default).
- `WebPageFormWidget`: `pageXml`/`draftPageXml` are now captured before `BeanUtils.populate()` and restored after, exactly like the four existing governed-review fields.

## Test plan
- [x] New/updated unit tests in `WebPageDesignerWidgetTest` (raw XML, designer-canvas, template-picker, content-removal branches, each gated and ungated) and `WebPageFormWidgetTest` (forged `pageXml`/`draftPageXml` ignored)
- [x] Full `ant ci-test` clean
- [x] `tools/check-unescaped-el.py` clean (no JSP changes)
- [x] Live-verified against a Docker rehearsal: with `webPage.review.required=true`, injecting content via both widgets on an existing live page leaves `page_xml` untouched and lands the injected content in `draft_page_xml` with `draft_status`/`submitted_by`/`approved_by` at their unsubmitted defaults; the public page still serves the original content