### PR TITLE
Reset governed-review fields when a web page draft is discarded

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -323,7 +323,12 @@ public class WebPageRepository {
     if (record == null || record.getId() == -1) {
       return;
     }
-    String set = "draft_page_xml = null, draft = false";
+    // Issue #958: also reset the governed-review fields, mirroring ContentRepository.removeDraft().
+    // Without this, discarding a draft leaves a stale draftStatus/submittedBy/approvedBy behind --
+    // reproducing the #948 bypass shape, since a later draft could inherit an approval it never
+    // actually earned.
+    String set = "draft_page_xml = null, draft = false, "
+        + "draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null";
     SqlUtils where = new SqlUtils().add("web_page_id = ?", record.getId());
     if (DB.update(TABLE_NAME, set, where)) {
       // Force the page to re-cache

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.infrastructure.persistence.cms;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -376,6 +377,54 @@ class WebPageRepositoryTest {
     WebPage beforeSecondPublish = WebPageRepository.findById(saved.getId());
     assertFalse(ContentReviewCommand.mayPublish(beforeSecondPublish, true),
         "a fresh draft must not inherit the prior cycle's approval -- it has to be resubmitted and reapproved");
+  }
+
+  // --- removeDraft() clears the review workflow (#958) ---
+
+  @Test
+  void removeDraftIsANoOpForAnUnsavedRecord() {
+    // The only real caller (PageServlet's discardDraft action) already pre-checks id == -1 before
+    // ever reaching this method, leaving the guard itself unexercised by anything -- this proves it
+    // directly, so a future refactor that loosens or reorders the guard, or a new caller that skips
+    // PageServlet's pre-check, fails loudly instead of throwing on an unsaved WebPage's null link.
+    WebPage neverSaved = new WebPage();
+    neverSaved.setLink("/never-saved");
+
+    assertDoesNotThrow(() -> WebPageRepository.removeDraft(neverSaved));
+    assertDoesNotThrow(() -> WebPageRepository.removeDraft(null));
+  }
+
+  @Test
+  void removeDraftClearsTheReviewWorkflowSoADiscardedDraftCannotLeaveAStaleApproval() throws DataException {
+    WebPage webPage = new WebPage();
+    webPage.setLink("/discarded");
+    webPage.setTitle("Discarded Draft Page");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>live</xml>");
+    webPage.setDraftPageXml("<xml>pending review</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+
+    // Submit and approve, then discard instead of publishing -- the exact scenario from #958: the
+    // approval must not survive to be inherited by whatever draft comes next.
+    ContentReviewCommand.submitForReview(saved, 10L);
+    WebPageRepository.save(saved);
+    ContentReviewCommand.approve(saved, 20L, "CAB-456");
+    WebPageRepository.save(saved);
+
+    WebPageRepository.removeDraft(saved);
+
+    WebPage afterDiscard = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>live</xml>", afterDiscard.getPageXml(), "discarding a draft must not touch the live page");
+    assertNull(afterDiscard.getDraftPageXml());
+    assertFalse(afterDiscard.getDraft());
+    assertNull(afterDiscard.getDraftStatus(),
+        "a discarded draft's review workflow must be cleared, not left \"submitted\"/approved");
+    assertEquals(-1L, afterDiscard.getSubmittedBy());
+    assertEquals(-1L, afterDiscard.getApprovedBy());
+    assertNull(afterDiscard.getReleaseReference());
   }
 
   @Test


### PR DESCRIPTION
## Summary
`WebPageRepository.removeDraft()` only cleared `draft_page_xml`/`draft`, unlike its precedent `ContentRepository.removeDraft()`, which also resets `draft_status`/`submitted_by`/`approved_by`/`release_reference`. Wired to `PageServlet`'s `discardDraft` action.

If a draft is submitted and approved, then discarded instead of published, the approval survives on the record. A later, entirely new and never-reviewed draft staged on the same page inherits that stale approval — the same bypass shape #948/PR #950 fixed for `publish()`, just via the discard path instead.

## Fix
Mirror `ContentRepository.removeDraft()`'s reset exactly: add `draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null` to the same SQL, alongside the existing `draft_page_xml = null, draft = false`.

## Test plan
- [x] New Testcontainers/Postgres regression tests in `WebPageRepositoryTest`: submit → approve → discard clears all four governed-review fields and leaves the live page untouched; `removeDraft()` is a no-op for an unsaved record (`id == -1` / `null`)
- [x] Full `ant ci-test` clean
- [x] `tools/check-unescaped-el.py` clean (no JSP changes)
- [x] Live-verified against a Docker rehearsal: a page submitted, approved, then discarded via the real `discardDraft` action shows `draft_status`/`submitted_by`/`approved_by`/`release_reference` all reset and `page_xml` unchanged