### PR TITLE
Pin attest-build-provenance action to a SHA in sbom.yml

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -43,7 +43,7 @@ jobs:
       # The WAR is attached to the release below so the attested subject is
       # retrievable; an attestation for an unfetchable artifact proves nothing.
       - name: Attest WAR build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: target/simis-cms.war
 


### PR DESCRIPTION
## What's wrong

`sbom.yml`'s "Attest WAR build provenance" step references `actions/attest-build-provenance@v4` -- a floating major-version tag rather than a SHA.

The same action is already pinned to a SHA twice in `publish-images.yml`:
```yaml
uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
```

## Fix

Match `sbom.yml` to the same pinned SHA. One line.

## Context

Found via a full sweep of every `.github/workflows/*.yml` file for `uses:` lines not pinned to a 40-char SHA, done alongside #971 (trufflehog pin). These were the only two stragglers left from #269's original SHA-pinning pass.