### PR TITLE
Add content block version history (#406)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentHtmlCommand.java
@@ -523,11 +523,16 @@ public class ContentHtmlCommand {
       context.setErrorMessage("This content must be submitted for review and approved before it can be published");
       return context;
     }
-    ContentRepository.publish(content);
+    ContentRepository.publish(content, resolveVersionHistoryLimit());
     AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.SUCCESS,
         "content", String.valueOf(content.getId()), content.getUniqueId(), null);
     purgeCacheForCurrentPage(context);
     return context;
+  }
+
+  /** The configured {@code content.versionHistoryLimit} (#406), resolved fresh at each publish call site. */
+  private static int resolveVersionHistoryLimit() {
+    return ContentRepository.resolveVersionHistoryLimit(LoadSitePropertyCommand.loadByName("content.versionHistoryLimit"));
   }
 
   private static WidgetContext submitForReview(WidgetContext context, Content content) {
@@ -583,7 +588,7 @@ public class ContentHtmlCommand {
       // approve() enforces separation of duties (the approver cannot be the submitter); approval then
       // promotes the draft to live and records the named approver + release authority in the audit trail.
       ContentReviewCommand.approve(content, context.getUserId(), releaseReference);
-      ContentRepository.publish(content);
+      ContentRepository.publish(content, resolveVersionHistoryLimit());
       AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.approve", AuditEventCommand.SUCCESS,
           "content", String.valueOf(content.getId()), content.getUniqueId(),
           StringUtils.isNotBlank(releaseReference) ? "release authority: " + releaseReference : null);

--- a/src/main/java/com/simisinc/platform/application/cms/ContentVersionDiffCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ContentVersionDiffCommand.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jsoup.Jsoup;
+
+/**
+ * Word-level diff between two stored {@code content_versions} rows (#406), rendered as HTML with
+ * {@code <ins>}/{@code <del>} markup for the admin version-history compare view.
+ *
+ * <p>Diffs at the level of visible words, not raw HTML tags: both inputs are reduced to plain text
+ * (Jsoup strips markup) before diffing, so purely structural changes -- which {@code <p>}/{@code
+ * <div>} happens to wrap a paragraph -- don't drown out the words an author actually changed. The
+ * classic LCS (longest common subsequence) algorithm identifies the words common to both versions in
+ * order; everything else is an insertion or a deletion, and consecutive same-type words are grouped
+ * into a single run so the output reads as phrases, not a word-by-word confetti of tags.
+ *
+ * <p>Both {@code content_versions.content} values (and the live {@code content.content} a caller may
+ * diff a version against) are already sanitized HTML by the time they reach here -- {@link
+ * ContentHtmlCommand#toHtml} rendered them at snapshot/save time -- but the diff output re-escapes
+ * every word regardless, since Jsoup's {@code .text()} decodes entities back to literal characters
+ * that must not be reinterpreted as markup when reassembled into this method's own HTML string.
+ *
+ * @author elizabeth houser
+ */
+public class ContentVersionDiffCommand {
+
+  private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+  /**
+   * The LCS table is O(n*m) time and space -- fine for a content block's handful of paragraphs, but a
+   * resource-exhaustion risk for an unbounded document. Beyond this many words in either version, the
+   * diff is skipped rather than computed.
+   */
+  static final int MAX_DIFF_WORDS = 3000;
+
+  private ContentVersionDiffCommand() {
+    // Static command
+  }
+
+  public static class Result {
+    private final String html;
+    private final boolean truncated;
+
+    Result(String html, boolean truncated) {
+      this.html = html;
+      this.truncated = truncated;
+    }
+
+    /** The rendered diff HTML, or null when {@link #isTruncated()} is true. */
+    public String getHtml() {
+      return html;
+    }
+
+    /** True when either version exceeded {@link #MAX_DIFF_WORDS} and no diff was computed. */
+    public boolean isTruncated() {
+      return truncated;
+    }
+  }
+
+  public static Result diff(String oldHtml, String newHtml) {
+    List<String> oldWords = tokenize(oldHtml);
+    List<String> newWords = tokenize(newHtml);
+    if (oldWords.size() > MAX_DIFF_WORDS || newWords.size() > MAX_DIFF_WORDS) {
+      return new Result(null, true);
+    }
+    return new Result(render(oldWords, newWords), false);
+  }
+
+  private static List<String> tokenize(String html) {
+    List<String> words = new ArrayList<>();
+    if (StringUtils.isBlank(html)) {
+      return words;
+    }
+    String text = Jsoup.parse(html).text().trim();
+    if (text.isEmpty()) {
+      return words;
+    }
+    for (String word : WHITESPACE.split(text)) {
+      if (!word.isEmpty()) {
+        words.add(word);
+      }
+    }
+    return words;
+  }
+
+  private static String render(List<String> oldWords, List<String> newWords) {
+    int n = oldWords.size();
+    int m = newWords.size();
+
+    // lcs[i][j] = length of the longest common subsequence of oldWords[i..] and newWords[j..]
+    int[][] lcs = new int[n + 1][m + 1];
+    for (int i = n - 1; i >= 0; i--) {
+      for (int j = m - 1; j >= 0; j--) {
+        lcs[i][j] = oldWords.get(i).equals(newWords.get(j))
+            ? lcs[i + 1][j + 1] + 1
+            : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      }
+    }
+
+    StringBuilder result = new StringBuilder();
+    StringBuilder run = new StringBuilder();
+    int runType = 0; // 0 = unchanged, 1 = deleted, 2 = inserted -- 0 doubles as "no run open" since run starts empty
+    int i = 0;
+    int j = 0;
+    while (i < n || j < m) {
+      int type;
+      String word;
+      if (i < n && j < m && oldWords.get(i).equals(newWords.get(j))) {
+        type = 0;
+        word = oldWords.get(i);
+        i++;
+        j++;
+      } else if (j >= m || (i < n && lcs[i + 1][j] >= lcs[i][j + 1])) {
+        type = 1;
+        word = oldWords.get(i);
+        i++;
+      } else {
+        type = 2;
+        word = newWords.get(j);
+        j++;
+      }
+      if (type != runType) {
+        flushRun(result, runType, run);
+        runType = type;
+        run.setLength(0);
+      }
+      if (run.length() > 0) {
+        run.append(' ');
+      }
+      run.append(StringEscapeUtils.escapeHtml4(word));
+    }
+    flushRun(result, runType, run);
+    return result.toString().trim();
+  }
+
+  private static void flushRun(StringBuilder result, int type, StringBuilder run) {
+    if (run.isEmpty()) {
+      return;
+    }
+    switch (type) {
+      case 1 -> result.append("<del>").append(run).append("</del> ");
+      case 2 -> result.append("<ins>").append(run).append("</ins> ");
+      default -> result.append(run).append(' ');
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/ContentVersion.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/ContentVersion.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A snapshot of a content block's live content taken at the moment it was replaced by a publish
+ * (#406) -- the outgoing content, not the incoming one, so a prior published state can be viewed,
+ * diffed, or restored. Always plain rendered HTML, regardless of whether the outgoing content was
+ * stored as legacy HTML or Quill Delta JSON at the time (see ContentRepository#publish).
+ *
+ * @author elizabeth houser
+ */
+public class ContentVersion extends Entity {
+
+  private long id = -1;
+  private long contentId = -1;
+  private String content = null;
+  private long approvedBy = -1;
+  private Timestamp publishedAt = null;
+  private String releaseReference = null;
+
+  public ContentVersion() {
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(long contentId) {
+    this.contentId = contentId;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public long getApprovedBy() {
+    return approvedBy;
+  }
+
+  public void setApprovedBy(long approvedBy) {
+    this.approvedBy = approvedBy;
+  }
+
+  public Timestamp getPublishedAt() {
+    return publishedAt;
+  }
+
+  public void setPublishedAt(Timestamp publishedAt) {
+    this.publishedAt = publishedAt;
+  }
+
+  public String getReleaseReference() {
+    return releaseReference;
+  }
+
+  public void setReleaseReference(String releaseReference) {
+    this.releaseReference = releaseReference;
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -16,9 +16,11 @@
 
 package com.simisinc.platform.infrastructure.persistence.cms;
 
+import com.simisinc.platform.application.cms.ContentHtmlCommand;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
 import com.simisinc.platform.application.cms.HtmlCommand;
 import com.simisinc.platform.domain.model.cms.Content;
+import com.simisinc.platform.domain.model.cms.ContentVersion;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.database.*;
 import org.apache.commons.lang3.StringUtils;
@@ -26,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -217,27 +220,92 @@ public class ContentRepository {
     return null;
   }
 
-  public static void publish(Content record) {
+  private static final int DEFAULT_VERSION_HISTORY_LIMIT = 20;
+
+  /** Parses the configured version-history cap to a bounded positive integer, defaulting to 20. */
+  public static int resolveVersionHistoryLimit(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_VERSION_HISTORY_LIMIT;
+    }
+    try {
+      int limit = Integer.parseInt(value.trim());
+      return Math.max(limit, 1);
+    } catch (NumberFormatException e) {
+      return DEFAULT_VERSION_HISTORY_LIMIT;
+    }
+  }
+
+  /**
+   * Promotes draftContent to the live content (#406). Before overwriting it, the outgoing content is
+   * rendered to plain HTML (format-aware, matching {@link ContentHtmlCommand#toHtml}) and snapshotted
+   * into content_versions -- within the same transaction as the publish itself, so a failed snapshot
+   * can't silently leave a publish with no recoverable prior state -- then pruned to
+   * versionHistoryLimit. The approver and release authority recorded on the version row come straight
+   * off {@code record}, which the caller (ContentHtmlCommand) has already stamped via
+   * ContentReviewCommand before reaching here; an ungoverned direct publish leaves them at their -1/
+   * null defaults, same as the live row itself. A content block with no live content yet (first-ever
+   * publish) has nothing to snapshot.
+   */
+  public static void publish(Content record, int versionHistoryLimit) {
     if (StringUtils.isBlank(record.getUniqueId())) {
       return;
     }
-    // Handle publishing and making sure there is content to publish
-    SqlUtils updateValues = new SqlUtils();
-    updateValues.add("content = draft_content");
-    updateValues.add("draft_content = null");
-    // Promote the draft's format stamp with its content, then clear it alongside the emptied draft.
-    updateValues.add("content_format = draft_content_format");
-    updateValues.add("draft_content_format = 0");
-    // The draft is consumed, so clear its review workflow. The durable record of who submitted and
-    // approved, and under what release authority, lives in the append-only audit trail, not here.
-    updateValues.add("draft_status = null");
-    updateValues.add("submitted_by = -1");
-    updateValues.add("approved_by = -1");
-    updateValues.add("release_reference = null");
-    updateValues.add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())));
-    SqlUtils where = new SqlUtils().add("draft_content IS NOT NULL AND content_unique_id = ?", record.getUniqueId());
-    if (DB.update(TABLE_NAME, updateValues, where)) {
-      CacheManager.invalidateKey(CacheManager.CONTENT_UNIQUE_ID_CACHE, record.getUniqueId());
+    try (Connection connection = DB.getConnection();
+        AutoStartTransaction ignored = new AutoStartTransaction(connection);
+        AutoRollback transaction = new AutoRollback(connection)) {
+
+      long contentId = -1;
+      String outgoingContent = null;
+      int outgoingContentFormat = 0;
+      try (PreparedStatement pst = connection.prepareStatement(
+          "SELECT content_id, content, content_format FROM " + TABLE_NAME
+              + " WHERE content_unique_id = ? AND draft_content IS NOT NULL")) {
+        pst.setString(1, record.getUniqueId());
+        try (ResultSet rs = pst.executeQuery()) {
+          if (!rs.next()) {
+            // Nothing to publish (no pending draft) -- matches the prior no-op behavior
+            return;
+          }
+          contentId = rs.getLong("content_id");
+          outgoingContent = rs.getString("content");
+          outgoingContentFormat = rs.getInt("content_format");
+        }
+      }
+
+      if (StringUtils.isNotBlank(outgoingContent)) {
+        ContentVersion version = new ContentVersion();
+        version.setContentId(contentId);
+        version.setContent(ContentHtmlCommand.toHtml(outgoingContent, outgoingContentFormat));
+        version.setApprovedBy(record.getApprovedBy());
+        version.setReleaseReference(record.getReleaseReference());
+        if (ContentVersionRepository.insert(connection, version) == -1) {
+          throw new SQLException("The prior content version was not saved");
+        }
+        ContentVersionRepository.pruneOldest(connection, contentId, versionHistoryLimit);
+      }
+
+      // Handle publishing and making sure there is content to publish
+      SqlUtils updateValues = new SqlUtils();
+      updateValues.add("content = draft_content");
+      updateValues.add("draft_content = null");
+      // Promote the draft's format stamp with its content, then clear it alongside the emptied draft.
+      updateValues.add("content_format = draft_content_format");
+      updateValues.add("draft_content_format = 0");
+      // The draft is consumed, so clear its review workflow. The durable record of who submitted and
+      // approved, and under what release authority, lives in the append-only audit trail (and now
+      // content_versions above), not here.
+      updateValues.add("draft_status = null");
+      updateValues.add("submitted_by = -1");
+      updateValues.add("approved_by = -1");
+      updateValues.add("release_reference = null");
+      updateValues.add("content_text", HtmlCommand.text(StringUtils.trimToNull(record.getContent())));
+      SqlUtils where = new SqlUtils().add("draft_content IS NOT NULL AND content_unique_id = ?", record.getUniqueId());
+      if (DB.update(connection, TABLE_NAME, updateValues, where)) {
+        transaction.commit();
+        CacheManager.invalidateKey(CacheManager.CONTENT_UNIQUE_ID_CACHE, record.getUniqueId());
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
     }
   }
 
@@ -251,6 +319,27 @@ public class ContentRepository {
     if (DB.update(TABLE_NAME, set, where)) {
       CacheManager.invalidateKey(CacheManager.CONTENT_UNIQUE_ID_CACHE, record.getUniqueId());
     }
+  }
+
+  /**
+   * Loads a prior version's content into the draft slot (#406) -- never touches the live content, so
+   * a subsequent publish is required to make the restored content live again. Also resets the
+   * governed-review fields unconditionally: unlike WebPageRepository#restoreDraftFromVersion (its
+   * #405 precedent, which leaves them untouched), a restore here always clears any
+   * draftStatus/submittedBy/approvedBy left over from whatever draft cycle was in progress before the
+   * restore -- otherwise a pending approval on the *old* draft could be inherited by the *restored*
+   * content, publishing it without ever actually being reviewed (the #957/#958 bypass shape).
+   */
+  public static boolean restoreDraftFromVersion(long contentId, String content) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("draft_content", content)
+        .add("draft_content_format", 0)
+        .add("draft_status = null")
+        .add("submitted_by = -1")
+        .add("approved_by = -1")
+        .add("release_reference = null");
+    SqlUtils where = new SqlUtils().add("content_id = ?", contentId);
+    return DB.update(TABLE_NAME, updateValues, where);
   }
 
   public static boolean remove(Content record) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentVersionRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentVersionRepository.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.ContentVersion;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves content block version snapshots (#406) -- each row is the content that was
+ * overwritten by a publish, so a prior published state can be listed, diffed, or restored.
+ *
+ * @author elizabeth houser
+ */
+public class ContentVersionRepository {
+
+  private static Log LOG = LogFactory.getLog(ContentVersionRepository.class);
+
+  private static String TABLE_NAME = "content_versions";
+  private static String[] PRIMARY_KEY = new String[]{"content_version_id"};
+
+  public static ContentVersion findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (ContentVersion) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("content_version_id = ?", id),
+        ContentVersionRepository::buildRecord);
+  }
+
+  public static List<ContentVersion> findByContentId(long contentId, DataConstraints constraints) {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME,
+        new SqlUtils().add("content_id = ?", contentId),
+        (constraints != null ? constraints : new DataConstraints()).setDefaultColumnToSortBy("published_at DESC"),
+        ContentVersionRepository::buildRecord);
+    if (result.hasRecords()) {
+      return (List<ContentVersion>) result.getRecords();
+    }
+    return null;
+  }
+
+  /** Inserts a version row within the caller's transaction. Returns the new id, or -1 on failure. */
+  public static long insert(Connection connection, ContentVersion record) throws SQLException {
+    SqlUtils insertValues = new SqlUtils()
+        .add("content_id", record.getContentId())
+        .add("content", record.getContent())
+        .add("approved_by", record.getApprovedBy(), -1)
+        .add("release_reference", record.getReleaseReference());
+    long id = DB.insertInto(connection, TABLE_NAME, insertValues, PRIMARY_KEY);
+    if (id == -1) {
+      LOG.error("A content version was not saved");
+    }
+    return id;
+  }
+
+  /**
+   * Deletes all but the {@code keepCount} most recent versions for the content block, within the
+   * caller's transaction. Called right after {@link #insert}, so the just-inserted row is included in
+   * the kept set as long as {@code keepCount >= 1}.
+   */
+  public static void pruneOldest(Connection connection, long contentId, int keepCount) {
+    String sql = "DELETE FROM " + TABLE_NAME + " WHERE content_id = ? AND content_version_id NOT IN ("
+        + "SELECT content_version_id FROM " + TABLE_NAME + " WHERE content_id = ? "
+        + "ORDER BY published_at DESC, content_version_id DESC LIMIT ?)";
+    try (PreparedStatement pst = connection.prepareStatement(sql)) {
+      pst.setLong(1, contentId);
+      pst.setLong(2, contentId);
+      pst.setInt(3, Math.max(keepCount, 0));
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+  }
+
+  private static ContentVersion buildRecord(ResultSet rs) {
+    try {
+      ContentVersion record = new ContentVersion();
+      record.setId(rs.getLong("content_version_id"));
+      record.setContentId(rs.getLong("content_id"));
+      record.setContent(rs.getString("content"));
+      record.setApprovedBy(DB.getLong(rs, "approved_by", -1));
+      Timestamp publishedAt = rs.getTimestamp("published_at");
+      record.setPublishedAt(publishedAt);
+      record.setReleaseReference(rs.getString("release_reference"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentVersionsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentVersionsListWidget.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.cms.ContentVersionDiffCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.Content;
+import com.simisinc.platform.domain.model.cms.ContentVersion;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentVersionRepository;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The /admin/content-versions admin page (issue #406): lists a content block's prior published
+ * revisions (approver, release reference, timestamp), offers a word-level diff between any two
+ * selected versions, and a restore action that loads the chosen version into the draft slot for
+ * review -- a subsequent submit/approve/publish cycle is required to make it live again.
+ *
+ * @author elizabeth houser
+ */
+public class ContentVersionsListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/admin/content-versions-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    String uniqueId = context.getParameter("uniqueId");
+    Content content = StringUtils.isNotBlank(uniqueId) ? ContentRepository.findByUniqueId(uniqueId) : null;
+    if (content == null) {
+      context.setErrorMessage("Content was not found");
+      return context;
+    }
+    context.getRequest().setAttribute("content", content);
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "20"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    List<ContentVersion> versionList = ContentVersionRepository.findByContentId(content.getId(), constraints);
+    context.getRequest().setAttribute("versionList", versionList);
+
+    // Resolve the approver display name for each version shown on this page
+    Map<Long, User> userMap = new HashMap<>();
+    if (versionList != null) {
+      for (ContentVersion version : versionList) {
+        long approvedBy = version.getApprovedBy();
+        if (approvedBy > -1 && !userMap.containsKey(approvedBy)) {
+          userMap.put(approvedBy, UserRepository.findByUserId(approvedBy));
+        }
+      }
+    }
+    context.getRequest().setAttribute("userMap", userMap);
+
+    context.getRequest().setAttribute("recordPagingParams", "uniqueId=" + uniqueId);
+
+    // An optional word-level diff between two versions selected on the page just rendered (#406).
+    // Both ids are re-checked against this content block's own versions -- a stray/foreign
+    // contentVersionId (typed into the URL, or left over from a different block) must never diff
+    // content that doesn't belong here.
+    long compareFromId = context.getParameterAsLong("compareFrom", -1);
+    long compareToId = context.getParameterAsLong("compareTo", -1);
+    if (compareFromId > -1 && compareToId > -1) {
+      ContentVersion from = ContentVersionRepository.findById(compareFromId);
+      ContentVersion to = ContentVersionRepository.findById(compareToId);
+      if (from != null && to != null
+          && from.getContentId() == content.getId() && to.getContentId() == content.getId()) {
+        context.getRequest().setAttribute("diffResult", ContentVersionDiffCommand.diff(from.getContent(), to.getContent()));
+        context.getRequest().setAttribute("compareFromId", compareFromId);
+        context.getRequest().setAttribute("compareToId", compareToId);
+      } else {
+        context.setWarningMessage("One or both selected versions could not be compared");
+      }
+    }
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    if (!"restore".equals(context.getParameter("action"))) {
+      return null;
+    }
+
+    long contentVersionId = context.getParameterAsLong("contentVersionId", -1);
+    ContentVersion version = contentVersionId > -1 ? ContentVersionRepository.findById(contentVersionId) : null;
+    if (version == null) {
+      context.setErrorMessage("The selected version was not found");
+      return execute(context);
+    }
+
+    if (!ContentRepository.restoreDraftFromVersion(version.getContentId(), version.getContent())) {
+      context.setErrorMessage("The version could not be restored");
+      return execute(context);
+    }
+
+    context.setSuccessMessage("The version was restored to the draft. It must be reviewed and published again to go live.");
+    return execute(context);
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -173,6 +173,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (2, 'Password Age Warning Threshold (days)', 'password.maxAgeDays', '90', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (11, 'Form submission failure retention (days)', 'formData.failureRetentionDays', '90');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'Web page version history limit (per page)', 'webPage.versionHistoryLimit', '20', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (13, 'Content block version history limit (per block)', 'content.versionHistoryLimit', '20', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (7, 'Honor Do-Not-Track / Global Privacy Control?', 'analytics.honorDnt', 'false', 'boolean');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (9, 'Require visitor consent before loading analytics?', 'analytics.consentRequired', 'false', 'boolean');

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -741,6 +741,22 @@ CREATE TABLE web_page_versions (
 );
 CREATE INDEX web_page_versions_web_idx ON web_page_versions(web_page_id, published_at DESC);
 
+-- Content block version history (#406): the same pattern as web_page_versions above, but for
+-- governed content blocks. One row per ContentRepository.publish() call, holding the outgoing
+-- content -- rendered to plain HTML (DeltaContentCommand-aware) at snapshot time, so a block that
+-- was published as Quill Delta on one cycle and legacy HTML on another still has a uniformly
+-- diffable history, with no format stamp needed on this table. Rows are pruned to a configurable
+-- cap (content.versionHistoryLimit) on insert; cascades on content deletion.
+CREATE TABLE content_versions (
+  content_version_id BIGSERIAL PRIMARY KEY,
+  content_id BIGINT REFERENCES content(content_id) ON DELETE CASCADE,
+  content TEXT,
+  approved_by BIGINT REFERENCES users(user_id),
+  published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  release_reference VARCHAR(255)
+);
+CREATE INDEX content_versions_content_idx ON content_versions(content_id, published_at DESC);
+
 -- Core Web Vitals RUM (Real User Monitoring, #429)
 -- Raw metrics collected from real page loads, one row per metric per page load
 CREATE TABLE web_vitals (

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1010__content_versions.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1010__content_versions.sql
@@ -1,0 +1,20 @@
+-- Content block version history (issue #406): one row per ContentRepository.publish() call, holding
+-- the OUTGOING content (the value about to be overwritten), rendered to plain HTML so a block that
+-- mixes Delta and legacy-HTML publishes over time still has a uniformly diffable history.
+-- Idempotent so it is safe on any existing install; fresh installs get the identical table from
+-- NEW_10010, mirroring UPGRADE_20260802.1007__web_page_versions.sql's pattern for #405.
+CREATE TABLE IF NOT EXISTS content_versions (
+  content_version_id BIGSERIAL PRIMARY KEY,
+  content_id BIGINT REFERENCES content(content_id) ON DELETE CASCADE,
+  content TEXT,
+  approved_by BIGINT REFERENCES users(user_id),
+  published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  release_reference VARCHAR(255)
+);
+CREATE INDEX IF NOT EXISTS content_versions_content_idx ON content_versions(content_id, published_at DESC);
+
+-- Caps how many prior versions are retained per content block (ContentRepository.publish() prunes to
+-- this limit right after each snapshot), mirroring webPage.versionHistoryLimit.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (13, 'Content block version history limit (per block)', 'content.versionHistoryLimit', '20', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/jsp/admin/content-versions-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/content-versions-list.jsp
@@ -1,0 +1,124 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="content" class="com.simisinc.platform.domain.model.cms.Content" scope="request"/>
+<jsp:useBean id="versionList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="userMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<p class="help-text">
+  Prior published versions of <code><c:out value="${content.uniqueId}" /></code>. Restoring a version
+  loads it into the draft slot for review -- it will not go live until it is submitted, approved, and
+  published again.
+</p>
+<c:if test="${fn:length(versionList) ge 2}">
+  <form method="get" class="margin-bottom-10">
+    <input type="hidden" name="uniqueId" value="<c:out value="${content.uniqueId}"/>" />
+    <div class="grid-x grid-margin-x align-bottom">
+      <div class="cell medium-4">
+        <label>Compare version
+          <select name="compareFrom">
+            <c:forEach items="${versionList}" var="version">
+              <option value="${version.id}"<c:if test="${compareFromId eq version.id}"> selected</c:if>>
+                <fmt:formatDate pattern="yyyy-MM-dd HH:mm" value="${version.publishedAt}" />
+              </option>
+            </c:forEach>
+          </select>
+        </label>
+      </div>
+      <div class="cell medium-4">
+        <label>...against version
+          <select name="compareTo">
+            <c:forEach items="${versionList}" var="version">
+              <option value="${version.id}"<c:if test="${compareToId eq version.id}"> selected</c:if>>
+                <fmt:formatDate pattern="yyyy-MM-dd HH:mm" value="${version.publishedAt}" />
+              </option>
+            </c:forEach>
+          </select>
+        </label>
+      </div>
+      <div class="cell medium-4">
+        <input type="submit" class="button radius secondary" value="Compare" />
+      </div>
+    </div>
+  </form>
+</c:if>
+<c:if test="${!empty diffResult}">
+  <div class="callout">
+    <h6>Word-level diff</h6>
+    <c:choose>
+      <c:when test="${diffResult.truncated}">
+        <p>This comparison is too large to diff word-by-word and was not shown.</p>
+      </c:when>
+      <c:otherwise>
+        <p class="content-version-diff">${diffResult.html}</p>
+      </c:otherwise>
+    </c:choose>
+  </div>
+</c:if>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Published</th>
+      <th>Approved By</th>
+      <th>Release Reference</th>
+      <th width="100" class="text-center">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${versionList}" var="version">
+      <c:set var="approver" value="${userMap[version.approvedBy]}" />
+      <tr>
+        <td><fmt:formatDate pattern="yyyy-MM-dd HH:mm" value="${version.publishedAt}" /></td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty approver}"><c:out value="${approver.fullName}" /></c:when>
+            <c:otherwise>&mdash;</c:otherwise>
+          </c:choose>
+        </td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty version.releaseReference}"><c:out value="${version.releaseReference}" /></c:when>
+            <c:otherwise>&mdash;</c:otherwise>
+          </c:choose>
+        </td>
+        <td class="text-center">
+          <form method="post" action="${widgetContext.uri}" onsubmit="return confirm('Restore this version to the draft slot? It will need to be reviewed and published again to go live.');">
+            <input type="hidden" name="widget" value="${widgetContext.uniqueId}" />
+            <input type="hidden" name="token" value="${userSession.formToken}" />
+            <input type="hidden" name="action" value="restore" />
+            <input type="hidden" name="uniqueId" value="<c:out value="${content.uniqueId}"/>" />
+            <input type="hidden" name="contentVersionId" value="${version.id}" />
+            <button type="submit" class="button tiny radius secondary" title="Restore to draft"><i class="fa fa-undo"></i></button>
+          </form>
+        </td>
+      </tr>
+    </c:forEach>
+    <c:if test="${empty versionList}">
+      <tr>
+        <td colspan="4">No prior versions yet -- one is recorded each time this content is published over an existing draft.</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>

--- a/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-editor.jsp
@@ -145,6 +145,7 @@
         <c:if test="${isDraft eq 'true'}">
           <input type="submit" class="button radius alert" name="save" value="Remove this Draft" />
         </c:if>
+        <a href="${ctx}/admin/content-versions?uniqueId=${content.uniqueId}" class="button radius secondary"><i class="fa fa-history"></i> Version History</a>
       </c:otherwise>
     </c:choose>
     <a href="${returnPage}" class="button radius secondary">Cancel</a>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1360,6 +1360,26 @@
     </section>
   </page>
 
+  <page name="/admin/content-versions" role="admin,content-manager" title="Content Version History">
+    <section>
+      <column class="small-12 cell">
+        <widget name="breadcrumbs">
+          <links>
+            <link name="Content" value="/admin/content-list" />
+            <link name="Version History" value="" />
+          </links>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 cell">
+        <widget name="contentVersionsList">
+          <title>Version History</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/web-page-versions" role="admin,content-manager" title="Web Page Version History">
     <section>
       <column class="small-12 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -176,6 +176,7 @@
   <widget name="webPageDesigner" class="com.simisinc.platform.presentation.widgets.cms.WebPageDesignerWidget" />
   <widget name="contentList" class="com.simisinc.platform.presentation.widgets.admin.cms.ContentListWidget" />
   <widget name="contentForm" class="com.simisinc.platform.presentation.widgets.admin.cms.ContentFormWidget" />
+  <widget name="contentVersionsList" class="com.simisinc.platform.presentation.widgets.admin.cms.ContentVersionsListWidget" />
   <widget name="adminImageBrowser" class="com.simisinc.platform.presentation.widgets.admin.cms.AdminImageBrowserWidget" />
   <widget name="blogList" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogListWidget" />
   <widget name="blogForm" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogFormWidget" />

--- a/src/test/java/com/simisinc/platform/application/cms/ContentVersionDiffCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ContentVersionDiffCommandTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the word-level LCS diff used by the content version-history compare view (#406).
+ *
+ * @author elizabeth houser
+ */
+class ContentVersionDiffCommandTest {
+
+  @Test
+  void identicalContentProducesNoInsOrDelMarkup() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff("<p>Hello world</p>", "<p>Hello world</p>");
+
+    assertFalse(result.isTruncated());
+    assertEquals("Hello world", result.getHtml());
+  }
+
+  @Test
+  void aChangedWordIsShownAsADeletionFollowedByAnInsertion() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff("<p>The quick fox</p>", "<p>The slow fox</p>");
+
+    assertEquals("The <del>quick</del> <ins>slow</ins> fox", result.getHtml());
+  }
+
+  @Test
+  void addedWordsAreWrappedInIns() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff("<p>Hello</p>", "<p>Hello there world</p>");
+
+    assertEquals("Hello <ins>there world</ins>", result.getHtml());
+  }
+
+  @Test
+  void removedWordsAreWrappedInDel() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff("<p>Hello there world</p>", "<p>Hello</p>");
+
+    assertEquals("Hello <del>there world</del>", result.getHtml());
+  }
+
+  @Test
+  void firstEverVersionAgainstBlankShowsEverythingAsInserted() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff(null, "<p>Brand new content</p>");
+
+    assertEquals("<ins>Brand new content</ins>", result.getHtml());
+  }
+
+  @Test
+  void purelyStructuralHtmlChangesProduceNoWordDiff() {
+    // Diffing is word-level, not tag-level: which element wraps the same words is not a content change.
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff(
+        "<p>Hello world</p>", "<div><span>Hello</span> world</div>");
+
+    assertEquals("Hello world", result.getHtml());
+  }
+
+  @Test
+  void wordsAreHtmlEscapedInTheOutput() {
+    // Jsoup's .text() decodes entities back to literal characters -- the diff renderer must
+    // re-escape them so the diff HTML itself cannot be reinterpreted as markup.
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff(
+        "<p>safe</p>", "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>");
+
+    assertFalse(result.getHtml().contains("<script>"), result.getHtml());
+    assertTrue(result.getHtml().contains("&lt;script&gt;"), result.getHtml());
+  }
+
+  @Test
+  void oversizedContentIsNotDiffedAndReportsTruncated() {
+    String hugeOld = "word ".repeat(ContentVersionDiffCommand.MAX_DIFF_WORDS + 1);
+    String hugeNew = "different ".repeat(ContentVersionDiffCommand.MAX_DIFF_WORDS + 1);
+
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff(hugeOld, hugeNew);
+
+    assertTrue(result.isTruncated());
+    assertNull(result.getHtml());
+  }
+
+  @Test
+  void blankInputsOnBothSidesProduceEmptyOutput() {
+    ContentVersionDiffCommand.Result result = ContentVersionDiffCommand.diff(null, null);
+
+    assertFalse(result.isTruncated());
+    assertEquals("", result.getHtml());
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -44,7 +44,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.simisinc.platform.application.DataException;
 import com.simisinc.platform.application.cms.ContentReviewCommand;
+import com.simisinc.platform.application.cms.DeltaContentCommand;
 import com.simisinc.platform.domain.model.cms.Content;
+import com.simisinc.platform.domain.model.cms.ContentVersion;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.database.DataSource;
@@ -127,7 +129,7 @@ class ContentRepositoryTest {
     }
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("TRUNCATE TABLE content RESTART IDENTITY");
+      statement.execute("TRUNCATE TABLE content_versions, content RESTART IDENTITY CASCADE");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not reset content table", se);
     }
@@ -199,6 +201,7 @@ class ContentRepositoryTest {
     // references content.
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS content_versions CASCADE");
       statement.execute("DROP TABLE IF EXISTS content CASCADE");
       statement.execute("CREATE TABLE content ("
           + "content_id BIGSERIAL PRIMARY KEY, "
@@ -228,6 +231,18 @@ class ContentRepositoryTest {
           + "$$ LANGUAGE plpgsql");
       statement.execute("CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE "
           + "ON content FOR EACH ROW EXECUTE PROCEDURE content_tsv_trigger()");
+
+      // #406: content_versions, mirroring NEW_10010__new_cms.sql. No users table in this fixture, so
+      // approved_by is a plain column rather than an FK -- same simplification WebPageVersionRepositoryTest
+      // uses for published_by.
+      statement.execute("CREATE TABLE content_versions ("
+          + "content_version_id BIGSERIAL PRIMARY KEY, "
+          + "content_id BIGINT REFERENCES content(content_id) ON DELETE CASCADE, "
+          + "content TEXT, "
+          + "approved_by BIGINT, "
+          + "published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL, "
+          + "release_reference VARCHAR(255))");
+      statement.execute("CREATE INDEX content_versions_content_idx ON content_versions(content_id, published_at DESC)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the content schema", se);
     }
@@ -267,7 +282,7 @@ class ContentRepositoryTest {
     content.setReleaseReference("cleared per PA case 2026-115");
     ContentRepository.save(content);
 
-    ContentRepository.publish(content);
+    ContentRepository.publish(content, 20);
 
     Content published = ContentRepository.findByUniqueId("to-publish");
     assertEquals("<p>approved draft</p>", published.getContent(), "the draft became the live content");
@@ -275,6 +290,147 @@ class ContentRepositoryTest {
     assertEquals(-1L, published.getSubmittedBy());
     assertEquals(-1L, published.getApprovedBy());
     assertNull(published.getReleaseReference());
+  }
+
+  // --- Version history on publish (issue #406) ---
+
+  @Test
+  void publishSnapshotsTheOutgoingContentBeforeOverwriting() {
+    Content content = new Content();
+    content.setUniqueId("versioned");
+    content.setContent("<p>original live content</p>");
+    ContentRepository.save(content);
+
+    content.setDraftContent("<p>new content</p>");
+    content.setDraftStatus("submitted");
+    content.setSubmittedBy(10L);
+    content.setApprovedBy(20L);
+    content.setReleaseReference("cleared per PA case 2026-406");
+    ContentRepository.save(content);
+
+    ContentRepository.publish(content, 20);
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(content.getId(), null);
+    assertNotNull(versions);
+    assertEquals(1, versions.size());
+    ContentVersion version = versions.get(0);
+    assertEquals("<p>original live content</p>", version.getContent(), "the OUTGOING content is snapshotted, not the new one");
+    assertEquals(20L, version.getApprovedBy());
+    assertEquals("cleared per PA case 2026-406", version.getReleaseReference());
+
+    Content published = ContentRepository.findByUniqueId("versioned");
+    assertEquals("<p>new content</p>", published.getContent());
+  }
+
+  @Test
+  void publishRendersDeltaContentToHtmlBeforeSnapshotting() {
+    // The outgoing content may itself have been published as Quill Delta JSON on a prior cycle -- the
+    // version row must always hold plain HTML (ContentHtmlCommand#toHtml), so a block that mixes Delta
+    // and legacy-HTML publishes over time still has a uniformly diffable history (#406).
+    Content content = new Content();
+    content.setUniqueId("delta-versioned");
+    content.setContent("{\"ops\":[{\"insert\":\"hi\\n\"}]}");
+    content.setContentFormat(DeltaContentCommand.DELTA_FORMAT_VERSION);
+    ContentRepository.save(content);
+
+    content.setDraftContent("<p>plain html draft</p>");
+    ContentRepository.save(content);
+
+    ContentRepository.publish(content, 20);
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(content.getId(), null);
+    assertNotNull(versions);
+    assertEquals("<p>hi</p>", versions.get(0).getContent(), "the Delta snapshot must be rendered to HTML, not stored raw");
+  }
+
+  @Test
+  void publishWithNoPriorLiveContentCreatesNoVersion() {
+    // A content block's first-ever publish has nothing to snapshot.
+    Content content = new Content();
+    content.setUniqueId("first-publish");
+    content.setDraftContent("<p>brand new</p>");
+    ContentRepository.save(content);
+
+    ContentRepository.publish(content, 20);
+
+    assertNull(ContentVersionRepository.findByContentId(content.getId(), null));
+    assertEquals("<p>brand new</p>", ContentRepository.findByUniqueId("first-publish").getContent());
+  }
+
+  @Test
+  void publishPrunesToTheVersionHistoryLimit() {
+    Content content = new Content();
+    content.setUniqueId("prune-me");
+    content.setContent("<p>v0</p>");
+    ContentRepository.save(content);
+
+    for (int i = 1; i <= 5; i++) {
+      content.setDraftContent("<p>v" + i + "</p>");
+      ContentRepository.save(content);
+      ContentRepository.publish(content, 2);
+    }
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(content.getId(), null);
+    assertNotNull(versions);
+    assertEquals(2, versions.size(), "only the 2 most recent snapshots should survive");
+  }
+
+  @Test
+  void publishIsANoOpWhenThereIsNoDraft() {
+    Content content = new Content();
+    content.setUniqueId("no-draft");
+    content.setContent("<p>live</p>");
+    ContentRepository.save(content);
+
+    ContentRepository.publish(content, 20);
+
+    assertEquals("<p>live</p>", ContentRepository.findByUniqueId("no-draft").getContent());
+    assertNull(ContentVersionRepository.findByContentId(content.getId(), null));
+  }
+
+  // --- Restore (issue #406) ---
+
+  @Test
+  void restoreDraftFromVersionLoadsTheContentIntoTheDraftSlot() {
+    Content content = new Content();
+    content.setUniqueId("to-restore");
+    content.setContent("<p>current live</p>");
+    ContentRepository.save(content);
+
+    boolean restored = ContentRepository.restoreDraftFromVersion(content.getId(), "<p>an older version</p>");
+
+    assertTrue(restored);
+    Content reloaded = ContentRepository.findByUniqueId("to-restore");
+    assertEquals("<p>an older version</p>", reloaded.getDraftContent());
+    assertEquals("<p>current live</p>", reloaded.getContent(), "restore never touches the live content directly");
+    assertEquals(0, reloaded.getDraftContentFormat(), "a restored version is always plain HTML");
+  }
+
+  @Test
+  void restoreDraftFromVersionClearsAnyStaleApprovalOnTheDraftItReplaces() {
+    // A draft already submitted-and-approved must not let its approval carry over to a DIFFERENT
+    // draft swapped in by a restore -- otherwise the restored content could publish without ever
+    // actually being reviewed (the same bypass shape fixed for WebPage by #957/#958). Unlike
+    // WebPageRepository#restoreDraftFromVersion (its #405 precedent, which leaves these fields
+    // untouched), this method resets them unconditionally.
+    Content content = new Content();
+    content.setUniqueId("stale-approval");
+    content.setContent("<p>live</p>");
+    content.setDraftContent("<p>a different, already-approved draft</p>");
+    content.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    content.setSubmittedBy(10L);
+    content.setApprovedBy(20L);
+    content.setReleaseReference("cleared per PA case 2026-407");
+    ContentRepository.save(content);
+
+    ContentRepository.restoreDraftFromVersion(content.getId(), "<p>an older version</p>");
+
+    Content reloaded = ContentRepository.findByUniqueId("stale-approval");
+    assertEquals("<p>an older version</p>", reloaded.getDraftContent());
+    assertNull(reloaded.getDraftStatus());
+    assertEquals(-1L, reloaded.getSubmittedBy());
+    assertEquals(-1L, reloaded.getApprovedBy(), "the restored draft must require a fresh approval, not inherit the old one");
+    assertNull(reloaded.getReleaseReference());
   }
 
   private static Content addContent(String uniqueId, String html) {

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentVersionRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentVersionRepositoryTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.ContentVersion;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link ContentVersionRepository} against a real PostgreSQL instance (#406).
+ *
+ * <p>
+ * This is an integration test: it starts a throwaway PostgreSQL container (Testcontainers) and
+ * exercises the repository through the real JDBC/HikariCP stack. It is skipped automatically when
+ * Docker is not available.
+ * </p>
+ *
+ * @author elizabeth houser
+ */
+class ContentVersionRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping ContentVersionRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // The DataSource is never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTable() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE content_versions, content RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset content_versions table", se);
+    }
+  }
+
+  @Test
+  void insertedVersionCanBeFoundById() {
+    long contentId = addContent("/insert-find");
+
+    long versionId = insertVersion(contentId, "<p>v1</p>", 7L, "cleared per PA case 2026-406");
+
+    ContentVersion found = ContentVersionRepository.findById(versionId);
+    assertEquals(contentId, found.getContentId());
+    assertEquals("<p>v1</p>", found.getContent());
+    assertEquals(7L, found.getApprovedBy());
+    assertEquals("cleared per PA case 2026-406", found.getReleaseReference());
+  }
+
+  @Test
+  void findByIdReturnsNullForAnUnknownId() {
+    assertNull(ContentVersionRepository.findById(999999L));
+  }
+
+  @Test
+  void findByContentIdReturnsNullWhenThereAreNoVersions() {
+    long contentId = addContent("/no-versions");
+
+    assertNull(ContentVersionRepository.findByContentId(contentId, null));
+  }
+
+  @Test
+  void findByContentIdOnlyReturnsVersionsForThatContentBlock() {
+    long contentOne = addContent("/content-one");
+    long contentTwo = addContent("/content-two");
+    insertVersion(contentOne, "<p>one</p>", 1L, null);
+    insertVersion(contentTwo, "<p>two</p>", 1L, null);
+
+    List<ContentVersion> results = ContentVersionRepository.findByContentId(contentOne, null);
+
+    assertEquals(1, results.size());
+    assertEquals("<p>one</p>", results.get(0).getContent());
+  }
+
+  @Test
+  void findByContentIdSortsNewestFirst() throws InterruptedException {
+    long contentId = addContent("/sort-order");
+    long olderId = insertVersion(contentId, "<p>older</p>", 1L, null);
+    Thread.sleep(5);
+    long newerId = insertVersion(contentId, "<p>newer</p>", 1L, null);
+
+    List<ContentVersion> results = ContentVersionRepository.findByContentId(contentId, null);
+
+    assertEquals(2, results.size());
+    assertEquals(newerId, results.get(0).getId(), "the most recently published version should be listed first");
+    assertEquals(olderId, results.get(1).getId());
+  }
+
+  @Test
+  void pruneOldestKeepsOnlyTheMostRecentVersions() throws SQLException {
+    long contentId = addContent("/prune-me");
+    for (int i = 0; i < 5; i++) {
+      insertVersion(contentId, "<p>v" + i + "</p>", 1L, null);
+    }
+
+    try (Connection connection = DB.getConnection()) {
+      ContentVersionRepository.pruneOldest(connection, contentId, 2);
+    }
+
+    // Rapid-fire inserts can land in the same published_at millisecond, and findByContentId only
+    // orders by published_at DESC (no id tiebreaker) -- so which of two same-millisecond rows sorts
+    // first is not guaranteed. Assert the surviving *set* (what pruneOldest is actually responsible
+    // for), not a tie-broken order that belongs to a different method.
+    List<ContentVersion> results = ContentVersionRepository.findByContentId(contentId, null);
+    Set<String> remaining = results.stream().map(ContentVersion::getContent).collect(Collectors.toSet());
+    assertEquals(Set.of("<p>v3</p>", "<p>v4</p>"), remaining);
+  }
+
+  @Test
+  void pruneOldestLeavesEverythingAloneWhenUnderTheLimit() throws SQLException {
+    long contentId = addContent("/under-limit");
+    insertVersion(contentId, "<p>only</p>", 1L, null);
+
+    try (Connection connection = DB.getConnection()) {
+      ContentVersionRepository.pruneOldest(connection, contentId, 20);
+    }
+
+    assertEquals(1, ContentVersionRepository.findByContentId(contentId, null).size());
+  }
+
+  @Test
+  void findByContentIdHonorsDataConstraintsPaging() {
+    long contentId = addContent("/paged");
+    for (int i = 0; i < 5; i++) {
+      insertVersion(contentId, "<p>v" + i + "</p>", 1L, null);
+    }
+
+    DataConstraints constraints = new DataConstraints(1, 2);
+    List<ContentVersion> firstPage = ContentVersionRepository.findByContentId(contentId, constraints);
+
+    assertEquals(2, firstPage.size());
+    assertNotEquals(firstPage.get(0).getId(), firstPage.get(1).getId());
+  }
+
+  @Test
+  void insertStoresNoApproverAsNullRatherThanNegativeOne() {
+    // approved_by is -1 by default for an ungoverned direct publish -- the FK-friendly sentinel
+    // convention used throughout this codebase (see SqlUtils#add(String, long, long)).
+    long contentId = addContent("/ungoverned-publish");
+
+    long versionId = insertVersion(contentId, "<p>direct publish</p>", -1L, null);
+
+    ContentVersion found = ContentVersionRepository.findById(versionId);
+    assertEquals(-1L, found.getApprovedBy(), "buildRecord defaults a null column back to -1");
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // A focused subset of the real schema -- no users table here, so approved_by is a plain column
+    // rather than an FK, matching the same simplification used elsewhere in this test suite.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS content_versions CASCADE");
+      statement.execute("DROP TABLE IF EXISTS content CASCADE");
+      statement.execute("CREATE TABLE content ("
+          + "content_id BIGSERIAL PRIMARY KEY, "
+          + "content_unique_id VARCHAR(255) UNIQUE NOT NULL)");
+      statement.execute("CREATE TABLE content_versions ("
+          + "content_version_id BIGSERIAL PRIMARY KEY, "
+          + "content_id BIGINT REFERENCES content(content_id) ON DELETE CASCADE, "
+          + "content TEXT, "
+          + "approved_by BIGINT, "
+          + "published_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP NOT NULL, "
+          + "release_reference VARCHAR(255))");
+      statement.execute("CREATE INDEX content_versions_content_idx ON content_versions(content_id, published_at DESC)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the content_versions schema", se);
+    }
+  }
+
+  private static long addContent(String uniqueId) {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement();
+        java.sql.ResultSet rs = statement.executeQuery(
+            "INSERT INTO content (content_unique_id) VALUES ('" + uniqueId.replace("'", "''")
+                + "') RETURNING content_id")) {
+      rs.next();
+      return rs.getLong("content_id");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a content record", se);
+    }
+  }
+
+  private static long insertVersion(long contentId, String content, long approvedBy, String releaseReference) {
+    ContentVersion version = new ContentVersion();
+    version.setContentId(contentId);
+    version.setContent(content);
+    version.setApprovedBy(approvedBy);
+    version.setReleaseReference(releaseReference);
+    try (Connection connection = DB.getConnection()) {
+      return ContentVersionRepository.insert(connection, version);
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert a content version", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentVersionsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/ContentVersionsListWidgetTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.ContentVersionDiffCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.Content;
+import com.simisinc.platform.domain.model.cms.ContentVersion;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.ContentVersionRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies the /admin/content-versions widget (#406): listing a content block's prior published
+ * versions, comparing two of them with a word-level diff, and restoring a selected one back into the
+ * draft slot.
+ *
+ * @author elizabeth houser
+ */
+class ContentVersionsListWidgetTest extends WidgetBase {
+
+  private static Content content(long id, String uniqueId) {
+    Content record = new Content();
+    record.setId(id);
+    record.setUniqueId(uniqueId);
+    return record;
+  }
+
+  private static ContentVersion version(long id, long contentId, String html, long approvedBy) {
+    ContentVersion record = new ContentVersion();
+    record.setId(id);
+    record.setContentId(contentId);
+    record.setContent(html);
+    record.setApprovedBy(approvedBy);
+    return record;
+  }
+
+  @Test
+  void executeLoadsTheContentVersionsAndApproverMap() {
+    addQueryParameter(widgetContext, "uniqueId", "example-block");
+    Content record = content(3L, "example-block");
+    ContentVersion version = version(10L, 3L, "<p>v1</p>", 7L);
+    User approver = new User();
+    approver.setId(7L);
+    approver.setFirstName("Jamie");
+
+    try (MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class);
+        MockedStatic<ContentVersionRepository> versionRepo = mockStatic(ContentVersionRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      contentRepo.when(() -> ContentRepository.findByUniqueId("example-block")).thenReturn(record);
+      versionRepo.when(() -> ContentVersionRepository.findByContentId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(List.of(version));
+      userRepo.when(() -> UserRepository.findByUserId(7L)).thenReturn(approver);
+
+      WidgetContext result = new ContentVersionsListWidget().execute(widgetContext);
+
+      assertEquals(record, result.getRequest().getAttribute("content"));
+      assertEquals(List.of(version), result.getRequest().getAttribute("versionList"));
+      Map<Long, User> userMap = (Map<Long, User>) result.getRequest().getAttribute("userMap");
+      assertEquals(approver, userMap.get(7L));
+    }
+  }
+
+  @Test
+  void executeSetsAnErrorWhenTheContentIsNotFound() {
+    addQueryParameter(widgetContext, "uniqueId", "missing-block");
+
+    try (MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class)) {
+      contentRepo.when(() -> ContentRepository.findByUniqueId("missing-block")).thenReturn(null);
+
+      WidgetContext result = new ContentVersionsListWidget().execute(widgetContext);
+
+      assertEquals("Content was not found", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void executeComputesAWordDiffWhenTwoOwnVersionsAreSelected() {
+    addQueryParameter(widgetContext, "uniqueId", "example-block");
+    addQueryParameter(widgetContext, "compareFrom", "10");
+    addQueryParameter(widgetContext, "compareTo", "11");
+    Content record = content(3L, "example-block");
+    ContentVersion from = version(10L, 3L, "<p>Hello world</p>", 7L);
+    ContentVersion to = version(11L, 3L, "<p>Hello there</p>", 7L);
+
+    try (MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class);
+        MockedStatic<ContentVersionRepository> versionRepo = mockStatic(ContentVersionRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      contentRepo.when(() -> ContentRepository.findByUniqueId("example-block")).thenReturn(record);
+      versionRepo.when(() -> ContentVersionRepository.findByContentId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(List.of(from, to));
+      versionRepo.when(() -> ContentVersionRepository.findById(10L)).thenReturn(from);
+      versionRepo.when(() -> ContentVersionRepository.findById(11L)).thenReturn(to);
+      userRepo.when(() -> UserRepository.findByUserId(7L)).thenReturn(null);
+
+      WidgetContext result = new ContentVersionsListWidget().execute(widgetContext);
+
+      ContentVersionDiffCommand.Result diffResult =
+          (ContentVersionDiffCommand.Result) result.getRequest().getAttribute("diffResult");
+      assertEquals("Hello <del>world</del> <ins>there</ins>", diffResult.getHtml());
+    }
+  }
+
+  @Test
+  void executeRejectsAComparisonVersionThatBelongsToADifferentContentBlock() {
+    // A stray/foreign contentVersionId must never diff content that doesn't belong to this block.
+    addQueryParameter(widgetContext, "uniqueId", "example-block");
+    addQueryParameter(widgetContext, "compareFrom", "10");
+    addQueryParameter(widgetContext, "compareTo", "99");
+    Content record = content(3L, "example-block");
+    ContentVersion from = version(10L, 3L, "<p>Hello world</p>", 7L);
+    ContentVersion foreign = version(99L, 999L, "<p>someone else's content</p>", 7L);
+
+    try (MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class);
+        MockedStatic<ContentVersionRepository> versionRepo = mockStatic(ContentVersionRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class)) {
+      contentRepo.when(() -> ContentRepository.findByUniqueId("example-block")).thenReturn(record);
+      versionRepo.when(() -> ContentVersionRepository.findByContentId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(List.of(from));
+      versionRepo.when(() -> ContentVersionRepository.findById(10L)).thenReturn(from);
+      versionRepo.when(() -> ContentVersionRepository.findById(99L)).thenReturn(foreign);
+      userRepo.when(() -> UserRepository.findByUserId(7L)).thenReturn(null);
+
+      WidgetContext result = new ContentVersionsListWidget().execute(widgetContext);
+
+      assertNull(result.getRequest().getAttribute("diffResult"));
+      assertEquals("One or both selected versions could not be compared", result.getWarningMessage());
+    }
+  }
+
+  @Test
+  void postRestoresTheDraftFromTheSelectedVersion() throws Exception {
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "uniqueId", "example-block");
+    addQueryParameter(widgetContext, "contentVersionId", "10");
+    ContentVersion version = version(10L, 3L, "<p>old</p>", 7L);
+    Content record = content(3L, "example-block");
+
+    try (MockedStatic<ContentVersionRepository> versionRepo = mockStatic(ContentVersionRepository.class);
+        MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class)) {
+      versionRepo.when(() -> ContentVersionRepository.findById(10L)).thenReturn(version);
+      contentRepo.when(() -> ContentRepository.findByUniqueId("example-block")).thenReturn(record);
+      contentRepo.when(() -> ContentRepository.restoreDraftFromVersion(3L, "<p>old</p>")).thenReturn(true);
+      versionRepo.when(() -> ContentVersionRepository.findByContentId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      WidgetContext result = new ContentVersionsListWidget().post(widgetContext);
+
+      contentRepo.verify(() -> ContentRepository.restoreDraftFromVersion(3L, "<p>old</p>"));
+      assertEquals("The version was restored to the draft. It must be reviewed and published again to go live.",
+          result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void postSetsAnErrorWhenTheVersionIsNotFound() throws Exception {
+    addQueryParameter(widgetContext, "action", "restore");
+    addQueryParameter(widgetContext, "uniqueId", "example-block");
+    addQueryParameter(widgetContext, "contentVersionId", "404");
+    Content record = content(3L, "example-block");
+
+    try (MockedStatic<ContentVersionRepository> versionRepo = mockStatic(ContentVersionRepository.class);
+        MockedStatic<ContentRepository> contentRepo = mockStatic(ContentRepository.class)) {
+      versionRepo.when(() -> ContentVersionRepository.findById(404L)).thenReturn(null);
+      contentRepo.when(() -> ContentRepository.findByUniqueId("example-block")).thenReturn(record);
+      versionRepo.when(() -> ContentVersionRepository.findByContentId(eq(3L), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      WidgetContext result = new ContentVersionsListWidget().post(widgetContext);
+
+      assertEquals("The selected version was not found", result.getErrorMessage(),
+          "the fallthrough execute() reload must not clobber the error set here (needs uniqueId to succeed)");
+      contentRepo.verify(() -> ContentRepository.restoreDraftFromVersion(anyLong(), any()), never());
+    }
+  }
+
+  @Test
+  void postIgnoresAnyActionOtherThanRestore() throws Exception {
+    addQueryParameter(widgetContext, "action", "somethingElse");
+
+    WidgetContext result = new ContentVersionsListWidget().post(widgetContext);
+
+    assertNull(result);
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/ContentWidgetTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -254,7 +255,7 @@ class ContentWidgetTest extends WidgetBase {
       ContentWidget contentWidget = new ContentWidget();
       widgetContext = contentWidget.action(widgetContext);
 
-      contentRepository.verify(() -> ContentRepository.publish(content));
+      contentRepository.verify(() -> ContentRepository.publish(eq(content), anyInt()));
     }
   }
 
@@ -293,7 +294,7 @@ class ContentWidgetTest extends WidgetBase {
       ContentWidget contentWidget = new ContentWidget();
       widgetContext = contentWidget.action(widgetContext);
 
-      contentRepository.verify(() -> ContentRepository.publish(content));
+      contentRepository.verify(() -> ContentRepository.publish(eq(content), anyInt()));
       purge.verify(() -> PublishEventCachePurgeHandler.onPageUpdated(webPage));
     }
   }
@@ -403,7 +404,7 @@ class ContentWidgetTest extends WidgetBase {
       assertDoesNotThrow(() -> contentWidget.action(widgetContext));
       long elapsed = System.currentTimeMillis() - start;
 
-      contentRepository.verify(() -> ContentRepository.publish(content));
+      contentRepository.verify(() -> ContentRepository.publish(eq(content), anyInt()));
       assertTrue(elapsed < 2000L,
           "Expected the unconfigured AFD purge path to return fast, took " + elapsed + "ms");
     }
@@ -462,6 +463,7 @@ class ContentWidgetTest extends WidgetBase {
         MockedStatic<ContentReviewCommand> contentReview = mockStatic(ContentReviewCommand.class);
         MockedStatic<ContentRepository> contentRepository = mockStatic(ContentRepository.class);
         MockedStatic<AuditEventCommand> auditEvent = mockStatic(AuditEventCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
         MockedStatic<LoadWebPageCommand> loadWebPage = mockStatic(LoadWebPageCommand.class);
         MockedStatic<PublishEventCachePurgeHandler> purge = mockStatic(PublishEventCachePurgeHandler.class)) {
       loadContent.when(() -> LoadContentCommand.loadContentByUniqueId(eq("hello-content"))).thenReturn(content);
@@ -469,11 +471,13 @@ class ContentWidgetTest extends WidgetBase {
       // Step-up already satisfied for this session -- the approval itself is what's under test here.
       stepUpAuth.when(() -> StepUpAuthCommand.isValid(any())).thenReturn(true);
       loadWebPage.when(() -> LoadWebPageCommand.loadByLink("/example/path")).thenReturn(webPage);
+      // #406: approveContent() now resolves content.versionHistoryLimit before publishing.
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName(anyString())).thenReturn(null);
 
       ContentHtmlCommand.performContentApproval(widgetContext);
 
       contentReview.verify(() -> ContentReviewCommand.approve(content, widgetContext.getUserId(), "CR-1234"));
-      contentRepository.verify(() -> ContentRepository.publish(content));
+      contentRepository.verify(() -> ContentRepository.publish(eq(content), anyInt()));
       purge.verify(() -> PublishEventCachePurgeHandler.onPageUpdated(webPage));
       Assertions.assertEquals("The content was approved and published", widgetContext.getSuccessMessage());
     }
@@ -501,7 +505,7 @@ class ContentWidgetTest extends WidgetBase {
 
       ContentHtmlCommand.performContentApproval(widgetContext);
 
-      contentRepository.verify(() -> ContentRepository.publish(any()), never());
+      contentRepository.verify(() -> ContentRepository.publish(any(), anyInt()), never());
       purge.verifyNoInteractions();
     }
   }
@@ -533,7 +537,7 @@ class ContentWidgetTest extends WidgetBase {
 
       ContentHtmlCommand.performContentApproval(widgetContext);
 
-      contentRepository.verify(() -> ContentRepository.publish(any()), never());
+      contentRepository.verify(() -> ContentRepository.publish(any(), anyInt()), never());
       purge.verifyNoInteractions();
       Assertions.assertEquals("You cannot approve your own submission", widgetContext.getErrorMessage());
     }

--- a/tools/check-unescaped-el.py
+++ b/tools/check-unescaped-el.py
@@ -164,6 +164,11 @@ ALLOWLIST: dict[str, str] = {
         "Sanitized on render by jsoup, not by HtmlCommand: RemoteContentWidget.java:122-143 builds Safelist.relaxed() (plus span/style), runs Cleaner.clean() and emits clean.body().html(),",
     "${data.value}":
         "Every report that can reach the bar/line chart JSPs populates StatisticsData.value with `String.valueOf(rs.getLong(...))` over a COUNT/aggregate column, so the field holds only dig",
+    "${diffResult.html}":
+        "content-versions-list.jsp (#406): ContentVersionDiffCommand.diff()/render() builds this string "
+        "itself from two content_versions rows -- every word is run through StringEscapeUtils.escapeHtml4 "
+        "before being appended, and the only unescaped literals concatenated in are the fixed wrapper tags "
+        "<ins>/<del>. No path lets a raw '<' or '>' from either version reach the output.",
     "${extraHTMLContent}":
         "N/A -- the attribute is never set for this JSP, and cross-widget leakage of the attribute is prevented by an explicit per-widget request-attribute reset.",
     "${facet.url}":


### PR DESCRIPTION
## Summary
- Every governed publish now snapshots the outgoing content into a new `content_versions` table before it's overwritten, mirroring #405's `web_page_versions` pattern
- `ContentRepository.publish()` is restructured into a transaction: captures the prior live content (rendered to plain HTML regardless of its Delta/legacy-HTML format via `ContentHtmlCommand#toHtml`), records the approver + release reference, prunes to a configurable `content.versionHistoryLimit` (default 20)
- New `/admin/content-versions` page lists a block's history and offers a word-level diff between any two selected versions (LCS-based, computed over Jsoup-extracted text so structural-only markup changes don't drown out real content changes)
- Restore action loads a chosen version into the draft slot; unlike the #405 WebPage precedent, this unconditionally resets `draftStatus`/`submittedBy`/`approvedBy`/`releaseReference` so a restored version always requires a fresh approval cycle rather than potentially inheriting a stale one from the draft it replaced

## Test plan
- [x] `ContentVersionRepositoryTest` + extended `ContentRepositoryTest` (Testcontainers, real Postgres) — snapshot-on-publish, Delta-to-HTML rendering, pruning, no-op on no-draft, restore + governance-field reset
- [x] `ContentVersionDiffCommandTest` — identical/added/removed words, HTML escaping, structural-only changes produce no diff, oversized-input truncation
- [x] `ContentVersionsListWidgetTest` + extended `ContentWidgetTest` (new 2-arg `publish()` signature)
- [x] Full `ant ci-test` suite green; `tools/check-unescaped-el.py --strict` clean (added one allowlist entry for the diff HTML, which is self-escaping)
- [x] Live Docker verification: published a content block twice through the real DRAFT-badge flow, confirmed `content_versions` rows and `approved_by` NULL-for-ungoverned-publish in the DB, confirmed the admin compare view renders the correct word-level `<ins>`/`<del>` diff, confirmed restore loads the old version into `draft_content` and clears governance fields