### PR TITLE
Fix WebPageRepository.restoreDraftFromVersion() stale-approval gap

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -304,12 +304,20 @@ public class WebPageRepository {
 
   /**
    * Loads a prior version's XML into the draft slot (#405) -- never touches the live pageXml, so a
-   * subsequent publish is required to make the restored content live again.
+   * subsequent publish is required to make the restored content live again. Also resets the
+   * governed-review fields unconditionally: without this, a restore over a draft that was already
+   * submitted-and-approved would let the *restored* content inherit the stale approval, publishing
+   * it without ever actually being reviewed -- the same bypass shape #957/#958 fixed elsewhere in
+   * this codebase, mirrored here and in ContentRepository#restoreDraftFromVersion (#406).
    */
   public static boolean restoreDraftFromVersion(long webPageId, String pageXml) {
     SqlUtils updateValues = new SqlUtils()
         .add("draft_page_xml", pageXml)
-        .add("draft", true);
+        .add("draft", true)
+        .add("draft_status = null")
+        .add("submitted_by = -1")
+        .add("approved_by = -1")
+        .add("release_reference = null");
     SqlUtils where = new SqlUtils().add("web_page_id = ?", webPageId);
     return DB.update(TABLE_NAME, updateValues, where);
   }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryTest.java
@@ -522,6 +522,36 @@ class WebPageRepositoryTest {
     assertTrue(reloaded.getDraft());
   }
 
+  @Test
+  void restoreDraftFromVersionClearsAnyStaleApprovalOnTheDraftItReplaces() {
+    // A draft already submitted-and-approved must not let its approval carry over to a DIFFERENT
+    // draft swapped in by a restore -- otherwise the restored content could publish without ever
+    // actually being reviewed (the same bypass shape fixed for #957/#958, and for Content's own
+    // restoreDraftFromVersion in #406).
+    WebPage webPage = new WebPage();
+    webPage.setLink("/restore-clears-approval");
+    webPage.setTitle("Restore Clears Approval");
+    webPage.setEnabled(true);
+    webPage.setSearchable(true);
+    webPage.setCreatedBy(1L);
+    webPage.setPageXml("<xml>live</xml>");
+    webPage.setDraftPageXml("<xml>a different, already-approved draft</xml>");
+    webPage.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    webPage.setSubmittedBy(10L);
+    webPage.setApprovedBy(20L);
+    webPage.setReleaseReference("cleared per PA case 2026-405");
+    WebPage saved = WebPageRepository.save(webPage);
+
+    WebPageRepository.restoreDraftFromVersion(saved.getId(), "<xml>an older version</xml>");
+
+    WebPage reloaded = WebPageRepository.findById(saved.getId());
+    assertEquals("<xml>an older version</xml>", reloaded.getDraftPageXml());
+    assertNull(reloaded.getDraftStatus());
+    assertEquals(-1L, reloaded.getSubmittedBy());
+    assertEquals(-1L, reloaded.getApprovedBy(), "the restored draft must require a fresh approval, not inherit the old one");
+    assertNull(reloaded.getReleaseReference());
+  }
+
   private static String addPreviewToken(long webPageId, String pagePath) {
     WebPagePreviewToken record = new WebPagePreviewToken();
     record.setWebPageId(webPageId);


### PR DESCRIPTION
## Summary
- `restoreDraftFromVersion()` (issue #405's restore action) loaded a prior page-XML version into the draft slot but left `draft_status`/`submitted_by`/`approved_by`/`release_reference` untouched
- If the page's existing draft had already been submitted and approved, restoring a different (older) version would let that RESTORED content inherit the stale approval -- the same review-bypass shape #957/#958 fixed elsewhere in this codebase
- `restoreDraftFromVersion()` now unconditionally resets those four fields, matching `ContentRepository#restoreDraftFromVersion()`'s equivalent fix already shipped in #406

## Test plan
- [x] New regression test `restoreDraftFromVersionClearsAnyStaleApprovalOnTheDraftItReplaces` (Testcontainers, real Postgres): seeds a page with an already-approved draft, restores a different version, asserts `draftStatus`/`submittedBy`/`approvedBy`/`releaseReference` are all cleared
- [x] Full `ant ci-test` green
- [x] `tools/check-unescaped-el.py --strict` clean (no JSP changes)