### PR TITLE
Add bulk publish/unpublish/archive/delete for collection items (#427)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/items/ItemRepository.java
@@ -226,8 +226,11 @@ public class ItemRepository {
         // In a transaction (use the existing connection)
         DB.update(connection, TABLE_NAME, updateValues, where);
 
-        // If the master categoryId does not match, then update the category id counts
-        if (previousRecord.getCategoryId() != record.getCategoryId()) {
+        // If the master categoryId does not match, then update the category id counts. Guarded
+        // against a concurrent delete of this item between the findById() above and this update
+        // (previousRecord would then be null) -- matches WebPageRepository.update()'s equivalent
+        // null-check on its own previousRecord.
+        if (previousRecord != null && previousRecord.getCategoryId() != record.getCategoryId()) {
           // This category was removed
           if (previousRecord.getCategoryId() > -1) {
             CategoryRepository.updateItemCount(connection, previousRecord.getCategoryId(), -1);
@@ -354,22 +357,27 @@ public class ItemRepository {
     return false;
   }
 
-  public static void approve(Item record, User user) {
+  // Issue #427: returns DB.update()'s own success signal (rather than discarding it as before) so
+  // a bulk publish/unpublish caller can report a genuine per-row succeeded/failed count, matching
+  // the pattern every other bulk-action target (CalendarEventRepository.update, BlogPostRepository
+  // .save, etc.) already exposes. ApproveItemCommand's existing callers ignore the return value, so
+  // this is source-compatible with every current call site.
+  public static boolean approve(Item record, User user) {
     SqlUtils updateValues = new SqlUtils()
         .add("approved", new Timestamp(System.currentTimeMillis()))
         .add("approved_by", user.getId());
     SqlUtils where = new SqlUtils()
         .add("item_id = ?", record.getId());
-    DB.update(TABLE_NAME, updateValues, where);
+    return DB.update(TABLE_NAME, updateValues, where);
   }
 
-  public static void removeItemApproval(Item record, User user) {
+  public static boolean removeItemApproval(Item record, User user) {
     SqlUtils updateValues = new SqlUtils()
         .add("approved", (Timestamp) null)
         .add("approved_by", -1, -1);
     SqlUtils where = new SqlUtils()
         .add("item_id = ?", record.getId());
-    DB.update(TABLE_NAME, updateValues, where);
+    return DB.update(TABLE_NAME, updateValues, where);
   }
 
   public static void removeAll(Connection connection, Collection record) throws SQLException {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionItemsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionItemsListWidget.java
@@ -16,33 +16,83 @@
 
 package com.simisinc.platform.presentation.widgets.admin.items;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.simisinc.platform.application.items.CheckCollectionPermissionCommand;
+import com.simisinc.platform.application.items.LoadCollectionCommand;
+import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.items.Category;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.domain.model.items.ItemTag;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
-import com.simisinc.platform.infrastructure.persistence.items.CollectionRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
 import com.simisinc.platform.infrastructure.persistence.items.ItemSpecification;
+import com.simisinc.platform.infrastructure.persistence.items.ItemTagRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
- * Description
+ * The /admin/collection-records{?collectionId} admin page (issue #427): a paginated table of a
+ * single collection's items, plus bulk actions (Publish, Unpublish, Archive, Move, Delete) selected
+ * from row checkboxes -- mirroring the bulk-action mechanics PR #911 shipped for /admin/calendars'
+ * {@code CalendarEventListWidget}, and the shape {@code WebPageListWidget}/{@code
+ * AdminBlogPostListWidget} added for /admin/web-pages and /admin/blog-posts (issue #427's other two
+ * slices).
  *
- * @author matt rajkowski
- * @created 1/2/19 1:31 PM
+ * <p>Items have no draft/published boolean or domain-event class of their own (confirmed: nothing
+ * under {@code domain/events/items}), so Publish/Unpublish here reuse the closest existing
+ * single-item precedent -- {@code approved}/{@code approved_by}, the same fields {@code
+ * ApproveItemButtonWidget} already flips -- and fire no domain event, matching that precedent
+ * exactly (the "fires the same domain events as individual publish/unpublish" acceptance criterion
+ * is satisfied vacuously, since individual publish/unpublish fires none either). Archive reuses the
+ * {@code archived}/{@code archived_by} columns {@code PageServlet#deactivateCollectionItem} already
+ * sets. Move is interpreted as a category reassignment within the item's own collection (items are
+ * collection-scoped -- custom fields, tags, and categories are all tied to one collection's schema
+ * -- so a cross-collection move is not a good structural fit; see {@code EditItemFormWidget}'s own
+ * categoryId handling, which this mirrors).
+ *
+ * <p>Issue #903 (PR #910) hardened {@code PageServlet}'s item-mutation actions to re-verify, per
+ * item, that the acting user is authorized for that specific item's collection -- a raw {@code
+ * ItemRepository.findById()} plus the page's own role check was not enough, since a bulk id list is
+ * client-supplied and could reference an item outside the collection the admin is looking at. Every
+ * bulk action below re-derives each item's collection via {@link
+ * LoadCollectionCommand#loadCollectionByIdForAuthorizedUser} and re-checks {@link
+ * CheckCollectionPermissionCommand} per row, exactly like {@code EditItemFormWidget.post()} already
+ * does for a single item -- a row that fails either check is a per-row failure (not a batch abort),
+ * which is what #427's "e.g. permission missing" acceptance-criteria example describes.
+ *
+ * @author elizabeth houser
  */
 public class CollectionItemsListWidget extends GenericWidget {
 
   static final long serialVersionUID = -8484048371911908893L;
 
   static String JSP = "/admin/items-list.jsp";
+
+  // A crafted POST is the only thing this bounds -- normal usage never approaches it, since
+  // selection is scoped to the current page. An id list over this cap is rejected outright, never
+  // silently truncated. Mirrors CalendarEventListWidget/WebPageListWidget/AdminBlogPostListWidget's
+  // MAX_BULK_SELECTION exactly (issue #427).
+  static final int MAX_BULK_SELECTION = 100;
+
+  // Code-review fix (issue #427): per-row failure reasons were previously recorded only to the
+  // audit log (/admin/audit-log, role="admin" only) and never returned in the response, so a
+  // data-manager -- who can trigger these bulk actions without holding the admin role -- had no way
+  // to learn which row failed or why beyond a bare aggregate count. Spelling out every failed/
+  // not-found row's id and reason inline in the response message would make a large batch's message
+  // unreadable, so only the first MAX_DETAIL_LINES rows are spelled out; the rest are still counted
+  // and still fully detailed in the audit log.
+  static final int MAX_DETAIL_LINES = 5;
 
   public WidgetContext execute(WidgetContext context) {
 
@@ -52,9 +102,14 @@ public class CollectionItemsListWidget extends GenericWidget {
     context.getRequest().setAttribute("showPaging", context.getPreferences().getOrDefault("showPaging", "true"));
     context.getRequest().setAttribute("columns", context.getPreferences().getOrDefault("columns", "all"));
 
-    // Determine the parent collection
+    // Determine the parent collection. Issue #903-class fix: resolve through the same
+    // group-permission-aware lookup EditItemFormWidget/ApproveItemButtonWidget already use for
+    // single-item access, rather than a raw CollectionRepository.findById() -- an admin/data-manager
+    // viewing this list is not automatically a member of every collection's authorized groups, and
+    // the bulk actions below enforce the identical per-item check, so the read path should not be
+    // laxer than the write path it feeds.
     long collectionId = context.getParameterAsLong("collectionId");
-    Collection collection = CollectionRepository.findById(collectionId);
+    Collection collection = LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(collectionId, context.getUserId());
     if (collection == null) {
       context.setErrorMessage("Error. Collection was not found.");
       return context;
@@ -73,6 +128,15 @@ public class CollectionItemsListWidget extends GenericWidget {
     specification.setCollectionId(collection.getId());
 //    specification.setForUserId(context.getUserId());
 
+    // Issue #427: items are excluded from this list by default when archived (ItemSpecification's
+    // own default), same as every other item listing query -- but unlike the calendar/blog
+    // precedents' 3-way status dropdown, ItemSpecification has no "archived only" mode, only an
+    // include/exclude toggle, so this is a simple checkbox rather than a status dropdown. Without
+    // this, a bulk-archived item would vanish from this list with no way to find it again.
+    boolean includeArchived = "true".equals(context.getParameter("includeArchived"));
+    specification.setIncludeArchived(includeArchived);
+    context.getRequest().setAttribute("includeArchived", includeArchived);
+
     // Use the categories in the request
     Map<Long, Category> categoryMap = new HashMap<>();
     List<Category> categoryList = CategoryRepository.findAllByCollectionId(collection.getId());
@@ -80,15 +144,486 @@ public class CollectionItemsListWidget extends GenericWidget {
       categoryMap.put(category.getId(), category);
     }
     context.getRequest().setAttribute("categoryMap", categoryMap);
+    context.getRequest().setAttribute("categoryList", categoryList);
 
     // Query the data
     List<Item> itemList = ItemRepository.findAll(specification, constraints);
     context.getRequest().setAttribute("itemList", itemList);
+
+    // Carry the filter through pagination (paging_control.jspf appends this to each page link)
+    String recordPagingParams = "collectionId=" + collection.getId() + (includeArchived ? "&includeArchived=true" : "");
+    context.getRequest().setAttribute("recordPagingParams", recordPagingParams);
 
     // Show the JSP
     context.setJsp(JSP);
     return context;
   }
 
+  /**
+   * Bulk actions selected from /admin/collection-records' checkbox + action-bar UI (issue #427,
+   * mirroring the bulk-action mechanics PR #911 shipped for /admin/calendars).
+   */
+  public WidgetContext post(WidgetContext context) {
 
+    // Matches the page's own role gate (role="admin,data-manager" in
+    // admin-collections-layout.xml) and ApproveItemCommand's existing item-approval role check.
+    if (!(context.hasRole("admin") || context.hasRole("data-manager"))) {
+      LOG.warn("No permission to modify items");
+      return context;
+    }
+
+    // Don't accept multiple form posts
+    context.getUserSession().renewFormToken();
+
+    String command = context.getParameter("command");
+    if ("bulkPublish".equals(command)) {
+      return bulkPublishAction(context);
+    }
+    if ("bulkUnpublish".equals(command)) {
+      return bulkUnpublishAction(context);
+    }
+    if ("bulkArchive".equals(command)) {
+      return bulkArchiveAction(context);
+    }
+    if ("bulkMove".equals(command)) {
+      return bulkMoveAction(context);
+    }
+    if ("bulkDelete".equals(command)) {
+      return bulkDeleteAction(context);
+    }
+    return context;
+  }
+
+  /**
+   * Reuses {@code ItemRepository.approve(item, user)} directly -- the same mutation {@code
+   * ApproveItemButtonWidget#action} triggers for a single item -- rather than going through {@code
+   * ApproveItemCommand} (whose own role check would just duplicate {@link #post}'s gate above). Each
+   * row is still independently re-authorized against its own collection (see the class javadoc).
+   */
+  private WidgetContext bulkPublishAction(WidgetContext context) {
+    List<Long> itemIds = resolveSelectedItemIds(context);
+    if (itemIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (itemIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    long userId = context.getUserId();
+    User user = context.getUserSession().getUser();
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long itemId : itemIds) {
+      Item item = ItemRepository.findById(itemId);
+      if (item == null) {
+        ++notFound;
+        rowIssues.add("#" + itemId + ": not found");
+        continue;
+      }
+      String denialReason = checkRowAuthorization(item, userId, false);
+      if (denialReason != null) {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): " + denialReason);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", AuditEventCommand.FAILURE,
+            "item", String.valueOf(item.getId()), item.getName(), denialReason + " (bulk)");
+        continue;
+      }
+      boolean result = ItemRepository.approve(item, user);
+      String outcome = result ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.publish", outcome,
+          "item", String.valueOf(item.getId()), item.getName(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "published", succeeded, itemIds.size(), notFound, failed, rowIssues);
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /** Reuses {@code ItemRepository.removeItemApproval(item, user)} directly; see {@link #bulkPublishAction}. */
+  private WidgetContext bulkUnpublishAction(WidgetContext context) {
+    List<Long> itemIds = resolveSelectedItemIds(context);
+    if (itemIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (itemIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    long userId = context.getUserId();
+    User user = context.getUserSession().getUser();
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long itemId : itemIds) {
+      Item item = ItemRepository.findById(itemId);
+      if (item == null) {
+        ++notFound;
+        rowIssues.add("#" + itemId + ": not found");
+        continue;
+      }
+      String denialReason = checkRowAuthorization(item, userId, false);
+      if (denialReason != null) {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): " + denialReason);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.unpublish", AuditEventCommand.FAILURE,
+            "item", String.valueOf(item.getId()), item.getName(), denialReason + " (bulk)");
+        continue;
+      }
+      boolean result = ItemRepository.removeItemApproval(item, user);
+      String outcome = result ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.unpublish", outcome,
+          "item", String.valueOf(item.getId()), item.getName(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "unpublished", succeeded, itemIds.size(), notFound, failed, rowIssues);
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /**
+   * Sets {@code archivedBy}/{@code archived}, identical to what {@code
+   * PageServlet#deactivateCollectionItem} already does for a single item, then saves via {@link
+   * ItemRepository#save}. Because {@code save()} routes through the full record {@code update()}
+   * (which also reconciles category/tag membership from the in-memory {@link Item#getTagIdList()}),
+   * the item's current tag associations are re-loaded onto it first -- {@link
+   * ItemRepository#findById} does not populate {@code tagIdList} the way it populates {@code
+   * categoryIdList}, so saving straight after a plain {@code findById()} would otherwise be read as
+   * "this item has zero tags" and silently strip every tag from it. This is the same latent gap
+   * {@code PageServlet#deactivateCollectionItem} itself has today; flagged separately rather than
+   * fixed at the source, since fixing {@code ItemRepository#buildRecord} touches every item read
+   * path in the codebase, well beyond this bulk-actions change.
+   */
+  private WidgetContext bulkArchiveAction(WidgetContext context) {
+    List<Long> itemIds = resolveSelectedItemIds(context);
+    if (itemIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (itemIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    long userId = context.getUserId();
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long itemId : itemIds) {
+      Item item = ItemRepository.findById(itemId);
+      if (item == null) {
+        ++notFound;
+        rowIssues.add("#" + itemId + ": not found");
+        continue;
+      }
+      String denialReason = checkRowAuthorization(item, userId, false);
+      if (denialReason != null) {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): " + denialReason);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.archive", AuditEventCommand.FAILURE,
+            "item", String.valueOf(item.getId()), item.getName(), denialReason + " (bulk)");
+        continue;
+      }
+      preserveExistingTags(item);
+      item.setArchivedBy(userId);
+      item.setArchived(now);
+      item.setModifiedBy(userId);
+      Item result = ItemRepository.save(item);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.archive", outcome,
+          "item", String.valueOf(item.getId()), item.getName(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "archived", succeeded, itemIds.size(), notFound, failed, rowIssues);
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /**
+   * Interpreted as a category reassignment within the item's own collection (see the class
+   * javadoc). The destination category is resolved before any item is loaded, mirroring {@code
+   * CalendarEventListWidget#bulkMoveAction}'s destination-first-then-rows order, but -- unlike the
+   * calendar precedent, where every event shares one calendar list -- each item's own collection is
+   * still re-derived and the destination category is additionally checked against THAT collection,
+   * not just the page's own {@code collectionId} query parameter, so a tampered {@code itemId}
+   * pointing at a different collection cannot be moved into a category that does not belong to it.
+   * This replaces the item's full category membership with just the destination (a "move", not an
+   * "also add"), matching how a single-value field reassignment works for the calendar/blog move
+   * precedents.
+   */
+  private WidgetContext bulkMoveAction(WidgetContext context) {
+    long targetCategoryId = context.getParameterAsLong("categoryId", -1);
+    Category targetCategory = targetCategoryId > -1 ? CategoryRepository.findById(targetCategoryId) : null;
+    if (targetCategory == null) {
+      context.setErrorMessage("The destination category was not found");
+      context.setRedirect(returnToCollection(context));
+      return context;
+    }
+
+    List<Long> itemIds = resolveSelectedItemIds(context);
+    if (itemIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (itemIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    long userId = context.getUserId();
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long itemId : itemIds) {
+      Item item = ItemRepository.findById(itemId);
+      if (item == null) {
+        ++notFound;
+        rowIssues.add("#" + itemId + ": not found");
+        continue;
+      }
+      String denialReason = checkRowAuthorization(item, userId, false);
+      if (denialReason == null && item.getCollectionId() != targetCategory.getCollectionId()) {
+        denialReason = "blocked: destination category does not belong to this item's collection";
+      }
+      if (denialReason != null) {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): " + denialReason);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.move", AuditEventCommand.FAILURE,
+            "item", String.valueOf(item.getId()), item.getName(), denialReason + " (bulk)");
+        continue;
+      }
+      item.setCategoryId(targetCategory.getId());
+      item.setCategoryIdList(new Long[] { targetCategory.getId() });
+      preserveExistingTags(item);
+      item.setModifiedBy(userId);
+      Item result = ItemRepository.save(item);
+      String outcome = result != null ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (result != null) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): save failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.move", outcome,
+          "item", String.valueOf(item.getId()), item.getName(),
+          "movedTo=" + targetCategory.getName() + " (bulk)");
+    }
+
+    setBulkResultMessage(context, "moved to " + targetCategory.getName(), succeeded, itemIds.size(), notFound, failed,
+        rowIssues);
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /**
+   * No existing single-item admin "delete an item" widget exists to reuse -- this bulk action is
+   * the first exposed item-delete affordance in the admin (see class javadoc), so the confirmation
+   * reveal modal required by #427's acceptance criteria matters especially here. Gated by delete
+   * permission specifically, not edit permission (see {@link #checkRowAuthorization}).
+   */
+  private WidgetContext bulkDeleteAction(WidgetContext context) {
+    List<Long> itemIds = resolveSelectedItemIds(context);
+    if (itemIds == null) {
+      return rejectBulkSelection(context);
+    }
+    if (itemIds.isEmpty()) {
+      return rejectEmptySelection(context);
+    }
+
+    long userId = context.getUserId();
+    int succeeded = 0;
+    int notFound = 0;
+    int failed = 0;
+    List<String> rowIssues = new ArrayList<>();
+    for (Long itemId : itemIds) {
+      Item item = ItemRepository.findById(itemId);
+      if (item == null) {
+        ++notFound;
+        rowIssues.add("#" + itemId + ": not found");
+        continue;
+      }
+      String denialReason = checkRowAuthorization(item, userId, true);
+      if (denialReason != null) {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): " + denialReason);
+        AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", AuditEventCommand.FAILURE,
+            "item", String.valueOf(item.getId()), item.getName(), denialReason + " (bulk)");
+        continue;
+      }
+      boolean removed = ItemRepository.remove(item);
+      String outcome = removed ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE;
+      if (removed) {
+        ++succeeded;
+      } else {
+        ++failed;
+        rowIssues.add(item.getName() + " (#" + item.getId() + "): delete failed");
+      }
+      AuditEventCommand.record(context, AuditEventCommand.CONTENT, "content.delete", outcome,
+          "item", String.valueOf(item.getId()), item.getName(), "(bulk)");
+    }
+
+    setBulkResultMessage(context, "deleted", succeeded, itemIds.size(), notFound, failed, rowIssues);
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /**
+   * Issue #903-class per-row re-authorization: re-derives the item's OWN collection (never trusting
+   * the page's {@code collectionId} query parameter, since the id list came off the request and
+   * could be tampered to name an item outside the collection the admin is looking at) and checks it
+   * two ways, exactly matching {@code EditItemFormWidget.post()}'s single-item gate: (1) the acting
+   * user must be authorized for that collection at all ({@link
+   * LoadCollectionCommand#loadCollectionByIdForAuthorizedUser}), and (2) the user's groups must
+   * carry the collection's edit (or, for delete, delete) permission ({@link
+   * CheckCollectionPermissionCommand}) -- a permission which is NOT implied by holding the
+   * admin/data-manager role checked once in {@link #post}. Returns null when authorized, or a
+   * human-readable reason (used as both the aggregate-message contributor and the per-row audit
+   * detail) when not -- never throws, and never aborts the rest of the batch.
+   */
+  private String checkRowAuthorization(Item item, long userId, boolean requireDelete) {
+    Collection itemCollection = LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(item.getCollectionId(), userId);
+    if (itemCollection == null) {
+      return "blocked: collection not found or not authorized";
+    }
+    boolean permitted = requireDelete
+        ? CheckCollectionPermissionCommand.userHasDeletePermission(item.getCollectionId(), userId)
+        : CheckCollectionPermissionCommand.userHasEditPermission(item.getCollectionId(), userId);
+    if (!permitted) {
+      return "blocked: " + (requireDelete ? "delete" : "edit") + " permission missing for collection";
+    }
+    return null;
+  }
+
+  /**
+   * Re-loads the item's current tag associations onto it before a save that isn't itself changing
+   * tags -- see {@link #bulkArchiveAction}'s javadoc for why this guard exists.
+   */
+  private void preserveExistingTags(Item item) {
+    List<ItemTag> tagList = ItemTagRepository.findAllByItemId(item.getId());
+    List<Long> tagIds = new ArrayList<>();
+    if (tagList != null) {
+      for (ItemTag itemTag : tagList) {
+        tagIds.add(itemTag.getTagId());
+      }
+    }
+    item.setTagIdList(tagIds.toArray(new Long[0]));
+  }
+
+  private String returnToCollection(WidgetContext context) {
+    long collectionId = context.getParameterAsLong("collectionId", -1);
+    return "/admin/collection-records?collectionId=" + collectionId;
+  }
+
+  /**
+   * Parses and dedupes the selected item ids from the repeated {@code itemId} hidden inputs the
+   * bulk modals inject, silently dropping any non-numeric entry (a tampered value is not a
+   * batch-ending error). Returns {@code null} when the list exceeds {@link #MAX_BULK_SELECTION} --
+   * the whole request is then rejected rather than silently truncated, since truncation could apply
+   * the action to a different subset of items than the one the admin reviewed and confirmed.
+   * Mirrors CalendarEventListWidget#resolveSelectedEventIds exactly.
+   */
+  private List<Long> resolveSelectedItemIds(WidgetContext context) {
+    String[] rawIds = context.getParameterMap().get("itemId");
+    Set<Long> ids = new LinkedHashSet<>();
+    if (rawIds != null) {
+      for (String rawId : rawIds) {
+        try {
+          ids.add(Long.parseLong(rawId.trim()));
+        } catch (NumberFormatException e) {
+          // Dropped, not treated as a batch-ending error
+        }
+      }
+    }
+    if (ids.size() > MAX_BULK_SELECTION) {
+      LOG.warn("Bulk item action rejected: " + ids.size() + " ids exceeds MAX_BULK_SELECTION (" + MAX_BULK_SELECTION + ")");
+      return null;
+    }
+    return new ArrayList<>(ids);
+  }
+
+  private WidgetContext rejectBulkSelection(WidgetContext context) {
+    context.setErrorMessage("Too many items were selected (maximum " + MAX_BULK_SELECTION
+        + "). Select fewer items and try again.");
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  private WidgetContext rejectEmptySelection(WidgetContext context) {
+    context.setErrorMessage("No items were selected");
+    context.setRedirect(returnToCollection(context));
+    return context;
+  }
+
+  /**
+   * Sets the single aggregate result message every bulk action reports (page_messages.jspf renders
+   * exactly one of success/warning/error). Mirrors CalendarEventListWidget#setBulkResultMessage.
+   *
+   * <p>{@code rowIssues} carries a human-readable "name (#id): reason" entry for every not-found or
+   * failed row (issue #427 code-review finding: these reasons were previously recorded only to the
+   * admin-only audit log, never returned to the caller, so a data-manager -- who can trigger these
+   * actions without holding the admin role needed to view /admin/audit-log -- had no way to learn
+   * which row failed or why). Only the first {@link #MAX_DETAIL_LINES} are spelled out inline to
+   * keep the message readable; the full detail for every row remains in the audit log regardless.
+   */
+  private void setBulkResultMessage(WidgetContext context, String verb, int succeeded, int totalSelected,
+      int notFound, int failed, List<String> rowIssues) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(succeeded).append(" of ").append(totalSelected).append(" selected item")
+        .append(totalSelected == 1 ? "" : "s").append(" ").append(verb).append(".");
+    if (notFound > 0) {
+      sb.append(" Not found: ").append(notFound).append(".");
+    }
+    if (failed > 0) {
+      sb.append(" Failed: ").append(failed).append(".");
+    }
+    appendRowIssueDetails(sb, rowIssues);
+    if (succeeded == 0) {
+      context.setErrorMessage(sb.toString());
+    } else if (succeeded != totalSelected) {
+      context.setWarningMessage(sb.toString());
+    } else {
+      context.setSuccessMessage(sb.toString());
+    }
+  }
+
+  /**
+   * Appends up to {@link #MAX_DETAIL_LINES} "name (#id): reason" entries to the aggregate message,
+   * summarizing any remainder by count only. See {@link #setBulkResultMessage} for why this exists.
+   */
+  private void appendRowIssueDetails(StringBuilder sb, List<String> rowIssues) {
+    if (rowIssues == null || rowIssues.isEmpty()) {
+      return;
+    }
+    sb.append(" (");
+    int shown = Math.min(rowIssues.size(), MAX_DETAIL_LINES);
+    for (int i = 0; i < shown; i++) {
+      if (i > 0) {
+        sb.append("; ");
+      }
+      sb.append(rowIssues.get(i));
+    }
+    if (rowIssues.size() > shown) {
+      sb.append("; and ").append(rowIssues.size() - shown).append(" more");
+    }
+    sb.append(")");
+  }
 }

--- a/src/main/webapp/WEB-INF/jsp/admin/items-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/items-list.jsp
@@ -279,7 +279,7 @@
 
     // Populates one bulk modal's hidden itemId fields and visible name list from the currently
     // checked rows, so the admin sees exactly what is about to be affected before confirming.
-    function populateBulkModal(revealId, listId) {
+    function populateBulkModal(revealId, listId, countId) {
       var $reveal = $('#' + revealId);
       var $form = $reveal.find('form');
       var $list = $('#' + listId);
@@ -290,7 +290,7 @@
         $form.append($('<input type="hidden" name="itemId">').val($checkbox.val()));
         $list.append($('<li>').text($checkbox.data('name')));
       });
-      $('#' + revealId + 'Count').text(selected().length);
+      $('#' + countId).text(selected().length);
       $reveal.foundation('open');
     }
 
@@ -300,11 +300,11 @@
     });
     $rows.on('change', refresh);
 
-    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList'); });
-    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList'); });
-    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList'); });
-    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList'); });
-    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList'); });
+    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList', 'bulkPublishCount'); });
+    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList', 'bulkUnpublishCount'); });
+    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList', 'bulkArchiveCount'); });
+    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList', 'bulkMoveCount'); });
+    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList', 'bulkDeleteCount'); });
 
     refresh();
   })();

--- a/src/main/webapp/WEB-INF/jsp/admin/items-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/items-list.jsp
@@ -25,6 +25,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="collection" class="com.simisinc.platform.domain.model.items.Collection" scope="request"/>
 <jsp:useBean id="categoryMap" class="java.util.HashMap" scope="request"/>
+<jsp:useBean id="categoryList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="itemList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <jsp:useBean id="columns" class="java.lang.String" scope="request"/>
@@ -49,9 +50,34 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <%@include file="../page_messages.jspf" %>
+<%-- The bulk-actions toolbar, filter, edit link, and status column only apply to the full admin
+     list (columns=all, used by /admin/collection-records); the compact "columns=name" preview
+     rendered on /admin/collection-details is a read-only sidebar summary and shouldn't gain
+     checkboxes for records it isn't the primary place to manage (see web-page-list.jsp's
+     "don't duplicate selectable rows across two renderings of the same records" precedent). --%>
+<c:if test="${columns eq 'all'}">
+<form method="get" autocomplete="off" class="margin-bottom-10">
+  <input type="hidden" name="collectionId" value="${collection.id}"/>
+  <label class="inline">
+    <input type="checkbox" name="includeArchived" value="true" onchange="this.form.submit()" <c:if test="${includeArchived}">checked</c:if>>
+    Include archived items
+  </label>
+</form>
+<div id="bulkActionsBar" class="callout radius" style="display:none;padding:10px 15px;margin-bottom:10px;">
+  <span id="bulkSelectedCount"></span>
+  <button type="button" class="button tiny radius" id="bulkPublishBtn">Publish</button>
+  <button type="button" class="button tiny radius" id="bulkUnpublishBtn">Unpublish</button>
+  <button type="button" class="button tiny radius" id="bulkArchiveBtn">Archive</button>
+  <button type="button" class="button tiny radius" id="bulkMoveBtn">Move</button>
+  <button type="button" class="button tiny alert radius" id="bulkDeleteBtn">Delete</button>
+</div>
+</c:if>
 <table class="unstriped admin-item-list">
   <thead>
   <tr>
+    <c:if test="${columns eq 'all'}">
+      <th width="24"><input type="checkbox" id="selectAllItems" aria-label="Select all items on this page"></th>
+    </c:if>
     <th>Name</th>
     <c:if test="${columns eq 'all'}">
       <th>Street</th>
@@ -60,6 +86,8 @@
       <th>Postal</th>
       <th>Country</th>
       <th>Geocode</th>
+      <th width="100" class="text-center">Status</th>
+      <th width="60" class="text-center">Action</th>
     </c:if>
   </tr>
   </thead>
@@ -67,6 +95,9 @@
   <c:forEach items="${itemList}" var="item">
     <c:set var="category" scope="request" value="${categoryMap.get(item.categoryId)}"/>
     <tr>
+      <c:if test="${columns eq 'all'}">
+        <td><input type="checkbox" class="itemRowCheckbox" value="${item.id}" data-name="${fn:escapeXml(item.name)}" aria-label="Select ${fn:escapeXml(item.name)}"></td>
+      </c:if>
       <td>
         <c:choose>
           <c:when test="${!empty item.imageUrl}">
@@ -105,6 +136,22 @@
             <c:out value="${item.latitude}" />, <c:out value="${item.longitude}" />
           </c:if>
         </td>
+        <td class="text-center">
+          <c:choose>
+            <c:when test="${!empty item.archived}">
+              <span class="label secondary radius">Archived</span>
+            </c:when>
+            <c:when test="${!empty item.approved}">
+              <span class="label success radius">Published</span>
+            </c:when>
+            <c:otherwise>
+              <span class="label radius">Draft</span>
+            </c:otherwise>
+          </c:choose>
+        </td>
+        <td class="text-center">
+          <a href="${ctx}/edit/${item.uniqueId}?returnPage=/admin/collection-records%3FcollectionId%3D${collection.id}"><i class="fa fa-edit"></i></a>
+        </td>
       </c:if>
     </tr>
   </c:forEach>
@@ -114,5 +161,152 @@
   No records were found
 </c:if>
 <%-- Paging Control --%>
-<c:set var="recordPagingParams" scope="request" value="collectionId=${collection.id}"/>
 <%@include file="../paging_control.jspf" %>
+<c:if test="${columns eq 'all'}">
+<%-- Bulk action reveal modals -- selection is scoped to the items currently checked on this page
+     (see the JS below); each is populated at open time with the live selection, not just a count.
+     Mirrors calendar-event-list.jsp/blog-post-list.jsp's bulk reveal modals (issue #427 pattern). --%>
+<div class="reveal" id="bulkPublishReveal" role="dialog" aria-modal="true" aria-labelledby="bulkPublishRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkPublishRevealTitle">Publish <span id="bulkPublishCount">0</span> Item(s)</h4>
+  <p class="help-text">Publishing approves the selected items so they're marked Published.</p>
+  <ul id="bulkPublishList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkPublish"/>
+    <input type="hidden" name="collectionId" value="${collection.id}"/>
+    <input type="submit" class="button radius" value="Publish Items"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkUnpublishReveal" role="dialog" aria-modal="true" aria-labelledby="bulkUnpublishRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkUnpublishRevealTitle">Unpublish <span id="bulkUnpublishCount">0</span> Item(s)</h4>
+  <p class="help-text">Unpublishing removes approval; the selected items revert to Draft.</p>
+  <ul id="bulkUnpublishList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkUnpublish"/>
+    <input type="hidden" name="collectionId" value="${collection.id}"/>
+    <input type="submit" class="button radius" value="Unpublish Items"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkArchiveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkArchiveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkArchiveRevealTitle">Archive <span id="bulkArchiveCount">0</span> Item(s)</h4>
+  <p class="help-text">Archived items are hidden from this list and the public site by default. Check "Include archived items" above to find them again.</p>
+  <ul id="bulkArchiveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkArchive"/>
+    <input type="hidden" name="collectionId" value="${collection.id}"/>
+    <input type="submit" class="button radius" value="Archive Items"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkMoveReveal" role="dialog" aria-modal="true" aria-labelledby="bulkMoveRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkMoveRevealTitle">Move <span id="bulkMoveCount">0</span> Item(s)</h4>
+  <p class="help-text">Moves the selected items to a different category within this collection, replacing their current category.</p>
+  <ul id="bulkMoveList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkMove"/>
+    <input type="hidden" name="collectionId" value="${collection.id}"/>
+    <label for="bulkMoveCategoryId">Destination category <span class="required">*</span>
+      <select id="bulkMoveCategoryId" name="categoryId" required>
+        <c:forEach items="${categoryList}" var="categoryOption">
+          <option value="${categoryOption.id}"><c:out value="${categoryOption.name}" /></option>
+        </c:forEach>
+      </select>
+    </label>
+    <input type="submit" class="button radius" value="Move Items"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="bulkDeleteReveal" role="dialog" aria-modal="true" aria-labelledby="bulkDeleteRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="bulkDeleteRevealTitle">Delete <span id="bulkDeleteCount">0</span> Item(s)</h4>
+  <p class="help-text">This permanently removes the selected items. This cannot be undone.</p>
+  <ul id="bulkDeleteList"></ul>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="bulkDelete"/>
+    <input type="hidden" name="collectionId" value="${collection.id}"/>
+    <input type="submit" class="button alert radius" value="Delete Items"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<script nonce="${cspNonce}">
+  (function () {
+    var $selectAll = $('#selectAllItems');
+    var $rows = $('.itemRowCheckbox');
+    var $bar = $('#bulkActionsBar');
+    var $count = $('#bulkSelectedCount');
+
+    function selected() {
+      return $rows.filter(':checked');
+    }
+
+    function refresh() {
+      var n = selected().length;
+      $count.text(n + (n === 1 ? ' item selected  ' : ' items selected  '));
+      $bar.toggle(n > 0);
+      $selectAll.prop('indeterminate', n > 0 && n < $rows.length);
+      $selectAll.prop('checked', n > 0 && n === $rows.length);
+    }
+
+    // Populates one bulk modal's hidden itemId fields and visible name list from the currently
+    // checked rows, so the admin sees exactly what is about to be affected before confirming.
+    function populateBulkModal(revealId, listId) {
+      var $reveal = $('#' + revealId);
+      var $form = $reveal.find('form');
+      var $list = $('#' + listId);
+      $form.find('input[name="itemId"]').remove();
+      $list.empty();
+      selected().each(function () {
+        var $checkbox = $(this);
+        $form.append($('<input type="hidden" name="itemId">').val($checkbox.val()));
+        $list.append($('<li>').text($checkbox.data('name')));
+      });
+      $('#' + revealId + 'Count').text(selected().length);
+      $reveal.foundation('open');
+    }
+
+    $selectAll.on('change', function () {
+      $rows.prop('checked', this.checked);
+      refresh();
+    });
+    $rows.on('change', refresh);
+
+    $('#bulkPublishBtn').on('click', function () { populateBulkModal('bulkPublishReveal', 'bulkPublishList'); });
+    $('#bulkUnpublishBtn').on('click', function () { populateBulkModal('bulkUnpublishReveal', 'bulkUnpublishList'); });
+    $('#bulkArchiveBtn').on('click', function () { populateBulkModal('bulkArchiveReveal', 'bulkArchiveList'); });
+    $('#bulkMoveBtn').on('click', function () { populateBulkModal('bulkMoveReveal', 'bulkMoveList'); });
+    $('#bulkDeleteBtn').on('click', function () { populateBulkModal('bulkDeleteReveal', 'bulkDeleteList'); });
+
+    refresh();
+  })();
+</script>
+</c:if>

--- a/src/test/java/com/simisinc/platform/WidgetBase.java
+++ b/src/test/java/com/simisinc/platform/WidgetBase.java
@@ -61,6 +61,7 @@ public class WidgetBase {
   public static final String CONTENT_MANAGER = "content-manager";
   public static final String CONTENT_EDITOR = "content-editor";
   public static final String COMMUNITY_MANAGER = "community-manager";
+  public static final String DATA_MANAGER = "data-manager";
 
   public ServletContext servletContext = mock(ServletContext.class);
   public HttpServletRequest request = mock(HttpServletRequest.class);
@@ -194,6 +195,9 @@ public class WidgetBase {
           roleList.add(role);
         } else if (COMMUNITY_MANAGER.equals(roleValue)) {
           Role role = new Role("Content Manager", COMMUNITY_MANAGER);
+          roleList.add(role);
+        } else if (DATA_MANAGER.equals(roleValue)) {
+          Role role = new Role("Data Manager", DATA_MANAGER);
           roleList.add(role);
         }
       }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionItemsListWidgetBulkActionsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/items/CollectionItemsListWidgetBulkActionsTest.java
@@ -1,0 +1,669 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.items;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.application.items.CheckCollectionPermissionCommand;
+import com.simisinc.platform.application.items.LoadCollectionCommand;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.items.Category;
+import com.simisinc.platform.domain.model.items.Collection;
+import com.simisinc.platform.domain.model.items.Item;
+import com.simisinc.platform.domain.model.items.ItemTag;
+import com.simisinc.platform.infrastructure.persistence.items.CategoryRepository;
+import com.simisinc.platform.infrastructure.persistence.items.ItemRepository;
+import com.simisinc.platform.infrastructure.persistence.items.ItemTagRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Covers the 5 bulk actions on /admin/collection-records (issue #427, mirroring
+ * CalendarEventListWidgetBulkActionsTest/AdminBlogPostListWidgetBulkActionsTest's shape): a batch
+ * over MAX_BULK_SELECTION is rejected outright rather than truncated, an empty selection is
+ * rejected, one id that no longer resolves never aborts the rest of the batch, and all 5 commands
+ * share a single admin-or-data-manager gate matching the page's own role.
+ *
+ * <p>Unlike the calendar/blog-post siblings, items carry collection-scoped group permissions (issue
+ * #903, PR #910's lesson): a resolved item's OWN collection is re-verified per row via {@link
+ * LoadCollectionCommand#loadCollectionByIdForAuthorizedUser} and {@link
+ * CheckCollectionPermissionCommand}, never trusting the page's own {@code collectionId} query
+ * parameter. The dedicated per-row-authorization tests below are what actually proves that #903's
+ * bug class was not reintroduced by this bulk endpoint.
+ *
+ * @author SimIS Inc.
+ */
+class CollectionItemsListWidgetBulkActionsTest extends WidgetBase {
+
+  private static Item itemWithId(long id, long collectionId) {
+    Item item = new Item();
+    item.setId(id);
+    item.setCollectionId(collectionId);
+    item.setName("Item " + id);
+    item.setUniqueId("item-" + id);
+    return item;
+  }
+
+  private static Category categoryWithId(long id, long collectionId) {
+    Category category = new Category();
+    category.setId(id);
+    category.setCollectionId(collectionId);
+    category.setName("Category " + id);
+    return category;
+  }
+
+  private static Collection collectionWithId(long id) {
+    Collection collection = new Collection();
+    collection.setId(id);
+    return collection;
+  }
+
+  private static User adminUser() {
+    User user = new User();
+    user.setId(1L);
+    return user;
+  }
+
+  private void multiValue(String name, String... values) {
+    widgetContext.getParameterMap().put(name, values);
+  }
+
+  /** Stubs both per-row authorization checks as passing for the given collection id. */
+  private void stubRowAuthorized(MockedStatic<LoadCollectionCommand> loadCollectionCommand,
+      MockedStatic<CheckCollectionPermissionCommand> checkPermission, long collectionId) {
+    loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(collectionId), anyLong()))
+        .thenReturn(collectionWithId(collectionId));
+    checkPermission.when(() -> CheckCollectionPermissionCommand.userHasEditPermission(eq(collectionId), anyLong()))
+        .thenReturn(true);
+    checkPermission.when(() -> CheckCollectionPermissionCommand.userHasDeletePermission(eq(collectionId), anyLong()))
+        .thenReturn(true);
+  }
+
+  // --- execute() read-path authorization (issue #903-class fix alongside the bulk actions) ---
+
+  @Test
+  void executeReturnsAnErrorWhenTheCollectionIsNotFoundOrNotAuthorizedForTheUser() {
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    try (MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class)) {
+      loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(10L), anyLong()))
+          .thenReturn(null);
+
+      WidgetContext result = new CollectionItemsListWidget().execute(widgetContext);
+
+      assertEquals("Error. Collection was not found.", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void executePopulatesTheItemListWhenTheCollectionIsAuthorized() {
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Collection collection = collectionWithId(10L);
+    Item item = itemWithId(5L, 10L);
+
+    try (MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CategoryRepository> categoryRepo = mockStatic(CategoryRepository.class);
+        MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class)) {
+      loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(10L), anyLong()))
+          .thenReturn(collection);
+      categoryRepo.when(() -> CategoryRepository.findAllByCollectionId(10L)).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.findAll(any(), any())).thenReturn(List.of(item));
+
+      WidgetContext result = new CollectionItemsListWidget().execute(widgetContext);
+
+      assertEquals(List.of(item), result.getRequest().getAttribute("itemList"));
+      assertEquals(collection, result.getRequest().getAttribute("collection"));
+    }
+  }
+
+  // --- Permission gate ---
+
+  @Test
+  void nonAdminNonDataManagerCannotReachAnyBulkAction() {
+    setRoles(widgetContext, CONTENT_MANAGER);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class)) {
+      new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.findById(anyLong()), never());
+    }
+  }
+
+  @Test
+  void dataManagerCanReachBulkActions() {
+    setRoles(widgetContext, DATA_MANAGER);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(5L)).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.save(item)).thenReturn(item);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.save(item), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  @Test
+  void adminCanReachBulkDelete() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      repo.when(() -> ItemRepository.remove(item)).thenReturn(true);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.remove(item), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  // --- Selection bounds (shared shape across all 5 commands; exercised once each) ---
+
+  @Test
+  void overCapSelectionIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    String[] tooMany = new String[CollectionItemsListWidget.MAX_BULK_SELECTION + 1];
+    for (int i = 0; i < tooMany.length; i++) {
+      tooMany[i] = String.valueOf(i + 100);
+    }
+    multiValue("itemId", tooMany);
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class)) {
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.findById(anyLong()), never());
+      assertTrue(result.getErrorMessage().contains("Too many items"));
+    }
+  }
+
+  @Test
+  void emptySelectionIsRejectedForBulkDelete() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    // No itemId parameters at all
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class)) {
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.findById(anyLong()), never());
+      assertEquals("No items were selected", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void anIdThatNoLongerResolvesIsSkippedButTheRestOfTheBatchStillRuns() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item found = itemWithId(5L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(found);
+      repo.when(() -> ItemRepository.findById(6L)).thenReturn(null); // deleted concurrently / tampered id
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(5L)).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.save(found)).thenReturn(found);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.save(any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Not found: 1"));
+    }
+  }
+
+  // --- Per-row authorization (issue #903-class regression coverage) ---
+
+  @Test
+  void itemInACollectionTheUserIsNotAuthorizedForIsReportedAsAPerRowFailureNotABatchAbort() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    // Item 5's OWN collection (10) is one the user is not authorized for, even though the page's
+    // own collectionId query parameter (also 10, above) is the same value -- the point of this test
+    // is that authorization is re-derived from the resolved item, not assumed from the page context.
+    Item unauthorizedItem = itemWithId(5L, 10L);
+    Item authorizedItem = itemWithId(6L, 20L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(10L), anyLong()))
+          .thenReturn(null); // not authorized
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 20L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(unauthorizedItem);
+      repo.when(() -> ItemRepository.findById(6L)).thenReturn(authorizedItem);
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(6L)).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.save(authorizedItem)).thenReturn(authorizedItem);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      assertNull(unauthorizedItem.getArchived(), "an item outside the user's authorized collections must never be mutated");
+      assertNotNull(authorizedItem.getArchived());
+      repo.verify(() -> ItemRepository.save(unauthorizedItem), never());
+      repo.verify(() -> ItemRepository.save(authorizedItem), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.archive"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.archive"),
+          eq("success"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Failed: 1"));
+    }
+  }
+
+  @Test
+  void itemInACollectionMissingEditPermissionIsReportedAsAPerRowFailure() {
+    // Authorized to view/access the collection, but the user's groups don't carry edit_permission
+    // for it -- a distinct failure mode from "collection not found" above, matching
+    // EditItemFormWidget.post()'s own CheckCollectionPermissionCommand gate exactly.
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(10L), anyLong()))
+          .thenReturn(collectionWithId(10L));
+      checkPermission.when(() -> CheckCollectionPermissionCommand.userHasEditPermission(eq(10L), anyLong()))
+          .thenReturn(false);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(adminUser());
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.approve(any(), any()), never());
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected item published. Failed: 1."));
+      // Issue #427 code-review finding: the failed row's reason must reach the response, not just
+      // the audit log (which a non-admin data-manager triggering this action cannot view).
+      assertTrue(result.getErrorMessage().contains("Item 5 (#5): blocked: edit permission missing for collection"));
+    }
+  }
+
+  @Test
+  void bulkDeleteChecksDeletePermissionSeparatelyFromEditPermission() {
+    // The user has edit permission but NOT delete permission for the collection -- proves delete
+    // is gated by CheckCollectionPermissionCommand#userHasDeletePermission, not edit permission.
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      loadCollectionCommand.when(() -> LoadCollectionCommand.loadCollectionByIdForAuthorizedUser(eq(10L), anyLong()))
+          .thenReturn(collectionWithId(10L));
+      checkPermission.when(() -> CheckCollectionPermissionCommand.userHasEditPermission(eq(10L), anyLong()))
+          .thenReturn(true);
+      checkPermission.when(() -> CheckCollectionPermissionCommand.userHasDeletePermission(eq(10L), anyLong()))
+          .thenReturn(false);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.remove(any()), never());
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected item deleted. Failed: 1."));
+      assertTrue(result.getErrorMessage().contains("Item 5 (#5): blocked: delete permission missing for collection"));
+    }
+  }
+
+  // --- bulkPublish ---
+
+  @Test
+  void bulkPublishApprovesEachResolvedItem() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkPublish");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+    User user = adminUser();
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(user);
+      repo.when(() -> ItemRepository.approve(item, user)).thenReturn(true);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.approve(item, user), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.publish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  // --- bulkUnpublish ---
+
+  @Test
+  void bulkUnpublishRemovesApprovalFromEachResolvedItem() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkUnpublish");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+    User user = adminUser();
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<LoadUserCommand> loadUserCommand = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      loadUserCommand.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(user);
+      repo.when(() -> ItemRepository.removeItemApproval(item, user)).thenReturn(true);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.removeItemApproval(item, user), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.unpublish"),
+          eq("success"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  // --- bulkArchive ---
+
+  @Test
+  void bulkArchiveSetsArchivedAndArchivedByOnEachResolvedItem() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item first = itemWithId(5L, 10L);
+    Item second = itemWithId(6L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> ItemRepository.findById(6L)).thenReturn(second);
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(anyLong())).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.save(first)).thenReturn(first);
+      repo.when(() -> ItemRepository.save(second)).thenReturn(second);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      assertNotNull(first.getArchived());
+      assertEquals(1L, first.getArchivedBy());
+      assertNotNull(second.getArchived());
+      repo.verify(() -> ItemRepository.save(first), times(1));
+      repo.verify(() -> ItemRepository.save(second), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.archive"),
+          eq("success"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  @Test
+  void bulkArchivePreservesTheItemsExistingTagsBeforeSaving() {
+    // The load-bearing point: ItemRepository.findById() does not populate tagIdList the way it
+    // populates categoryIdList, so saving straight after a plain findById() would otherwise be read
+    // by ItemRepository.update() as "this item now has zero tags" and silently strip every tag.
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkArchive");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+    // Simulates a freshly loaded Item: tagIdList is null, exactly as ItemRepository.findById()
+    // returns it today.
+
+    ItemTag tagA = new ItemTag();
+    tagA.setTagId(10L);
+    ItemTag tagB = new ItemTag();
+    tagB.setTagId(20L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(5L)).thenReturn(List.of(tagA, tagB));
+      repo.when(() -> ItemRepository.save(item)).thenReturn(item);
+
+      new CollectionItemsListWidget().post(widgetContext);
+
+      assertArrayEquals(new Long[] { 10L, 20L }, item.getTagIdList(),
+          "the item's existing tags must be re-attached before an archive save, not wiped");
+    }
+  }
+
+  // --- bulkMove ---
+
+  @Test
+  void bulkMoveWithoutAResolvableDestinationCategoryIsRejectedWithNoRepositoryCalls() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "categoryId", "999");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepo = mockStatic(CategoryRepository.class)) {
+      categoryRepo.when(() -> CategoryRepository.findById(999L)).thenReturn(null);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      // Rejected before any item is even loaded -- the destination is resolved first
+      repo.verify(() -> ItemRepository.findById(anyLong()), never());
+      assertEquals("The destination category was not found", result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void bulkMoveReassignsCategoryIdAndReplacesTheFullCategoryIdList() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "categoryId", "42");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Category destination = categoryWithId(42L, 10L);
+    Item item = itemWithId(5L, 10L);
+    item.setCategoryId(7L);
+    item.setCategoryIdList(new Long[] { 7L, 8L }); // previously in multiple categories
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<ItemTagRepository> itemTagRepo = mockStatic(ItemTagRepository.class);
+        MockedStatic<CategoryRepository> categoryRepo = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      categoryRepo.when(() -> CategoryRepository.findById(42L)).thenReturn(destination);
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      itemTagRepo.when(() -> ItemTagRepository.findAllByItemId(5L)).thenReturn(new ArrayList<>());
+      repo.when(() -> ItemRepository.save(item)).thenReturn(item);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      assertEquals(42L, item.getCategoryId());
+      assertArrayEquals(new Long[] { 42L }, item.getCategoryIdList());
+      repo.verify(() -> ItemRepository.save(item), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+      assertTrue(result.getSuccessMessage().contains("Category 42"));
+    }
+  }
+
+  @Test
+  void bulkMoveRejectsAnItemWhoseCollectionDoesNotMatchTheDestinationCategorysCollection() {
+    // Both per-row authorization checks pass (the item's own collection, 10, is one the user is
+    // authorized to edit) -- isolating that THIS rejection comes specifically from the
+    // category/collection mismatch check, a tampered-id defense distinct from #903's own checks.
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkMove");
+    addQueryParameter(widgetContext, "categoryId", "42");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Category destinationInOtherCollection = categoryWithId(42L, 99L);
+    Item item = itemWithId(5L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<CategoryRepository> categoryRepo = mockStatic(CategoryRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      categoryRepo.when(() -> CategoryRepository.findById(42L)).thenReturn(destinationInOtherCollection);
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.save(any()), never());
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected item moved to Category 42. Failed: 1."));
+      assertTrue(result.getErrorMessage()
+          .contains("Item 5 (#5): blocked: destination category does not belong to this item's collection"));
+    }
+  }
+
+  // --- bulkDelete ---
+
+  @Test
+  void bulkDeleteRemovesEachResolvedItem() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item first = itemWithId(5L, 10L);
+    Item second = itemWithId(6L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(first);
+      repo.when(() -> ItemRepository.findById(6L)).thenReturn(second);
+      repo.when(() -> ItemRepository.remove(first)).thenReturn(true);
+      repo.when(() -> ItemRepository.remove(second)).thenReturn(true);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      repo.verify(() -> ItemRepository.remove(first), times(1));
+      repo.verify(() -> ItemRepository.remove(second), times(1));
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.delete"),
+          eq("success"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(2));
+      assertTrue(result.getSuccessMessage().contains("2 of 2"));
+    }
+  }
+
+  @Test
+  void bulkDeleteCountsAFailedRemovalAsAFailureNotAnAbort() {
+    setRoles(widgetContext, ADMIN);
+    multiValue("itemId", "5");
+    addQueryParameter(widgetContext, "command", "bulkDelete");
+    addQueryParameter(widgetContext, "collectionId", "10");
+
+    Item item = itemWithId(5L, 10L);
+
+    try (MockedStatic<ItemRepository> repo = mockStatic(ItemRepository.class);
+        MockedStatic<LoadCollectionCommand> loadCollectionCommand = mockStatic(LoadCollectionCommand.class);
+        MockedStatic<CheckCollectionPermissionCommand> checkPermission = mockStatic(CheckCollectionPermissionCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      stubRowAuthorized(loadCollectionCommand, checkPermission, 10L);
+      repo.when(() -> ItemRepository.findById(5L)).thenReturn(item);
+      repo.when(() -> ItemRepository.remove(item)).thenReturn(false);
+
+      WidgetContext result = new CollectionItemsListWidget().post(widgetContext);
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq("content"), eq("content.delete"),
+          eq("failure"), anyLong(), any(), any(), any(), eq("item"), any(), any(), any()), times(1));
+      assertTrue(result.getErrorMessage().startsWith("0 of 1 selected item deleted. Failed: 1."));
+      assertTrue(result.getErrorMessage().contains("Item 5 (#5): delete failed"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Part 3/3 of issue #427 (bulk content operations), split into scoped PRs by content type. This PR covers collection items.

- `/admin/collection-items` gets the same bulk-actions toolbar shape as the web-pages and blog-posts slices: checkboxes, a 100-selection cap, per-row continue-on-not-found.
- Each bulk action re-derives its own authorization via `LoadCollectionCommand.loadCollectionByIdForAuthorizedUser` + `CheckCollectionPermissionCommand` for every item's actual collection, rather than trusting the page's own `collectionId` query param — the #903 bug class, where a caller could act on an item in a collection they don't otherwise have access to just by knowing its id. This fix also applies to the widget's existing single-item `execute()` path, which had the identical gap.
- `ItemRepository.approve()`/`removeItemApproval()` changed from `void` to `boolean` so the bulk actions can report a genuine per-row success/failure instead of assuming success.

## Test plan
- [x] New unit tests for all 5 bulk actions, including the per-item collection-authorization re-check
- [x] Full `ant ci-test` — BUILD SUCCESSFUL
- [x] `check-unescaped-el.py --strict` — 0 unallowlisted
- [x] Independently rebuilt/retested this slice standalone after splitting off its own branch