### PR TITLE
Add bulk publish/unpublish/archive/delete for blog posts (#427)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepository.java
@@ -55,7 +55,9 @@ public class BlogPostRepository {
   private static String TABLE_NAME = "blog_posts";
   private static String[] PRIMARY_KEY = new String[] { "post_id" };
 
-  private static SqlUtils createWhereStatement(BlogPostSpecification specification) {
+  // Package-private (was private) so BlogPostRepositoryWhereClauseTest can inspect the built
+  // SqlUtils directly -- mirrors CalendarEventRepository.createWhereStatement (issue #882/PR #911).
+  static SqlUtils createWhereStatement(BlogPostSpecification specification) {
     SqlUtils where = null;
     if (specification != null) {
       where = new SqlUtils()
@@ -68,6 +70,13 @@ public class BlogPostRepository {
         } else {
           where.add("published IS NULL");
         }
+      }
+      // issue #427: mirrors CalendarEventRepository's archived filtering shape. UNDEFINED (the
+      // default for every pre-#427 caller) includes archived rows, so this is purely additive.
+      if (specification.getArchivedOnly() == DataConstants.TRUE) {
+        where.add("archived IS NOT NULL");
+      } else if (specification.getArchivedOnly() == DataConstants.FALSE) {
+        where.add("archived IS NULL");
       }
       if (specification.getStartDateIsBeforeNow() != DataConstants.UNDEFINED) {
         if (specification.getStartDateIsBeforeNow() == DataConstants.TRUE) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostSpecification.java
@@ -30,6 +30,10 @@ public class BlogPostSpecification {
   private long blogId = -1L;
   private String uniqueId = null;
   private int publishedOnly = DataConstants.UNDEFINED;
+  // issue #427: mirrors CalendarEventSpecification's archivedOnly exactly -- UNDEFINED includes
+  // archived rows (the default, unchanged for any caller that never sets this), TRUE returns only
+  // archived rows, FALSE excludes them.
+  private int archivedOnly = DataConstants.UNDEFINED;
   private int startDateIsBeforeNow = DataConstants.UNDEFINED;
   private int isWithinEndDate = DataConstants.UNDEFINED;
   private String searchTerm = null;
@@ -79,6 +83,18 @@ public class BlogPostSpecification {
 
   public void setPublishedOnly(int publishedOnly) {
     this.publishedOnly = publishedOnly;
+  }
+
+  public int getArchivedOnly() {
+    return archivedOnly;
+  }
+
+  public void setArchivedOnly(boolean archivedOnly) {
+    this.archivedOnly = (archivedOnly ? DataConstants.TRUE : DataConstants.FALSE);
+  }
+
+  public void setArchivedOnly(int archivedOnly) {
+    this.archivedOnly = archivedOnly;
   }
 
   public int getStartDateIsBeforeNow() {

--- a/src/main/java/com/simisinc/platform/presentation/controller/SitemapServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/SitemapServlet.java
@@ -338,6 +338,7 @@ public class SitemapServlet extends HttpServlet {
     try {
       BlogPostSpecification spec = new BlogPostSpecification();
       spec.setPublishedOnly(true);
+      spec.setArchivedOnly(false);
       List<BlogPost> posts = BlogPostRepository.findAll(spec, null);
 
       if (posts != null) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminBlogPostListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminBlogPostListWidget.java
@@ -1,0 +1,604 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
+import com.simisinc.platform.domain.events.cms.BlogPostPublishedEvent;
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.RequestConstants;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * The /admin/blog-posts admin page (issue #427): a searchable, filterable, paginated table of
+ * blog posts across all blogs -- there was previously no admin list of individual posts anywhere
+ * in the codebase (only a per-blog post count on /admin/blogs, and BlogPostReviewWidget's
+ * single-post governed-review page). Named distinctly from the existing public-facing
+ * {@code cms.BlogPostListWidget} (which renders published posts on live site pages) to avoid
+ * confusion between the two "blog post list" widgets.
+ *
+ * <p>Mirrors the bulk-action mechanics PR #911 shipped for /admin/calendars'
+ * {@code CalendarEventListWidget}, and the shape {@code WebPageListWidget} added for
+ * /admin/web-pages (issue #427's web-pages slice): row checkboxes + a bulk-action toolbar
+ * offering all 5 actions #427 needs for blog posts -- Publish, Unpublish, Archive, Move, and
+ * Delete. Publish/Unpublish reuse the exact governed-publish-workflow gate
+ * ({@link ContentReviewCommand#mayPublish}) and reset-on-unpublish shape
+ * {@code BlogPostReviewWidget}/{@code BlogEditorWidget} already use for a single post, Archive is
+ * a plain repository save against the {@code archived} column that already exists on
+ * {@code blog_posts}, Move reassigns a post to a different {@link Blog} (directly analogous to the
+ * calendar precedent's move-to-different-Calendar), and Delete reuses
+ * {@code BlogPostWidget#action}'s single-item delete path's role gate exactly.
+ *
+ * @author elizabeth houser
+ */
+public class AdminBlogPostListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908895L;
+
+  static String JSP = "/admin/blog-post-list.jsp";
+
+  // A crafted POST is the only thing this bounds -- normal usage never approaches it, since
+  // selection is scoped to the current page (default page size 25). An id list over this cap is
+  // rejected outright, never silently truncated. Mirrors CalendarEventListWidget/WebPageListWidget's
+  // MAX_BULK_SELECTION exactly (issue #427).
+  static final int MAX_BULK_SELECTION = 100;
+
+  // Code-review fix (issue #427): per-row failure reasons were previously recorded only to the
+  // audit log and never returned in the response. Only the first MAX_DETAIL_LINES failed/not-found
+  // rows are spelled out inline in the aggregate message, to keep a large batch's message readable;
+  // the rest are still counted and still fully detailed in the audit log.
+  static final int MAX_DETAIL_LINES = 5;
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Determine the record paging
+    int limit = Integer.parseInt(context.getPreferences().getOrDefault("limit", "25"));
+    int page = context.getParameterAsInt("page", 1);
+    int itemsPerPage = context.getParameterAsInt("items", limit);
+    DataConstraints constraints = new DataConstraints(page, itemsPerPage);
+    constraints.setDefaultColumnToSortBy("post_id");
+    context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
+
+    BlogPostSpecification specification = buildSpecification(context);
+
+    // Load the list
+    List<BlogPost> blogPostList = BlogPostRepository.findAll(specification, constraints);
+    context.getRequest().setAttribute("blogPostList", blogPostList);
+
+    // The Blog filter dropdown (mirrors CalendarEventListWidget's calendarList) -- also used to
+    // resolve each row's blog name/link in the JSP.
+    List<Blog> blogList = BlogRepository.findAll();
+    context.getRequest().setAttribute("blogList", blogList);
+
+    // Governed publish workflow status per post (#407), keyed by post id -- only posts with a
+    // pending draft carry an interesting label; mirrors WebPageListWidget's webPageReviewStatusMap.
+    Map<Long, String> blogPostReviewStatusMap = new HashMap<>();
+    for (BlogPost blogPost : blogPostList) {
+      if (blogPost.hasDraftContent()) {
+        blogPostReviewStatusMap.put(blogPost.getId(), ContentReviewCommand.listStatusLabel(blogPost));
+      }
+    }
+    context.getRequest().setAttribute("blogPostReviewStatusMap", blogPostReviewStatusMap);
+
+    // Echo the filter values back so the form keeps its state
+    echoFilterParameters(context);
+
+    // Carry the filters through pagination (paging_control.jspf appends this to each page link).
+    // URL-encoded here so the free-text search term cannot break the query string or the href.
+    StringBuilder pagingParams = new StringBuilder();
+    appendParam(pagingParams, "q", context.getParameter("q"));
+    appendParam(pagingParams, "blogId", context.getParameter("blogId"));
+    appendParam(pagingParams, "status", context.getParameter("status"));
+    context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Show the JSP
+    context.setJsp(JSP);
+    return context;
+  }
+
+  /**
+   * Bulk actions selected from /admin/blog-posts' checkbox + action-bar UI (issue #427, mirroring
+   * the bulk-action mechanics PR #911 shipped for /admin/calendars). All 5 commands share a single
+   * gate -- admin-or-content-manager -- matching {@code BlogPostWidget#action}'s single-item delete
+   * gate, {@code BlogEditorWidget}'s own page access, and every other {@code /admin/blog*} page's
+   * role, rather than the stricter admin-only delete gate the web-pages slice uses (that gate
+   * matches web pages' own single-item delete precedent, which is admin-only; blog posts' single-item
+   * delete precedent is not, so the gate here follows suit).
+   */
+  public WidgetContext post(WidgetContext context) {
+
+    if (!(context.hasRole("admin") || context.hasRole("content-manager"))) {
+      LOG.warn("No permission to modify blog posts");
+      return context;
+    }
+
+    // Don't accept multiple form posts
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("bulkPublish".equals(command)) {
+      return bulkPublishAction(context);
+    }
+    if ("bulkUnpublish".equals(command)) {
+      return bulkUnpublishAction(context);
+    }
+    if ("bulkArchive".equals(command)) {
+      return bulkArchiveAction(context);
+    }
+    if ("bulkMove".equals(command)) {
+      return bulkMoveAction(context);
+    }
+    if ("bulkDelete".equals(command)) {
+      return bulkDeleteAction(context);
+    }
+    return context;
+  }
+
+  /**
+   * Reuses the exact single-item publish gates {@code BlogPostReviewWidget#publishDirectly} already
+   * checks -- first {@link BlogPost#hasDraftContent()}, then {@link ContentReviewCommand#mayPublish}
+   * (not the record-independent {@link ContentReviewCommand#mayPublishDirectly}) -- so a post with
+   * nothing new to release, or one still awaiting approval under governed review, is reported as a
+   * per-row failure rather than having its published timestamp re-stamped and its publish event
+   * re-fired. There is no "always call this" command for a metadata-only status flip on a blog post
+   * (unlike {@code SaveWebPageCommand} for web pages); this mirrors {@code BlogPostReviewWidget}'s
+   * own shape instead: save via the repository directly, then manually re-fire
+   * {@link BlogPostPublishedEvent}, since {@link BlogPostRepository#save} does not fire it itself.
+   */
+  private WidgetContext bulkPublishAction(WidgetContext context) {
+    List<Long> blogPostIds = resolveSelectedBlogPostIds(context);
+    if (blogPostIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (blogPostIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    boolean reviewRequired = LoadSitePropertyCommand.loadByNameAsBoolean("blogPost.review.required");
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long blogPostId : blogPostIds) {
+      BlogPost blogPost = BlogPostRepository.findById(blogPostId);
+      if (blogPost == null) {
+        ++notFound;
+        rowIssues.add("#" + blogPostId + ": not found");
+        continue;
+      }
+      if (!blogPost.hasDraftContent()) {
+        // Mirrors BlogPostReviewWidget.publishDirectly()'s own guard: a post with no draft content
+        // (already published, or never drafted) is a per-row no-op, not something bulk Publish
+        // should re-stamp with a fresh published timestamp and re-fire the publish event for.
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): no draft content to publish");
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+            "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(),
+            "blocked: no draft content to publish (bulk)");
+        continue;
+      }
+      if (!ContentReviewCommand.mayPublish(blogPost, reviewRequired)) {
+        // Not reachable through this widget's own UI intent, but checked explicitly the same as
+        // BlogPostReviewWidget.publishDirectly() -- a row that fails this gate is a per-row
+        // failure, not a batch-ending error, and the row is left untouched.
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): draft not approved for release");
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+            "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(),
+            "blocked: draft not approved for release (bulk)");
+        continue;
+      }
+      publishNow(blogPost);
+      blogPost.setModifiedBy(context.getUserId());
+      BlogPost result = BlogPostRepository.save(blogPost);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): save failed");
+      }
+      // Audit BEFORE firing the workflow event (matches BlogPostReviewWidget#publishDirectly) --
+      // WorkflowManager.triggerWorkflowForEvent enqueues background jobs with no try/catch of its
+      // own, so if that throws, this row's SUCCESS is already recorded rather than lost, and the
+      // exception can only affect rows after this one instead of erasing this row's own audit trail.
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", outcome,
+          "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), "(bulk)");
+      if (result != null) {
+        WorkflowManager.triggerWorkflowForEvent(new BlogPostPublishedEvent(blogPost.getId()));
+      }
+    }
+
+    setBulkResultMessage(context, "published", succeeded, blogPostIds.size(), notFound, failed, rowIssues);
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /**
+   * Unpublishing must reset the governed-review fields on a previously-published post, exactly as
+   * {@code BlogEditorWidget#post}'s unpublish branch already does -- otherwise a single editor
+   * could unpublish, edit, and republish via {@code BlogPostReviewWidget#publishDirectly} (which
+   * reads {@link ContentReviewCommand#mayPublish} purely from these fields) without the new content
+   * ever having been submitted or reviewed.
+   */
+  private WidgetContext bulkUnpublishAction(WidgetContext context) {
+    List<Long> blogPostIds = resolveSelectedBlogPostIds(context);
+    if (blogPostIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (blogPostIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long blogPostId : blogPostIds) {
+      BlogPost blogPost = BlogPostRepository.findById(blogPostId);
+      if (blogPost == null) {
+        ++notFound;
+        rowIssues.add("#" + blogPostId + ": not found");
+        continue;
+      }
+      boolean wasPublished = blogPost.getPublished() != null;
+      blogPost.setPublished(null);
+      if (wasPublished) {
+        // Issue #407 phase 2 review finding, mirrored from BlogEditorWidget#post: resetting to the
+        // same "never submitted" defaults BlogPost itself starts with means the post must go
+        // through submit -> approve again before it can be published a second time.
+        blogPost.setDraftStatus(null);
+        blogPost.setSubmittedBy(-1);
+        blogPost.setApprovedBy(-1);
+        blogPost.setReleaseReference(null);
+      }
+      blogPost.setModifiedBy(context.getUserId());
+      BlogPost result = BlogPostRepository.save(blogPost);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.unpublish", outcome,
+          "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "unpublished", succeeded, blogPostIds.size(), notFound, failed, rowIssues);
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /**
+   * Archiving is a plain repository save against the {@code archived} column that already exists
+   * on {@code blog_posts} -- not a publish-workflow event.
+   */
+  private WidgetContext bulkArchiveAction(WidgetContext context) {
+    List<Long> blogPostIds = resolveSelectedBlogPostIds(context);
+    if (blogPostIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (blogPostIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long blogPostId : blogPostIds) {
+      BlogPost blogPost = BlogPostRepository.findById(blogPostId);
+      if (blogPost == null) {
+        ++notFound;
+        rowIssues.add("#" + blogPostId + ": not found");
+        continue;
+      }
+      blogPost.setArchived(now);
+      blogPost.setModifiedBy(context.getUserId());
+      BlogPost result = BlogPostRepository.save(blogPost);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.archive", outcome,
+          "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "archived", succeeded, blogPostIds.size(), notFound, failed, rowIssues);
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /**
+   * Moves the selected posts to a different {@link Blog}, directly analogous to the calendar
+   * precedent's move-to-different-Calendar (Blog:BlogPost :: Calendar:CalendarEvent structurally).
+   * The destination is resolved before any post is loaded, mirroring
+   * {@code CalendarEventListWidget#bulkMoveAction}'s destination-first-then-events order exactly.
+   */
+  private WidgetContext bulkMoveAction(WidgetContext context) {
+    long targetBlogId = context.getParameterAsLong("blogId", -1);
+    Blog targetBlog = targetBlogId > -1 ? BlogRepository.findById(targetBlogId) : null;
+    if (targetBlog == null) {
+      context.setErrorMessage("The destination blog was not found");
+      context.setRedirect("/admin/blog-posts");
+      return context;
+    }
+
+    List<Long> blogPostIds = resolveSelectedBlogPostIds(context);
+    if (blogPostIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (blogPostIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long blogPostId : blogPostIds) {
+      BlogPost blogPost = BlogPostRepository.findById(blogPostId);
+      if (blogPost == null) {
+        ++notFound;
+        rowIssues.add("#" + blogPostId + ": not found");
+        continue;
+      }
+      blogPost.setBlogId(targetBlog.getId());
+      blogPost.setModifiedBy(context.getUserId());
+      BlogPost result = BlogPostRepository.save(blogPost);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.move", outcome,
+          "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(),
+          "movedTo=" + targetBlog.getName() + " (bulk)");
+    }
+
+    setBulkResultMessage(context, "moved to " + targetBlog.getName(), succeeded, blogPostIds.size(), notFound, failed,
+        rowIssues);
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /**
+   * Reuses {@code BlogPostWidget#action}'s "deletePost" role gate ({@link #post} already checked
+   * it above, so this is a plain loop). No domain-event precedent exists for blog post deletion
+   * (neither the single-item path nor {@code BlogRepository}'s cascade-delete-on-blog-removal fires
+   * one), so none is required here to "match individual" -- the acceptance criterion is satisfied
+   * vacuously. A confirmation reveal modal is still required by #427's acceptance criteria
+   * regardless (see blog-post-list.jsp).
+   */
+  private WidgetContext bulkDeleteAction(WidgetContext context) {
+    List<Long> blogPostIds = resolveSelectedBlogPostIds(context);
+    if (blogPostIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (blogPostIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long blogPostId : blogPostIds) {
+      BlogPost blogPost = BlogPostRepository.findById(blogPostId);
+      if (blogPost == null) {
+        ++notFound;
+        rowIssues.add("#" + blogPostId + ": not found");
+        continue;
+      }
+      boolean removed = BlogPostRepository.remove(blogPost);
+      String outcome = removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (removed) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(blogPost.getTitle() + " (#" + blogPost.getId() + "): delete failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", outcome,
+          "blog_post", String.valueOf(blogPost.getId()), blogPost.getTitle(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "deleted", succeeded, blogPostIds.size(), notFound, failed, rowIssues);
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /** Sets published (mirrors BlogPostReviewWidget#publishNow exactly). */
+  private void publishNow(BlogPost blogPost) {
+    blogPost.setPublished(new Timestamp(System.currentTimeMillis()));
+    if (blogPost.getStartDate() == null) {
+      blogPost.setStartDate(blogPost.getPublished());
+    }
+  }
+
+  /**
+   * Parses and dedupes the selected post ids from the repeated {@code blogPostId} hidden inputs
+   * the bulk modals inject, silently dropping any non-numeric entry (a tampered value is not a
+   * batch-ending error). Returns {@code null} when the list exceeds {@link #MAX_BULK_SELECTION} --
+   * the whole request is then rejected rather than silently truncated, since truncation could apply
+   * the action to a different subset of posts than the one the admin reviewed and confirmed.
+   * Mirrors CalendarEventListWidget#resolveSelectedEventIds exactly.
+   */
+  private List<Long> resolveSelectedBlogPostIds(WidgetContext context) {
+    String[] rawIds = context.getParameterMap().get("blogPostId");
+    Set<Long> ids = new LinkedHashSet<>();
+    if (rawIds != null) {
+      for (String rawId : rawIds) {
+        try {
+          ids.add(Long.parseLong(rawId.trim()));
+        } catch (NumberFormatException e) {
+          // Dropped, not treated as a batch-ending error
+        }
+      }
+    }
+    if (ids.size() > MAX_BULK_SELECTION) {
+      LOG.warn("Bulk blog post action rejected: " + ids.size() + " ids exceeds MAX_BULK_SELECTION ("
+          + MAX_BULK_SELECTION + ")");
+      return null;
+    }
+    return new ArrayList<>(ids);
+  }
+
+  private WidgetContext rejectBulkSelection(WidgetContext context) {
+    context.setErrorMessage("Too many blog posts were selected (maximum " + MAX_BULK_SELECTION
+        + "). Select fewer posts and try again.");
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  private WidgetContext rejectEmptySelection(WidgetContext context) {
+    context.setErrorMessage("No blog posts were selected");
+    context.setRedirect("/admin/blog-posts");
+    return context;
+  }
+
+  /**
+   * Sets the single aggregate result message every bulk action reports (page_messages.jspf renders
+   * exactly one of success/warning/error). Mirrors CalendarEventListWidget#setBulkResultMessage.
+   *
+   * <p>{@code rowIssues} carries a human-readable "title (#id): reason" entry for every not-found
+   * or failed row (issue #427 code-review finding: these reasons were previously recorded only to
+   * the admin-only audit log, never returned to the caller). Only the first
+   * {@link #MAX_DETAIL_LINES} are spelled out inline to keep the message readable; the full detail
+   * for every row remains in the audit log regardless.
+   */
+  private void setBulkResultMessage(WidgetContext context, String verb, int succeeded, int totalSelected,
+      int notFound, int failed, List<String> rowIssues) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(succeeded).append(" of ").append(totalSelected).append(" selected blog post")
+        .append(totalSelected == 1 ? "" : "s").append(" ").append(verb).append(".");
+    if (notFound > 0) {
+      sb.append(" Not found: ").append(notFound).append(".");
+    }
+    if (failed > 0) {
+      sb.append(" Failed: ").append(failed).append(".");
+    }
+    appendRowIssueDetails(sb, rowIssues);
+    if (succeeded == 0) {
+      context.setErrorMessage(sb.toString());
+    } else if (succeeded != totalSelected) {
+      context.setWarningMessage(sb.toString());
+    } else {
+      context.setSuccessMessage(sb.toString());
+    }
+  }
+
+  /**
+   * Appends up to {@link #MAX_DETAIL_LINES} "title (#id): reason" entries to the aggregate message,
+   * summarizing any remainder by count only. See {@link #setBulkResultMessage} for why this exists.
+   */
+  private void appendRowIssueDetails(StringBuilder sb, List<String> rowIssues) {
+    if (rowIssues == null || rowIssues.isEmpty()) {
+      return;
+    }
+    sb.append(" (");
+    int shown = Math.min(rowIssues.size(), MAX_DETAIL_LINES);
+    for (int i = 0; i < shown; i++) {
+      if (i > 0) {
+        sb.append("; ");
+      }
+      sb.append(rowIssues.get(i));
+    }
+    if (rowIssues.size() > shown) {
+      sb.append("; and ").append(rowIssues.size() - shown).append(" more");
+    }
+    sb.append(")");
+  }
+
+  /** Builds the filter specification from request parameters. */
+  private BlogPostSpecification buildSpecification(WidgetContext context) {
+    String q = context.getParameter("q");
+    long blogId = context.getParameterAsLong("blogId", -1);
+    String status = context.getParameter("status");
+
+    BlogPostSpecification specification = new BlogPostSpecification();
+    if (StringUtils.isNotBlank(q)) {
+      specification.setSearchTerm(q.trim());
+    }
+    if (blogId > -1) {
+      specification.setBlogId(blogId);
+    }
+    // issue #427: archived posts are excluded from this list by default -- "Archived" is its own
+    // status option (rather than combined with published/draft) since a post's archived state is
+    // orthogonal to whether it was ever published. Mirrors CalendarEventListWidget's identical
+    // status-dropdown handling.
+    if ("archived".equals(status)) {
+      specification.setArchivedOnly(true);
+    } else {
+      specification.setArchivedOnly(false);
+      if ("published".equals(status)) {
+        specification.setPublishedOnly(true);
+      } else if ("draft".equals(status)) {
+        specification.setPublishedOnly(false);
+      }
+    }
+    return specification;
+  }
+
+  /** Echoes the raw filter parameters back to the request so the filter form keeps its state. */
+  private void echoFilterParameters(WidgetContext context) {
+    context.getRequest().setAttribute("q", context.getParameter("q"));
+    context.getRequest().setAttribute("blogId", context.getParameter("blogId"));
+    context.getRequest().setAttribute("status", context.getParameter("status"));
+  }
+
+  /** Appends {@code name=urlEncoded(value)} to the paging query string when the value is present. */
+  private void appendParam(StringBuilder sb, String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if (sb.length() > 0) {
+      sb.append("&");
+    }
+    sb.append(name).append("=").append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidget.java
@@ -135,6 +135,9 @@ public class BlogPostListWidget extends GenericWidget {
       blogPostSpecification.setPublishedOnly(true);
       blogPostSpecification.setStartDateIsBeforeNow(true);
       blogPostSpecification.setIsWithinEndDate(true);
+      // Issue #427: an archived post must actually disappear from this public listing -- mirrors
+      // the UpcomingCalendarEventsWidget/CalendarSearchResultsWidget exclusion added for #882.
+      blogPostSpecification.setArchivedOnly(false);
     }
 
     // Load the blog posts

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidget.java
@@ -122,6 +122,13 @@ public class BlogPostWidget extends GenericWidget {
         !(context.hasRole("admin") || context.hasRole("content-manager"))) {
       return null;
     }
+    // Issue #427: an archived post must actually come offline for the public too, same as an
+    // unpublished one -- BlogPostRepository.findByUniqueId doesn't go through createWhereStatement
+    // (and so never considers the archived column at all), so this is the only place left to check.
+    if (blogPost.getArchived() != null &&
+        !(context.hasRole("admin") || context.hasRole("content-manager"))) {
+      return null;
+    }
     return blogPost;
   }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blog-list.jsp
@@ -36,6 +36,7 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <a class="button small radius primary" href="${ctx}/admin/blog?returnPage=/admin/blogs">Add a Blog <i class="fa fa-arrow-circle-right"></i></a>
+<a class="button small radius secondary" href="${ctx}/admin/blog-posts">All Blog Posts <i class="fa fa-arrow-circle-right"></i></a>
 <%@include file="../page_messages.jspf" %>
 <table class="unstriped">
   <thead>

--- a/src/main/webapp/WEB-INF/jsp/admin/blog-post-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blog-post-list.jsp
@@ -250,7 +250,7 @@
     // Populates one bulk modal's hidden blogPostId fields and visible title list from the
     // currently checked rows, so the admin sees exactly what is about to be affected before
     // confirming.
-    function populateBulkModal(revealId, listId) {
+    function populateBulkModal(revealId, listId, countId) {
       var $reveal = $('#' + revealId);
       var $form = $reveal.find('form');
       var $list = $('#' + listId);
@@ -261,7 +261,7 @@
         $form.append($('<input type="hidden" name="blogPostId">').val($checkbox.val()));
         $list.append($('<li>').text($checkbox.data('title')));
       });
-      $('#' + revealId + 'Count').text(selected().length);
+      $('#' + countId).text(selected().length);
       $reveal.foundation('open');
     }
 
@@ -271,11 +271,11 @@
     });
     $rows.on('change', refresh);
 
-    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList'); });
-    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList'); });
-    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList'); });
-    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList'); });
-    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList'); });
+    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList', 'bulkPublishCount'); });
+    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList', 'bulkUnpublishCount'); });
+    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList', 'bulkArchiveCount'); });
+    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList', 'bulkMoveCount'); });
+    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList', 'bulkDeleteCount'); });
 
     refresh();
   })();

--- a/src/main/webapp/WEB-INF/jsp/admin/blog-post-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/blog-post-list.jsp
@@ -1,0 +1,282 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="blogPostList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="blogList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="blogPostReviewStatusMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<%-- Filters (GET so the criteria live in the URL and paging preserves them) --%>
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <div class="grid-x grid-margin-x">
+    <div class="cell medium-4">
+      <label>Search
+        <input type="text" name="q" placeholder="post title" value="<c:out value='${q}'/>">
+      </label>
+    </div>
+    <div class="cell medium-4">
+      <label>Blog
+        <select name="blogId">
+          <option value="">All</option>
+          <c:forEach items="${blogList}" var="blog">
+            <option value="${blog.id}" <c:if test="${blogId == blog.id}">selected</c:if>><c:out value="${blog.name}" /></option>
+          </c:forEach>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-4">
+      <label>Status
+        <select name="status">
+          <option value="">All</option>
+          <option value="published" <c:if test="${status == 'published'}">selected</c:if>>Published</option>
+          <option value="draft" <c:if test="${status == 'draft'}">selected</c:if>>Draft</option>
+          <%-- Archived posts are excluded from every other option above by default (issue #427);
+               this is the only way to see them in the admin list. --%>
+          <option value="archived" <c:if test="${status == 'archived'}">selected</c:if>>Archived</option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <button type="submit" class="button small primary radius"><i class="fa fa-filter"></i> Filter</button>
+  <a href="${widgetContext.uri}" class="button small secondary radius">Clear</a>
+</form>
+<div id="bulkActionsBar" class="callout radius" style="display:none;padding:10px 15px;margin-bottom:10px;">
+  <span id="bulkSelectedCount"></span>
+  <button type="button" class="button tiny radius" id="bulkPublishBtn">Publish</button>
+  <button type="button" class="button tiny radius" id="bulkUnpublishBtn">Unpublish</button>
+  <button type="button" class="button tiny radius" id="bulkArchiveBtn">Archive</button>
+  <button type="button" class="button tiny radius" id="bulkMoveBtn">Move</button>
+  <button type="button" class="button tiny alert radius" id="bulkDeleteBtn">Delete</button>
+</div>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th width="24"><input type="checkbox" id="selectAllBlogPosts" aria-label="Select all blog posts on this page"></th>
+      <th>Title</th>
+      <th width="160">Blog</th>
+      <th width="120" class="text-center">Status</th>
+      <th width="160" class="text-center">Published</th>
+      <th width="80" class="text-center">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${blogPostList}" var="blogPost">
+      <c:set var="postBlog" value="${null}" />
+      <c:forEach items="${blogList}" var="blog">
+        <c:if test="${blog.id == blogPost.blogId}"><c:set var="postBlog" value="${blog}" /></c:if>
+      </c:forEach>
+      <tr>
+        <td><input type="checkbox" class="blogPostRowCheckbox" value="${blogPost.id}" data-title="${fn:escapeXml(blogPost.title)}" aria-label="Select ${fn:escapeXml(blogPost.title)}"></td>
+        <td>
+          <c:choose>
+            <c:when test="${!empty postBlog}">
+              <a href="${ctx}/blog-editor?blogUniqueId=${postBlog.uniqueId}&returnPage=/admin/blog-posts&blogPostId=${blogPost.id}"><c:out value="${blogPost.title}" /></a>
+            </c:when>
+            <c:otherwise>
+              <c:out value="${blogPost.title}" />
+            </c:otherwise>
+          </c:choose>
+          <c:if test="${!empty blogPostReviewStatusMap[blogPost.id]}">
+            <br /><a href="${ctx}/admin/blog-post-review?blogPostId=${blogPost.id}" class="secondary label">
+              <i class="fa fa-clipboard-check"></i> <c:out value="${blogPostReviewStatusMap[blogPost.id]}" />
+            </a>
+          </c:if>
+        </td>
+        <td>
+          <c:if test="${!empty postBlog}"><c:out value="${postBlog.name}" /></c:if>
+        </td>
+        <td class="text-center">
+          <c:choose>
+            <c:when test="${!empty blogPost.archived}">
+              <span class="label secondary radius">Archived</span>
+            </c:when>
+            <c:when test="${!empty blogPost.published}">
+              <span class="label success radius">Published</span>
+            </c:when>
+            <c:otherwise>
+              <span class="label radius">Draft</span>
+            </c:otherwise>
+          </c:choose>
+        </td>
+        <td class="text-center">
+          <c:if test="${!empty blogPost.published}">
+            <fmt:formatDate pattern="yyyy-MM-dd" value="${blogPost.published}" />
+          </c:if>
+        </td>
+        <td class="text-center">
+          <c:if test="${!empty postBlog}">
+            <a href="${ctx}/blog-editor?blogUniqueId=${postBlog.uniqueId}&returnPage=/admin/blog-posts&blogPostId=${blogPost.id}"><i class="fa fa-edit"></i></a>
+          </c:if>
+        </td>
+      </tr>
+    </c:forEach>
+    <c:if test="${empty blogPostList}">
+      <tr>
+        <td colspan="6">No blog posts match the current filters</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>
+<%@include file="../paging_control.jspf" %>
+<%-- Bulk action reveal modals -- selection is scoped to the blog posts currently checked on this
+     page (see the JS below); each is populated at open time with the live selection, not just a
+     count. Mirrors calendar-event-list.jsp/web-page-list.jsp's bulk reveal modals (issue #427
+     pattern). --%>
+<div class="reveal" id="bulkPublishReveal" role="dialog" aria-modal="true" aria-labelledby="bulkPublishRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkPublishRevealTitle">Publish <span id="bulkPublishCount">0</span> Blog Post(s)</h4>
+  <p class="help-text">A post still awaiting review approval will be reported as a per-row failure and left unpublished; the rest of the selection is still processed.</p>
+  <ul id="bulkPublishList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkPublish"/>
+    <input type="submit" class="button radius" value="Publish Posts"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkUnpublishReveal" role="dialog" aria-modal="true" aria-labelledby="bulkUnpublishRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkUnpublishRevealTitle">Unpublish <span id="bulkUnpublishCount">0</span> Blog Post(s)</h4>
+  <p class="help-text">Unpublished posts are taken out of live view and marked as drafts. Any prior review approval is cleared, so the post must be re-approved before it can be published again.</p>
+  <ul id="bulkUnpublishList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkUnpublish"/>
+    <input type="submit" class="button radius" value="Unpublish Posts"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkArchiveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkArchiveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkArchiveRevealTitle">Archive <span id="bulkArchiveCount">0</span> Blog Post(s)</h4>
+  <p class="help-text">Archived posts are hidden from this list by default. They can still be found with the Archived status filter.</p>
+  <ul id="bulkArchiveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkArchive"/>
+    <input type="submit" class="button radius" value="Archive Posts"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkMoveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkMoveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkMoveRevealTitle">Move <span id="bulkMoveCount">0</span> Blog Post(s)</h4>
+  <ul id="bulkMoveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkMove"/>
+    <label for="bulkMoveBlogId">Destination blog <span class="required">*</span>
+      <select id="bulkMoveBlogId" name="blogId" required>
+        <c:forEach items="${blogList}" var="blog">
+          <option value="${blog.id}"><c:out value="${blog.name}" /></option>
+        </c:forEach>
+      </select>
+    </label>
+    <input type="submit" class="button radius" value="Move Posts"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkDeleteReveal" role="dialog" aria-modal="true" aria-labelledby="bulkDeleteRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkDeleteRevealTitle">Delete <span id="bulkDeleteCount">0</span> Blog Post(s)</h4>
+  <p class="help-text">This permanently removes the selected blog posts. This cannot be undone.</p>
+  <ul id="bulkDeleteList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkDelete"/>
+    <input type="submit" class="button alert radius" value="Delete Posts"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<script nonce="${cspNonce}">
+  (function () {
+    var $selectAll = $('#selectAllBlogPosts');
+    var $rows = $('.blogPostRowCheckbox');
+    var $bar = $('#bulkActionsBar');
+    var $count = $('#bulkSelectedCount');
+
+    function selected() {
+      return $rows.filter(':checked');
+    }
+
+    function refresh() {
+      var n = selected().length;
+      $count.text(n + (n === 1 ? ' post selected  ' : ' posts selected  '));
+      $bar.toggle(n > 0);
+      $selectAll.prop('indeterminate', n > 0 && n < $rows.length);
+      $selectAll.prop('checked', n > 0 && n === $rows.length);
+    }
+
+    // Populates one bulk modal's hidden blogPostId fields and visible title list from the
+    // currently checked rows, so the admin sees exactly what is about to be affected before
+    // confirming.
+    function populateBulkModal(revealId, listId) {
+      var $reveal = $('#' + revealId);
+      var $form = $reveal.find('form');
+      var $list = $('#' + listId);
+      $form.find('input[name="blogPostId"]').remove();
+      $list.empty();
+      selected().each(function () {
+        var $checkbox = $(this);
+        $form.append($('<input type="hidden" name="blogPostId">').val($checkbox.val()));
+        $list.append($('<li>').text($checkbox.data('title')));
+      });
+      $('#' + revealId + 'Count').text(selected().length);
+      $reveal.foundation('open');
+    }
+
+    $selectAll.on('change', function () {
+      $rows.prop('checked', this.checked);
+      refresh();
+    });
+    $rows.on('change', refresh);
+
+    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList'); });
+    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList'); });
+    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList'); });
+    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList'); });
+    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList'); });
+
+    refresh();
+  })();
+</script>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1591,6 +1591,26 @@
     </section>
   </page>
 
+  <page name="/admin/blog-posts{?blogId}" role="admin,content-manager" title="Blog Posts">
+    <section>
+      <column class="small-12 cell">
+        <widget name="breadcrumbs">
+          <links>
+            <link name="Blogs" value="/admin/blogs" />
+            <link name="Blog Posts" value="" />
+          </links>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 cell">
+        <widget name="adminBlogPostList">
+          <title>Blog Posts</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/calendars" role="admin,content-manager,community-manager" title="Calendars">
     <!--<section>-->
       <!--<column class="small-12 cell">-->

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -183,6 +183,7 @@
   <widget name="blogTagsList" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogTagsListWidget" />
   <widget name="blogTagForm" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogTagFormWidget" />
   <widget name="blogPostReview" class="com.simisinc.platform.presentation.widgets.admin.cms.BlogPostReviewWidget" />
+  <widget name="adminBlogPostList" class="com.simisinc.platform.presentation.widgets.admin.cms.AdminBlogPostListWidget" />
   <widget name="calendarList" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarListWidget" />
   <widget name="calendarEventList" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarEventListWidget" />
   <widget name="calendarForm" class="com.simisinc.platform.presentation.widgets.admin.cms.CalendarFormWidget" />

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepositoryWhereClauseTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+import com.simisinc.platform.infrastructure.database.SqlValue;
+
+/**
+ * Pure unit tests (no database) on {@link BlogPostRepository#createWhereStatement}'s built
+ * {@link SqlUtils} output for the archived filter issue #427 adds -- mirrors the shape of
+ * {@code CalendarEventRepositoryWhereClauseTest}.
+ *
+ * @author SimIS Inc.
+ */
+class BlogPostRepositoryWhereClauseTest {
+
+  private static boolean whereContains(SqlUtils where, String fragment) {
+    // Unlike CalendarEventRepository#createWhereStatement (which always allocates a SqlUtils),
+    // BlogPostRepository#createWhereStatement returns null outright for a null specification --
+    // pre-existing behavior, unrelated to the archived filter this test targets. Mirrors
+    // WebPageRepositoryWhereClauseTest's identical guard.
+    if (where == null) {
+      return false;
+    }
+    for (SqlValue value : where.getValues()) {
+      if (value.getFieldOrClause() != null && value.getFieldOrClause().contains(fragment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  void archivedOnlyTrueAddsAnArchivedIsNotNullClause() {
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setArchivedOnly(true);
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "archived IS NOT NULL"));
+    assertFalse(whereContains(where, "archived IS NULL"));
+  }
+
+  @Test
+  void archivedOnlyFalseAddsAnArchivedIsNullClause() {
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setArchivedOnly(false);
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void archivedOnlyUndefinedByDefaultAddsNoArchivedClauseAtAll() {
+    // The default for every pre-#427 caller (and every caller that never touches this field) --
+    // proves the new filter is purely additive and does not change existing query behavior.
+    BlogPostSpecification specification = new BlogPostSpecification();
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertFalse(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void archivedFilterCombinesWithPublishedFilterAsAnd() {
+    // "Archived" is orthogonal to published/draft (an archived post may have been published or
+    // still a draft), so both clauses must be present together, not one replacing the other.
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setPublishedOnly(true);
+    specification.setArchivedOnly(true);
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "published IS NOT NULL"));
+    assertTrue(whereContains(where, "archived IS NOT NULL"));
+  }
+
+  @Test
+  void aNullSpecificationProducesNoArchivedClause() {
+    SqlUtils where = BlogPostRepository.createWhereStatement(null);
+
+    assertFalse(whereContains(where, "archived IS NULL"));
+    assertFalse(whereContains(where, "archived IS NOT NULL"));
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminBlogPostListWidgetBulkActionsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminBlogPostListWidgetBulkActionsTest.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.application.cms.ContentReviewCommand;
+import com.simisinc.platform.domain.model.cms.Blog;
+import com.simisinc.platform.domain.model.cms.BlogPost;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Covers the 5 bulk actions on /admin/blog-posts (issue #427, mirroring
+ * CalendarEventListWidgetBulkActionsTest's shape for issue #882/PR #911): a batch over
+ * MAX_BULK_SELECTION is rejected outright rather than truncated, an empty selection is rejected,
+ * one id that no longer resolves never aborts the rest of the batch, bulkPublish reuses the exact
+ * governed-publish-workflow gate {@link ContentReviewCommand#mayPublish} (not the record-independent
+ * {@link ContentReviewCommand#mayPublishDirectly}) so a post still awaiting approval is a per-row
+ * failure rather than a bypass, bulkUnpublish resets the governed-review fields on a
+ * previously-published post exactly as {@code BlogEditorWidget} already does, and all 5 commands
+ * share a single admin-or-content-manager gate matching {@code BlogPostWidget#action}'s single-item
+ * delete gate.
+ *
+ * @author SimIS Inc.
+ */
+class AdminBlogPostListWidgetBulkActionsTest extends WidgetBase {
+
+  private static BlogPost blogPostWithId(long id) {
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(id);
+    blogPost.setBlogId(1L);
+    blogPost.setTitle("Post " + id);
+    return blogPost;
+  }
+
+  private static Blog blogWithId(long id) {
+    Blog blog = new Blog();
+    blog.setId(id);
+    blog.setName("Blog " + id);
+    return blog;
+  }
+
+  private void multiValue(String name, String... values) {
+    widgetContext.getParameterMap().put(name, values);
+  }
+
+  // --- Permission gate ---
+
+  @Test
+  void nonAdminNonContentManagerCannotReachAnyBulkAction() {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class)) {
+      new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.findById(anyLong()), never());
+    }
+  }
+
+  @Test
+  void contentManagerCanReachBulkActions() {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.save(blogPost)).thenReturn(blogPost);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.save(blogPost), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  @Test
+  void adminCanReachBulkDelete() {
+    // Unlike WebPageListWidget's stricter admin-only delete gate, blog post delete matches
+    // BlogPostWidget#action's own admin-or-content-manager gate -- content-manager suffices too.
+    setRoles(widgetContext, CONTENT_MANAGER);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.remove(blogPost)).thenReturn(true);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.remove(blogPost), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  // --- Selection bounds (shared shape across all 5 commands; exercised once each) ---
+
+  @Test
+  void overCapSelectionIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    String[] tooMany = new String[AdminBlogPostListWidget.MAX_BULK_SELECTION + 1];
+    for (int i = 0; i < tooMany.length; i++) {
+      tooMany[i] = String.valueOf(i + 100);
+    }
+    multiValue("blogPostId", tooMany);
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class)) {
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.findById(anyLong()), never());
+      assertTrue(result.getErrorMessage().contains("Too many blog posts"));
+    }
+  }
+
+  @Test
+  void emptySelectionIsRejectedForBulkDelete() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    // No blogPostId parameters at all
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class)) {
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.findById(anyLong()), never());
+      assertEquals("No blog posts were selected", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void anIdThatNoLongerResolvesIsSkippedButTheRestOfTheBatchStillRuns() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    BlogPost found = blogPostWithId(5L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(found);
+      repo.when(() -> BlogPostRepository.findById(6L)).thenReturn(null); // deleted concurrently / tampered id
+      repo.when(() -> BlogPostRepository.save(found)).thenReturn(found);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.save(any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Not found: 1"));
+    }
+  }
+
+  // --- bulkPublish ---
+
+  @Test
+  void bulkPublishSetsPublishedAndTriggersTheWorkflowWhenReviewIsNotRequired() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    // hasDraftContent() requires a non-blank body -- see bulkPublishSkipsAPostWithNoDraftContentAsAPerRowFailure
+    // for the no-draft-content case this test must NOT exercise.
+    blogPost.setBody("Some content");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.save(blogPost)).thenReturn(blogPost);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("blogPost.review.required")).thenReturn(false);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertNotNull(blogPost.getPublished());
+      repo.verify(() -> BlogPostRepository.save(blogPost), times(1));
+      workflow.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  @Test
+  void bulkPublishReportsAPostFailingContentReviewGateAsAPerRowFailureWithoutBlockingTheRestOfTheBatch() {
+    // The load-bearing point (#427's acceptance criterion): a bulk publish must never bypass
+    // governed review. This uses the real ContentReviewCommand state machine (not mocked) so the
+    // gate is proven, not assumed.
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+
+    BlogPost notApproved = blogPostWithId(5L);
+    notApproved.setBody("Some content"); // has draft content, so the failure is purely the review gate
+    // draftStatus null: never submitted, so mayPublish() is false under governed review.
+
+    BlogPost approved = blogPostWithId(6L);
+    approved.setBody("Some content");
+    approved.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    approved.setSubmittedBy(2L);
+    approved.setApprovedBy(3L); // a different user than the submitter
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(notApproved);
+      repo.when(() -> BlogPostRepository.findById(6L)).thenReturn(approved);
+      repo.when(() -> BlogPostRepository.save(approved)).thenReturn(approved);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("blogPost.review.required")).thenReturn(true);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertNull(notApproved.getPublished(), "an unapproved draft must never be published by the bulk action");
+      assertNotNull(approved.getPublished(), "an approved draft must still be published");
+      repo.verify(() -> BlogPostRepository.save(notApproved), never());
+      repo.verify(() -> BlogPostRepository.save(approved), times(1));
+      workflow.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Failed: 1"));
+    }
+  }
+
+  @Test
+  void bulkPublishSkipsAPostWithNoDraftContentAsAPerRowFailure() {
+    // Code-review fix (issue #427): bulkPublishAction must mirror BlogPostReviewWidget#
+    // publishDirectly's hasDraftContent() guard, not just mayPublish() -- otherwise, with
+    // blogPost.review.required off, selecting an already-published post (or one with no draft
+    // content at all) for bulk Publish would re-stamp its published timestamp and re-fire
+    // BlogPostPublishedEvent. blogPostWithId() leaves body blank, so hasDraftContent() is false
+    // here without needing to fake an already-published state.
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+
+    BlogPost blogPost = blogPostWithId(5L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("blogPost.review.required")).thenReturn(false);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertNull(blogPost.getPublished(), "a post with no draft content must not be re-published by the bulk action");
+      repo.verify(() -> BlogPostRepository.save(any()), never());
+      workflow.verifyNoInteractions();
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected blog post published. Failed: 1."));
+      assertTrue(result.getErrorMessage().contains("Post 5 (#5): no draft content to publish"));
+    }
+  }
+
+  @Test
+  void bulkPublishRecordsTheSuccessAuditEntryBeforeFiringTheWorkflowEventSoALostWorkflowCallCannotEraseIt() {
+    // Review fix (issue #427): the workflow event now fires AFTER the audit record, not before --
+    // so if WorkflowManager throws (e.g. the job-queue backend is unavailable), this row's SUCCESS
+    // audit entry is already durably recorded, matching BlogPostReviewWidget#publishDirectly's
+    // audit-before-workflow ordering. Previously the audit call for this row would never run.
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    blogPost.setBody("Some content");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.save(blogPost)).thenReturn(blogPost);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByNameAsBoolean("blogPost.review.required")).thenReturn(false);
+      workflow.when(() -> WorkflowManager.triggerWorkflowForEvent(any()))
+          .thenThrow(new IllegalStateException("job queue unavailable"));
+
+      assertThrows(IllegalStateException.class, () -> new AdminBlogPostListWidget().post(widgetContext));
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+    }
+  }
+
+  // --- bulkUnpublish ---
+
+  @Test
+  void bulkUnpublishResetsTheGovernedReviewFieldsOnAPreviouslyPublishedPost() {
+    // Issue #407 phase 2 correctness requirement: skipping this reset would let a single editor
+    // unpublish, edit, and republish without the new content ever being reviewed.
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkUnpublish");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    blogPost.setPublished(new Timestamp(System.currentTimeMillis()));
+    blogPost.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    blogPost.setSubmittedBy(2L);
+    blogPost.setApprovedBy(3L);
+    blogPost.setReleaseReference("CR-1234");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.save(blogPost)).thenReturn(blogPost);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertNull(blogPost.getPublished());
+      assertNull(blogPost.getDraftStatus());
+      assertEquals(-1, blogPost.getSubmittedBy());
+      assertEquals(-1, blogPost.getApprovedBy());
+      assertNull(blogPost.getReleaseReference());
+      repo.verify(() -> BlogPostRepository.save(blogPost), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.unpublish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  @Test
+  void bulkUnpublishDoesNotTouchReviewFieldsForAPostThatWasNotYetPublished() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkUnpublish");
+
+    BlogPost blogPost = blogPostWithId(5L);
+    blogPost.setPublished(null);
+    blogPost.setDraftStatus(ContentReviewCommand.STATUS_SUBMITTED);
+    blogPost.setSubmittedBy(2L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.save(blogPost)).thenReturn(blogPost);
+
+      new AdminBlogPostListWidget().post(widgetContext);
+
+      // Still pending review -- unpublishing a post that was never live must not disturb its
+      // in-progress review state.
+      assertEquals(ContentReviewCommand.STATUS_SUBMITTED, blogPost.getDraftStatus());
+      assertEquals(2L, blogPost.getSubmittedBy());
+    }
+  }
+
+  // --- bulkArchive ---
+
+  @Test
+  void bulkArchiveSetsTheArchivedTimestampOnEachResolvedPost() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    BlogPost first = blogPostWithId(5L);
+    BlogPost second = blogPostWithId(6L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> BlogPostRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> BlogPostRepository.save(first)).thenReturn(first);
+      repo.when(() -> BlogPostRepository.save(second)).thenReturn(second);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertNotNull(first.getArchived());
+      assertNotNull(second.getArchived());
+      repo.verify(() -> BlogPostRepository.save(first), times(1));
+      repo.verify(() -> BlogPostRepository.save(second), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.archive"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  // --- bulkMove ---
+
+  @Test
+  void bulkMoveWithoutAResolvableDestinationBlogIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "blogId", "999");
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class)) {
+      blogRepo.when(() -> BlogRepository.findById(999L)).thenReturn(null);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      // Rejected before any post is even loaded -- the destination is resolved first
+      repo.verify(() -> BlogPostRepository.findById(anyLong()), never());
+      assertEquals("The destination blog was not found", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void bulkMoveUpdatesTheBlogIdOnEachResolvedPost() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "blogId", "42");
+
+    Blog destination = blogWithId(42L);
+    BlogPost first = blogPostWithId(5L);
+    BlogPost second = blogPostWithId(6L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<BlogRepository> blogRepo = mockStatic(BlogRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      blogRepo.when(() -> BlogRepository.findById(42L)).thenReturn(destination);
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> BlogPostRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> BlogPostRepository.save(first)).thenReturn(first);
+      repo.when(() -> BlogPostRepository.save(second)).thenReturn(second);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      assertEquals(42L, first.getBlogId());
+      assertEquals(42L, second.getBlogId());
+      repo.verify(() -> BlogPostRepository.save(first), times(1));
+      repo.verify(() -> BlogPostRepository.save(second), times(1));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+      assertTrue(result.getSuccessMessage().contains("Blog 42"));
+    }
+  }
+
+  // --- bulkDelete ---
+
+  @Test
+  void bulkDeleteRemovesEachResolvedPost() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    BlogPost first = blogPostWithId(5L);
+    BlogPost second = blogPostWithId(6L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> BlogPostRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> BlogPostRepository.remove(first)).thenReturn(true);
+      repo.when(() -> BlogPostRepository.remove(second)).thenReturn(true);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      repo.verify(() -> BlogPostRepository.remove(first), times(1));
+      repo.verify(() -> BlogPostRepository.remove(second), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.delete"),
+          eq("success"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  @Test
+  void bulkDeleteCountsAFailedRemovalAsAFailureNotAnAbort() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("blogPostId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+
+    BlogPost blogPost = blogPostWithId(5L);
+
+    try (MockedStatic<BlogPostRepository> repo = mockStatic(BlogPostRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      repo.when(() -> BlogPostRepository.findById(5L)).thenReturn(blogPost);
+      repo.when(() -> BlogPostRepository.remove(blogPost)).thenReturn(false);
+
+      WidgetContext result = new AdminBlogPostListWidget().post(widgetContext);
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.delete"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("blog_post"), any(), any(), any()), times(1));
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected blog post deleted. Failed: 1."));
+      // Issue #427 code-review finding: the failed row's reason must reach the response, not just
+      // the audit log (which a non-admin content-manager triggering this action cannot view).
+      assertTrue(result.getErrorMessage().contains("Post 5 (#5): delete failed"));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostListWidgetTest.java
@@ -22,9 +22,12 @@ import com.simisinc.platform.domain.model.cms.Blog;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.BlogPostRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.BlogPostSpecification;
+import com.simisinc.platform.presentation.controller.DataConstants;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
@@ -81,5 +84,33 @@ class BlogPostListWidgetTest extends WidgetBase {
     Assertions.assertNotNull(widgetContext);
     Assertions.assertTrue(widgetContext.hasJsp());
     Assertions.assertEquals(JSP, widgetContext.getJsp());
+  }
+
+  @Test
+  void executeExcludesArchivedPostsForAGuest() {
+    // Issue #427: bulk Archive must actually take a post out of this public listing -- review
+    // caught that this widget set publishedOnly/date-range filters for a guest but never
+    // archivedOnly, so an archived post stayed fully visible here.
+    preferences.put("blogUniqueId", "news");
+
+    Blog blog = new Blog();
+    blog.setId(1L);
+    blog.setUniqueId("news");
+    blog.setName("News");
+    blog.setEnabled(true);
+
+    try (MockedStatic<LoadBlogCommand> loadBlogCommandMockedStatic = mockStatic(LoadBlogCommand.class);
+        MockedStatic<BlogPostRepository> blogPostRepositoryMockedStatic = mockStatic(BlogPostRepository.class)) {
+      loadBlogCommandMockedStatic.when(() -> LoadBlogCommand.loadBlogByUniqueId(eq("news"))).thenReturn(blog);
+      blogPostRepositoryMockedStatic.when(() -> BlogPostRepository.findAll(any(), any()))
+          .thenReturn(new ArrayList<>());
+
+      new BlogPostListWidget().execute(widgetContext);
+
+      ArgumentCaptor<BlogPostSpecification> specCaptor = ArgumentCaptor.forClass(BlogPostSpecification.class);
+      blogPostRepositoryMockedStatic.verify(() -> BlogPostRepository.findAll(specCaptor.capture(), any()));
+      Assertions.assertEquals(DataConstants.FALSE, specCaptor.getValue().getArchivedOnly(),
+          "a guest must never see archived posts in this listing");
+    }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/BlogPostWidgetTest.java
@@ -153,4 +153,51 @@ class BlogPostWidgetTest extends WidgetBase {
     Assertions.assertNull(widgetContext.getArticleModifiedDate());
     Assertions.assertNull(widgetContext.getArticleAuthorName());
   }
+
+  // Issue #427: bulk Archive on a blog post must actually take it offline for the public --
+  // review caught that BlogPostRepository.findByUniqueId never considers the archived column, so
+  // retrieveValidatedBlogPostFromUrl is the only remaining place that can enforce it.
+
+  @Test
+  void retrieveValidatedBlogPostFromUrlBlocksAGuestFromAnArchivedPost() {
+    Mockito.when(request.getRequestURI()).thenReturn("/news/launch-announcement");
+
+    Blog blog = new Blog();
+    blog.setId(2L);
+
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(9L);
+    blogPost.setPublished(Timestamp.valueOf("2026-07-01 09:00:00"));
+    blogPost.setArchived(Timestamp.valueOf("2026-08-01 09:00:00"));
+
+    try (MockedStatic<LoadBlogPostCommand> loadBlogPost = mockStatic(LoadBlogPostCommand.class)) {
+      loadBlogPost.when(() -> LoadBlogPostCommand.loadBlogPostByUniqueId(2L, "launch-announcement")).thenReturn(blogPost);
+
+      BlogPost result = BlogPostWidget.retrieveValidatedBlogPostFromUrl(widgetContext, blog);
+
+      Assertions.assertNull(result, "a guest must not be able to reach an archived post's permalink");
+    }
+  }
+
+  @Test
+  void retrieveValidatedBlogPostFromUrlStillAllowsAContentManagerToSeeAnArchivedPost() {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    Mockito.when(request.getRequestURI()).thenReturn("/news/launch-announcement");
+
+    Blog blog = new Blog();
+    blog.setId(2L);
+
+    BlogPost blogPost = new BlogPost();
+    blogPost.setId(9L);
+    blogPost.setPublished(Timestamp.valueOf("2026-07-01 09:00:00"));
+    blogPost.setArchived(Timestamp.valueOf("2026-08-01 09:00:00"));
+
+    try (MockedStatic<LoadBlogPostCommand> loadBlogPost = mockStatic(LoadBlogPostCommand.class)) {
+      loadBlogPost.when(() -> LoadBlogPostCommand.loadBlogPostByUniqueId(2L, "launch-announcement")).thenReturn(blogPost);
+
+      BlogPost result = BlogPostWidget.retrieveValidatedBlogPostFromUrl(widgetContext, blog);
+
+      Assertions.assertSame(blogPost, result, "a content-manager should still be able to preview an archived post");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Part 2/3 of issue #427 (bulk content operations), split into scoped PRs by content type. This PR covers blog posts.

- New `/admin/blog-posts` page (`AdminBlogPostListWidget`/`blog-post-list.jsp`) — the first admin listing of individual blog posts; previously only reachable one at a time via the per-blog editor.
- Same bulk-actions shape as the web-pages slice: 100-selection cap, per-row continue-on-not-found.
- Publish/unpublish reuse the governed-review gate (`ContentReviewCommand.mayPublish`, not the record-independent `mayPublishDirectly`) so a post still awaiting approval is a per-row failure, not a bypass. Unpublish resets the governed-review fields exactly as `BlogEditorWidget`'s own unpublish branch already does.
- Archiving reuses the `archived` column shape `BlogPostSpecification`/`BlogPostRepository` already had. An archived post now actually disappears from the public blog listing and its direct permalink — both previously ignored the `archived` column entirely, so "Archive" would only have hidden the row from admin views while the post stayed fully live.
- `bulkPublishAction` now records its audit entry before firing the publish workflow event rather than after, so a downstream failure in the workflow trigger can't erase that row's own audit trail.

## Test plan
- [x] New unit + Testcontainers-backed tests for the repository where-clause, all 5 bulk actions (including a regression test proving the audit entry survives a workflow-trigger exception), and the public-listing/permalink archived-exclusion
- [x] Full `ant ci-test` — BUILD SUCCESSFUL
- [x] `check-unescaped-el.py --strict` — 0 unallowlisted
- [x] Independently rebuilt/retested this slice standalone after splitting off its own branch