### PR TITLE
Pin trufflehog action to a SHA in publish-images.yml

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -60,7 +60,7 @@ jobs:
       # Leaving them unset lets the action fall back to its own event-aware detection,
       # which correctly derives the commit range from the triggering event instead.
       - name: Scan for secrets in code and history
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           path: ./
           # The action already runs with --fail internally; adding it again in


### PR DESCRIPTION
## What's wrong

`publish-images.yml`'s "Scan for secrets in code and history" step references `trufflesecurity/trufflehog@main` -- a floating branch ref to a third-party action -- inside the `publish` job, which holds `packages: write`, `id-token: write`, and `attestations: write`. If that action's `main` branch is ever compromised, the injected code runs with registry-publish and signing permissions.

`secret-scan-pr.yml` already pins the same action to a SHA:
```yaml
uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
```

## Fix

Match `publish-images.yml` to the same pinned SHA. One line.

## Verification

Checked recent `publish-images.yml` runs on `main` -- currently green (the trufflehog step itself works correctly since #543's base/head fix), so this is a pure supply-chain hardening change with no expected behavior difference: same effective version, no longer a floating ref.