### PR TITLE
Snapshot outgoing content on direct-publish before overwrite (#406 follow-up)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveContentCommand.java
@@ -61,7 +61,10 @@ public class SaveContentCommand {
     }
     // Determine if the content is immediately published
     if (publish) {
-      // Publish it
+      // Publish it -- snapshot the OUTGOING content (#406) before it's overwritten below. This is
+      // the direct-write publish path (distinct from ContentRepository#publish's draft-promotion
+      // path), so it needs its own snapshot call; see snapshotBeforeDirectPublish's javadoc.
+      ContentRepository.snapshotBeforeDirectPublish(content, resolveVersionHistoryLimit());
       content.setContent(cleanedContent);
       content.setDraftContent(null);
     } else {
@@ -72,6 +75,11 @@ public class SaveContentCommand {
     content.setModifiedBy(userId);
     return ContentRepository.save(content);
 
+  }
+
+  /** The configured {@code content.versionHistoryLimit} (#406), resolved fresh at each publish call site. */
+  private static int resolveVersionHistoryLimit() {
+    return ContentRepository.resolveVersionHistoryLimit(LoadSitePropertyCommand.loadByName("content.versionHistoryLimit"));
   }
 
   /**
@@ -106,7 +114,10 @@ public class SaveContentCommand {
       content.setUniqueId(contentUniqueId);
     }
     if (publish) {
-      // Publish: the Delta becomes the live version and the draft is cleared.
+      // Publish: the Delta becomes the live version and the draft is cleared. Snapshot the
+      // OUTGOING content (#406) first -- see saveSafeContent's identical call for why this direct
+      // publish path needs its own snapshot rather than reusing ContentRepository#publish.
+      ContentRepository.snapshotBeforeDirectPublish(content, resolveVersionHistoryLimit());
       content.setContent(deltaJson);
       content.setContentFormat(DeltaContentCommand.DELTA_FORMAT_VERSION);
       content.setDraftContent(null);

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepository.java
@@ -309,6 +309,44 @@ public class ContentRepository {
     }
   }
 
+  /**
+   * Snapshots {@code record}'s current live content into content_versions (#406) before a caller is
+   * about to overwrite it directly -- i.e. SaveContentCommand#saveSafeContent/saveSafeDeltaContent's
+   * "publish immediately" path, which (unlike {@link #publish}) writes the new value straight onto
+   * the in-memory record rather than promoting it from draft_content in SQL, so there is no
+   * outgoing-value SELECT for {@link #publish} to do this snapshot as part of. Must be
+   * called with {@code record} still holding its OLD content/contentFormat, before the caller
+   * mutates it to the new value. A brand-new record (id == -1) or one with no live content yet has
+   * nothing to snapshot.
+   *
+   * <p>This insert+prune is its own standalone transaction, not shared with the caller's subsequent
+   * {@link #save}: if the save that follows fails, the snapshot is not rolled back with it. That is
+   * an accepted, narrow inconsistency (an orphaned version row for a publish that didn't actually
+   * happen) rather than a correctness or security issue, and avoids threading a shared Connection
+   * through save()/update(), which do not currently accept one.
+   */
+  public static void snapshotBeforeDirectPublish(Content record, int versionHistoryLimit) {
+    if (record == null || record.getId() == -1 || StringUtils.isBlank(record.getContent())) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        AutoStartTransaction ignored = new AutoStartTransaction(connection);
+        AutoRollback transaction = new AutoRollback(connection)) {
+      ContentVersion version = new ContentVersion();
+      version.setContentId(record.getId());
+      version.setContent(ContentHtmlCommand.toHtml(record.getContent(), record.getContentFormat()));
+      version.setApprovedBy(record.getApprovedBy());
+      version.setReleaseReference(record.getReleaseReference());
+      if (ContentVersionRepository.insert(connection, version) == -1) {
+        throw new SQLException("The prior content version was not saved");
+      }
+      ContentVersionRepository.pruneOldest(connection, record.getId(), versionHistoryLimit);
+      transaction.commit();
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+  }
+
   public static void removeDraft(Content record) {
     if (record == null || StringUtils.isBlank(record.getUniqueId())) {
       return;

--- a/src/test/java/com/simisinc/platform/application/cms/SaveContentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveContentCommandTest.java
@@ -20,12 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.domain.model.cms.Content;
 import com.simisinc.platform.infrastructure.persistence.cms.ContentRepository;
 
@@ -79,9 +83,12 @@ class SaveContentCommandTest {
 
   @Test
   void publishStampsDeltaFormatAndClearsTheDraft() throws DataException {
-    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class)) {
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
       repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(null);
       repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+      // #406: a publish now also resolves content.versionHistoryLimit before snapshotting.
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("content.versionHistoryLimit")).thenReturn(null);
 
       Content saved = SaveContentCommand.saveSafeDeltaContent("uid", VALID_DELTA, 7L, true);
 
@@ -89,6 +96,103 @@ class SaveContentCommandTest {
       assertEquals(DeltaContentCommand.DELTA_FORMAT_VERSION, saved.getContentFormat());
       assertNull(saved.getDraftContent());
       assertEquals(DeltaContentCommand.LEGACY_HTML_FORMAT, saved.getDraftContentFormat());
+    }
+  }
+
+  // --- Version history on direct publish (issue #406 follow-up) ---
+  //
+  // ContentRepository#publish() (the governed/widget publish path) already snapshots the outgoing
+  // content, but saveSafeContent/saveSafeDeltaContent's own "publish immediately" branch writes the
+  // new value straight onto the record instead of promoting it from draft_content in SQL -- so it
+  // needs its own call to ContentRepository#snapshotBeforeDirectPublish, made BEFORE the record is
+  // mutated to the new value. These tests prove that wiring, not snapshotBeforeDirectPublish's own
+  // snapshot/prune/no-op logic -- that's covered directly against a real database in
+  // ContentRepositoryTest.
+
+  @Test
+  void publishOfHtmlContentSnapshotsTheOutgoingContentBeforeOverwritingIt() throws DataException {
+    Content existing = new Content();
+    existing.setId(5L);
+    existing.setUniqueId("uid");
+    existing.setContent("<p>old content</p>");
+
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(existing);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+      repo.when(() -> ContentRepository.resolveVersionHistoryLimit(any())).thenReturn(20);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("content.versionHistoryLimit")).thenReturn("20");
+
+      // The Content object is mutated in place, so capture its content at CALL time -- by the time
+      // this test asserts, the same reference would already read the new, post-overwrite value.
+      String[] snapshottedContent = new String[1];
+      repo.when(() -> ContentRepository.snapshotBeforeDirectPublish(any(Content.class), eq(20)))
+          .thenAnswer(invocation -> {
+            snapshottedContent[0] = ((Content) invocation.getArgument(0)).getContent();
+            return null;
+          });
+
+      Content saved = SaveContentCommand.saveSafeContent("uid", "<p>new content</p>", 7L, true);
+
+      assertEquals("<p>old content</p>", snapshottedContent[0],
+          "the snapshot must capture the OUTGOING content, taken before it's overwritten");
+      assertEquals("<p>new content</p>", saved.getContent());
+      repo.verify(() -> ContentRepository.snapshotBeforeDirectPublish(any(Content.class), eq(20)));
+    }
+  }
+
+  @Test
+  void draftSaveOfHtmlContentNeverSnapshots() throws DataException {
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(null);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+
+      SaveContentCommand.saveSafeContent("uid", "<p>draft</p>", 7L, false);
+
+      repo.verify(() -> ContentRepository.snapshotBeforeDirectPublish(any(), anyInt()), never());
+    }
+  }
+
+  @Test
+  void publishOfDeltaContentSnapshotsTheOutgoingContentBeforeOverwritingIt() throws DataException {
+    Content existing = new Content();
+    existing.setId(9L);
+    existing.setUniqueId("uid");
+    existing.setContent("<p>old html content</p>");
+    existing.setContentFormat(DeltaContentCommand.LEGACY_HTML_FORMAT);
+
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(existing);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+      repo.when(() -> ContentRepository.resolveVersionHistoryLimit(any())).thenReturn(20);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("content.versionHistoryLimit")).thenReturn("20");
+
+      String[] snapshottedContent = new String[1];
+      repo.when(() -> ContentRepository.snapshotBeforeDirectPublish(any(Content.class), eq(20)))
+          .thenAnswer(invocation -> {
+            snapshottedContent[0] = ((Content) invocation.getArgument(0)).getContent();
+            return null;
+          });
+
+      Content saved = SaveContentCommand.saveSafeDeltaContent("uid", VALID_DELTA, 7L, true);
+
+      assertEquals("<p>old html content</p>", snapshottedContent[0],
+          "a block that was legacy HTML on a prior cycle must still be snapshotted before this Delta publish overwrites it");
+      assertEquals(VALID_DELTA, saved.getContent());
+      repo.verify(() -> ContentRepository.snapshotBeforeDirectPublish(any(Content.class), eq(20)));
+    }
+  }
+
+  @Test
+  void draftSaveOfDeltaContentNeverSnapshots() throws DataException {
+    try (MockedStatic<ContentRepository> repo = mockStatic(ContentRepository.class)) {
+      repo.when(() -> ContentRepository.findByUniqueId("uid")).thenReturn(null);
+      repo.when(() -> ContentRepository.save(any(Content.class))).thenAnswer(i -> i.getArgument(0));
+
+      SaveContentCommand.saveSafeDeltaContent("uid", VALID_DELTA, 7L, false);
+
+      repo.verify(() -> ContentRepository.snapshotBeforeDirectPublish(any(), anyInt()), never());
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ContentRepositoryTest.java
@@ -388,6 +388,93 @@ class ContentRepositoryTest {
     assertNull(ContentVersionRepository.findByContentId(content.getId(), null));
   }
 
+  // --- Version history on the direct-write publish path (issue #406 follow-up) ---
+  //
+  // SaveContentCommand's "publish immediately" branch (the /content-editor "Publish Immediately"
+  // button, and the ungoverned inline-overlay Publish path) never calls ContentRepository#publish --
+  // it writes the new content straight onto the record and calls save(). These tests exercise
+  // ContentRepository#snapshotBeforeDirectPublish directly, the method that path must call before
+  // overwriting, mirroring the equivalent publish() tests above.
+
+  @Test
+  void snapshotBeforeDirectPublishSnapshotsTheCurrentContentBeforeItIsOverwritten() {
+    Content content = new Content();
+    content.setUniqueId("direct-publish-snapshot");
+    content.setContent("<p>original live content</p>");
+    content.setApprovedBy(20L);
+    content.setReleaseReference("cleared per PA case 2026-406b");
+    Content saved = ContentRepository.save(content);
+
+    ContentRepository.snapshotBeforeDirectPublish(saved, 20);
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(saved.getId(), null);
+    assertNotNull(versions);
+    assertEquals(1, versions.size());
+    ContentVersion version = versions.get(0);
+    assertEquals("<p>original live content</p>", version.getContent());
+    assertEquals(20L, version.getApprovedBy());
+    assertEquals("cleared per PA case 2026-406b", version.getReleaseReference());
+  }
+
+  @Test
+  void snapshotBeforeDirectPublishRendersDeltaContentToHtmlBeforeSnapshotting() {
+    Content content = new Content();
+    content.setUniqueId("direct-publish-delta-snapshot");
+    content.setContent("{\"ops\":[{\"insert\":\"hi\\n\"}]}");
+    content.setContentFormat(DeltaContentCommand.DELTA_FORMAT_VERSION);
+    Content saved = ContentRepository.save(content);
+
+    ContentRepository.snapshotBeforeDirectPublish(saved, 20);
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(saved.getId(), null);
+    assertNotNull(versions);
+    assertEquals("<p>hi</p>", versions.get(0).getContent(),
+        "the Delta snapshot must be rendered to HTML, not stored raw, matching publish()'s own behavior");
+  }
+
+  @Test
+  void snapshotBeforeDirectPublishIsANoOpForABrandNewUnsavedRecord() {
+    Content content = new Content();
+    content.setUniqueId("brand-new");
+    content.setContent("<p>about to be saved for the first time</p>");
+    // record.getId() is still -1 -- this is exactly the state SaveContentCommand's own Content is in
+    // when a uniqueId has never been saved before.
+
+    ContentRepository.snapshotBeforeDirectPublish(content, 20);
+
+    assertNull(ContentVersionRepository.findByContentId(content.getId(), null));
+  }
+
+  @Test
+  void snapshotBeforeDirectPublishIsANoOpWhenThereIsNoLiveContentYet() {
+    Content content = new Content();
+    content.setUniqueId("no-live-content-yet");
+    content.setDraftContent("<p>only ever saved as a draft so far</p>");
+    Content saved = ContentRepository.save(content);
+
+    ContentRepository.snapshotBeforeDirectPublish(saved, 20);
+
+    assertNull(ContentVersionRepository.findByContentId(saved.getId(), null));
+  }
+
+  @Test
+  void snapshotBeforeDirectPublishPrunesToTheVersionHistoryLimit() {
+    Content content = new Content();
+    content.setUniqueId("direct-publish-prune-me");
+    content.setContent("<p>v0</p>");
+    Content saved = ContentRepository.save(content);
+
+    for (int i = 1; i <= 5; i++) {
+      ContentRepository.snapshotBeforeDirectPublish(saved, 2);
+      saved.setContent("<p>v" + i + "</p>");
+      ContentRepository.save(saved);
+    }
+
+    List<ContentVersion> versions = ContentVersionRepository.findByContentId(saved.getId(), null);
+    assertNotNull(versions);
+    assertEquals(2, versions.size(), "only the 2 most recent snapshots should survive");
+  }
+
   // --- Restore (issue #406) ---
 
   @Test


### PR DESCRIPTION
## Summary
- #406 added content version history, but only on the governed draft-promotion path (`ContentRepository.publish()`). The `/content-editor` "Publish Immediately" path (`SaveContentCommand.saveSafeContent`/`saveSafeDeltaContent`) writes new content straight onto the record and calls a plain `save()`, bypassing that snapshot entirely — the most common way content actually gets published on ungoverned sites got no version history.
- Adds `ContentRepository.snapshotBeforeDirectPublish(record, versionHistoryLimit)`, called before either save method mutates the record to its new value, so a version row is captured on this path too. Runs in its own standalone transaction.

## Test plan
- [x] New unit tests in `SaveContentCommandTest` proving both methods snapshot the OUTGOING content before overwrite, and that a draft save never snapshots
- [x] New Testcontainers-backed tests in `ContentRepositoryTest` covering `snapshotBeforeDirectPublish` directly: Delta-to-HTML rendering, no-op on a brand-new record, no-op when there's no live content yet, and pruning to the version-history limit
- [x] Full `ant ci-test` — BUILD SUCCESSFUL, zero failures
- [x] `check-unescaped-el.py --strict` — 0 unallowlisted (no JSP changes in this fix)