### PR TITLE
Draft preview mode: render unpublished draft at full page URL (#419)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/GeneratePreviewLinkCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/GeneratePreviewLinkCommand.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPagePreviewTokenRepository;
+
+/**
+ * Issues a time-limited bearer token (#419) that lets a visitor holding the link view a web
+ * page's current draft content at its real URL, before the draft is reviewed or published.
+ * Modeled on {@code UserRepository.createAccountToken}: a plaintext {@link UUID}, expiry enforced
+ * SQL-side by every lookup ({@link WebPagePreviewTokenRepository#findValidToken}) rather than a
+ * separate cleanup job.
+ *
+ * @author SimIS Inc.
+ * @created 8/4/2026
+ */
+public class GeneratePreviewLinkCommand {
+
+  private static final int DEFAULT_TTL_HOURS = 24;
+
+  private GeneratePreviewLinkCommand() {
+    // Static command
+  }
+
+  /**
+   * @param pagePath the exact request path the visitor was previewing (not just {@code
+   *        webPage.getLink()}) -- required so the token can be scoped to that one URL rather than
+   *        the whole page template, which matters for a wildcard page like "/news/*" that backs
+   *        many distinct URLs from a single {@code WebPage} row.
+   */
+  public static WebPagePreviewToken generateFor(WebPage webPage, String pagePath, long createdBy) throws DataException {
+    if (webPage == null || webPage.getId() == -1) {
+      throw new DataException("A valid web page is required");
+    }
+    if (StringUtils.isBlank(pagePath)) {
+      throw new DataException("A valid page path is required");
+    }
+    int ttlHours = resolvePreviewLinkTtlHours(LoadSitePropertyCommand.loadByName("security.previewLinkTtlHours"));
+    WebPagePreviewToken record = new WebPagePreviewToken();
+    record.setWebPageId(webPage.getId());
+    record.setPagePath(pagePath);
+    record.setToken(UUID.randomUUID().toString());
+    record.setExpiresAt(new Timestamp(System.currentTimeMillis() + (ttlHours * 3600L * 1000L)));
+    record.setCreatedBy(createdBy);
+    WebPagePreviewToken savedRecord = WebPagePreviewTokenRepository.add(record);
+    if (savedRecord == null) {
+      throw new DataException("The preview link could not be created");
+    }
+    return savedRecord;
+  }
+
+  /** @return the configured TTL in hours, or {@link #DEFAULT_TTL_HOURS} for a blank/invalid value. */
+  public static int resolvePreviewLinkTtlHours(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_TTL_HOURS;
+    }
+    int hours;
+    try {
+      hours = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_TTL_HOURS;
+    }
+    return hours > 0 ? hours : DEFAULT_TTL_HOURS;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/WebPagePreviewToken.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/WebPagePreviewToken.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import com.simisinc.platform.domain.model.Entity;
+
+import java.sql.Timestamp;
+
+/**
+ * A time-limited bearer token that lets a visitor holding the link view a web page's current
+ * draft content at its real URL, before the draft is reviewed or published (issue #419)
+ *
+ * @author matt rajkowski
+ * @created 8/4/26 9:00 AM
+ */
+public class WebPagePreviewToken extends Entity {
+
+  private Long id = -1L;
+
+  private long webPageId = -1L;
+  // The exact request path the token was minted for (#419 review finding): a WebPage row can back
+  // many distinct URLs for a wildcard/dynamic page (link ending in "/*", e.g. "/news/*"), so scoping
+  // a token by webPageId alone would let it validate -- and disclose the shared draft -- against
+  // every other URL matching that same template, not just the one page the link-holder was shown.
+  private String pagePath = null;
+  private String token = null;
+  private Timestamp expiresAt = null;
+  private long createdBy = -1L;
+  private Timestamp created = null;
+
+  public WebPagePreviewToken() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public long getWebPageId() {
+    return webPageId;
+  }
+
+  public void setWebPageId(long webPageId) {
+    this.webPageId = webPageId;
+  }
+
+  public String getPagePath() {
+    return pagePath;
+  }
+
+  public void setPagePath(String pagePath) {
+    this.pagePath = pagePath;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public Timestamp getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(Timestamp expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public long getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(long createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPagePreviewTokenRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPagePreviewTokenRepository.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves draft preview link tokens (#419) -- a time-limited bearer token that
+ * lets a visitor holding the link view a web page's current draft content before it's published.
+ *
+ * @author SimIS Inc.
+ * @created 8/4/2026
+ */
+public class WebPagePreviewTokenRepository {
+
+  private static Log LOG = LogFactory.getLog(WebPagePreviewTokenRepository.class);
+
+  private static String TABLE_NAME = "web_page_preview_tokens";
+  private static String[] PRIMARY_KEY = new String[]{"web_page_preview_token_id"};
+
+  public static WebPagePreviewToken add(WebPagePreviewToken record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("web_page_id", record.getWebPageId())
+        .add("page_path", record.getPagePath())
+        .add("token", record.getToken())
+        .add("expires_at", record.getExpiresAt())
+        .add("created_by", record.getCreatedBy(), -1);
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  /**
+   * Returns the token record only if it exists, matches the given page AND the exact path it was
+   * minted for, and has not expired. The path check matters for a wildcard page (e.g. "/news/*"):
+   * without it, a token minted while previewing one URL would also validate for every other URL
+   * backed by that same WebPage row.
+   */
+  public static WebPagePreviewToken findValidToken(String token, long webPageId, String pagePath) {
+    if (StringUtils.isBlank(token) || webPageId == -1 || StringUtils.isBlank(pagePath)) {
+      return null;
+    }
+    return (WebPagePreviewToken) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils()
+            .add("token = ?", token)
+            .add("web_page_id = ?", webPageId)
+            .add("page_path = ?", pagePath)
+            .add("expires_at > ?", new Timestamp(System.currentTimeMillis())),
+        WebPagePreviewTokenRepository::buildRecord);
+  }
+
+  /**
+   * Deletes every outstanding token for a page (#419 review finding): called whenever its draft is
+   * published or discarded, so a still-unexpired, previously-issued link can never later resurface
+   * a different, unrelated draft than the one it was generated against.
+   */
+  public static void removeAllForPage(Connection connection, long webPageId) throws SQLException {
+    DB.deleteFrom(connection, TABLE_NAME, new SqlUtils().add("web_page_id = ?", webPageId));
+  }
+
+  /** Non-transactional variant for call sites that don't already hold a connection. */
+  public static void removeAllForPage(long webPageId) {
+    DB.deleteFrom(TABLE_NAME, new SqlUtils().add("web_page_id = ?", webPageId));
+  }
+
+  private static WebPagePreviewToken buildRecord(ResultSet rs) {
+    try {
+      WebPagePreviewToken record = new WebPagePreviewToken();
+      record.setId(rs.getLong("web_page_preview_token_id"));
+      record.setWebPageId(rs.getLong("web_page_id"));
+      record.setPagePath(rs.getString("page_path"));
+      record.setToken(rs.getString("token"));
+      record.setExpiresAt(rs.getTimestamp("expires_at"));
+      record.setCreatedBy(DB.getLong(rs, "created_by", -1));
+      record.setCreated(rs.getTimestamp("created"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -287,6 +287,12 @@ public class WebPageRepository {
         updated = pst.executeUpdate();
       }
       if (updated > 0) {
+        // Issue #419 review finding: a preview link is a standing credential to view this page's
+        // draft. Once the draft is consumed by publish, any outstanding token for it must stop
+        // working -- otherwise a still-unexpired link could later resurface a completely different,
+        // unrelated draft staged on this page afterward, which its holder was never shown or
+        // authorized to see.
+        WebPagePreviewTokenRepository.removeAllForPage(connection, record.getId());
         transaction.commit();
         // Force the page to re-cache
         WebPageXmlLayoutCommand.removeCustomPage(record.getLink());
@@ -331,6 +337,10 @@ public class WebPageRepository {
         + "draft_status = null, submitted_by = -1, approved_by = -1, release_reference = null";
     SqlUtils where = new SqlUtils().add("web_page_id = ?", record.getId());
     if (DB.update(TABLE_NAME, set, where)) {
+      // Issue #419 review finding: same reasoning as publish() above -- a discarded draft's
+      // preview links must stop working, or a still-unexpired one could later resurface a
+      // different draft staged on this page before it expires.
+      WebPagePreviewTokenRepository.removeAllForPage(record.getId());
       // Force the page to re-cache
       WebPageXmlLayoutCommand.removeCustomPage(record.getLink());
     }

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -31,8 +31,10 @@ import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.Stylesheet;
 import com.simisinc.platform.domain.model.cms.TableOfContents;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
 import com.simisinc.platform.infrastructure.cache.PublishEventCachePurgeHandler;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPagePreviewTokenRepository;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
@@ -216,9 +218,21 @@ public class PageServlet extends HttpServlet {
 
       // Always access the webPage record so it can be used downstream
       WebPage webPage = LoadWebPageCommand.loadByLink(pagePath);
+
+      // Draft preview links (#419): a valid, unexpired bearer token lets an anonymous visitor
+      // view this page's current draft content at its real URL, before it's reviewed or
+      // published. Checked here, ahead of the draft-blocking and layout-resolution logic below,
+      // so both can be bypassed for exactly this one request.
+      boolean validPreviewToken = webPage != null
+          && WebPagePreviewTokenRepository.findValidToken(request.getParameter("previewToken"), webPage.getId(), pagePath) != null;
+      if (validPreviewToken) {
+        // A preview link renders unreviewed content -- never let it leak into a search index.
+        response.setHeader("X-Robots-Tag", "noindex");
+      }
+
       if (webPage != null) {
         // Determine if this is a draft page
-        if (isDraftBlockedFromPublicAccess(webPage, userSession)) {
+        if (!validPreviewToken && isDraftBlockedFromPublicAccess(webPage, userSession)) {
           LOG.error("DRAFT FOUND, no access: " + pagePath + " " + request.getRemoteAddr());
           controllerSession.clearAllWidgetData();
           response.sendError(HttpServletResponse.SC_NOT_FOUND);
@@ -400,6 +414,47 @@ public class PageServlet extends HttpServlet {
         WebPageRepository.removeDraft(webPage);
         LOG.info("Draft discarded for " + pagePath + " by user " + userSession.getUserId());
         response.getWriter().print("{\"success\":true}");
+        return;
+      }
+
+      // generatePreviewLink: issue a bearer token (#419) that lets an anonymous visitor view this
+      // page's current draft at its real URL, without publishing it
+      if ("generatePreviewLink".equals(request.getParameter("action"))
+          && request.getParameter("widget") == null
+          && pageLayoutMode) {
+        String formToken = request.getParameter("token");
+        if (!userSession.getFormToken().equals(formToken)) {
+          LOG.warn("generatePreviewLink CSRF token mismatch from " + request.getRemoteAddr());
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          response.getWriter().print("{\"success\":false,\"error\":\"Session expired\"}");
+          return;
+        }
+        if (webPage == null || webPage.getId() == -1) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"Page not found\"}");
+          return;
+        }
+        if (StringUtils.isBlank(webPage.getDraftPageXml())) {
+          response.setContentType("application/json");
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.getWriter().print("{\"success\":false,\"error\":\"No draft to preview\"}");
+          return;
+        }
+        response.setContentType("application/json");
+        try {
+          WebPagePreviewToken previewToken = GeneratePreviewLinkCommand.generateFor(webPage, pagePath, userSession.getUserId());
+          ObjectMapper mapper = new ObjectMapper();
+          String link = buildPreviewLink(pagePath, request.getParameter("originalQuery"), previewToken.getToken());
+          response.getWriter().print("{\"success\":true,\"link\":" + mapper.writeValueAsString(link)
+              + ",\"expiresAt\":" + mapper.writeValueAsString(previewToken.getExpiresAt().toInstant().toString()) + "}");
+        } catch (Exception e) {
+          LOG.warn("generatePreviewLink failed for " + pagePath + ": " + e.getMessage());
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          String msg = e.getMessage() != null ? e.getMessage().replace("\"", "'") : "Could not create the preview link";
+          response.getWriter().print("{\"success\":false,\"error\":\"" + msg + "\"}");
+        }
         return;
       }
 
@@ -718,13 +773,27 @@ public class PageServlet extends HttpServlet {
       }
 
       // In edit mode, layout builders preview the draft layout (bypasses cache)
+      boolean previewingDraft = false;
       if (pageEditMode && EditorPermissionCommand.canBuildLayout(userSession)
           && webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml())) {
         Page draftRef = WebPageXmlLayoutCommand.parseFreshDraft(webPage, pagePath);
         if (draftRef != null) {
           pageRef = draftRef;
         }
+      } else if (validPreviewToken && webPage != null && StringUtils.isNotBlank(webPage.getDraftPageXml())) {
+        // Draft preview links (#419): the same live-updating draft render an editor gets above,
+        // for an anonymous visitor holding a valid token instead. A token that has outlived its
+        // draft (published or discarded since the link was generated) simply falls back to
+        // whatever pageRef already resolved to -- the current live page.
+        Page draftRef = WebPageXmlLayoutCommand.parseFreshDraft(webPage, pagePath);
+        if (draftRef != null) {
+          pageRef = draftRef;
+          previewingDraft = true;
+        }
       }
+      // Page-level request attribute read via JSP EL (main.jsp) -- must stay in sync with
+      // WebContainerCommand.PAGE_LEVEL_ATTRIBUTE_NAMES, like pageEditMode/hasDraft above.
+      request.setAttribute("previewingDraft", previewingDraft ? "true" : "false");
 
       // Load the properties
       Map<String, String> systemPropertyMap = LoadSitePropertyCommand.loadAsMap("system");
@@ -1414,6 +1483,30 @@ public class PageServlet extends HttpServlet {
    */
   static boolean isFormTokenValid(String requestToken, String sessionToken) {
     return StringUtils.isNotEmpty(requestToken) && sessionToken != null && sessionToken.equals(requestToken);
+  }
+
+  /**
+   * Builds a shareable preview link (#419) from the page path plus the caller's original query
+   * string (already percent-encoded by the client's own URLSearchParams), so a page addressed by a
+   * query parameter (e.g. {@code ?collectionId=5}) previews the same content the editor was
+   * looking at, not just the bare path. Any {@code previewToken} pair already present in {@code
+   * originalQuery} is dropped so the caller cannot smuggle in a second, conflicting token value.
+   */
+  static String buildPreviewLink(String pagePath, String originalQuery, String token) {
+    StringBuilder link = new StringBuilder(pagePath).append('?');
+    if (StringUtils.isNotBlank(originalQuery)) {
+      for (String pair : originalQuery.split("&")) {
+        if (pair.isEmpty()) {
+          continue;
+        }
+        String key = pair.contains("=") ? pair.substring(0, pair.indexOf('=')) : pair;
+        if ("previewToken".equals(key)) {
+          continue;
+        }
+        link.append(pair).append('&');
+      }
+    }
+    return link.append("previewToken=").append(token).toString();
   }
 
   /**

--- a/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/WebContainerCommand.java
@@ -71,7 +71,7 @@ public class WebContainerCommand implements Serializable {
   // leftovers can't bleed into the next widget's render. These names must be kept in sync with the
   // request.setAttribute(...) calls in PageServlet.java that set them.
   private static final Set<String> PAGE_LEVEL_ATTRIBUTE_NAMES = Set.of(
-      "pageEditMode", "pageLayoutMode", "hasDraft", "widgetLibraryJson", "cspNonce",
+      "pageEditMode", "pageLayoutMode", "hasDraft", "previewingDraft", "widgetLibraryJson", "cspNonce",
       "systemPropertyMap", "sitePropertyMap", "themePropertyMap", "socialPropertyMap",
       "socialMediaLinkList", "analyticsPropertyMap", "ecommercePropertyMap");
 

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -741,6 +741,30 @@ CREATE TABLE web_page_versions (
 );
 CREATE INDEX web_page_versions_web_idx ON web_page_versions(web_page_id, published_at DESC);
 
+-- Draft preview links (#419): a time-limited bearer token that lets an anonymous visitor holding
+-- the link view a page's current draftPageXml at its real URL, before it's reviewed or published.
+-- Deliberately NOT tied to a specific web_page_versions row -- the preview always reflects
+-- whatever is currently in draftPageXml, the same live-updating view an editor already gets in
+-- pageEditMode (see PageServlet's parseFreshDraft usage). Expiry is enforced SQL-side by every
+-- lookup, so an expired row is simply inert rather than requiring a cleanup job to be correct.
+-- page_path pins the token to the exact URL it was minted for -- web_page_id alone is not enough
+-- because a wildcard page (link ending "/*", e.g. "/news/*") backs many distinct URLs from one row,
+-- and a token scoped only to web_page_id would validate against every one of them, not just the
+-- single URL the link recipient was shown (review finding on this issue). Every outstanding token
+-- for a page is also deleted the moment its draft is published or discarded (see
+-- WebPageRepository.publish()/removeDraft()), so a still-unexpired link can never later resurface
+-- a different, unrelated draft than the one it was generated for.
+CREATE TABLE web_page_preview_tokens (
+  web_page_preview_token_id BIGSERIAL PRIMARY KEY,
+  web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE,
+  page_path VARCHAR(255) NOT NULL,
+  token VARCHAR(255) UNIQUE NOT NULL,
+  expires_at TIMESTAMP(3) NOT NULL,
+  created_by BIGINT REFERENCES users(user_id),
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+CREATE INDEX web_page_preview_tokens_token_idx ON web_page_preview_tokens(token);
+
 -- Core Web Vitals RUM (Real User Monitoring, #429)
 -- Raw metrics collected from real page loads, one row per metric per page load
 CREATE TABLE web_vitals (

--- a/src/main/resources/database/install/NEW_10140__new_security_properties.sql
+++ b/src/main/resources/database/install/NEW_10140__new_security_properties.sql
@@ -13,3 +13,9 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 -- so it surfaces on this same Security Settings page and requires step-up auth to change, like the
 -- rate-limit properties above.
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (30, 'IP Request Rate Alert Threshold (hits/hour)', 'security.ipRequestRateAlertThreshold', '300', 'text');
+
+-- Issue #419: how long a generated draft-preview link stays valid before it stops showing the
+-- draft and silently falls back to the live page. Under the "security" prefix (same as the
+-- properties above) since it's a bearer-token TTL -- changing it requires step-up auth like
+-- every other security-sensitive setting on this page.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (40, 'Draft Preview Link Expiry (hours)', 'security.previewLinkTtlHours', '24', 'text');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1002__web_page_preview_tokens.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1002__web_page_preview_tokens.sql
@@ -1,0 +1,31 @@
+-- Draft preview links (#419): a time-limited bearer token that lets an anonymous visitor holding
+-- the link view a page's current draftPageXml at its real URL, before it's reviewed or published.
+-- Deliberately NOT tied to a specific web_page_versions row -- the preview always reflects
+-- whatever is currently in draftPageXml, the same live-updating view an editor already gets in
+-- pageEditMode (see PageServlet's parseFreshDraft usage). Expiry is enforced SQL-side by every
+-- lookup, so an expired row is simply inert rather than requiring a cleanup job to be correct.
+-- page_path pins the token to the exact URL it was minted for -- web_page_id alone is not enough
+-- because a wildcard page (link ending "/*", e.g. "/news/*") backs many distinct URLs from one row,
+-- and a token scoped only to web_page_id would validate against every one of them, not just the
+-- single URL the link recipient was shown (review finding on this issue). Every outstanding token
+-- for a page is also deleted the moment its draft is published or discarded (see
+-- WebPageRepository.publish()/removeDraft()), so a still-unexpired link can never later resurface
+-- a different, unrelated draft than the one it was generated for.
+-- Idempotent so it is safe on any existing install; fresh installs get the identical table from NEW_10010.
+CREATE TABLE IF NOT EXISTS web_page_preview_tokens (
+  web_page_preview_token_id BIGSERIAL PRIMARY KEY,
+  web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE,
+  page_path VARCHAR(255) NOT NULL,
+  token VARCHAR(255) UNIQUE NOT NULL,
+  expires_at TIMESTAMP(3) NOT NULL,
+  created_by BIGINT REFERENCES users(user_id),
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+CREATE INDEX IF NOT EXISTS web_page_preview_tokens_token_idx ON web_page_preview_tokens(token);
+
+-- Issue #419: how long a generated draft-preview link stays valid before it stops showing the
+-- draft and silently falls back to the live page. Under the "security" prefix so it surfaces on
+-- the Security Settings page and requires step-up auth to change, like security.ipRequestRateAlertThreshold.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (40, 'Draft Preview Link Expiry (hours)', 'security.previewLinkTtlHours', '24', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -156,6 +156,10 @@
   <c:if test="${!empty pageRenderInfo.canonicalUrl}">
     <link rel="canonical" href="<c:out value="${pageRenderInfo.canonicalUrl}"/>" />
   </c:if>
+  <%-- Issue #419: a draft preview link renders unreviewed content -- keep it out of search indexes --%>
+  <c:if test="${previewingDraft eq 'true'}">
+    <meta name="robots" content="noindex" />
+  </c:if>
   <%-- JSON-LD structured data for search engines and AI (issue #403) --%>
   <c:if test="${!empty pageRenderInfo.jsonLdData}">
     <script type="application/ld+json"><c:out value="${pageRenderInfo.jsonLdData}" escapeXml="false" /></script>
@@ -384,6 +388,7 @@
   <style>
     .platform-skip-link { position: absolute; left: -9999px; top: -9999px; z-index: 9999; }
     .platform-skip-link:focus { left: 0; top: 0; background: #fff; color: #000; padding: 0.5rem 1rem; text-decoration: none; border: 2px solid #000; }
+    .platform-preview-draft-banner { background: #fef6e0; color: #7a5c00; border-bottom: 1px solid #f0d98c; padding: 0.5rem 1rem; text-align: center; font-size: 0.9rem; }
   </style>
 </head>
 <c:set var="bodyClass" value="${pageRenderInfo.cssClass}"/>
@@ -396,6 +401,9 @@
 <body<c:if test="${pageRenderInfo.name eq '/'}"> id="body-home"</c:if><c:if test="${!empty bodyClass}"> class="<c:out value="${bodyClass}" />"</c:if>>
   <!-- Skip link for keyboard navigation (WCAG 2.4.1) -->
   <a href="#main" class="platform-skip-link">Skip to main content</a>
+  <c:if test="${previewingDraft eq 'true'}">
+    <div class="platform-preview-draft-banner"><i class="${font:far()} fa-eye fa-fw"></i> You are previewing an unpublished draft. This page is not visible to the public.</div>
+  </c:if>
   <c:if test="${pageEditMode eq 'true'}">
     <div id="sc-editor-toolbar" role="toolbar" aria-label="Page editor"
          data-page-path="<c:out value="${pageRenderInfo.pagePath}"/>"

--- a/src/main/webapp/javascript/platform-editor.js
+++ b/src/main/webapp/javascript/platform-editor.js
@@ -813,6 +813,67 @@
     return btn;
   }
 
+  // ── Preview link (#419) ──────────────────────────────────────────────────
+
+  function buildPreviewLinkButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'sc-preview-link-btn';
+    btn.className = 'button small hollow secondary';
+    btn.textContent = 'Get Preview Link';
+    if (toolbar.dataset.hasDraft !== 'true') btn.style.display = 'none';
+    btn.addEventListener('click', doGeneratePreviewLink);
+    var exitBtn = document.getElementById('sc-editor-exit');
+    if (exitBtn) toolbar.insertBefore(btn, exitBtn);
+    else toolbar.appendChild(btn);
+    return btn;
+  }
+
+  function doGeneratePreviewLink() {
+    var btn = document.getElementById('sc-preview-link-btn');
+    btn.disabled = true;
+    var originalLabel = btn.textContent;
+    btn.textContent = 'Generating…';
+    setToolbarStatus('Generating preview link…');
+
+    // Preserve the page's current query string (e.g. ?collectionId=5) so the generated link shows
+    // the reviewer the same content the editor was looking at, not just the bare path -- pagePath
+    // alone never carries it server-side. previewToken is stripped so a caller can't smuggle in a
+    // second, conflicting token value.
+    var originalQuery = new URLSearchParams(window.location.search);
+    originalQuery.delete('previewToken');
+
+    var qs = new URLSearchParams();
+    qs.append('action', 'generatePreviewLink');
+    qs.append('token', getToken());
+    qs.append('originalQuery', originalQuery.toString());
+
+    fetch(window.location.pathname + '?' + qs.toString(), {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      if (!data.success) throw new Error(data.error || 'Could not create the preview link');
+      var url = window.location.origin + data.link;
+      copyTextToClipboard(url).then(function () {
+        setToolbarStatus('Preview link copied to clipboard (expires ' + new Date(data.expiresAt).toLocaleString() + ')');
+      }, function () {
+        setToolbarStatus('Preview link: ' + url);
+      });
+      btn.disabled = false;
+      btn.textContent = originalLabel;
+    })
+    .catch(function (err) {
+      setToolbarStatus('Could not create preview link: ' + err.message);
+      btn.disabled = false;
+      btn.textContent = originalLabel;
+    });
+  }
+
   function doPublishDraft() {
     var btn = document.getElementById('sc-publish-btn');
     btn.disabled = true;
@@ -1628,7 +1689,8 @@
 
   if (layoutMode) {
     buildSaveLayoutButton();      // inserts before Exit
-    buildPublishButton();         // inserts before Exit (right of Save Layout)
+    buildPreviewLinkButton();     // inserts before Exit (right of Save Layout)
+    buildPublishButton();         // inserts before Exit (right of Preview Link)
     buildDiscardDraftButton();    // inserts before Exit (between Save Layout and Publish)
   }
 

--- a/src/test/java/com/simisinc/platform/application/cms/GeneratePreviewLinkCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/GeneratePreviewLinkCommandTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPagePreviewTokenRepository;
+
+/**
+ * Verifies {@link GeneratePreviewLinkCommand} (#419): the TTL resolver's defaulting behavior, and
+ * that {@code generateFor} issues a plaintext token expiring per the configured
+ * {@code security.previewLinkTtlHours} setting.
+ *
+ * @author elizabeth houser
+ */
+class GeneratePreviewLinkCommandTest {
+
+  @Test
+  void resolvePreviewLinkTtlHoursDefaultsForABlankValue() {
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours(null));
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours(""));
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours("   "));
+  }
+
+  @Test
+  void resolvePreviewLinkTtlHoursDefaultsForANonNumericValue() {
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours("not-a-number"));
+  }
+
+  @Test
+  void resolvePreviewLinkTtlHoursDefaultsForAZeroOrNegativeValue() {
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours("0"));
+    assertEquals(24, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours("-5"));
+  }
+
+  @Test
+  void resolvePreviewLinkTtlHoursHonorsAValidValue() {
+    assertEquals(72, GeneratePreviewLinkCommand.resolvePreviewLinkTtlHours("72"));
+  }
+
+  @Test
+  void generateForRejectsANullWebPage() {
+    assertThrows(DataException.class, () -> GeneratePreviewLinkCommand.generateFor(null, "/page", 1L));
+  }
+
+  @Test
+  void generateForRejectsAnUnsavedWebPage() {
+    WebPage webPage = new WebPage();
+    assertThrows(DataException.class, () -> GeneratePreviewLinkCommand.generateFor(webPage, "/page", 1L));
+  }
+
+  @Test
+  void generateForRejectsABlankPagePath() {
+    WebPage webPage = new WebPage();
+    webPage.setId(42L);
+    assertThrows(DataException.class, () -> GeneratePreviewLinkCommand.generateFor(webPage, "", 1L));
+    assertThrows(DataException.class, () -> GeneratePreviewLinkCommand.generateFor(webPage, null, 1L));
+  }
+
+  @Test
+  void generateForIssuesATokenExpiringPerTheConfiguredTtl() throws DataException {
+    WebPage webPage = new WebPage();
+    webPage.setId(42L);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPagePreviewTokenRepository> repository = mockStatic(WebPagePreviewTokenRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.previewLinkTtlHours")).thenReturn("2");
+      repository.when(() -> WebPagePreviewTokenRepository.add(any(WebPagePreviewToken.class)))
+          .thenAnswer(invocation -> {
+            WebPagePreviewToken saved = invocation.getArgument(0);
+            saved.setId(99L);
+            return saved;
+          });
+
+      Timestamp beforeCall = Timestamp.from(Instant.now().plusSeconds(2 * 3600 - 5));
+      WebPagePreviewToken result = GeneratePreviewLinkCommand.generateFor(webPage, "/news/my-post", 7L);
+      Timestamp afterCall = Timestamp.from(Instant.now().plusSeconds(2 * 3600 + 5));
+
+      assertNotNull(result.getToken());
+      assertEquals(42L, result.getWebPageId());
+      assertEquals("/news/my-post", result.getPagePath());
+      assertEquals(7L, result.getCreatedBy());
+      assertTrue(result.getExpiresAt().after(beforeCall) && result.getExpiresAt().before(afterCall),
+          "expiry should be roughly 2 hours (the configured TTL) from now");
+    }
+  }
+
+  @Test
+  void generateForThrowsWhenTheRepositoryFailsToSave() {
+    WebPage webPage = new WebPage();
+    webPage.setId(42L);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WebPagePreviewTokenRepository> repository = mockStatic(WebPagePreviewTokenRepository.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("security.previewLinkTtlHours")).thenReturn("24");
+      repository.when(() -> WebPagePreviewTokenRepository.add(any(WebPagePreviewToken.class))).thenReturn(null);
+
+      assertThrows(DataException.class, () -> GeneratePreviewLinkCommand.generateFor(webPage, "/page", 7L));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPagePreviewTokenRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPagePreviewTokenRepositoryTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link WebPagePreviewTokenRepository} against a real PostgreSQL instance (#419).
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class WebPagePreviewTokenRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+  private static final String PAGE_PATH = "/find-me";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping WebPagePreviewTokenRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE web_page_preview_tokens, web_pages RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset web_page_preview_tokens table", se);
+    }
+  }
+
+  @Test
+  void addedTokenCanBeFoundByFindValidToken() {
+    long webPageId = addWebPage("/find-me");
+    String token = UUID.randomUUID().toString();
+
+    WebPagePreviewToken saved = addToken(webPageId, PAGE_PATH, token, future(60));
+
+    assertNotEquals(-1L, saved.getId());
+    WebPagePreviewToken found = WebPagePreviewTokenRepository.findValidToken(token, webPageId, PAGE_PATH);
+    assertNotNull(found);
+    assertEquals(webPageId, found.getWebPageId());
+    assertEquals(PAGE_PATH, found.getPagePath());
+    assertEquals(token, found.getToken());
+  }
+
+  @Test
+  void findValidTokenReturnsNullForAnExpiredToken() {
+    long webPageId = addWebPage("/expired");
+    String token = UUID.randomUUID().toString();
+    addToken(webPageId, "/expired", token, past(60));
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, webPageId, "/expired"));
+  }
+
+  @Test
+  void findValidTokenReturnsNullForAnUnknownToken() {
+    long webPageId = addWebPage("/unknown-token");
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken("not-a-real-token", webPageId, "/unknown-token"));
+  }
+
+  @Test
+  void findValidTokenReturnsNullWhenTheTokenBelongsToADifferentPage() {
+    long pageOne = addWebPage("/page-one");
+    long pageTwo = addWebPage("/page-two");
+    String token = UUID.randomUUID().toString();
+    addToken(pageOne, "/page-one", token, future(60));
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, pageTwo, "/page-one"));
+  }
+
+  @Test
+  void findValidTokenReturnsNullForABlankToken() {
+    long webPageId = addWebPage("/blank-token");
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken("", webPageId, "/blank-token"));
+    assertNull(WebPagePreviewTokenRepository.findValidToken(null, webPageId, "/blank-token"));
+  }
+
+  @Test
+  void findValidTokenReturnsNullWhenThePathDoesNotMatchTheOneItWasMintedFor() {
+    // Regression test (#419 review finding): a wildcard page like "/news/*" backs many distinct
+    // URLs from a single web_page_id -- a token minted while previewing one article must not
+    // validate for any other URL that happens to resolve to the same page row.
+    long webPageId = addWebPage("/news/*");
+    String token = UUID.randomUUID().toString();
+    addToken(webPageId, "/news/my-post-slug", token, future(60));
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, webPageId, "/news/some-other-slug"));
+    assertNotNull(WebPagePreviewTokenRepository.findValidToken(token, webPageId, "/news/my-post-slug"));
+  }
+
+  @Test
+  void findValidTokenReturnsNullForABlankPagePath() {
+    long webPageId = addWebPage("/blank-path");
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken("some-token", webPageId, ""));
+    assertNull(WebPagePreviewTokenRepository.findValidToken("some-token", webPageId, null));
+  }
+
+  @Test
+  void removeAllForPageDeletesOnlyThatPagesTokens() {
+    long pageOne = addWebPage("/page-one");
+    long pageTwo = addWebPage("/page-two");
+    String tokenOne = UUID.randomUUID().toString();
+    String tokenTwo = UUID.randomUUID().toString();
+    addToken(pageOne, "/page-one", tokenOne, future(60));
+    addToken(pageTwo, "/page-two", tokenTwo, future(60));
+
+    WebPagePreviewTokenRepository.removeAllForPage(pageOne);
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(tokenOne, pageOne, "/page-one"),
+        "the removed page's token must no longer validate");
+    assertNotNull(WebPagePreviewTokenRepository.findValidToken(tokenTwo, pageTwo, "/page-two"),
+        "an unrelated page's token must be untouched");
+  }
+
+  @Test
+  void removeAllForPageWithAConnectionParticipatesInTheCallersTransaction() throws SQLException {
+    long webPageId = addWebPage("/tx-page");
+    String token = UUID.randomUUID().toString();
+    addToken(webPageId, "/tx-page", token, future(60));
+
+    try (Connection connection = DB.getConnection()) {
+      WebPagePreviewTokenRepository.removeAllForPage(connection, webPageId);
+    }
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, webPageId, "/tx-page"));
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real schema -- no users table here, so created_by is a plain
+    // column rather than an FK, matching the same simplification used elsewhere in this test suite.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS web_page_preview_tokens CASCADE");
+      statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
+      statement.execute("CREATE TABLE web_pages ("
+          + "web_page_id BIGSERIAL PRIMARY KEY, "
+          + "link VARCHAR(255) UNIQUE NOT NULL)");
+      statement.execute("CREATE TABLE web_page_preview_tokens ("
+          + "web_page_preview_token_id BIGSERIAL PRIMARY KEY, "
+          + "web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE, "
+          + "page_path VARCHAR(255) NOT NULL, "
+          + "token VARCHAR(255) UNIQUE NOT NULL, "
+          + "expires_at TIMESTAMP(3) NOT NULL, "
+          + "created_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL)");
+      statement.execute("CREATE INDEX web_page_preview_tokens_token_idx ON web_page_preview_tokens(token)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the web_page_preview_tokens schema", se);
+    }
+  }
+
+  private static long addWebPage(String link) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        java.sql.ResultSet rs = statement.executeQuery(
+            "INSERT INTO web_pages (link) VALUES ('" + link.replace("'", "''") + "') RETURNING web_page_id")) {
+      rs.next();
+      return rs.getLong("web_page_id");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a web page", se);
+    }
+  }
+
+  private static WebPagePreviewToken addToken(long webPageId, String pagePath, String token, Timestamp expiresAt) {
+    WebPagePreviewToken record = new WebPagePreviewToken();
+    record.setWebPageId(webPageId);
+    record.setPagePath(pagePath);
+    record.setToken(token);
+    record.setExpiresAt(expiresAt);
+    record.setCreatedBy(1L);
+    return WebPagePreviewTokenRepository.add(record);
+  }
+
+  private static Timestamp future(int seconds) {
+    return Timestamp.from(Instant.now().plusSeconds(seconds));
+  }
+
+  private static Timestamp past(int seconds) {
+    return Timestamp.from(Instant.now().minusSeconds(seconds));
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.infrastructure.persistence.cms;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,6 +28,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
 
@@ -43,6 +45,7 @@ import org.testcontainers.utility.DockerImageName;
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
 import com.simisinc.platform.domain.model.cms.WebPageVersion;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataSource;
@@ -379,6 +382,57 @@ class WebPageRepositoryTest {
         "a fresh draft must not inherit the prior cycle's approval -- it has to be resubmitted and reapproved");
   }
 
+  // --- publish() invalidates outstanding preview links (#419 review finding) ---
+
+  @Test
+  void publishInvalidatesAnyOutstandingPreviewTokenForThePage() {
+    // Without this, a still-unexpired preview link generated for the draft that was just published
+    // would keep validating afterward and could later resurface a completely different, unrelated
+    // draft staged on this page before the token expires -- the review finding on issue #419.
+    WebPage webPage = new WebPage();
+    webPage.setLink("/preview-then-publish");
+    webPage.setTitle("Preview Then Publish");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setDraftPageXml("<xml>v1</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+    String token = addPreviewToken(saved.getId(), "/preview-then-publish");
+
+    WebPageRepository.publish(saved, 42L, 20);
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, saved.getId(), "/preview-then-publish"),
+        "a preview token must stop working once its draft has been published");
+  }
+
+  @Test
+  void publishLeavesOtherPagesPreviewTokensAlone() {
+    WebPage published = new WebPage();
+    published.setLink("/gets-published");
+    published.setEnabled(true);
+    published.setSearchable(true);
+    published.setCreatedBy(1L);
+    published.setDraftPageXml("<xml>v1</xml>");
+    published.setDraft(true);
+    WebPage savedPublished = WebPageRepository.save(published);
+
+    WebPage untouched = new WebPage();
+    untouched.setLink("/stays-in-draft");
+    untouched.setEnabled(true);
+    untouched.setSearchable(true);
+    untouched.setCreatedBy(1L);
+    untouched.setDraftPageXml("<xml>still pending</xml>");
+    untouched.setDraft(true);
+    WebPage savedUntouched = WebPageRepository.save(untouched);
+    String untouchedToken = addPreviewToken(savedUntouched.getId(), "/stays-in-draft");
+
+    WebPageRepository.publish(savedPublished, 42L, 20);
+
+    assertNotNull(WebPagePreviewTokenRepository.findValidToken(untouchedToken, savedUntouched.getId(), "/stays-in-draft"),
+        "publishing one page must not invalidate an unrelated page's preview token");
+  }
+
   // --- removeDraft() clears the review workflow (#958) ---
 
   @Test
@@ -428,6 +482,27 @@ class WebPageRepositoryTest {
   }
 
   @Test
+  void removeDraftInvalidatesAnyOutstandingPreviewTokenForThePage() {
+    // Same reasoning as publish() above (#419 review finding): a preview link for a discarded
+    // draft must stop working immediately, or it could later resurface a different, unrelated
+    // draft staged on this page before the token expires.
+    WebPage webPage = new WebPage();
+    webPage.setLink("/preview-then-discard");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setDraftPageXml("<xml>pending</xml>");
+    webPage.setDraft(true);
+    WebPage saved = WebPageRepository.save(webPage);
+    String token = addPreviewToken(saved.getId(), "/preview-then-discard");
+
+    WebPageRepository.removeDraft(saved);
+
+    assertNull(WebPagePreviewTokenRepository.findValidToken(token, saved.getId(), "/preview-then-discard"),
+        "a preview token must stop working once its draft has been discarded");
+  }
+
+  @Test
   void restoreDraftFromVersionLoadsXmlIntoTheDraftSlotWithoutTouchingTheLivePage() {
     WebPage webPage = new WebPage();
     webPage.setLink("/restore-me");
@@ -445,6 +520,17 @@ class WebPageRepositoryTest {
     assertEquals("<xml>live</xml>", reloaded.getPageXml(), "restoring must not touch the live page_xml");
     assertEquals("<xml>restored</xml>", reloaded.getDraftPageXml());
     assertTrue(reloaded.getDraft());
+  }
+
+  private static String addPreviewToken(long webPageId, String pagePath) {
+    WebPagePreviewToken record = new WebPagePreviewToken();
+    record.setWebPageId(webPageId);
+    record.setPagePath(pagePath);
+    record.setToken(java.util.UUID.randomUUID().toString());
+    record.setExpiresAt(Timestamp.from(Instant.now().plusSeconds(3600)));
+    record.setCreatedBy(1L);
+    WebPagePreviewToken saved = WebPagePreviewTokenRepository.add(record);
+    return saved.getToken();
   }
 
   private static boolean isDockerAvailable() {
@@ -526,6 +612,18 @@ class WebPageRepositoryTest {
           + "published_by BIGINT, "
           + "published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL, "
           + "label VARCHAR(255))");
+
+      // Draft preview links (#419) -- publish()/removeDraft() both delete a page's outstanding
+      // tokens, so this table must exist here even though this test never populates it directly.
+      statement.execute("DROP TABLE IF EXISTS web_page_preview_tokens CASCADE");
+      statement.execute("CREATE TABLE web_page_preview_tokens ("
+          + "web_page_preview_token_id BIGSERIAL PRIMARY KEY, "
+          + "web_page_id BIGINT REFERENCES web_pages(web_page_id) ON DELETE CASCADE, "
+          + "page_path VARCHAR(255) NOT NULL, "
+          + "token VARCHAR(255) UNIQUE NOT NULL, "
+          + "expires_at TIMESTAMP(3) NOT NULL, "
+          + "created_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the web_pages schema", se);
     }

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletPreviewTokenTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletPreviewTokenTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.LoadWebPageCommand;
+import com.simisinc.platform.application.cms.WebPageXmlLayoutCommand;
+import com.simisinc.platform.domain.model.cms.WebPage;
+import com.simisinc.platform.domain.model.cms.WebPagePreviewToken;
+import com.simisinc.platform.infrastructure.persistence.cms.WebPagePreviewTokenRepository;
+
+/**
+ * Regression test for issue #419: a page that has never been published ({@code draft=true},
+ * blank {@code pageXml}) normally 404s for a guest via {@link PageServlet#isDraftBlockedFromPublicAccess}
+ * -- this is what {@link PageServletTest} already covers for the un-tokened case. This test covers
+ * the new bypass: a valid, unexpired preview token must let that same request past the block (proven
+ * here by observing that {@link WebPageXmlLayoutCommand#retrievePageForRequest} -- unreachable code
+ * on the blocked path -- gets invoked), and must mark the response {@code X-Robots-Tag: noindex} so
+ * the unreviewed content can never be indexed.
+ *
+ * <p>Reuses {@link PageServletSecurityHeadersTest}'s minimal mocking scaffold, stopping the request
+ * at the "page not found" branch just past the bypass point under test -- deep widget/JSP rendering
+ * is exercised by live Docker verification instead, not by this unit test.
+ *
+ * @author elizabeth houser
+ */
+class PageServletPreviewTokenTest {
+
+  private static final String REQUEST_URI = "/never-published-page";
+  private static final long WEB_PAGE_ID = 42L;
+
+  private WebPage neverPublishedWebPageWithDraft() {
+    WebPage webPage = new WebPage();
+    webPage.setId(WEB_PAGE_ID);
+    webPage.setLink(REQUEST_URI);
+    webPage.setDraft(true);
+    webPage.setPageXml(null);
+    webPage.setDraftPageXml("<page><section/></page>");
+    return webPage;
+  }
+
+  private HttpServletRequest mockRequest(HttpSession session, String previewToken) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    ServletContext servletContext = mock(ServletContext.class);
+    when(request.getServletContext()).thenReturn(servletContext);
+    when(servletContext.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn(REQUEST_URI);
+    when(request.getSession()).thenReturn(session);
+    when(request.getParameter("previewToken")).thenReturn(previewToken);
+    return request;
+  }
+
+  private HttpSession mockSession() {
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(SessionConstants.CONTROLLER)).thenReturn(new ControllerSession());
+    when(session.getAttribute(SessionConstants.USER)).thenReturn(new UserSession());
+    return session;
+  }
+
+  @Test
+  void serviceBypassesTheDraftBlockAndMarksNoindexWhenAValidPreviewTokenIsPresented() throws Exception {
+    HttpServletRequest request = mockRequest(mockSession(), "valid-token");
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    WebPage webPage = neverPublishedWebPageWithDraft();
+
+    try (MockedStatic<LoadWebPageCommand> loadWebPage = mockStatic(LoadWebPageCommand.class);
+        MockedStatic<WebPagePreviewTokenRepository> previewTokens = mockStatic(WebPagePreviewTokenRepository.class);
+        MockedStatic<WebPageXmlLayoutCommand> webPageXmlLayout = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> loadSiteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+
+      loadWebPage.when(() -> LoadWebPageCommand.loadByLink(REQUEST_URI)).thenReturn(webPage);
+      previewTokens.when(() -> WebPagePreviewTokenRepository.findValidToken("valid-token", WEB_PAGE_ID, REQUEST_URI))
+          .thenReturn(new WebPagePreviewToken());
+      loadSiteProperty.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+      loadSiteProperty.when(() -> LoadSitePropertyCommand.loadAsMap(anyString())).thenAnswer(inv -> new HashMap<String, String>());
+      // Let the request 404 cleanly just past the bypass point under test, rather than mocking the
+      // full widget/JSP render pipeline -- that end-to-end behavior is covered by live Docker verification.
+      webPageXmlLayout.when(() -> WebPageXmlLayoutCommand.retrievePageForRequest(eq(webPage), anyString())).thenReturn(null);
+      webPageXmlLayout.when(WebPageXmlLayoutCommand::getWidgetLibrary).thenReturn(new HashMap<>());
+
+      new PageServlet().service(request, response);
+
+      // Reaching retrievePageForRequest proves the isDraftBlockedFromPublicAccess 404 (which returns
+      // before this line) was skipped for this token-bearing request.
+      webPageXmlLayout.verify(() -> WebPageXmlLayoutCommand.retrievePageForRequest(eq(webPage), anyString()), times(1));
+    }
+
+    verify(response, times(1)).setHeader("X-Robots-Tag", "noindex");
+  }
+
+  @Test
+  void serviceStillBlocksTheSamePageForAGuestWithNoPreviewToken() throws Exception {
+    HttpServletRequest request = mockRequest(mockSession(), null);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    WebPage webPage = neverPublishedWebPageWithDraft();
+
+    try (MockedStatic<LoadWebPageCommand> loadWebPage = mockStatic(LoadWebPageCommand.class);
+        MockedStatic<WebPagePreviewTokenRepository> previewTokens = mockStatic(WebPagePreviewTokenRepository.class);
+        MockedStatic<WebPageXmlLayoutCommand> webPageXmlLayout = mockStatic(WebPageXmlLayoutCommand.class);
+        MockedStatic<LoadSitePropertyCommand> loadSiteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+
+      loadWebPage.when(() -> LoadWebPageCommand.loadByLink(REQUEST_URI)).thenReturn(webPage);
+      previewTokens.when(() -> WebPagePreviewTokenRepository.findValidToken(any(), eq(WEB_PAGE_ID), anyString())).thenReturn(null);
+      loadSiteProperty.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
+
+      new PageServlet().service(request, response);
+
+      verify(response, times(1)).sendError(HttpServletResponse.SC_NOT_FOUND);
+      // The block must return before layout resolution is ever attempted.
+      webPageXmlLayout.verifyNoMoreInteractions();
+    }
+
+    verify(response, never()).setHeader(eq("X-Robots-Tag"), anyString());
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -590,4 +590,33 @@ class PageServletTest {
 
     assertFalse(PageServlet.isPubliclyUnrestrictedPage(pageRef));
   }
+
+  // Issue #419 review finding: generatePreviewLink previously built the shareable link from
+  // pagePath alone, which never carries a query string (request.getRequestURI() never does), so a
+  // page addressed by a query parameter (e.g. a "?collectionId=5" collection page) silently lost
+  // that parameter in the generated link.
+
+  @Test
+  void buildPreviewLinkAppendsTheTokenWhenThereIsNoOriginalQuery() {
+    assertEquals("/some-page?previewToken=abc123", PageServlet.buildPreviewLink("/some-page", null, "abc123"));
+    assertEquals("/some-page?previewToken=abc123", PageServlet.buildPreviewLink("/some-page", "", "abc123"));
+  }
+
+  @Test
+  void buildPreviewLinkPreservesTheOriginalQueryString() {
+    assertEquals("/some-collection-page?collectionId=5&previewToken=abc123",
+        PageServlet.buildPreviewLink("/some-collection-page", "collectionId=5", "abc123"));
+  }
+
+  @Test
+  void buildPreviewLinkPreservesMultipleOriginalQueryParameters() {
+    assertEquals("/page?a=1&b=2&previewToken=abc123", PageServlet.buildPreviewLink("/page", "a=1&b=2", "abc123"));
+  }
+
+  @Test
+  void buildPreviewLinkDropsAPreviewTokenAlreadyPresentInTheOriginalQuery() {
+    // A caller cannot smuggle in a second, conflicting token value via originalQuery.
+    assertEquals("/page?a=1&previewToken=abc123",
+        PageServlet.buildPreviewLink("/page", "a=1&previewToken=SMUGGLED", "abc123"));
+  }
 }


### PR DESCRIPTION
## Summary
- Resolves #419: an editor with a pending draft can click **Get Preview Link** in the visual editor toolbar to generate a time-limited bearer link (default 24h, configurable via the new `security.previewLinkTtlHours` site property) that lets anyone holding it view the page's current draft at its real URL, without publishing it.
- The response is marked `X-Robots-Tag: noindex` and `<meta name="robots" content="noindex">`, and shows a visible "You are previewing an unpublished draft" banner, so a shared link can never leak into search results or be mistaken for the live page.
- Preview tokens are scoped to both the web page **and** the exact request path they were minted for (not just the page — a wildcard page like `/news/*` backs many distinct URLs from one row), and every outstanding token for a page is deleted the moment its draft is published or discarded, so a still-unexpired link can never later resurface a different, unrelated draft staged on the same page.

## Changes
- New `web_page_preview_tokens` table (install + upgrade migrations), domain model, repository, and `GeneratePreviewLinkCommand`.
- `PageServlet`: token lookup + `X-Robots-Tag: noindex`, bypass of the existing draft-blocked-from-public-access check for a valid token, a parallel `parseFreshDraft` render branch alongside the existing editor-preview path, and a new `generatePreviewLink` POST action.
- `WebPageRepository.publish()`/`removeDraft()`: delete all outstanding preview tokens for the page as part of the same operation.
- `WebContainerCommand`: `previewingDraft` added to the page-level request-attribute allowlist.
- `main.jsp`: noindex meta tag + preview banner.
- `platform-editor.js`: new "Get Preview Link" toolbar button.

## Review
An adversarial multi-agent review flagged three real gaps in the first pass, all fixed and covered by new tests before this PR was opened:
- **High** — tokens weren't invalidated on publish/discard, so a stale link could later resurface an unrelated later draft.
- **Medium** — tokens were scoped only by page, not path, so a wildcard page's token would validate for every URL under that template.
- **Low** — the generated link dropped the page's original query string (e.g. `?collectionId=5`).

## Test plan
- [x] Full `ant ci-test` (all suites, zero failures) and the unescaped-EL gate (0 unallowlisted) both clean.
- [x] New unit/integration tests: `WebPagePreviewTokenRepositoryTest`, `GeneratePreviewLinkCommandTest`, `PageServletPreviewTokenTest`, plus new cases in `WebPageRepositoryTest` and `PageServletTest` (61+ new assertions across all of the above).
- [x] Live Docker rehearsal, verified anonymously (no cookies):
  - Valid token renders the draft at the real URL with the noindex header/meta/banner present.
  - No token / wrong token silently falls back to the live page, no banner, no noindex.
  - A token minted for one path 404s/falls back when used against the DB directly-verified scoping (`page_path` column).
  - Discarding the draft immediately invalidates the token (`web_page_preview_tokens` row deleted; the same link then falls back to the live page).

## Known limitation (follow-up filed separately)
On a site that hasn't launched yet (`site.online=false`), a preview link for the homepage `/` specifically is overridden by the existing pre-launch placeholder page — every other page, and any already-launched site, work correctly. This is an interaction with a separate, pre-existing feature and is being tracked as its own follow-up rather than expanding this PR's scope.