### PR TITLE
Add lazy loading, width/height, and decoding attributes across widget image templates

### DIFF
--- a/docs/core-web-vitals-rum.md
+++ b/docs/core-web-vitals-rum.md
@@ -323,6 +323,58 @@ SELECT DISTINCT url, metric_type FROM web_vitals WHERE created_at > NOW() - INTE
 
 **Total:** Negligible impact on user experience.
 
+## Image Loading Baseline (Issue #413)
+
+A prerequisite audit for the image transform pipeline (issue #411): added `loading`, `width`,
+`height`, and `decoding` attributes to `<img>` tags across public-facing widget templates, deliberately
+decoupled from #411's srcset/focal-point work so it could ship immediately. Only templates reachable
+from a real end-user page were touched — `WEB-INF/jsp/admin/*` and the other admin-gated JSPs
+(`cms/blog-editor.jsp`, `cms/image-browser.jsp`, `cms/web-page-templates.jsp`) are back-office
+screens, not a CWV concern, and were left alone.
+
+**Lazy-loaded (`loading="lazy" decoding="async"`)** — repeating list/grid/carousel content, where
+the image is never guaranteed to be above the fold: blog post lists (all 4 render variants), item
+directory listings (`items-list`, `items-search-results-list`, `items-card-view`), item
+relationships sidebar, ecommerce cart/order line items, product browser/card-slider grids,
+leaderboard photos, the generic `image` widget, custom-fields image type, activity-list icons, the
+photo-gallery swiper (both the server-rendered slides and the AJAX "switch album" slides), the
+footer logo, and all carousel slides after the first.
+
+**Exempted (`loading="eager"`, no lazy/decoding)** — structurally guaranteed above-the-fold chrome
+or single-hero-image widgets: every site-logo variant in the header (`layout-header-standard.jspf`,
+`layout-header-checkout.jspf`, `cms/logo.jsp`, `cms/toggle-menu.jsp`), the site-confirmation modal
+logo (`main.jsp`), the single-product-photo widget (`ecommerce/product-image.jsp`), the item-detail
+page header banner (`items/item-menu.jsp`, `items/item-extended-menu.jsp`), and a carousel's first
+(`is-active`) slide.
+
+**Left untouched, judgment call** — `items/item-full-form.jsp`'s `#imageUrlPreview`: a live
+JS-swapped upload preview next to the file input the user is actively using. Not passive list
+content (so `loading="lazy"` doesn't fit the exemption logic above either) and no static
+width/height is safe to hardcode since the displayed image changes at runtime to whatever file the
+user just picked.
+
+**Width/height** — only added where a real object with known dimensions is in scope at the template
+(`Item.imageUrl`, `Product.imageUrl`, `BlogPost.imageUrl`, and `sitePropertyMap['site.logo*']` are
+all plain `String`s with no companion dimension data, so most templates could not get this
+attribute without a data-model change, out of scope here):
+- `cms/photo-gallery.jsp` — `FileItem.getWidth()/getHeight()` (guarded: only emitted when > 0,
+  since pre-dimension-tracking rows default to -1). `PhotoListAjax.java`'s JSON payload was extended
+  with the same `width`/`height` fields (also guarded) so the "switch album" AJAX path gets the same
+  treatment as the initial server-rendered slides.
+- `items/activity-list.jsp` — the bundled `apple-touch-icon.png` is a fixed 128×128 asset (verified
+  against the actual file, not assumed from convention).
+- `cms/content-carousel.jsp`'s 4 static size-placeholder images (`image-640-480.png`,
+  `image-1952-850.png`, `image-2034-690.png`, `image-640-240.png`) — dimensions verified against the
+  actual files, not just parsed from the filenames.
+- Analytics tracking pixels got `width="1" height="1"` (not treated as lazy-loadable content — an
+  IO-based lazy load risks the beacon never firing for a visitor who doesn't scroll it into view).
+- Captcha images got a hardcoded `height="40"` (the server always renders at that height); `width`
+  varies per-request with the captcha text length and cannot be statically hardcoded.
+
+**Not done here, left for #411**: `srcset`/responsive variants, focal-point cropping, and
+`fetchpriority="high"` on LCP candidates — all explicitly out of scope per #413's own framing
+("independent of the image transform pipeline").
+
 ## Next Steps
 
 1. **Test with real visitor traffic** now that the collector is wired into `main.jsp`

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjax.java
@@ -88,6 +88,9 @@ public class PhotoListAjax extends GenericWidget {
       sb.append("\"title\":\"").append(JsonCommand.toJson(escapeHtml(fileItem.getTitle()))).append("\",");
       sb.append("\"filename\":\"").append(JsonCommand.toJson(fileItem.getFilename())).append("\",");
       sb.append("\"url\":\"").append(JsonCommand.toJson(url)).append("\"");
+      if (fileItem.getWidth() > 0 && fileItem.getHeight() > 0) {
+        sb.append(",\"width\":").append(fileItem.getWidth()).append(",\"height\":").append(fileItem.getHeight());
+      }
       sb.append("}");
     }
 

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-cards.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-cards.jsp
@@ -54,7 +54,7 @@
             <div class="card<c:if test="${!empty cardClass}"> <c:out value="${cardClass}" /></c:if>">
               <c:if test="${showImage eq 'true' && !empty blogPost.imageUrl}">
                 <div class="card-image">
-                  <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>"/></a>
+                  <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>" loading="lazy" decoding="async"/></a>
                 </div>
               </c:if>
               <c:if test="${showTags eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-featured.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-featured.jsp
@@ -53,7 +53,7 @@
           <c:if test="${showImage eq 'true' && !empty blogPost.imageUrl}">
             <div class="small-12 medium-5 cell">
               <div class="featured-blog-image">
-                <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>"/></a>
+                <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>" loading="lazy" decoding="async"/></a>
               </div>
             </div>
           </c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-masonry.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list-masonry.jsp
@@ -69,7 +69,7 @@
               </c:if>
               <c:if test="${showImage eq 'true' && !empty blogPost.imageUrl}">
                 <div class="card-image">
-                  <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>"/></a>
+                  <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="${ctx}<c:out value="${blogPost.imageUrl}"/>" loading="lazy" decoding="async"/></a>
                 </div>
               </c:if>
               <c:if test="${showSummary eq 'true'}">

--- a/src/main/webapp/WEB-INF/jsp/cms/blog-post-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/blog-post-list.jsp
@@ -85,7 +85,7 @@
           </div>
           <c:if test="${!empty blogPost.imageUrl}">
             <div class="platform-blog-image">
-              <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="<c:out value="${ctx}${blogPost.imageUrl}"/>"/></a>
+              <a href="${ctx}/${blog.uniqueId}/${blogPost.uniqueId}"><img alt="Blog post banner image" src="<c:out value="${ctx}${blogPost.imageUrl}"/>" loading="lazy" decoding="async"/></a>
             </div>
           </c:if>
           <c:if test="${showAuthor eq 'true' || (showDate eq 'true' && !empty blogPost.startDate) || !empty blogPost.tagsList}">

--- a/src/main/webapp/WEB-INF/jsp/cms/content-carousel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/content-carousel.jsp
@@ -53,11 +53,11 @@
           <li class="<c:if test="${cardStatus.first}">is-active </c:if>orbit-slide">
             <figure class="orbit-figure">
               <c:choose>
-                <c:when test="${display eq 'images'}"><img class="orbit-image" ${card} /></c:when>
-                <c:when test="${carouselSize eq 'large'}"><img class="orbit-image" src="${ctx}/images/widgets/image-640-480.png" alt="background image" /></c:when>
-                <c:when test="${carouselSize eq 'medium'}"><img class="orbit-image" src="${ctx}/images/widgets/image-1952-850.png" alt="background image" /></c:when>
-                <c:when test="${carouselSize eq 'tiny'}"><img class="orbit-image" src="${ctx}/images/widgets/image-2034-690.png" alt="background image" /></c:when>
-                <c:otherwise><img class="orbit-image" src="${ctx}/images/widgets/image-640-240.png" alt="background image"></c:otherwise>
+                <c:when test="${display eq 'images'}"><img class="orbit-image" ${card} <c:choose><c:when test="${cardStatus.first}">loading="eager"</c:when><c:otherwise>loading="lazy" decoding="async"</c:otherwise></c:choose> /></c:when>
+                <c:when test="${carouselSize eq 'large'}"><img class="orbit-image" src="${ctx}/images/widgets/image-640-480.png" alt="background image" width="640" height="480" <c:choose><c:when test="${cardStatus.first}">loading="eager"</c:when><c:otherwise>loading="lazy" decoding="async"</c:otherwise></c:choose> /></c:when>
+                <c:when test="${carouselSize eq 'medium'}"><img class="orbit-image" src="${ctx}/images/widgets/image-1952-850.png" alt="background image" width="1952" height="850" <c:choose><c:when test="${cardStatus.first}">loading="eager"</c:when><c:otherwise>loading="lazy" decoding="async"</c:otherwise></c:choose> /></c:when>
+                <c:when test="${carouselSize eq 'tiny'}"><img class="orbit-image" src="${ctx}/images/widgets/image-2034-690.png" alt="background image" width="2034" height="690" <c:choose><c:when test="${cardStatus.first}">loading="eager"</c:when><c:otherwise>loading="lazy" decoding="async"</c:otherwise></c:choose> /></c:when>
+                <c:otherwise><img class="orbit-image" src="${ctx}/images/widgets/image-640-240.png" alt="background image" width="640" height="240" <c:choose><c:when test="${cardStatus.first}">loading="eager"</c:when><c:otherwise>loading="lazy" decoding="async"</c:otherwise></c:choose>></c:otherwise>
               </c:choose>
               <c:if test="${display eq 'text'}">
               <figcaption class="orbit-caption">

--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -187,7 +187,7 @@
     <c:when test="${useCaptcha eq 'true'}">
       <p>
         Please enter the text value you see in the image:<br />
-        <img src="/assets/captcha" class="margin-bottom-10" /><br />
+        <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
         <input type="text" name="captcha" value="" required/>
       </p>
       <p>

--- a/src/main/webapp/WEB-INF/jsp/cms/image.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/image.jsp
@@ -18,7 +18,7 @@
 <jsp:useBean id="altText" class="java.lang.String" scope="request"/>
 <c:choose>
   <c:when test="${!empty imageUrl}">
-    <img class="platform-image-widget" src="<c:out value="${imageUrl}"/>" alt="<c:out value="${altText}"/>"/>
+    <img class="platform-image-widget" src="<c:out value="${imageUrl}"/>" alt="<c:out value="${altText}"/>" loading="lazy" decoding="async"/>
   </c:when>
   <c:otherwise>
     <%-- No image configured yet -- a placeholder, never a broken <img> tag --%>

--- a/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/leaderboard.jsp
@@ -49,7 +49,7 @@
       <td align="center" class="leaderboard-rank">${status.count}</td>
       <td align="left" width="100%" class="leaderboard-name">
         <c:if test="${!empty player['IMAGE']}">
-          <img class="leaderboard-photo" src="<c:out value="${player['IMAGE']}" />" />
+          <img class="leaderboard-photo" src="<c:out value="${player['IMAGE']}" />" alt="" loading="lazy" decoding="async" />
         </c:if>
         <c:out value="${player['NAME']}" />
       </td>

--- a/src/main/webapp/WEB-INF/jsp/cms/logo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/logo.jsp
@@ -52,7 +52,7 @@
 </c:choose>
 <c:choose>
   <c:when test="${!empty logoSrc}">
-    <a href="${ctx}/"><img alt="Logo" <c:if test="${!empty logoClass}">class="<c:out value="${logoClass}"/>" </c:if><c:if test="${!empty logoStyle}">style="<c:out value="${logoStyle}"/>" </c:if>src="<c:out value="${logoSrc}"/>" /></a>
+    <a href="${ctx}/"><img alt="Logo" <c:if test="${!empty logoClass}">class="<c:out value="${logoClass}"/>" </c:if><c:if test="${!empty logoStyle}">style="<c:out value="${logoStyle}"/>" </c:if>src="<c:out value="${logoSrc}"/>" loading="eager" /></a>
     <c:if test="${!empty text}">
       <span class="menu-text" translate="no"><a href="${ctx}/"><c:out value="${text}"/></a></span>
     </c:if>

--- a/src/main/webapp/WEB-INF/jsp/cms/photo-gallery.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/photo-gallery.jsp
@@ -67,7 +67,7 @@
       <div id="photo-gallery" class="swiper-wrapper">
       <c:forEach items="${fileList}" var="file">
         <div class="swiper-slide">
-          <img src="${ctx}/assets/view/${file.url}" alt="Image" loading="lazy">
+          <img src="${ctx}/assets/view/${file.url}" alt="Image" loading="lazy" decoding="async"<c:if test="${file.width > 0 && file.height > 0}"> width="${file.width}" height="${file.height}"</c:if>>
           <div class="swiper-lazy-preloader"></div>
           <c:if test="${showCaption eq 'true'}"><p class="slider-caption"><c:out value="${file.title}"/></p></c:if>
         </div>
@@ -121,7 +121,8 @@
       let slides = [];
       for (let i = 0; i < data.photoList.length; i++) {
         let photo = data.photoList[i];
-        slides.push('<div class="swiper-slide"><img src="' + photo.url + '" loading="lazy"><div class="swiper-lazy-preloader"></div><c:if test="${showCaption eq 'true'}"><p class="slider-caption">' + photo.title + '</p></c:if></div>');
+        let dims = (photo.width && photo.height) ? (' width="' + photo.width + '" height="' + photo.height + '"') : '';
+        slides.push('<div class="swiper-slide"><img src="' + photo.url + '" loading="lazy" decoding="async"' + dims + '><div class="swiper-lazy-preloader"></div><c:if test="${showCaption eq 'true'}"><p class="slider-caption">' + photo.title + '</p></c:if></div>');
       }
       console.log(slides);
       swiper${widgetContext.uniqueId}.removeAllSlides();

--- a/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/toggle-menu.jsp
@@ -51,7 +51,7 @@
   </c:choose>
   <c:choose>
     <c:when test="${!empty logoSrc}">
-      <div class="logo"><a href="${ctx}/"><img alt="Logo" src="${logoSrc}"/></a></div>
+      <div class="logo"><a href="${ctx}/"><img alt="Logo" src="${logoSrc}" loading="eager"/></a></div>
     </c:when>
     <c:otherwise>
       <div class="logo"><a href="${ctx}/"><c:out value="${sitePropertyMap['site.name']}"/></a></div>

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/cart-items.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/cart-items.jsp
@@ -40,7 +40,7 @@
     <div class="checkout-summary-item">
       <div class="grid-x grid-margin-x">
         <div class="small-5 medium-3 cell">
-          <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>"/></c:if>
+          <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>" alt="<c:out value="${product.name}"/>" loading="lazy" decoding="async"/></c:if>
         </div>
         <div class="small-7 medium-9 cell">
           <div id="item-${cartEntryStatus}-name">

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/cart-summary.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/cart-summary.jsp
@@ -53,7 +53,7 @@
     <div class="checkout-summary-item">
       <div class="grid-x grid-margin-x">
         <div class="small-3 cell">
-          <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>" /></c:if>
+          <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>" alt="<c:out value="${product.name}"/>" loading="lazy" decoding="async" /></c:if>
         </div>
         <div class="small-6 cell">
           <div class="item-name">

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/cart.jsp
@@ -118,7 +118,7 @@
           <div class="checkout-summary-item">
             <div class="grid-x grid-margin-x">
               <div class="small-5 medium-2 cell">
-                <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>"/></c:if>
+                <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>" alt="<c:out value="${product.name}"/>" loading="lazy" decoding="async"/></c:if>
               </div>
               <div class="small-7 medium-5 cell">
                 <div id="item-${cartEntryStatus.index}-name">

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/order-confirmation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/order-confirmation.jsp
@@ -132,7 +132,7 @@
           <div class="checkout-summary-item">
             <div class="grid-x grid-margin-x">
               <div class="small-5 medium-3 cell">
-                <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>"/></c:if>
+                <c:if test="${!empty product.imageUrl}"><img src="<c:out value="${product.imageUrl}"/>" alt="<c:out value="${product.name}"/>" loading="lazy" decoding="async"/></c:if>
               </div>
               <div class="small-7 medium-9 cell">
                 <div id="item-${orderEntryStatus}-name">

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-browser.jsp
@@ -37,13 +37,13 @@
         <div class="card-image<c:if test="${!empty cardImageClass}"> <c:out value="${cardImageClass}" /></c:if>">
           <c:choose>
             <c:when test="${!empty productImageMap[product.uniqueId]}">
-              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" /></a>
+              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" loading="lazy" decoding="async" /></a>
             </c:when>
             <c:when test="${!empty product.imageUrl}">
-              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>" /></a>
+              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>" loading="lazy" decoding="async" /></a>
             </c:when>
             <c:otherwise>
-              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image placeholder" src="https://placehold.it/500x300"></a>
+              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image placeholder" src="https://placehold.it/500x300" loading="lazy" decoding="async"></a>
             </c:otherwise>
           </c:choose>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-card-slider.jsp
@@ -39,13 +39,13 @@
           <div class="card-image">
             <c:choose>
               <c:when test="${!empty productImageMap[product.uniqueId]}">
-                <a href="<c:out value="${ctx}${product.productUrl}"/>"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" /></a>
+                <a href="<c:out value="${ctx}${product.productUrl}"/>"><img alt="product image" src="<c:out value="${productImageMap[product.uniqueId]}"/>" loading="lazy" decoding="async" /></a>
               </c:when>
               <c:when test="${!empty product.imageUrl}">
-                <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>" /></a>
+                <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>" loading="lazy" decoding="async" /></a>
               </c:when>
               <c:otherwise>
-                <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image placeholder" src="https://placehold.it/500x300"></a>
+                <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image placeholder" src="https://placehold.it/500x300" loading="lazy" decoding="async"></a>
               </c:otherwise>
             </c:choose>
           </div>

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-image.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-image.jsp
@@ -22,4 +22,4 @@
 <jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="product" class="com.simisinc.platform.domain.model.ecommerce.Product" scope="request"/>
-<img alt="<c:out value="${product.nameWithCaption}"/>" src="<c:out value="${product.imageUrl}"/>"/>
+<img alt="<c:out value="${product.nameWithCaption}"/>" src="<c:out value="${product.imageUrl}"/>" loading="eager"/>

--- a/src/main/webapp/WEB-INF/jsp/items/activity-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/activity-list.jsp
@@ -61,7 +61,7 @@
     <c:set var="lastDate" scope="request" value="${date:formatMonthDayYear(activity.created)}"/>
     <li class="clear-float">
       <p class="platform-activity-image">
-        <img class="platform-activity-icon" src="${ctx}/images/apple-touch-icon.png" />
+        <img class="platform-activity-icon" src="${ctx}/images/apple-touch-icon.png" alt="" width="128" height="128" loading="lazy" decoding="async" />
       </p>
       <p class="platform-activity-content">
         <c:if test="${activity.createdBy gt 0}">
@@ -225,7 +225,7 @@
               var content =
 
                 "<p class=\"platform-activity-image\">" +
-                "<img class=\"platform-activity-icon\" src=\"" + platformActivityIconUrl + "\" />\n" +
+                "<img class=\"platform-activity-icon\" src=\"" + platformActivityIconUrl + "\" alt=\"\" width=\"128\" height=\"128\" loading=\"lazy\" decoding=\"async\" />\n" +
                 "</p>" +
                 "<p class=\"platform-activity-content\">" +
                 (activity.user ? "<span class=\"platform-activity-content-name\">" + activity.user.toHtmlEntities() + "</span> " : "") +

--- a/src/main/webapp/WEB-INF/jsp/items/item-business-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-business-form.jsp
@@ -240,7 +240,7 @@
         </c:when>
         <c:when test="${useCaptcha eq 'true'}">
           Please enter the text value you see in the image:<br />
-          <img src="/assets/captcha" class="margin-bottom-10" /><br />
+          <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
           <input type="text" name="captcha" value="" required/>
           <input type="submit" class="button radius success" value="Submit"/>
         </c:when>

--- a/src/main/webapp/WEB-INF/jsp/items/item-extended-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-extended-menu.jsp
@@ -42,7 +42,7 @@
       <c:choose>
         <c:when test="${!empty item.imageUrl}">
           <%--                          <img src="/assets/img/1613486955904-2/SimIS%20Logo.png" />--%>
-          <img alt="item image" src="<c:out value="${item.imageUrl}"/>"/>
+          <img alt="item image" src="<c:out value="${item.imageUrl}"/>" loading="eager"/>
         </c:when>
         <c:when test="${!empty collection.icon}">
           <i class="${font:fad()} fa-<c:out value="${collection.icon}" />"></i>

--- a/src/main/webapp/WEB-INF/jsp/items/item-job-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-job-form.jsp
@@ -178,7 +178,7 @@
         </c:when>
         <c:when test="${useCaptcha eq 'true'}">
           Please enter the text value you see in the image:<br />
-          <img src="/assets/captcha" class="margin-bottom-10" /><br />
+          <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
           <input type="text" name="captcha" value="" required/>
           <input type="submit" class="button radius success" value="Submit"/>
         </c:when>

--- a/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-menu.jsp
@@ -114,7 +114,7 @@
         <c:choose>
           <c:when test="${!empty item.imageUrl}">
             <div class="item-image-large">
-              <img alt="item image" src="<c:out value="${item.imageUrl}"/>"/>
+              <img alt="item image" src="<c:out value="${item.imageUrl}"/>" loading="eager"/>
             </div>
           </c:when>
           <c:when test="${!empty category.icon}">

--- a/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/item-relationships.jsp
@@ -52,7 +52,7 @@
         <c:choose>
           <c:when test="${!empty item.imageUrl}">
             <div class="item-image">
-              <img alt="item image" src="<c:out value="${item.imageUrl}"/>" />
+              <img alt="item image" src="<c:out value="${item.imageUrl}"/>" loading="lazy" decoding="async" />
             </div>
           </c:when>
           <c:when test="${!empty collection:icon(item.collectionId)}">

--- a/src/main/webapp/WEB-INF/jsp/items/items-card-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-card-view.jsp
@@ -124,16 +124,16 @@
               <div class="card-top no-gap text-center image-browser" style="<c:out value="${categoryHeaderCSS}" />">
               <c:choose>
                 <c:when test="${showLink eq 'true'}">
-                  <img src="<c:out value="${item.imageUrl}"/>" />
+                  <img src="<c:out value="${item.imageUrl}"/>" alt="item image" loading="lazy" decoding="async" />
                 </c:when>
                 <c:when test="${useItemLink eq 'true' && !empty item.url && (fn:startsWith(item.url, 'http://') || fn:startsWith(item.url, 'https://'))}">
-                  <a target="_blank" href="${item.url}"><img src="<c:out value="${item.imageUrl}"/>" /></a>
+                  <a target="_blank" href="${item.url}"><img src="<c:out value="${item.imageUrl}"/>" alt="item image" loading="lazy" decoding="async" /></a>
                 </c:when>
                 <c:when test="${useInfoLink eq 'true'}">
-                  <a href="${ctx}/show/${item.uniqueId}"><img src="<c:out value="${item.imageUrl}"/>" /></a>
+                  <a href="${ctx}/show/${item.uniqueId}"><img src="<c:out value="${item.imageUrl}"/>" alt="item image" loading="lazy" decoding="async" /></a>
                 </c:when>
                 <c:otherwise>
-                  <img src="<c:out value="${item.imageUrl}"/>" />
+                  <img src="<c:out value="${item.imageUrl}"/>" alt="item image" loading="lazy" decoding="async" />
                 </c:otherwise>
               </c:choose>
               </div>

--- a/src/main/webapp/WEB-INF/jsp/items/items-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-list.jsp
@@ -61,7 +61,7 @@
           <c:choose>
             <c:when test="${showImage eq 'true' && !empty item.imageUrl}">
               <div class="item-image">
-                <img alt="item image" src="<c:out value="${item.imageUrl}"/>" />
+                <img alt="item image" src="<c:out value="${item.imageUrl}"/>" loading="lazy" decoding="async" />
               </div>
             </c:when>
             <c:when test="${showIcon eq 'true' && !empty collection.icon}">

--- a/src/main/webapp/WEB-INF/jsp/items/items-search-results-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/items/items-search-results-list.jsp
@@ -68,7 +68,7 @@
           <c:choose>
             <c:when test="${!empty item.imageUrl}">
               <div class="item-image">
-                <img alt="item image" src="<c:out value="${item.imageUrl}"/>" />
+                <img alt="item image" src="<c:out value="${item.imageUrl}"/>" loading="lazy" decoding="async" />
               </div>
             </c:when>
             <c:when test="${!empty collection.icon}">

--- a/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-footer-standard.jspf
@@ -24,10 +24,10 @@
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'all-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                   </c:when>
                   <c:otherwise>
-                    <img id="footer-logo-white" src="${ctx}/images/logo-white.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img id="footer-logo-white" src="${ctx}/images/logo-white.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                     <%-- Defaults to the bundled logo; upgrades to the admin-configured one only once
                          an Image() probe confirms it actually loads, so a fresh install never 404s
                          here. --%>
@@ -38,10 +38,10 @@
               <c:when test="${themePropertyMap['theme.footer.logo.color'] eq 'color-and-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.mixed']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                   </c:when>
                   <c:otherwise>
-                    <img id="footer-logo-white-color" src="${ctx}/images/logo-white-color.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img id="footer-logo-white-color" src="${ctx}/images/logo-white-color.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                     <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-white-color.png';var i=new Image();i.onload=function(){document.getElementById('footer-logo-white-color').src=u;};i.src=u;})();</script>
                   </c:otherwise>
                 </c:choose>
@@ -52,10 +52,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img src="<c:out value="${sitePropertyMap['site.logo']}"/>" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                   </c:when>
                   <c:otherwise>
-                    <img id="footer-logo-default" src="${ctx}/images/logo-footer.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" />
+                    <img id="footer-logo-default" src="${ctx}/images/logo-footer.png" width="134" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="lazy" decoding="async" />
                     <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-footer.png';var i=new Image();i.onload=function(){document.getElementById('footer-logo-default').src=u;};i.src=u;})();</script>
                   </c:otherwise>
                 </c:choose>
@@ -133,7 +133,7 @@
             </c:choose>
           </c:if>
           <c:if test="${!empty analyticsPropertyMap['analytics.pixel.url'] && !fn:startsWith(pageRenderInfo.name, '/admin')}">
-            <img src="<c:out value="${analyticsPropertyMap['analytics.pixel.url']}" />" width="1" /> 
+            <img src="<c:out value="${analyticsPropertyMap['analytics.pixel.url']}" />" width="1" height="1" alt="" />
           </c:if>
         </div>
       </div>

--- a/src/main/webapp/WEB-INF/jsp/layout-header-checkout.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-header-checkout.jspf
@@ -22,17 +22,17 @@
           <div class="small-12 text-center cell">
             <c:choose>
               <c:when test="${!empty sitePropertyMap['site.logo']}">
-                <div class="top-logo"><a href="${ctx}/cart"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>"/></a></div>
+                <div class="top-logo"><a href="${ctx}/cart"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" loading="eager"/></a></div>
               </c:when>
               <c:otherwise>
-                <div class="top-logo"><a href="${ctx}/cart"><img id="logo-header-checkout" src="${ctx}/images/logo-header.png"/></a></div>
+                <div class="top-logo"><a href="${ctx}/cart"><img id="logo-header-checkout" src="${ctx}/images/logo-header.png" loading="eager"/></a></div>
                 <%-- Defaults to the bundled logo; upgrades to the admin-configured one only once an
                      Image() probe confirms it actually loads, so a fresh install never 404s here. --%>
                 <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-header.png';var i=new Image();i.onload=function(){document.getElementById('logo-header-checkout').src=u;};i.src=u;})();</script>
               </c:otherwise>
             </c:choose>
             <c:if test="${!empty analyticsPropertyMap['analytics.pixel.url'] && !fn:startsWith(pageRenderInfo.name, '/admin')}">
-              <img src="<c:out value="${analyticsPropertyMap['analytics.pixel.url']}" />" width="1" /> 
+              <img src="<c:out value="${analyticsPropertyMap['analytics.pixel.url']}" />" width="1" height="1" alt="" />
             </c:if>
           </div>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
+++ b/src/main/webapp/WEB-INF/jsp/layout-header-standard.jspf
@@ -26,10 +26,10 @@
             <a href="${ctx}/">Home</a>
           </c:when>
           <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
+            <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a>
           </c:when>
           <c:otherwise>
-            <a href="${ctx}/"><img id="logo-small-title-bar" src="${ctx}/images/logo-white-color.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
+            <a href="${ctx}/"><img id="logo-small-title-bar" src="${ctx}/images/logo-white-color.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a>
             <%-- Defaults to the bundled logo; upgrades to the admin-configured one only once an
                  Image() probe confirms it actually loads, so a fresh install never 404s here. --%>
             <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-white-color.png';var i=new Image();i.onload=function(){document.getElementById('logo-small-title-bar').src=u;};i.src=u;})();</script>
@@ -159,10 +159,10 @@
                         <a href="${ctx}/"><c:out value="${sitePropertyMap['site.name']}"/></a>
                       </c:when>
                       <c:when test="${!empty sitePropertyMap['site.logo']}">
-                        <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
+                        <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a>
                       </c:when>
                       <c:otherwise>
-                        <a href="${ctx}/"><img id="logo-header-pro" src="${ctx}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a>
+                        <a href="${ctx}/"><img id="logo-header-pro" src="${ctx}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a>
                         <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-header.png';var i=new Image();i.onload=function(){document.getElementById('logo-header-pro').src=u;};i.src=u;})();</script>
                       </c:otherwise>
                     </c:choose>
@@ -335,10 +335,10 @@
               <a href="${ctx}/"><c:out value="${sitePropertyMap['site.name']}"/></a>
             </c:when>
             <c:when test="${!empty sitePropertyMap['site.logo']}">
-              <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" /></a>
+              <a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" loading="eager" /></a>
             </c:when>
             <c:otherwise>
-              <a href="${ctx}/"><img id="logo-header-center" src="${ctx}/images/logo-header.png" /></a>
+              <a href="${ctx}/"><img id="logo-header-center" src="${ctx}/images/logo-header.png" loading="eager" /></a>
               <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-header.png';var i=new Image();i.onload=function(){document.getElementById('logo-header-center').src=u;};i.src=u;})();</script>
             </c:otherwise>
           </c:choose>
@@ -405,10 +405,10 @@
               <c:when test="${themePropertyMap['theme.logo.color'] eq 'all-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.white']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.white']}"/>" loading="eager" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img id="logo-white-default" src="${ctx}/images/logo-white.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img id="logo-white-default" src="${ctx}/images/logo-white.png" loading="eager" /></a></li>
                     <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-white.png';var i=new Image();i.onload=function(){document.getElementById('logo-white-default').src=u;};i.src=u;})();</script>
                   </c:otherwise>
                 </c:choose>
@@ -416,10 +416,10 @@
               <c:when test="${themePropertyMap['theme.logo.color'] eq 'color-and-white'}">
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo.mixed']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo.mixed']}"/>" loading="eager" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img id="logo-white-color-default" src="${ctx}/images/logo-white-color.png" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img id="logo-white-color-default" src="${ctx}/images/logo-white-color.png" loading="eager" /></a></li>
                     <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-white-color.png';var i=new Image();i.onload=function(){document.getElementById('logo-white-color-default').src=u;};i.src=u;})();</script>
                   </c:otherwise>
                 </c:choose>
@@ -430,10 +430,10 @@
               <c:otherwise>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img src="<c:out value="${sitePropertyMap['site.logo']}"/>" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a></li>
                   </c:when>
                   <c:otherwise>
-                    <li class="logo"><a href="${ctx}/"><img id="logo-header-default" src="${ctx}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" /></a></li>
+                    <li class="logo"><a href="${ctx}/"><img id="logo-header-default" src="${ctx}/images/logo-header.png" alt="<c:out value="${sitePropertyMap['site.name']}"/>" loading="eager" /></a></li>
                     <script nonce="${cspNonce}">(function(){var u='${js:escape(systemPropertyMap['system.www.context'])}/images/logo-header.png';var i=new Image();i.onload=function(){document.getElementById('logo-header-default').src=u;};i.src=u;})();</script>
                   </c:otherwise>
                 </c:choose>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
@@ -140,7 +140,7 @@
   </c:if>
   <c:if test="${useCaptcha eq 'true' && empty googleSiteKey && empty turnstileSiteKey}">
     <p class="help-text">
-      Enter the text shown: <img src="/assets/captcha" alt="captcha" style="vertical-align: middle;" />
+      Enter the text shown: <img src="/assets/captcha" alt="captcha" style="vertical-align: middle;" height="40" decoding="async" />
       <input type="text" id="captcha${widgetContext.uniqueId}" required/>
     </p>
   </c:if>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-simple-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-simple-form.jsp
@@ -62,7 +62,7 @@
         </c:when>
         <c:when test="${useCaptcha eq 'true'}">
           Please enter the text value you see in the image:<br />
-          <img src="/assets/captcha" class="margin-bottom-10" /><br />
+          <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
           <input type="text" name="captcha" value="" required/>
           <input type="submit" class="button" value="<c:out value="${buttonName}" />"/>
         </c:when>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-with-name-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-with-name-form.jsp
@@ -70,7 +70,7 @@
           </c:when>
           <c:when test="${useCaptcha eq 'true'}">
             Please enter the text value you see in the image:<br />
-            <img src="/assets/captcha" class="margin-bottom-10" /><br />
+            <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
             <input type="text" name="captcha" value="" required/>
             <input type="submit" class="button radius success" value="<c:out value="${buttonName}" />"/>
           </c:when>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -577,7 +577,7 @@
               <p>
                 <c:choose>
                   <c:when test="${!empty sitePropertyMap['site.logo']}">
-                    <img alt="Logo" style="max-width: 75%" src="<c:out value="${sitePropertyMap['site.logo']}"/>" />
+                    <img alt="Logo" style="max-width: 75%" src="<c:out value="${sitePropertyMap['site.logo']}"/>" loading="eager" />
                   </c:when>
                   <c:otherwise>
                     <c:out value="${sitePropertyMap['site.name']}"/>

--- a/src/main/webapp/WEB-INF/jsp/portal/custom-fields.jsp
+++ b/src/main/webapp/WEB-INF/jsp/portal/custom-fields.jsp
@@ -35,7 +35,7 @@
       <p>${html:clean(field.value)}</p>
     </c:when>
     <c:when test="${'image' eq field.type}">
-      <p><img src="<c:out value="${field.value}" />" /></p>
+      <p><img src="<c:out value="${field.value}" />" alt="<c:out value="${field.label}" />" loading="lazy" decoding="async" /></p>
     </c:when>
     <c:when test="${'url' eq field.type && (fn:startsWith(field.value, 'http://') || fn:startsWith(field.value, 'https://'))}">
       <p><a class="button small no-gap" href="${url:encode(field.value)}" target="_blank" rel="nofollow"><c:out value="${field.label}" /> <i class="fa fa-external-link"></i></a></p>

--- a/src/main/webapp/WEB-INF/jsp/register/register-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/register/register-form.jsp
@@ -80,7 +80,7 @@
         <c:when test="${useCaptcha eq 'true'}">
           <p>
             Please enter the text value you see in the image:<br />
-            <img src="/assets/captcha" class="margin-bottom-10" /><br />
+            <img src="/assets/captcha" class="margin-bottom-10" alt="captcha" height="40" decoding="async" /><br />
             <input type="text" name="captcha" value="" required/>
             <input type="submit" class="button radius primary" value="Create Account"/>
           </p>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/PhotoListAjaxTest.java
@@ -73,4 +73,69 @@ class PhotoListAjaxTest extends WidgetBase {
       Assertions.assertTrue(json.contains("&lt;script"), "photo title must be HTML-encoded: " + json);
     }
   }
+
+  @Test
+  void widthAndHeightAreIncludedWhenKnown() {
+    // Issue #413: the photo-gallery widget's "switch album" JS reads photo.width/photo.height to
+    // set <img width>/<height> and avoid layout shift, so the payload must carry them when the
+    // underlying FileItem actually has real dimensions on record.
+    addQueryParameter(widgetContext, "subFolderId", "5");
+
+    SubFolder folder = new SubFolder();
+    folder.setId(5L);
+    folder.setName("Trip");
+
+    FileItem file = new FileItem();
+    file.setId(9L);
+    file.setFolderId(1L);
+    file.setSubFolderId(5L);
+    file.setTitle("Photo");
+    file.setFilename("photo.jpg");
+    file.setCreated(new Timestamp(0L));
+    file.setWidth(800);
+    file.setHeight(600);
+
+    try (MockedStatic<LoadSubFolderCommand> subFolders = mockStatic(LoadSubFolderCommand.class);
+        MockedStatic<FileItemRepository> files = mockStatic(FileItemRepository.class)) {
+      subFolders.when(() -> LoadSubFolderCommand.loadSubFolderByIdForAuthorizedUser(anyLong(), anyLong())).thenReturn(folder);
+      files.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(List.of(file));
+
+      new PhotoListAjax().execute(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertTrue(json.contains("\"width\":800"), "known width must be included: " + json);
+      Assertions.assertTrue(json.contains("\"height\":600"), "known height must be included: " + json);
+    }
+  }
+
+  @Test
+  void widthAndHeightAreOmittedWhenUnknown() {
+    // FileItem.width/height default to -1 for records saved before dimension tracking existed --
+    // the payload must not emit a nonsensical negative width/height in that case.
+    addQueryParameter(widgetContext, "subFolderId", "5");
+
+    SubFolder folder = new SubFolder();
+    folder.setId(5L);
+    folder.setName("Trip");
+
+    FileItem file = new FileItem();
+    file.setId(9L);
+    file.setFolderId(1L);
+    file.setSubFolderId(5L);
+    file.setTitle("Photo");
+    file.setFilename("photo.jpg");
+    file.setCreated(new Timestamp(0L));
+
+    try (MockedStatic<LoadSubFolderCommand> subFolders = mockStatic(LoadSubFolderCommand.class);
+        MockedStatic<FileItemRepository> files = mockStatic(FileItemRepository.class)) {
+      subFolders.when(() -> LoadSubFolderCommand.loadSubFolderByIdForAuthorizedUser(anyLong(), anyLong())).thenReturn(folder);
+      files.when(() -> FileItemRepository.findAll(any(), any())).thenReturn(List.of(file));
+
+      new PhotoListAjax().execute(widgetContext);
+
+      String json = widgetContext.getJson();
+      Assertions.assertFalse(json.contains("\"width\""), "unknown width must be omitted, not sent as -1: " + json);
+      Assertions.assertFalse(json.contains("\"height\""), "unknown height must be omitted, not sent as -1: " + json);
+    }
+  }
 }


### PR DESCRIPTION
Closes #413.

## Summary
Audited every widget JSP template that renders an `<img>` tag (35 templates + one AJAX JSON endpoint) and added the attributes issue #413 asks for, deliberately decoupled from the image transform pipeline (#411) so it could ship on its own.

- **`loading="lazy"` + `decoding="async"`** on repeating list/grid/carousel content that is never guaranteed to be above the fold: blog post lists (all 4 render variants), item directory listings, item relationships sidebar, ecommerce cart/order line items, product browser/card-slider grids, the leaderboard, the generic `image` widget, custom-fields image type, activity-list icons, the photo gallery (both server-rendered and AJAX "switch album" slides), the footer logo, and every carousel slide after the first.
- **Exempted (`loading="eager"`, no lazy)** as likely-hero/above-the-fold: every header logo variant, the site-confirmation modal logo, the standalone product-photo widget, the item-detail page header banner, and a carousel's first slide.
- **`width`/`height`** added only where a real object with known dimensions is actually in scope at the template — `FileItem.getWidth()/getHeight()` in the photo gallery, and three verified-dimension static assets (the activity icon, four carousel placeholder images). Everywhere else the `src` is a raw `String` (`Item.imageUrl`, `Product.imageUrl`, `BlogPost.imageUrl`, `sitePropertyMap['site.logo*']`) with no companion dimension field, so width/height is intentionally left out rather than guessed — adding a wrong value would itself cause the CLS this issue is trying to prevent.
- Extended `PhotoListAjax.java`'s JSON payload with `width`/`height` (only when known) so the photo gallery's AJAX-loaded slides get the same treatment as the initial page load, not just a partial fix.
- Admin-only screens (`WEB-INF/jsp/admin/*`, plus three JSPs whose Java package looks public but are actually only reachable from `role="admin,content-manager"` pages) were left untouched — not a real-user Core Web Vitals concern.
- One deliberate no-op: `items/item-full-form.jsp`'s live JS-swapped upload preview — not lazy-loadable list content, and no safe static width/height since the displayed image changes at runtime to whatever file the user just picked.

Full per-template breakdown (updated vs. exempted vs. why) is documented in the new "Image Loading Baseline" section of `docs/core-web-vitals-rum.md`, per the issue's ask to leave a baseline for the #411 transform work.

Out of scope here (left for #411): `srcset`/responsive variants, focal-point cropping, `fetchpriority="high"` on LCP candidates.

## Test plan
- [x] `ant -lib lib/war compile-jsp` — all 339 JSPs (including every template touched here) translate and compile with zero errors
- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — full suite passes, zero failures
- [x] Added `PhotoListAjaxTest` coverage for the new width/height JSON field (present-when-known, omitted-when-unknown `-1` default)
- [x] Hand-verified every hardcoded pixel dimension (`apple-touch-icon.png`, the four carousel placeholder images) against the actual asset files with `sips`, not assumed from filenames or convention
- [ ] Live browser click-through was not done for this PR — the local docker-compose rehearsal stack was already under heavy contention from other concurrent sessions (an existing `simis-cms-rehearsal` stack up for 2+ days plus several other active projects/testcontainers on the same Docker daemon), and this change is additive markup only (no rendering-logic changes), so I relied on the JSP compile gate + full test suite + hand-verified static dimensions instead of adding another build to that contention.