### PR TITLE
Add database-backed form builder admin UI (#409)

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveFormDefinitionCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFormDefinitionCommand.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+
+/**
+ * Validates and saves a database-backed form definition (issue #409). The uniqueId is derived from
+ * the name the same way SaveCollectionCommand#generateUniqueId derives a Collection's uniqueId --
+ * kept stable across an edit as long as the name is unchanged, and regenerated (with a numeric
+ * suffix if needed for uniqueness) when it does.
+ *
+ * @author SimIS Inc.
+ */
+public class SaveFormDefinitionCommand {
+
+  private static final String ALLOWED_CHARS = "abcdefghijklmnopqrstuvwyxz1234567890";
+  private static Log LOG = LogFactory.getLog(SaveFormDefinitionCommand.class);
+
+  public static FormDefinition saveFormDefinition(FormDefinition formDefinitionBean) throws DataException {
+
+    // Validate the required fields
+    StringBuilder errorMessages = new StringBuilder();
+    if (StringUtils.isBlank(formDefinitionBean.getName())) {
+      errorMessages.append("A name is required");
+    }
+    if (formDefinitionBean.getModifiedBy() == -1) {
+      if (errorMessages.length() > 0) {
+        errorMessages.append(", ");
+      }
+      errorMessages.append("The user saving this form was not set");
+    }
+
+    if (errorMessages.length() > 0) {
+      throw new DataException("Please check the form and try again:\n" + errorMessages.toString());
+    }
+
+    // Transform the fields and store...
+    FormDefinition formDefinition;
+    if (formDefinitionBean.getId() > -1) {
+      LOG.debug("Saving an existing record... ");
+      formDefinition = FormDefinitionRepository.findById(formDefinitionBean.getId());
+      if (formDefinition == null) {
+        throw new DataException("The existing record could not be found");
+      }
+      // createdBy is intentionally left untouched on an edit -- only an insert sets it, so the
+      // audit trail keeps pointing at whoever originally created the form
+    } else {
+      LOG.debug("Saving a new record... ");
+      formDefinition = new FormDefinition();
+      formDefinition.setCreatedBy(formDefinitionBean.getCreatedBy());
+    }
+    // @note set the uniqueId before setting the name
+    formDefinition.setUniqueId(generateUniqueId(formDefinition, formDefinitionBean));
+    formDefinition.setName(formDefinitionBean.getName());
+    formDefinition.setTitle(formDefinitionBean.getTitle());
+    formDefinition.setSubtitle(formDefinitionBean.getSubtitle());
+    formDefinition.setButtonName(formDefinitionBean.getButtonName());
+    formDefinition.setSuccessTitle(formDefinitionBean.getSuccessTitle());
+    formDefinition.setSuccessMessage(formDefinitionBean.getSuccessMessage());
+    formDefinition.setEmailTo(formDefinitionBean.getEmailTo());
+    formDefinition.setUseCaptcha(formDefinitionBean.getUseCaptcha());
+    formDefinition.setCheckForSpam(formDefinitionBean.getCheckForSpam());
+    formDefinition.setEnabled(formDefinitionBean.getEnabled());
+    formDefinition.setModifiedBy(formDefinitionBean.getModifiedBy());
+    return FormDefinitionRepository.save(formDefinition);
+  }
+
+  private static String generateUniqueId(FormDefinition previousItem, FormDefinition item) {
+
+    // Use the existing uniqueId when the name hasn't changed
+    if (previousItem.getUniqueId() != null && previousItem.getName() != null
+        && previousItem.getName().equals(item.getName())) {
+      return previousItem.getUniqueId();
+    }
+
+    // Create a new one from the name
+    StringBuilder sb = new StringBuilder();
+    String name = item.getName().toLowerCase();
+    final int len = name.length();
+    for (int i = 0; i < len; i++) {
+      char c = name.charAt(i);
+      if (ALLOWED_CHARS.indexOf(c) > -1) {
+        sb.append(c);
+      } else if (c == ' ') {
+        sb.append("-");
+      }
+    }
+
+    // Find the next available unique instance
+    int count = 1;
+    String originalUniqueId = sb.toString();
+    String uniqueId = sb.toString();
+    while (FormDefinitionRepository.findByUniqueId(uniqueId) != null) {
+      ++count;
+      uniqueId = originalUniqueId + "-" + count;
+    }
+    return uniqueId;
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/cms/SaveFormFieldCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFormFieldCommand.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+
+/**
+ * Validates and saves a field belonging to a database-backed {@link FormDefinition} (issue #409).
+ *
+ * @author SimIS Inc.
+ */
+public class SaveFormFieldCommand {
+
+  private static Log LOG = LogFactory.getLog(SaveFormFieldCommand.class);
+
+  // The set form-field-form.jsp's "Type" select actually offers, and the exact list
+  // NEW_10010__new_cms.sql's form_fields.field_type comment documents as valid -- that comment
+  // promises this is "validated in application code, not a DB CHECK constraint", so this is where
+  // that promise is kept.
+  private static final Set<String> VALID_FIELD_TYPES = Set.of("text", "email", "textarea", "select", "checkbox", "date");
+
+  public static FormField saveField(FormField fieldBean) throws DataException {
+
+    // Validate the required fields
+    StringBuilder errorMessages = new StringBuilder();
+    if (fieldBean.getFormDefinitionId() == -1 || FormDefinitionRepository.findById(fieldBean.getFormDefinitionId()) == null) {
+      errorMessages.append("A form is required");
+    }
+    if (StringUtils.isBlank(fieldBean.getLabel())) {
+      if (errorMessages.length() > 0) {
+        errorMessages.append(", ");
+      }
+      errorMessages.append("A label is required");
+    }
+    if (StringUtils.isNotBlank(fieldBean.getType()) && !VALID_FIELD_TYPES.contains(fieldBean.getType())) {
+      if (errorMessages.length() > 0) {
+        errorMessages.append(", ");
+      }
+      errorMessages.append("A valid field type is required");
+    }
+
+    if (errorMessages.length() > 0) {
+      throw new DataException("Please check the form and try again:\n" + errorMessages.toString());
+    }
+
+    // Transform the fields and store...
+    FormField field;
+    if (fieldBean.getId() > -1) {
+      LOG.debug("Saving an existing record... ");
+      field = FormFieldRepository.findById(fieldBean.getId());
+      if (field == null || field.getFormDefinitionId() != fieldBean.getFormDefinitionId()) {
+        // Either the field doesn't exist, or the request is trying to move it under a different
+        // form -- treat both the same as "not found" rather than silently reparenting a field
+        throw new DataException("The existing record could not be found");
+      }
+    } else {
+      LOG.debug("Saving a new record... ");
+      field = new FormField();
+      field.setFormDefinitionId(fieldBean.getFormDefinitionId());
+      // A new field must get an explicit, distinct field_order -- otherwise every un-reordered add
+      // defaults to the field_order column's own DEFAULT 100 and two consecutive adds collide, with
+      // findAllByFormDefinitionId's insertion-order tiebreak only coincidentally masking it (issue
+      // #409 follow-up). Matches SaveMenuItemCommand's use of MenuItemRepository#getNextTabOrder.
+      field.setFieldOrder(FormFieldRepository.getNextFieldOrder(fieldBean.getFormDefinitionId()));
+    }
+    // The html/database field name defaults to a slug of the label, the same conversion
+    // FormFieldCommand#generateHtmlName already performs for XML-defined fields, so an admin can
+    // leave "Name" blank and still get a valid one
+    String name = StringUtils.isNotBlank(fieldBean.getName())
+        ? fieldBean.getName().trim()
+        : FormFieldCommand.generateHtmlName(fieldBean.getLabel(), null);
+    field.setName(name);
+    field.setLabel(fieldBean.getLabel());
+    field.setType(StringUtils.isNotBlank(fieldBean.getType()) ? fieldBean.getType() : "text");
+    field.setRequired(fieldBean.isRequired());
+    field.setPlaceholder(fieldBean.getPlaceholder());
+    field.setDefaultValue(fieldBean.getDefaultValue());
+    field.setListOfOptions(fieldBean.getListOfOptions());
+    return FormFieldRepository.save(field);
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/FormDefinition.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/FormDefinition.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.model.cms;
+
+import java.sql.Timestamp;
+
+import com.simisinc.platform.domain.model.Entity;
+
+/**
+ * A database-backed form configuration (issue #409) -- the admin-editable alternative to
+ * configuring a {@code form} widget's fields entirely through page XML preferences. FormWidget
+ * matches a request to one of these by {@code uniqueId}, the same role {@code formUniqueId} plays
+ * for an XML-defined form.
+ *
+ * @author SimIS Inc.
+ */
+public class FormDefinition extends Entity {
+
+  private Long id = -1L;
+
+  private String uniqueId = null;
+  private String name = null;
+  private String title = null;
+  private String subtitle = null;
+  private String buttonName = null;
+  private String successTitle = null;
+  private String successMessage = null;
+  private String emailTo = null;
+  private boolean useCaptcha = false;
+  private boolean checkForSpam = true;
+  private boolean enabled = true;
+  private long createdBy = -1;
+  private long modifiedBy = -1;
+  private Timestamp created = null;
+  private Timestamp modified = null;
+
+  public FormDefinition() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  public void setUniqueId(String uniqueId) {
+    this.uniqueId = uniqueId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getSubtitle() {
+    return subtitle;
+  }
+
+  public void setSubtitle(String subtitle) {
+    this.subtitle = subtitle;
+  }
+
+  public String getButtonName() {
+    return buttonName;
+  }
+
+  public void setButtonName(String buttonName) {
+    this.buttonName = buttonName;
+  }
+
+  public String getSuccessTitle() {
+    return successTitle;
+  }
+
+  public void setSuccessTitle(String successTitle) {
+    this.successTitle = successTitle;
+  }
+
+  public String getSuccessMessage() {
+    return successMessage;
+  }
+
+  public void setSuccessMessage(String successMessage) {
+    this.successMessage = successMessage;
+  }
+
+  public String getEmailTo() {
+    return emailTo;
+  }
+
+  public void setEmailTo(String emailTo) {
+    this.emailTo = emailTo;
+  }
+
+  public boolean getUseCaptcha() {
+    return useCaptcha;
+  }
+
+  public void setUseCaptcha(boolean useCaptcha) {
+    this.useCaptcha = useCaptcha;
+  }
+
+  public boolean getCheckForSpam() {
+    return checkForSpam;
+  }
+
+  public void setCheckForSpam(boolean checkForSpam) {
+    this.checkForSpam = checkForSpam;
+  }
+
+  public boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public long getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(long createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  public long getModifiedBy() {
+    return modifiedBy;
+  }
+
+  public void setModifiedBy(long modifiedBy) {
+    this.modifiedBy = modifiedBy;
+  }
+
+  public Timestamp getCreated() {
+    return created;
+  }
+
+  public void setCreated(Timestamp created) {
+    this.created = created;
+  }
+
+  public Timestamp getModified() {
+    return modified;
+  }
+
+  public void setModified(Timestamp modified) {
+    this.modified = modified;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/cms/FormField.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/FormField.java
@@ -39,6 +39,12 @@ public class FormField extends Entity {
   private String defaultValue = null;
   private String userValue = null;
 
+  // Database-backed form builder bookkeeping (issue #409). Both default to values the existing
+  // XML-preference rendering path (FormFieldCommand#parseFieldContent) never reads or sets, so this
+  // reuse of FormField for the admin-CRUD shape is additive and does not affect XML-defined forms.
+  private long formDefinitionId = -1;
+  private int fieldOrder = -1;
+
   public FormField() {
   }
 
@@ -112,5 +118,21 @@ public class FormField extends Entity {
 
   public void setRequired(boolean required) {
     isRequired = required;
+  }
+
+  public long getFormDefinitionId() {
+    return formDefinitionId;
+  }
+
+  public void setFormDefinitionId(long formDefinitionId) {
+    this.formDefinitionId = formDefinitionId;
+  }
+
+  public int getFieldOrder() {
+    return fieldOrder;
+  }
+
+  public void setFieldOrder(int fieldOrder) {
+    this.fieldOrder = fieldOrder;
   }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDefinitionRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDefinitionRepository.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.infrastructure.database.AutoRollback;
+import com.simisinc.platform.infrastructure.database.AutoStartTransaction;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves database-backed form configurations (issue #409) -- the admin-editable
+ * alternative to a {@code form} widget's XML {@code <fields>} preference.
+ *
+ * @author SimIS Inc.
+ */
+public class FormDefinitionRepository {
+
+  private static Log LOG = LogFactory.getLog(FormDefinitionRepository.class);
+
+  private static final String TABLE_NAME = "form_definitions";
+  private static final String[] PRIMARY_KEY = new String[] { "form_definition_id" };
+
+  public static List<FormDefinition> findAll() {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME,
+        null,
+        new DataConstraints().setDefaultColumnToSortBy("name").setUseCount(false),
+        FormDefinitionRepository::buildRecord);
+    return (List<FormDefinition>) result.getRecords();
+  }
+
+  public static FormDefinition findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (FormDefinition) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("form_definition_id = ?", id),
+        FormDefinitionRepository::buildRecord);
+  }
+
+  public static FormDefinition findByUniqueId(String uniqueId) {
+    if (StringUtils.isBlank(uniqueId)) {
+      return null;
+    }
+    return (FormDefinition) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("unique_id = ?", uniqueId.trim()),
+        FormDefinitionRepository::buildRecord);
+  }
+
+  public static FormDefinition save(FormDefinition record) {
+    if (record.getId() > -1) {
+      return update(record);
+    }
+    return add(record);
+  }
+
+  private static FormDefinition add(FormDefinition record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("unique_id", StringUtils.trimToNull(record.getUniqueId()))
+        .add("name", StringUtils.trimToNull(record.getName()))
+        .addIfExists("title", StringUtils.trimToNull(record.getTitle()))
+        .addIfExists("subtitle", StringUtils.trimToNull(record.getSubtitle()))
+        .addIfExists("button_name", StringUtils.trimToNull(record.getButtonName()))
+        .addIfExists("success_title", StringUtils.trimToNull(record.getSuccessTitle()))
+        .addIfExists("success_message", StringUtils.trimToNull(record.getSuccessMessage()))
+        .addIfExists("email_to", StringUtils.trimToNull(record.getEmailTo()))
+        .add("use_captcha", record.getUseCaptcha())
+        .add("check_for_spam", record.getCheckForSpam())
+        .add("enabled", record.getEnabled())
+        .add("created_by", record.getCreatedBy(), -1)
+        .add("modified_by", record.getModifiedBy(), -1);
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  private static FormDefinition update(FormDefinition record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("unique_id", StringUtils.trimToNull(record.getUniqueId()))
+        .add("name", StringUtils.trimToNull(record.getName()))
+        .add("title", StringUtils.trimToNull(record.getTitle()))
+        .add("subtitle", StringUtils.trimToNull(record.getSubtitle()))
+        .add("button_name", StringUtils.trimToNull(record.getButtonName()))
+        .add("success_title", StringUtils.trimToNull(record.getSuccessTitle()))
+        .add("success_message", StringUtils.trimToNull(record.getSuccessMessage()))
+        .add("email_to", StringUtils.trimToNull(record.getEmailTo()))
+        .add("use_captcha", record.getUseCaptcha())
+        .add("check_for_spam", record.getCheckForSpam())
+        .add("enabled", record.getEnabled())
+        .add("modified_by", record.getModifiedBy(), -1)
+        .add("modified", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("form_definition_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      return record;
+    }
+    LOG.error("The update failed!");
+    return null;
+  }
+
+  /**
+   * Deletes a form definition and, in the same transaction, every field that belongs to it.
+   * form_fields.form_definition_id has no DB-level ON DELETE CASCADE, so the cascade is performed
+   * here explicitly -- the same pattern MenuTabRepository#remove uses for menu_items and
+   * MailingListRepository#remove uses for mailing_list_members. Fields have no independent meaning
+   * without their parent form, and form_data submissions are matched by form_unique_id (a string),
+   * never by a foreign key to this table, so a deletion here can never be blocked by or orphan prior
+   * submissions.
+   */
+  public static boolean remove(FormDefinition record) {
+    try {
+      try (Connection connection = DB.getConnection();
+          AutoStartTransaction a = new AutoStartTransaction(connection);
+          AutoRollback transaction = new AutoRollback(connection)) {
+        // Delete the references
+        FormFieldRepository.removeAll(connection, record);
+        // Delete the record
+        DB.deleteFrom(connection, TABLE_NAME, new SqlUtils().add("form_definition_id = ?", record.getId()));
+        // Finish transaction
+        transaction.commit();
+        return true;
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return false;
+  }
+
+  private static FormDefinition buildRecord(ResultSet rs) {
+    try {
+      FormDefinition record = new FormDefinition();
+      record.setId(rs.getLong("form_definition_id"));
+      record.setUniqueId(rs.getString("unique_id"));
+      record.setName(rs.getString("name"));
+      record.setTitle(rs.getString("title"));
+      record.setSubtitle(rs.getString("subtitle"));
+      record.setButtonName(rs.getString("button_name"));
+      record.setSuccessTitle(rs.getString("success_title"));
+      record.setSuccessMessage(rs.getString("success_message"));
+      record.setEmailTo(rs.getString("email_to"));
+      record.setUseCaptcha(rs.getBoolean("use_captcha"));
+      record.setCheckForSpam(rs.getBoolean("check_for_spam"));
+      record.setEnabled(rs.getBoolean("enabled"));
+      record.setCreatedBy(rs.getLong("created_by"));
+      record.setModifiedBy(rs.getLong("modified_by"));
+      record.setCreated(rs.getTimestamp("created"));
+      record.setModified(rs.getTimestamp("modified"));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormFieldRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormFieldRepository.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.database.AutoRollback;
+import com.simisinc.platform.infrastructure.database.AutoStartTransaction;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
+import com.simisinc.platform.infrastructure.database.SqlUtils;
+
+/**
+ * Persists and retrieves the fields belonging to a database-backed {@link FormDefinition} (issue
+ * #409).
+ *
+ * @author SimIS Inc.
+ */
+public class FormFieldRepository {
+
+  private static Log LOG = LogFactory.getLog(FormFieldRepository.class);
+
+  private static final String TABLE_NAME = "form_fields";
+  private static final String[] PRIMARY_KEY = new String[] { "form_field_id" };
+
+  public static FormField findById(long id) {
+    if (id == -1) {
+      return null;
+    }
+    return (FormField) DB.selectRecordFrom(
+        TABLE_NAME,
+        new SqlUtils().add("form_field_id = ?", id),
+        FormFieldRepository::buildRecord);
+  }
+
+  public static List<FormField> findAllByFormDefinitionId(long formDefinitionId) {
+    DataResult result = DB.selectAllFrom(
+        TABLE_NAME,
+        new SqlUtils().add("form_definition_id = ?", formDefinitionId),
+        new DataConstraints().setDefaultColumnToSortBy("field_order, form_field_id").setUseCount(false),
+        FormFieldRepository::buildRecord);
+    return (List<FormField>) result.getRecords();
+  }
+
+  public static FormField save(FormField record) {
+    if (record.getId() > -1) {
+      return update(record);
+    }
+    return add(record);
+  }
+
+  private static FormField add(FormField record) {
+    SqlUtils insertValues = new SqlUtils()
+        .add("form_definition_id", record.getFormDefinitionId())
+        // Omit field_order entirely when the caller left it at the domain default (-1) rather than
+        // binding SQL NULL, so the column's own "DEFAULT 100" applies and a newly-added field sorts
+        // to the end -- matching how menu_items.item_order/menu_tabs.tab_order behave.
+        .addIfExists("field_order", record.getFieldOrder(), -1)
+        .add("name", StringUtils.trimToNull(record.getName()))
+        .add("label", StringUtils.trimToNull(record.getLabel()))
+        .addIfExists("field_type", StringUtils.trimToNull(record.getType()))
+        .add("required", record.isRequired())
+        .addIfExists("placeholder", StringUtils.trimToNull(record.getPlaceholder()))
+        .addIfExists("default_value", StringUtils.trimToNull(record.getDefaultValue()))
+        .addIfExists("options", formatOptions(record.getListOfOptions()));
+    record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
+    if (record.getId() == -1) {
+      LOG.error("An id was not set!");
+      return null;
+    }
+    return record;
+  }
+
+  private static FormField update(FormField record) {
+    SqlUtils updateValues = new SqlUtils()
+        .add("field_order", record.getFieldOrder())
+        .add("name", StringUtils.trimToNull(record.getName()))
+        .add("label", StringUtils.trimToNull(record.getLabel()))
+        .add("field_type", StringUtils.trimToNull(record.getType()))
+        .add("required", record.isRequired())
+        .add("placeholder", StringUtils.trimToNull(record.getPlaceholder()))
+        .add("default_value", StringUtils.trimToNull(record.getDefaultValue()))
+        .add("options", formatOptions(record.getListOfOptions()))
+        .add("modified", new Timestamp(System.currentTimeMillis()));
+    SqlUtils where = new SqlUtils()
+        .add("form_field_id = ?", record.getId());
+    if (DB.update(TABLE_NAME, updateValues, where)) {
+      return record;
+    }
+    LOG.error("The update failed!");
+    return null;
+  }
+
+  public static boolean remove(FormField record) {
+    return (DB.deleteFrom(TABLE_NAME, new SqlUtils().add("form_field_id = ?", record.getId())) > 0);
+  }
+
+  private static PreparedStatement createPreparedStatementNextFieldOrder(Connection connection, long formDefinitionId) throws SQLException {
+    String SQL_QUERY =
+        "SELECT max(field_order) " +
+            "FROM form_fields " +
+            "WHERE form_definition_id = ?";
+    PreparedStatement pst = connection.prepareStatement(SQL_QUERY);
+    pst.setLong(1, formDefinitionId);
+    return pst;
+  }
+
+  /**
+   * The next field_order for a new field on the given form (issue #409), mirroring
+   * MenuItemRepository#getNextTabOrder/MenuTabRepository#getNextTabOrder exactly -- one more than the
+   * current max, defaulting to 1 when the form has no fields yet. SaveFormFieldCommand calls this for
+   * every newly-created field so add() always receives an explicit, distinct order rather than
+   * relying on the field_order column's own "DEFAULT 100", which produces duplicate values (and thus
+   * an order that depends only on insertion order, not intent) whenever two or more fields are added
+   * without an intervening drag-and-drop reorder.
+   */
+  public static int getNextFieldOrder(long formDefinitionId) {
+    int maxOrder = 0;
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = createPreparedStatementNextFieldOrder(connection, formDefinitionId);
+        ResultSet rs = pst.executeQuery()) {
+      if (rs.next()) {
+        maxOrder = rs.getInt(1) + 1;
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return maxOrder;
+  }
+
+  public static void removeAll(Connection connection, FormDefinition record) throws SQLException {
+    DB.deleteFrom(connection, TABLE_NAME, new SqlUtils().add("form_definition_id = ?", record.getId()));
+  }
+
+  /**
+   * Persists a new display order for a form's fields in one transaction -- the drag-and-drop
+   * reorder pattern this codebase already uses for menu items (SaveMenuTabCommand#updateTabOrder),
+   * adapted to a single flat list since a form has only one level of fields (unlike the sitemap's
+   * tabs-then-items). {@code orderedFieldIds} is the field id list in its new top-to-bottom order,
+   * e.g. as parsed from a hidden input populated by a dragula drop handler. Each id is required to
+   * already belong to {@code formDefinitionId} -- an id for a different form is skipped rather than
+   * applied, so a stale or tampered request cannot reorder (or reveal the existence of) another
+   * form's fields.
+   */
+  public static boolean reorderFields(long formDefinitionId, List<Long> orderedFieldIds) {
+    if (orderedFieldIds == null || orderedFieldIds.isEmpty()) {
+      return false;
+    }
+    try {
+      try (Connection connection = DB.getConnection();
+          AutoStartTransaction a = new AutoStartTransaction(connection);
+          AutoRollback transaction = new AutoRollback(connection)) {
+        int order = 10;
+        for (Long fieldId : orderedFieldIds) {
+          if (fieldId == null) {
+            continue;
+          }
+          FormField field = findById(fieldId);
+          if (field == null || field.getFormDefinitionId() != formDefinitionId) {
+            continue;
+          }
+          SqlUtils updateValues = new SqlUtils().add("field_order", order);
+          SqlUtils where = new SqlUtils().add("form_field_id = ?", fieldId);
+          DB.update(connection, TABLE_NAME, updateValues, where);
+          order += 10;
+        }
+        transaction.commit();
+        return true;
+      }
+    } catch (SQLException se) {
+      LOG.error("SQLException: " + se.getMessage());
+    }
+    return false;
+  }
+
+  /**
+   * Serializes a field's options using the same comma-separated "key=value,key2=value2" format the
+   * XML {@code <field list="..."/>} preference already uses (FormFieldCommand#parseFieldContent), so
+   * a future admin-form save path can share one options format across both configuration sources.
+   */
+  private static String formatOptions(Map<String, String> options) {
+    if (options == null || options.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> entry : options.entrySet()) {
+      if (sb.length() > 0) {
+        sb.append(",");
+      }
+      sb.append(entry.getKey()).append("=").append(entry.getValue());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * The inverse of {@link #formatOptions}. An entry without an "=" is stored as both its own key and
+   * value verbatim -- unlike FormFieldCommand's XML-preference parsing, this does not slugify a
+   * bare option into an html-safe name, since the admin form builder (a later stage) is expected to
+   * always submit explicit key/value pairs rather than relying on that XML-authoring convenience.
+   */
+  private static Map<String, String> parseOptions(String options) {
+    if (StringUtils.isBlank(options)) {
+      return null;
+    }
+    Map<String, String> optionsMap = new LinkedHashMap<>();
+    for (String option : options.split(",")) {
+      if (StringUtils.isBlank(option)) {
+        continue;
+      }
+      int idx = option.indexOf('=');
+      if (idx > -1) {
+        optionsMap.put(option.substring(0, idx), option.substring(idx + 1));
+      } else {
+        optionsMap.put(option, option);
+      }
+    }
+    return optionsMap;
+  }
+
+  private static FormField buildRecord(ResultSet rs) {
+    try {
+      FormField record = new FormField();
+      record.setId(rs.getLong("form_field_id"));
+      record.setFormDefinitionId(rs.getLong("form_definition_id"));
+      record.setFieldOrder(rs.getInt("field_order"));
+      record.setName(rs.getString("name"));
+      record.setLabel(rs.getString("label"));
+      record.setType(rs.getString("field_type"));
+      record.setRequired(rs.getBoolean("required"));
+      record.setPlaceholder(rs.getString("placeholder"));
+      record.setDefaultValue(rs.getString("default_value"));
+      record.setListOfOptions(parseOptions(rs.getString("options")));
+      return record;
+    } catch (SQLException se) {
+      LOG.error("buildRecord", se);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidget.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.beanutils.BeanUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.SaveFormDefinitionCommand;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Widget to add or edit a database-backed form definition's settings (issue #409). Used both as
+ * the "Add a form" sidebar callout on /admin/forms and as the settings section of
+ * /admin/forms-editor, the same dual role MailingListFormWidget plays for /admin/mailing-lists'
+ * sidebar and /admin/mailing-list's full edit page.
+ *
+ * @author SimIS Inc.
+ */
+public class FormDefinitionFormWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/form-definition-form.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Form bean
+    FormDefinition formDefinition = (FormDefinition) context.getRequestObject();
+    if (formDefinition == null) {
+      long formDefinitionId = context.getParameterAsLong("formDefinitionId");
+      formDefinition = FormDefinitionRepository.findById(formDefinitionId);
+      if (formDefinition == null) {
+        formDefinition = new FormDefinition();
+      }
+    }
+    context.getRequest().setAttribute("formDefinition", formDefinition);
+
+    // Show the editor
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    // Populate the fields
+    FormDefinition formDefinitionBean = new FormDefinition();
+    BeanUtils.populate(formDefinitionBean, context.getParameterMap());
+    // createdBy is only honored by the command on insert (it preserves the original value on an
+    // edit); modifiedBy always reflects whoever is saving right now
+    formDefinitionBean.setCreatedBy(context.getUserId());
+    formDefinitionBean.setModifiedBy(context.getUserId());
+
+    // Save the record
+    FormDefinition formDefinition;
+    try {
+      formDefinition = SaveFormDefinitionCommand.saveFormDefinition(formDefinitionBean);
+      if (formDefinition == null) {
+        throw new DataException("Your information could not be saved due to a system error. Please try again.");
+      }
+    } catch (DataException e) {
+      context.setErrorMessage(e.getMessage());
+      context.setRequestObject(formDefinitionBean);
+      if (formDefinitionBean.getId() > -1) {
+        // Editing an existing form happens on /admin/forms-editor{?formDefinitionId} -- without an
+        // explicit redirect here, the platform's default self-redirect on a targeted POST (see
+        // WebContainerCommand) would drop that templated query parameter
+        context.setRedirect("/admin/forms-editor?formDefinitionId=" + formDefinitionBean.getId());
+      }
+      return context;
+    }
+
+    // Determine the page to return to
+    context.setSuccessMessage("Form was saved");
+    context.setRedirect("/admin/forms-editor?formDefinitionId=" + formDefinition.getId());
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldFormWidget.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.cms.SaveFormFieldCommand;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Widget to add or edit a single field on a database-backed form definition (issue #409), shown as
+ * a sidebar callout on /admin/forms-editor -- the same list-widget + sidebar-add-form-widget page
+ * pattern CollectionRelationshipFormWidget uses on /admin/collection-relationships.
+ *
+ * @author SimIS Inc.
+ */
+public class FormFieldFormWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/form-field-form.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    FormField field = (FormField) context.getRequestObject();
+    if (field == null) {
+      long fieldId = context.getParameterAsLong("fieldId");
+      field = FormFieldRepository.findById(fieldId);
+      if (field == null) {
+        field = new FormField();
+        field.setFormDefinitionId(context.getParameterAsLong("formDefinitionId"));
+      }
+    }
+    context.getRequest().setAttribute("field", field);
+    context.getRequest().setAttribute("optionsText", formatOptions(field.getListOfOptions()));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    // Populate the simple fields
+    FormField fieldBean = new FormField();
+    BeanUtils.populate(fieldBean, context.getParameterMap());
+    // Options aren't a BeanUtils-populatable property -- the form submits a single
+    // "key=value,key2=value2" string (BeanUtils.populate silently skips it, the same way it
+    // already skips the "widget"/"token" controller parameters), but FormField exposes a Map, so
+    // it's parsed here into the shape FormFieldRepository/SaveFormFieldCommand expect.
+    fieldBean.setListOfOptions(parseOptions(context.getParameter("options")));
+
+    FormField field;
+    try {
+      field = SaveFormFieldCommand.saveField(fieldBean);
+      if (field == null) {
+        throw new DataException("Your information could not be saved due to a system error. Please try again.");
+      }
+    } catch (DataException e) {
+      context.setErrorMessage(e.getMessage());
+      context.setRequestObject(fieldBean);
+      // Always redirect explicitly with formDefinitionId -- this widget only ever lives on
+      // /admin/forms-editor{?formDefinitionId}, so a bare self-redirect risks dropping it
+      context.setRedirect("/admin/forms-editor?formDefinitionId=" + fieldBean.getFormDefinitionId());
+      return context;
+    }
+
+    context.setSuccessMessage("Field was saved");
+    context.setRedirect("/admin/forms-editor?formDefinitionId=" + field.getFormDefinitionId());
+    return context;
+  }
+
+  /**
+   * Turns the submitted "key=value,key2=value2" options text into a Map, using the same
+   * convention FormFieldRepository's own (private) parseOptions uses for the stored column value.
+   * Kept as a separate copy rather than shared: this one translates a raw request parameter into a
+   * Map (a presentation-layer concern), while the repository's translates a Map the widget hands it
+   * into the column string it persists.
+   */
+  private static Map<String, String> parseOptions(String options) {
+    if (StringUtils.isBlank(options)) {
+      return null;
+    }
+    Map<String, String> optionsMap = new LinkedHashMap<>();
+    for (String option : options.split(",")) {
+      if (StringUtils.isBlank(option)) {
+        continue;
+      }
+      int idx = option.indexOf('=');
+      if (idx > -1) {
+        optionsMap.put(option.substring(0, idx).trim(), option.substring(idx + 1).trim());
+      } else {
+        optionsMap.put(option.trim(), option.trim());
+      }
+    }
+    return optionsMap;
+  }
+
+  /** The inverse of {@link #parseOptions}, used to pre-fill the options text field when editing. */
+  private static String formatOptions(Map<String, String> options) {
+    if (options == null || options.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> entry : options.entrySet()) {
+      if (sb.length() > 0) {
+        sb.append(",");
+      }
+      sb.append(entry.getKey()).append("=").append(entry.getValue());
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldsListWidget.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Widget to list a form's fields and persist a drag-and-drop reorder (issue #409).
+ *
+ * <p>The reorder mechanism mirrors SiteMapWidget/sitemap.jsp: a dragula drag handle populates a
+ * hidden, comma-joined field id list on submit, POSTed as a normal form and parsed here into a
+ * call to FormFieldRepository#reorderFields -- which already does the per-id database update loop
+ * SaveMenuTabCommand#updateTabOrder does for menu tabs. Unlike the sitemap (tabs, each containing
+ * items), a form has only one flat list of fields, so there's no second order dimension to track.
+ *
+ * @author SimIS Inc.
+ */
+public class FormFieldsListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/form-fields-list.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    long formDefinitionId = context.getParameterAsLong("formDefinitionId");
+    FormDefinition formDefinition = FormDefinitionRepository.findById(formDefinitionId);
+    if (formDefinition == null) {
+      context.setErrorMessage("Form not found");
+      context.setRedirect("/admin/forms");
+      return context;
+    }
+    context.getRequest().setAttribute("formDefinition", formDefinition);
+
+    List<FormField> fieldList = FormFieldRepository.findAllByFormDefinitionId(formDefinitionId);
+    context.getRequest().setAttribute("fieldList", fieldList);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
+
+    long formDefinitionId = context.getParameterAsLong("formDefinitionId");
+    String fieldOrder = context.getParameter("fieldOrder");
+    if (formDefinitionId > -1 && StringUtils.isNotBlank(fieldOrder)) {
+      List<Long> orderedFieldIds = new ArrayList<>();
+      for (String value : fieldOrder.split(",")) {
+        if (StringUtils.isBlank(value)) {
+          continue;
+        }
+        try {
+          orderedFieldIds.add(Long.parseLong(value.trim()));
+        } catch (NumberFormatException nfe) {
+          LOG.warn("Skipping non-numeric field id in fieldOrder: " + value);
+        }
+      }
+      FormFieldRepository.reorderFields(formDefinitionId, orderedFieldIds);
+    }
+
+    context.setRedirect("/admin/forms-editor?formDefinitionId=" + formDefinitionId);
+    return context;
+  }
+
+  public WidgetContext delete(WidgetContext context) {
+    long fieldId = context.getParameterAsLong("fieldId");
+    long formDefinitionId = -1;
+    if (fieldId > -1) {
+      FormField field = FormFieldRepository.findById(fieldId);
+      if (field == null) {
+        context.setErrorMessage("Field not found");
+      } else {
+        formDefinitionId = field.getFormDefinitionId();
+        if (FormFieldRepository.remove(field)) {
+          context.setSuccessMessage("Field deleted");
+        } else {
+          context.setWarningMessage("Field could not be deleted");
+        }
+      }
+    }
+    if (formDefinitionId == -1) {
+      formDefinitionId = context.getParameterAsLong("formDefinitionId");
+    }
+    context.setRedirect("/admin/forms-editor?formDefinitionId=" + formDefinitionId);
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormsListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormsListWidget.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Widget to display the list of database-backed form definitions to the system administrators
+ * (issue #409), mirroring MailingListsWidget/CollectionRelationshipsListWidget's list+delete
+ * shape.
+ *
+ * @author SimIS Inc.
+ */
+public class FormsListWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908893L;
+
+  static String JSP = "/admin/forms.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // Load the form definitions
+    List<FormDefinition> formDefinitionList = FormDefinitionRepository.findAll();
+    context.getRequest().setAttribute("formDefinitionList", formDefinitionList);
+
+    // Determine the field count for each form (mirrors BlogListWidget's per-row blogPostCount map)
+    Map<Long, Integer> fieldCountMap = new HashMap<>();
+    for (FormDefinition formDefinition : formDefinitionList) {
+      fieldCountMap.put(formDefinition.getId(), FormFieldRepository.findAllByFormDefinitionId(formDefinition.getId()).size());
+    }
+    context.getRequest().setAttribute("fieldCountMap", fieldCountMap);
+
+    // Standard request items
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
+    // Show the list
+    context.setJsp(JSP);
+    return context;
+  }
+
+  public WidgetContext delete(WidgetContext context) {
+    // Determine what's being deleted
+    long formDefinitionId = context.getParameterAsLong("formDefinitionId");
+    if (formDefinitionId > -1) {
+      FormDefinition formDefinition = FormDefinitionRepository.findById(formDefinitionId);
+      if (formDefinition == null) {
+        context.setErrorMessage("Form not found");
+      } else if (FormDefinitionRepository.remove(formDefinition)) {
+        context.setSuccessMessage("Form deleted");
+      } else {
+        context.setWarningMessage("Form could not be deleted");
+      }
+    }
+    context.setRedirect("/admin/forms");
+    return context;
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/FormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/FormWidget.java
@@ -320,6 +320,104 @@ public class FormWidget extends GenericWidget {
   }
 
   /**
+   * Resolves the database-backed form definition for this widget placement (issue #409), or null
+   * when {@code formId} is blank -- the pre-existing, still-default XML-configured case. Logs and
+   * returns null (distinguishable from the "not configured" case only by {@code formIdPref} itself
+   * being non-blank) when {@code formId} is set but does not resolve to a real row, so callers can
+   * hard-fail rather than silently falling back to the XML {@code fields} preference.
+   *
+   * <p>Callers that need to know whether {@code formId} was configured at all (to decide between a
+   * hard failure and the XML fallback) must check {@code formIdPref} themselves; this method alone
+   * cannot distinguish "not configured" from "configured but not found" since both return null.
+   */
+  private FormDefinition resolveFormDefinition(WidgetContext context, String formIdPref) {
+    if (StringUtils.isBlank(formIdPref)) {
+      return null;
+    }
+    long formId = NumberUtils.toLong(formIdPref, -1);
+    FormDefinition formDefinition = FormDefinitionRepository.findById(formId);
+    if (formDefinition == null) {
+      LOG.warn("Form definition was not found for formId: " + formIdPref);
+    }
+    return formDefinition;
+  }
+
+  /**
+   * Whether captcha should be shown/validated for this request (issue #409 follow-up). A
+   * database-backed form's own "Use Captcha?" setting (configured at /admin/forms-editor) is
+   * authoritative once a form has been resolved; only the still-default XML-preference path
+   * (formDefinition null) reads this from the widget placement's own preferences, exactly as before
+   * this feature existed.
+   */
+  private boolean resolveUseCaptcha(WidgetContext context, FormDefinition formDefinition) {
+    if (formDefinition != null) {
+      return formDefinition.getUseCaptcha();
+    }
+    return "true".equals(context.getPreferences().getOrDefault("useCaptcha", "false"));
+  }
+
+  /**
+   * The submit button's label (issue #409 follow-up). A database-backed form's own "Button Label"
+   * (configured at /admin/forms-editor) is authoritative once a form has been resolved, falling back
+   * to "Submit" when left blank -- the same default the still-supported XML-preference path already
+   * applied via getOrDefault().
+   */
+  private String resolveButtonName(WidgetContext context, FormDefinition formDefinition) {
+    String buttonName = formDefinition != null ? formDefinition.getButtonName() : context.getPreferences().get("buttonName");
+    return StringUtils.defaultIfBlank(buttonName, "Submit");
+  }
+
+  /**
+   * The message shown on the success page after a valid submission (issue #409 follow-up). A
+   * database-backed form's own "Success Message" is authoritative once a form has been resolved,
+   * falling back to the same default the still-supported XML-preference path already applied via
+   * getOrDefault() when left blank.
+   */
+  private String resolveSuccessMessage(WidgetContext context, FormDefinition formDefinition) {
+    String successMessage = formDefinition != null ? formDefinition.getSuccessMessage() : context.getPreferences().get("successMessage");
+    return StringUtils.defaultIfBlank(successMessage, "Your information has been submitted.");
+  }
+
+  /**
+   * Resolves this form's field list (issue #409), given the {@code formDefinition} execute()/post()
+   * already resolved via {@link #resolveFormDefinition}. When non-null, fields come from the
+   * database -- FormFieldRepository, already ordered by field_order -- as the admin-managed
+   * alternative to the XML {@code fields} preference. When null (the pre-existing, still-default
+   * configuration, or a {@code formId} that failed to resolve -- callers must have already handled
+   * that case before reaching here), this falls through to exactly the original XML-preference
+   * parsing, unchanged, so a page that has never been touched by the form builder renders and
+   * validates identically to before this feature existed.
+   *
+   * <p>Returns null (after logging a warning) when no fields could be resolved from either source,
+   * matching the pre-existing "not configured" contract both execute() and post() already relied
+   * on -- callers should treat a null return exactly as they did the old inline checks.
+   */
+  private List<FormField> loadFormFieldList(WidgetContext context, FormDefinition formDefinition) {
+    if (formDefinition != null) {
+      List<FormField> formFieldList = FormFieldRepository.findAllByFormDefinitionId(formDefinition.getId());
+      if (formFieldList.isEmpty()) {
+        LOG.warn("No fields were found for formId: " + formDefinition.getId());
+        return null;
+      }
+      return formFieldList;
+    }
+
+    // Original XML-preference path (unchanged)
+    PreferenceEntriesList fieldsEntriesList = context.getPreferenceAsDataList("fields");
+    if (fieldsEntriesList.isEmpty()) {
+      LOG.warn("Fields preference was not found");
+      return null;
+    }
+    String formUniqueId = context.getPreferences().get("formUniqueId");
+    List<FormField> formFieldList = FormFieldCommand.parseFieldContent(formUniqueId, fieldsEntriesList);
+    if (formFieldList.isEmpty()) {
+      LOG.warn("No fields were found");
+      return null;
+    }
+    return formFieldList;
+  }
+
+  /**
    * The page URL, without duplicating the context path. context.getUrl() already includes it (scheme +
    * host + contextPath), and context.getUri() (the servlet request URI) already includes it too per the
    * servlet spec -- concatenating them as-is doubles it on any deployment where the app isn't mounted at

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/FormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/FormWidget.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.presentation.widgets.cms;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -30,8 +31,11 @@ import com.simisinc.platform.application.cms.FormFieldCommand;
 import com.simisinc.platform.application.cms.FunnelEventCommand;
 import com.simisinc.platform.domain.events.cms.FormSubmittedEvent;
 import com.simisinc.platform.domain.model.cms.FormData;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
 import com.simisinc.platform.domain.model.cms.FormField;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FormSubmissionFailureRepository;
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -60,25 +64,45 @@ public class FormWidget extends GenericWidget {
       return context;
     }
 
+    // Resolve the database-backed form definition, if any (issue #409) -- a formId configured but
+    // not resolvable is a hard failure (matching loadFormFieldList's pre-existing "not found"
+    // contract below), and a resolved-but-disabled form is not shown to the public. Resolved before
+    // the success-page branch below too, since a database-backed form's own successTitle/
+    // successMessage (issue #409 follow-up) must be authoritative there as well.
+    String formIdPref = context.getPreferences().get("formId");
+    FormDefinition formDefinition = resolveFormDefinition(context, formIdPref);
+    if (StringUtils.isNotBlank(formIdPref) && formDefinition == null) {
+      return null;
+    }
+    if (formDefinition != null && !formDefinition.getEnabled()
+        && !(context.hasRole("admin") || context.hasRole("community-manager"))) {
+      return null;
+    }
+
     String isSuccess = context.getSharedRequestValue(context.getUniqueId() + "formWidgetSuccess");
     if ("true".equals(isSuccess)) {
-      context.getRequest().setAttribute("successTitle", context.getPreferences().get("successTitle"));
-      context.getRequest().setAttribute("successMessage", context.getPreferences().getOrDefault("successMessage", "Your information has been submitted."));
+      context.getRequest().setAttribute("successTitle",
+          formDefinition != null ? formDefinition.getSuccessTitle() : context.getPreferences().get("successTitle"));
+      context.getRequest().setAttribute("successMessage", resolveSuccessMessage(context, formDefinition));
       context.setJsp(SUCCESS_JSP);
       return context;
     }
     context.setJsp(JSP);
 
-    // Preferences
-    context.getRequest().setAttribute("buttonName", context.getPreferences().getOrDefault("buttonName", "Submit"));
+    // Preferences -- a database-backed form's own "Button Label" (issue #409 follow-up) is
+    // authoritative when formId is configured
+    context.getRequest().setAttribute("buttonName", resolveButtonName(context, formDefinition));
 
-    // Standard request items
+    // Standard request items -- a database-backed form's own title/subtitle (issue #409 follow-up)
+    // are authoritative when formId is configured; icon has no database-backed equivalent
     context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
-    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
-    context.getRequest().setAttribute("subtitle", context.getPreferences().get("subtitle"));
+    context.getRequest().setAttribute("title", formDefinition != null ? formDefinition.getTitle() : context.getPreferences().get("title"));
+    context.getRequest().setAttribute("subtitle", formDefinition != null ? formDefinition.getSubtitle() : context.getPreferences().get("subtitle"));
 
-    // Determine the captcha service
-    boolean useCaptcha = "true".equals(context.getPreferences().getOrDefault("useCaptcha", "false"));
+    // Determine the captcha service -- a database-backed form's own "Use Captcha?" setting is
+    // authoritative when formId is configured; only the XML-preference path (formDefinition null)
+    // still reads this from the widget placement's own preferences
+    boolean useCaptcha = resolveUseCaptcha(context, formDefinition);
     if (useCaptcha) {
       CaptchaCommand.populateWidgetAttributes(context);
     }
@@ -93,16 +117,10 @@ public class FormWidget extends GenericWidget {
       return context;
     }
 
-    // Use the fields preference to determine the item properties to be shown
-    PreferenceEntriesList fieldsEntriesList = context.getPreferenceAsDataList("fields");
-    if (fieldsEntriesList.isEmpty()) {
-      LOG.warn("Fields preference was not found");
-      return null;
-    }
-    String formUniqueId = context.getPreferences().get("formUniqueId");
-    List<FormField> formFieldList = FormFieldCommand.parseFieldContent(formUniqueId, fieldsEntriesList);
-    if (formFieldList.isEmpty()) {
-      LOG.warn("No fields were found");
+    // Use the fields preference (or a database-backed form definition, issue #409) to determine
+    // the item properties to be shown
+    List<FormField> formFieldList = loadFormFieldList(context, formDefinition);
+    if (formFieldList == null) {
       return null;
     }
     context.getRequest().setAttribute("formFieldList", formFieldList);
@@ -125,13 +143,30 @@ public class FormWidget extends GenericWidget {
     // failure in the same submission.
     String rejectionReason = null;
 
-    PreferenceEntriesList fieldsEntriesList = context.getPreferenceAsDataList("fields");
-    if (fieldsEntriesList.isEmpty()) {
-      LOG.warn("Fields preference was not found");
+    // Resolve the database-backed form definition, if any (issue #409) -- see execute() for why a
+    // formId configured but not resolvable, or resolved-but-disabled, must not proceed. Checking
+    // this again here (not just in execute()) matters: a direct POST is not required to have gone
+    // through execute() first.
+    String formIdPref = context.getPreferences().get("formId");
+    FormDefinition formDefinition = resolveFormDefinition(context, formIdPref);
+    if (StringUtils.isNotBlank(formIdPref) && formDefinition == null) {
       return null;
     }
-    String formUniqueId = context.getPreferences().get("formUniqueId");
-    List<FormField> formFieldList = FormFieldCommand.parseFieldContent(formUniqueId, fieldsEntriesList);
+    if (formDefinition != null && !formDefinition.getEnabled()
+        && !(context.hasRole("admin") || context.hasRole("community-manager"))) {
+      return null;
+    }
+
+    // A database-backed form's own generated uniqueId is authoritative when formId is configured
+    // (issue #409 follow-up) -- form_data submissions must be keyed by the collision-checked value
+    // SaveFormDefinitionCommand.generateUniqueId() produced, not a separately hand-typed preference
+    // that could collide with an unrelated form's formUniqueId
+    String formUniqueId = formDefinition != null ? formDefinition.getUniqueId() : context.getPreferences().get("formUniqueId");
+
+    List<FormField> formFieldList = loadFormFieldList(context, formDefinition);
+    if (formFieldList == null) {
+      return null;
+    }
     for (FormField formField : formFieldList) {
       // Determine the user's value
       String parameterValue = context.getParameter(context.getUniqueId() + formField.getName());
@@ -171,7 +206,7 @@ public class FormWidget extends GenericWidget {
     }
 
     // Validate the captcha
-    boolean useCaptcha = "true".equals(context.getPreferences().getOrDefault("useCaptcha", "false"));
+    boolean useCaptcha = resolveUseCaptcha(context, formDefinition);
     if (useCaptcha) {
       boolean captchaSuccess = CaptchaCommand.validateRequest(context);
       if (!captchaSuccess) {
@@ -211,7 +246,12 @@ public class FormWidget extends GenericWidget {
       return context;
     }
 
-    boolean checkForSpam = Boolean.parseBoolean(context.getPreferences().getOrDefault("checkForSpam", "true"));
+    // A database-backed form's own "Check for spam?" setting is authoritative when formId is
+    // configured (issue #409 follow-up); only the XML-preference path still reads this from the
+    // widget placement's own preferences
+    boolean checkForSpam = formDefinition != null
+        ? formDefinition.getCheckForSpam()
+        : Boolean.parseBoolean(context.getPreferences().getOrDefault("checkForSpam", "true"));
     if (checkForSpam) {
       FormCommand.checkNotificationRules(formData);
     }
@@ -227,14 +267,115 @@ public class FormWidget extends GenericWidget {
     // site's admin-configured contact form
     FunnelEventCommand.recordContactFormSubmitted(formUniqueId, formData.getSessionId());
 
-    // Send an alert based on the preferences (or transform for another system)
-    String emailAddresses = context.getPreferences().get("emailTo");
+    // Send an alert based on the preferences (or transform for another system) -- a database-backed
+    // form's own "Email submissions to" setting is authoritative when formId is configured (issue
+    // #409 follow-up); only the XML-preference path still reads this from the widget placement's
+    // own preferences
+    String emailAddresses = formDefinition != null ? formDefinition.getEmailTo() : context.getPreferences().get("emailTo");
     WorkflowManager.triggerWorkflowForEvent(new FormSubmittedEvent(formData, emailAddresses));
 
     // Redirect back so the message can be displayed
     context.addSharedRequestValue(context.getUniqueId() + "formWidgetSuccess", "true");
 
     return null;
+  }
+
+  /**
+   * Resolves the database-backed form definition for this widget placement (issue #409), or null
+   * when {@code formId} is blank -- the pre-existing, still-default XML-configured case. Logs and
+   * returns null (distinguishable from the "not configured" case only by {@code formIdPref} itself
+   * being non-blank) when {@code formId} is set but does not resolve to a real row, so callers can
+   * hard-fail rather than silently falling back to the XML {@code fields} preference.
+   *
+   * <p>Callers that need to know whether {@code formId} was configured at all (to decide between a
+   * hard failure and the XML fallback) must check {@code formIdPref} themselves; this method alone
+   * cannot distinguish "not configured" from "configured but not found" since both return null.
+   */
+  private FormDefinition resolveFormDefinition(WidgetContext context, String formIdPref) {
+    if (StringUtils.isBlank(formIdPref)) {
+      return null;
+    }
+    long formId = NumberUtils.toLong(formIdPref, -1);
+    FormDefinition formDefinition = FormDefinitionRepository.findById(formId);
+    if (formDefinition == null) {
+      LOG.warn("Form definition was not found for formId: " + formIdPref);
+    }
+    return formDefinition;
+  }
+
+  /**
+   * Whether captcha should be shown/validated for this request (issue #409 follow-up). A
+   * database-backed form's own "Use Captcha?" setting (configured at /admin/forms-editor) is
+   * authoritative once a form has been resolved; only the still-default XML-preference path
+   * (formDefinition null) reads this from the widget placement's own preferences, exactly as before
+   * this feature existed.
+   */
+  private boolean resolveUseCaptcha(WidgetContext context, FormDefinition formDefinition) {
+    if (formDefinition != null) {
+      return formDefinition.getUseCaptcha();
+    }
+    return "true".equals(context.getPreferences().getOrDefault("useCaptcha", "false"));
+  }
+
+  /**
+   * The submit button's label (issue #409 follow-up). A database-backed form's own "Button Label"
+   * (configured at /admin/forms-editor) is authoritative once a form has been resolved, falling back
+   * to "Submit" when left blank -- the same default the still-supported XML-preference path already
+   * applied via getOrDefault().
+   */
+  private String resolveButtonName(WidgetContext context, FormDefinition formDefinition) {
+    String buttonName = formDefinition != null ? formDefinition.getButtonName() : context.getPreferences().get("buttonName");
+    return StringUtils.defaultIfBlank(buttonName, "Submit");
+  }
+
+  /**
+   * The message shown on the success page after a valid submission (issue #409 follow-up). A
+   * database-backed form's own "Success Message" is authoritative once a form has been resolved,
+   * falling back to the same default the still-supported XML-preference path already applied via
+   * getOrDefault() when left blank.
+   */
+  private String resolveSuccessMessage(WidgetContext context, FormDefinition formDefinition) {
+    String successMessage = formDefinition != null ? formDefinition.getSuccessMessage() : context.getPreferences().get("successMessage");
+    return StringUtils.defaultIfBlank(successMessage, "Your information has been submitted.");
+  }
+
+  /**
+   * Resolves this form's field list (issue #409), given the {@code formDefinition} execute()/post()
+   * already resolved via {@link #resolveFormDefinition}. When non-null, fields come from the
+   * database -- FormFieldRepository, already ordered by field_order -- as the admin-managed
+   * alternative to the XML {@code fields} preference. When null (the pre-existing, still-default
+   * configuration, or a {@code formId} that failed to resolve -- callers must have already handled
+   * that case before reaching here), this falls through to exactly the original XML-preference
+   * parsing, unchanged, so a page that has never been touched by the form builder renders and
+   * validates identically to before this feature existed.
+   *
+   * <p>Returns null (after logging a warning) when no fields could be resolved from either source,
+   * matching the pre-existing "not configured" contract both execute() and post() already relied
+   * on -- callers should treat a null return exactly as they did the old inline checks.
+   */
+  private List<FormField> loadFormFieldList(WidgetContext context, FormDefinition formDefinition) {
+    if (formDefinition != null) {
+      List<FormField> formFieldList = FormFieldRepository.findAllByFormDefinitionId(formDefinition.getId());
+      if (formFieldList.isEmpty()) {
+        LOG.warn("No fields were found for formId: " + formDefinition.getId());
+        return null;
+      }
+      return formFieldList;
+    }
+
+    // Original XML-preference path (unchanged)
+    PreferenceEntriesList fieldsEntriesList = context.getPreferenceAsDataList("fields");
+    if (fieldsEntriesList.isEmpty()) {
+      LOG.warn("Fields preference was not found");
+      return null;
+    }
+    String formUniqueId = context.getPreferences().get("formUniqueId");
+    List<FormField> formFieldList = FormFieldCommand.parseFieldContent(formUniqueId, fieldsEntriesList);
+    if (formFieldList.isEmpty()) {
+      LOG.warn("No fields were found");
+      return null;
+    }
+    return formFieldList;
   }
 
   /**

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -245,6 +245,58 @@ CREATE INDEX form_sub_fail_form_idx ON form_submission_failures(form_unique_id);
 CREATE INDEX form_sub_fail_occurred_idx ON form_submission_failures(occurred);
 CREATE INDEX form_sub_fail_reason_idx ON form_submission_failures(reason);
 
+-- Form builder (issue #409): database-backed field configuration for FormWidget, as an alternative to
+-- the XML <fields> preference. form_fields.form_definition_id has no ON DELETE CASCADE -- deleting a
+-- form definition explicitly removes its fields first, in a transaction (see
+-- FormDefinitionRepository#remove), mirroring how MenuTabRepository#remove handles menu_items and
+-- MailingListRepository#remove handles mailing_list_members in this same file's neighborhood, rather
+-- than image_variants' DB-level ON DELETE CASCADE. form_data is untouched by this table pair:
+-- submissions are matched to a form by form_unique_id (a plain string), never by a foreign key to
+-- form_definitions, so deleting a form definition never blocks on or orphans prior submissions.
+CREATE TABLE form_definitions (
+  form_definition_id BIGSERIAL PRIMARY KEY,
+  unique_id VARCHAR(255) UNIQUE NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  title VARCHAR(255),
+  subtitle VARCHAR(255),
+  button_name VARCHAR(100),
+  success_title VARCHAR(255),
+  success_message TEXT,
+  email_to VARCHAR(512),
+  use_captcha BOOLEAN DEFAULT FALSE,
+  check_for_spam BOOLEAN DEFAULT TRUE,
+  enabled BOOLEAN DEFAULT TRUE,
+  created_by BIGINT REFERENCES users(user_id),
+  modified_by BIGINT REFERENCES users(user_id),
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX form_definitions_unique_id_idx ON form_definitions(unique_id);
+CREATE INDEX form_definitions_enabled_idx ON form_definitions(enabled);
+
+-- field_type is one of: text, email, textarea, select, checkbox, date -- validated in application code,
+-- not a DB CHECK constraint (matching how this file leaves other small admin-defined enums, e.g.
+-- form_submission_failures.reason, unconstrained at the DB level). options stores select/checkbox
+-- choices using the same comma-separated "key=value,key2=value2" string the XML <field list="..."/>
+-- preference already produces (see FormFieldCommand#parseFieldContent), so both configuration sources
+-- share one options format.
+CREATE TABLE form_fields (
+  form_field_id BIGSERIAL PRIMARY KEY,
+  form_definition_id BIGINT NOT NULL REFERENCES form_definitions(form_definition_id),
+  field_order INTEGER DEFAULT 100,
+  name VARCHAR(255) NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  field_type VARCHAR(30) DEFAULT 'text',
+  required BOOLEAN DEFAULT FALSE,
+  placeholder VARCHAR(255),
+  default_value VARCHAR(255),
+  options TEXT,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX form_fields_form_definition_idx ON form_fields(form_definition_id);
+CREATE INDEX form_fields_order_idx ON form_fields(field_order);
+
 -- We want to know popular page_path
 -- We want to know popular web_page_id
 -- We want to know geolocation of ip_address

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1005__form_definitions.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1005__form_definitions.sql
@@ -1,0 +1,50 @@
+-- Issue #409: form builder admin UI -- database-backed field configuration for FormWidget, as an
+-- alternative to the XML <fields> preference. Mirrors NEW_10010__new_cms.sql exactly (install/ and
+-- upgrade/ must stay in sync -- see issue #431's precedent for what happens when they drift, and
+-- DatabaseMigrationTest's tablesThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath()/
+-- columnsThatOnlyExistedInUpgradeMigrationsAreOnTheInstallPath() for the regression class this
+-- guards against).
+--
+-- form_fields.form_definition_id has no ON DELETE CASCADE -- deleting a form definition explicitly
+-- removes its fields first, in a transaction (see FormDefinitionRepository#remove). form_data is
+-- untouched by this table pair: submissions are matched to a form by form_unique_id (a plain string),
+-- never by a foreign key to form_definitions, so existing forms and submissions are unaffected by
+-- this migration.
+
+CREATE TABLE IF NOT EXISTS form_definitions (
+  form_definition_id BIGSERIAL PRIMARY KEY,
+  unique_id VARCHAR(255) UNIQUE NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  title VARCHAR(255),
+  subtitle VARCHAR(255),
+  button_name VARCHAR(100),
+  success_title VARCHAR(255),
+  success_message TEXT,
+  email_to VARCHAR(512),
+  use_captcha BOOLEAN DEFAULT FALSE,
+  check_for_spam BOOLEAN DEFAULT TRUE,
+  enabled BOOLEAN DEFAULT TRUE,
+  created_by BIGINT REFERENCES users(user_id),
+  modified_by BIGINT REFERENCES users(user_id),
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS form_definitions_unique_id_idx ON form_definitions(unique_id);
+CREATE INDEX IF NOT EXISTS form_definitions_enabled_idx ON form_definitions(enabled);
+
+CREATE TABLE IF NOT EXISTS form_fields (
+  form_field_id BIGSERIAL PRIMARY KEY,
+  form_definition_id BIGINT NOT NULL REFERENCES form_definitions(form_definition_id),
+  field_order INTEGER DEFAULT 100,
+  name VARCHAR(255) NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  field_type VARCHAR(30) DEFAULT 'text',
+  required BOOLEAN DEFAULT FALSE,
+  placeholder VARCHAR(255),
+  default_value VARCHAR(255),
+  options TEXT,
+  created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+  modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS form_fields_form_definition_idx ON form_fields(form_definition_id);
+CREATE INDEX IF NOT EXISTS form_fields_order_idx ON form_fields(field_order);

--- a/src/main/webapp/WEB-INF/jsp/admin/form-definition-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-definition-form.jsp
@@ -1,0 +1,80 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="formDefinition" class="com.simisinc.platform.domain.model.cms.FormDefinition" scope="request"/>
+<form method="post">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Form values --%>
+  <input type="hidden" name="id" value="${formDefinition.id}"/>
+  <%-- Title and Message block --%>
+  <c:if test="${!empty title}">
+    <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+  </c:if>
+  <%@include file="../page_messages.jspf" %>
+  <%-- Form Content --%>
+  <div class="grid-x grid-margin-x">
+    <div class="small-12 medium-6 cell">
+      <label>Name <span class="required">*</span>
+        <input type="text" placeholder="e.g. Contact Us" name="name" value="<c:out value="${formDefinition.name}"/>" required>
+      </label>
+    </div>
+    <div class="small-12 medium-6 cell">
+      <label>Button Label
+        <input type="text" placeholder="Submit" name="buttonName" value="<c:out value="${formDefinition.buttonName}"/>">
+      </label>
+    </div>
+  </div>
+  <label>Title
+    <input type="text" placeholder="Heading shown above the form..." name="title" value="<c:out value="${formDefinition.title}"/>">
+  </label>
+  <label>Subtitle
+    <input type="text" placeholder="Optional text shown under the title..." name="subtitle" value="<c:out value="${formDefinition.subtitle}"/>">
+  </label>
+  <div class="grid-x grid-margin-x">
+    <div class="small-12 medium-6 cell">
+      <label>Success Title
+        <input type="text" placeholder="Shown after a successful submission..." name="successTitle" value="<c:out value="${formDefinition.successTitle}"/>">
+      </label>
+    </div>
+    <div class="small-12 medium-6 cell">
+      <label>Email submissions to
+        <input type="text" placeholder="name@example.com" name="emailTo" value="<c:out value="${formDefinition.emailTo}"/>">
+      </label>
+    </div>
+  </div>
+  <label>Success Message
+    <input type="text" placeholder="Optional message shown after a successful submission..." name="successMessage" value="<c:out value="${formDefinition.successMessage}"/>">
+  </label>
+  <input id="useCaptcha" type="checkbox" name="useCaptcha" value="true" <c:if test="${formDefinition.useCaptcha}">checked</c:if>/><label for="useCaptcha">Use Captcha?</label>
+  <input id="checkForSpam" type="checkbox" name="checkForSpam" value="true" <c:if test="${formDefinition.checkForSpam}">checked</c:if>/><label for="checkForSpam">Check for spam?</label>
+  <input id="enabled" type="checkbox" name="enabled" value="true" <c:if test="${formDefinition.enabled}">checked</c:if>/><label for="enabled">Enabled?</label>
+  <div class="button-container">
+    <c:choose>
+      <c:when test="${formDefinition.id eq -1}">
+        <input type="submit" class="button radius success expanded" value="Save"/>
+      </c:when>
+      <c:otherwise>
+        <input type="submit" class="button radius success" value="Save"/>
+        <a href="${ctx}/admin/forms" class="button radius secondary">Cancel</a>
+      </c:otherwise>
+    </c:choose>
+  </div>
+</form>

--- a/src/main/webapp/WEB-INF/jsp/admin/form-field-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-field-form.jsp
@@ -1,0 +1,71 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="field" class="com.simisinc.platform.domain.model.cms.FormField" scope="request"/>
+<form method="post">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Form values --%>
+  <input type="hidden" name="id" value="${field.id}"/>
+  <input type="hidden" name="formDefinitionId" value="${field.formDefinitionId}"/>
+  <%-- Title and Message block --%>
+  <c:if test="${!empty title}">
+    <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+  </c:if>
+  <%@include file="../page_messages.jspf" %>
+  <%-- Form Content --%>
+  <label>Label <span class="required">*</span>
+    <input type="text" placeholder="What the visitor sees, e.g. Full Name" name="label" value="<c:out value="${field.label}"/>" required>
+  </label>
+  <label>Name
+    <input type="text" placeholder="Auto-generated from the label if left blank" name="name" value="<c:out value="${field.name}"/>">
+  </label>
+  <label>Type
+    <select name="type">
+      <option value="text" <c:if test="${empty field.type || field.type eq 'text'}">selected</c:if>>Text</option>
+      <option value="email" <c:if test="${field.type eq 'email'}">selected</c:if>>Email</option>
+      <option value="textarea" <c:if test="${field.type eq 'textarea'}">selected</c:if>>Textarea</option>
+      <option value="select" <c:if test="${field.type eq 'select'}">selected</c:if>>Select (dropdown)</option>
+      <option value="checkbox" <c:if test="${field.type eq 'checkbox'}">selected</c:if>>Checkbox</option>
+      <option value="date" <c:if test="${field.type eq 'date'}">selected</c:if>>Date</option>
+    </select>
+  </label>
+  <label>Placeholder
+    <input type="text" placeholder="Optional hint text shown inside the field..." name="placeholder" value="<c:out value="${field.placeholder}"/>">
+  </label>
+  <label>Default Value
+    <input type="text" name="defaultValue" value="<c:out value="${field.defaultValue}"/>">
+  </label>
+  <label>Options
+    <input type="text" placeholder="Select/Checkbox only, e.g. red=Red,blue=Blue,green=Green" name="options" value="<c:out value="${optionsText}"/>">
+  </label>
+  <input id="fieldRequired" type="checkbox" name="required" value="true" <c:if test="${field.required}">checked</c:if>/><label for="fieldRequired">Required?</label>
+  <div class="button-container">
+    <c:choose>
+      <c:when test="${field.id eq -1}">
+        <input type="submit" class="button radius success expanded" value="Save"/>
+      </c:when>
+      <c:otherwise>
+        <input type="submit" class="button radius success" value="Save"/>
+        <a href="${ctx}/admin/forms-editor?formDefinitionId=${field.formDefinitionId}" class="button radius secondary">Cancel</a>
+      </c:otherwise>
+    </c:choose>
+  </div>
+</form>

--- a/src/main/webapp/WEB-INF/jsp/admin/form-fields-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-fields-list.jsp
@@ -1,0 +1,100 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="formDefinition" class="com.simisinc.platform.domain.model.cms.FormDefinition" scope="request"/>
+<jsp:useBean id="fieldList" class="java.util.ArrayList" scope="request"/>
+<link rel="stylesheet" href="${ctx}/javascript/dragula-3.7.3/dragula.min.css"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
+</c:if>
+<p class="help-text">
+  Drag the <i class="fa fa-arrows"></i> handle to reorder fields, click <i class="${font:fas()} fa-edit"></i> to edit
+  a field, or <i class="fa fa-circle-xmark"></i> to remove it. Reordering is saved when you click
+  <strong>Save Field Order</strong> below.
+</p>
+<%@include file="../page_messages.jspf" %>
+<c:if test="${empty fieldList}">
+  <p class="subheader">No fields were found, add one!</p>
+</c:if>
+<form method="post" onsubmit="return checkFieldOrder()">
+  <%-- Required by controller --%>
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <%-- Form values --%>
+  <input type="hidden" name="formDefinitionId" value="${formDefinition.id}"/>
+  <input type="hidden" id="fieldOrder" name="fieldOrder" value=""/>
+  <div id="form-fields-container" class="form-fields-container">
+    <c:forEach items="${fieldList}" var="field">
+      <div id="form-field-row-${field.id}" class="form-field-row">
+        <div style="position: absolute; right: 5px; top: 5px;">
+          <small>
+            <a href="${ctx}/admin/forms-editor?formDefinitionId=${formDefinition.id}&fieldId=${field.id}" title="Edit this field"><i class="${font:fas()} fa-edit"></i></a>
+            <a href="javascript:deleteField(${field.id}, '<c:out value="${js:escape(field.label)}" />');" title="Delete this field"><i class="fa fa-circle-xmark"></i></a>
+          </small>
+        </div>
+        <div>
+          <i class="fa fa-arrows form-field-drag-handle" title="Drag to reorder"></i>
+          <strong><c:out value="${field.label}"/></strong><c:if test="${field.required}"> <span class="required">*</span></c:if>
+        </div>
+        <div>
+          <small class="subheader">
+            <c:out value="${field.name}"/> &middot; <c:out value="${field.type}"/>
+            <c:if test="${!empty field.placeholder}"> &middot; placeholder: "<c:out value="${field.placeholder}"/>"</c:if>
+          </small>
+        </div>
+      </div>
+    </c:forEach>
+  </div>
+  <c:if test="${!empty fieldList}">
+    <div class="button-container">
+      <input type="submit" class="button radius success" value="Save Field Order"/>
+    </div>
+  </c:if>
+</form>
+<script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
+<script nonce="${cspNonce}">
+  dragula([document.getElementById('form-fields-container')], {
+    moves: function (el, container, handle) {
+      return handle.classList.contains('form-field-drag-handle');
+    }
+  });
+
+  function deleteField(fieldId, label) {
+    if (!confirm("Delete the field \"" + label + "\"? This cannot be undone.")) {
+      return;
+    }
+    postAction('${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&fieldId=' + fieldId);
+  }
+
+  function checkFieldOrder() {
+    var container = document.getElementById("form-fields-container");
+    var rows = container.querySelectorAll(".form-field-row");
+    var order = "";
+    for (var i = 0; i < rows.length; i++) {
+      if (i > 0) {
+        order += ",";
+      }
+      order += rows[i].id.substring(rows[i].id.lastIndexOf("-") + 1);
+    }
+    document.getElementById("fieldOrder").value = order;
+    return true;
+  }
+</script>

--- a/src/main/webapp/WEB-INF/jsp/admin/forms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/forms.jsp
@@ -1,0 +1,66 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="font" uri="/WEB-INF/tlds/font-functions.tld" %>
+<%@ taglib prefix="js" uri="/WEB-INF/tlds/javascript-escape.tld" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<jsp:useBean id="formDefinitionList" class="java.util.ArrayList" scope="request"/>
+<jsp:useBean id="fieldCountMap" class="java.util.HashMap" scope="request"/>
+<c:if test="${!empty title}">
+  <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
+</c:if>
+<%@include file="../page_messages.jspf" %>
+<table class="unstriped">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th width="100" class="text-center"># of Fields</th>
+      <th width="150" class="text-center">Last Modified</th>
+      <th width="100" class="text-center">Enabled?</th>
+      <th width="100" class="text-center">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <c:forEach items="${formDefinitionList}" var="formDefinition">
+    <tr>
+      <td>
+        <a href="${ctx}/admin/forms-editor?formDefinitionId=${formDefinition.id}"><c:out value="${formDefinition.name}" /></a>
+        <br /><small class="subheader"><c:out value="${formDefinition.uniqueId}" /></small>
+      </td>
+      <td class="text-center"><fmt:formatNumber value="${fieldCountMap[formDefinition.id]}" /></td>
+      <td class="text-center"><fmt:formatDate pattern="yyyy-MM-dd hh:mm a" value="${formDefinition.modified}" /></td>
+      <td class="text-center">
+        <c:choose>
+          <c:when test="${formDefinition.enabled}"><span class="label success">Yes</span></c:when>
+          <c:otherwise><span class="label warning">No</span></c:otherwise>
+        </c:choose>
+      </td>
+      <td class="text-center">
+        <a href="${ctx}/admin/forms-editor?formDefinitionId=${formDefinition.id}"><i class="${font:fas()} fa-edit"></i></a>
+        <a href="#" onclick="return confirmPostAction('Are you sure you want to delete <c:out value="${js:escape(formDefinition.name)}" />? This also deletes all of its fields.', '${widgetContext.uri}?command=delete&widget=${widgetContext.uniqueId}&token=${userSession.formToken}&formDefinitionId=${formDefinition.id}');"><i class="fa fa-remove"></i></a>
+      </td>
+    </tr>
+    </c:forEach>
+    <c:if test="${empty formDefinitionList}">
+      <tr>
+        <td colspan="5">No forms were found</td>
+      </tr>
+    </c:if>
+  </tbody>
+</table>

--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -141,6 +141,21 @@
   <c:forEach items="${formFieldList}" var="formField" varStatus="status">
     <label><c:out value="${formField.label}"/><c:if test="${formField.required}"> <span class="required">*</span></c:if>
     <c:choose>
+      <c:when test="${formField.type eq 'checkbox' && !empty formField.listOfOptions}">
+        <c:forEach items="${formField.listOfOptions}" var="option">
+          <input type="checkbox"
+              id="${widgetContext.uniqueId}<c:out value="${formField.name}"/>_<c:out value="${option.key}"/>"
+              name="${widgetContext.uniqueId}<c:out value="${formField.name}"/>" value="<c:out value="${option.key}"/>"/>
+          <label for="${widgetContext.uniqueId}<c:out value="${formField.name}"/>_<c:out value="${option.key}"/>"><c:out value="${option.value}" /></label>
+        </c:forEach>
+      </c:when>
+      <c:when test="${formField.type eq 'checkbox'}">
+        <input type="checkbox"
+            id="${widgetContext.uniqueId}<c:out value="${formField.name}"/>" name="${widgetContext.uniqueId}<c:out value="${formField.name}"/>"
+            value="true"
+            <c:if test="${!empty formField.userValue}">checked</c:if>
+            <c:if test="${formField.required}">required</c:if>/>
+      </c:when>
       <c:when test="${!empty formField.listOfOptions}">
         <select id="${widgetContext.uniqueId}<c:out value="${formField.name}"/>" name="${widgetContext.uniqueId}<c:out value="${formField.name}"/>">
           <option value="">&lt; Please Choose &gt;</option>

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -453,6 +453,7 @@
               <c:if test="${userSession.hasRole('admin')}">
                 <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/web-vitals')}"> class="is-active"</c:if>><a href="${ctx}/admin/web-vitals"><i class="${font:far()} fa-tachometer-alt fa-fw"></i> <span>Web Vitals</span></a></li>
               </c:if>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/forms')}"> class="is-active"</c:if>><a href="${ctx}/admin/forms"><i class="${font:far()} fa-file-lines fa-fw"></i> <span>Form Builder</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/form-')}"> class="is-active"</c:if>><a href="${ctx}/admin/form-data"><i class="${font:far()} fa-list-alt fa-fw"></i> <span>Form Data</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/mailing-list') && !fn:startsWith(pageRenderInfo.name, '/admin/mailing-list-properties')}"> class="is-active"</c:if>><a href="${ctx}/admin/mailing-lists"><i class="${font:far()} fa-envelope fa-fw"></i> <span>Mailing Lists</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/newsletter-send')}"> class="is-active"</c:if>><a href="${ctx}/admin/newsletter-send"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>Send Newsletter</span></a></li>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -390,6 +390,53 @@
     </section>
   </page>
 
+  <page name="/admin/forms" role="admin,community-manager" title="Form Builder">
+    <section>
+      <column class="small-12 medium-10 large-9 cell">
+        <widget name="formsList">
+          <title>Forms</title>
+        </widget>
+      </column>
+      <column class="small-12 medium-2 large-3 cell">
+        <widget name="formDefinitionForm" class="callout radius primary">
+          <title>Add a form</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
+  <page name="/admin/forms-editor{?formDefinitionId}" role="admin,community-manager" title="Form Editor">
+    <section>
+      <column class="small-12 cell">
+        <widget name="breadcrumbs">
+          <links>
+            <link name="Forms" value="/admin/forms" />
+            <link name="Edit Form" value="" />
+          </links>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 cell">
+        <widget name="formDefinitionForm">
+          <title>Form Settings</title>
+        </widget>
+      </column>
+    </section>
+    <section>
+      <column class="small-12 medium-8 large-8 cell">
+        <widget name="formFieldsList">
+          <title>Fields</title>
+        </widget>
+      </column>
+      <column class="small-12 medium-4 large-4 cell">
+        <widget name="formFieldForm" class="callout radius primary">
+          <title>Add a field</title>
+        </widget>
+      </column>
+    </section>
+  </page>
+
   <page name="/admin/mailing-lists" role="admin,community-manager" title="Mailing Lists">
     <!--<section>-->
       <!--<column class="small-12 cell">-->

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -243,6 +243,10 @@
   <widget name="socialMediaLinkList" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkListWidget" />
   <widget name="socialMediaLinkForm" class="com.simisinc.platform.presentation.widgets.admin.SocialMediaLinkFormWidget" />
   <widget name="formDataList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormDataListWidget" />
+  <widget name="formsList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormsListWidget" />
+  <widget name="formDefinitionForm" class="com.simisinc.platform.presentation.widgets.admin.cms.FormDefinitionFormWidget" />
+  <widget name="formFieldsList" class="com.simisinc.platform.presentation.widgets.admin.cms.FormFieldsListWidget" />
+  <widget name="formFieldForm" class="com.simisinc.platform.presentation.widgets.admin.cms.FormFieldFormWidget" />
   <widget name="datasets" class="com.simisinc.platform.presentation.widgets.admin.datasets.DatasetsWidget" />
   <widget name="datasetName" class="com.simisinc.platform.presentation.widgets.datasets.DatasetNameWidget" />
   <widget name="datasetUpload" class="com.simisinc.platform.presentation.widgets.admin.datasets.DatasetUploadWidget" />

--- a/src/main/webapp/WEB-INF/widgets/widget-schema.json
+++ b/src/main/webapp/WEB-INF/widgets/widget-schema.json
@@ -287,6 +287,7 @@
       "icon": "fa-wpforms",
       "preferences": [
         {"name": "formUniqueId",  "label": "Form Unique ID", "type": "text"},
+        {"name": "formId",        "label": "Database Form ID (from /admin/forms -- when set, fields are loaded from the database instead of the Form Fields list below)", "type": "text"},
         {"name": "icon",          "label": "Icon (FA)",      "type": "text"},
         {"name": "title",         "label": "Form Title",     "type": "text"},
         {"name": "subtitle",      "label": "Subtitle",       "type": "text"},

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDefinitionRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDefinitionRepositoryTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link FormDefinitionRepository} against a real PostgreSQL instance (issue #409),
+ * including the app-level cascade delete of a form's fields.
+ *
+ * @author SimIS Inc.
+ */
+class FormDefinitionRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+  private static long userId;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(), "Docker is not available - skipping FormDefinitionRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+    userId = insertUser("form-editor");
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE form_fields, form_definitions RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset form_definitions/form_fields tables", se);
+    }
+  }
+
+  @Test
+  void saveInsertsANewFormDefinition() {
+    FormDefinition definition = newDefinition("contact-us", "Contact Us");
+
+    FormDefinition saved = FormDefinitionRepository.save(definition);
+
+    assertNotNull(saved);
+    assertNotNull(saved.getId());
+    assertTrue(saved.getId() > -1);
+    assertEquals("contact-us", saved.getUniqueId());
+  }
+
+  @Test
+  void saveOnAnExistingIdUpdatesRatherThanDuplicating() {
+    FormDefinition saved = FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+
+    saved.setName("Contact Us (Updated)");
+    saved.setEnabled(false);
+    FormDefinitionRepository.save(saved);
+
+    assertEquals(1, DB.selectCountFrom("form_definitions"), "an update must not insert a second row");
+    FormDefinition reloaded = FormDefinitionRepository.findById(saved.getId());
+    assertEquals("Contact Us (Updated)", reloaded.getName());
+    assertFalse(reloaded.getEnabled());
+  }
+
+  @Test
+  void findByUniqueIdReturnsNullWhenNoSuchFormExists() {
+    assertNull(FormDefinitionRepository.findByUniqueId("does-not-exist"));
+  }
+
+  @Test
+  void findByUniqueIdFindsAnEnabledOrDisabledForm() {
+    FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+
+    FormDefinition found = FormDefinitionRepository.findByUniqueId("contact-us");
+
+    assertNotNull(found);
+    assertEquals("Contact Us", found.getName());
+  }
+
+  @Test
+  void findAllReturnsEveryDefinition() {
+    FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+    FormDefinitionRepository.save(newDefinition("volunteer-signup", "Volunteer Signup"));
+
+    List<FormDefinition> all = FormDefinitionRepository.findAll();
+
+    assertEquals(2, all.size());
+  }
+
+  @Test
+  void removeDeletesTheFormDefinitionRow() {
+    FormDefinition saved = FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+
+    boolean removed = FormDefinitionRepository.remove(saved);
+
+    assertTrue(removed);
+    assertNull(FormDefinitionRepository.findById(saved.getId()));
+  }
+
+  @Test
+  void removeCascadesToTheFormsFields() {
+    // Deleting a form definition is a deliberate app-level cascade (see
+    // FormDefinitionRepository#remove's javadoc): form_fields.form_definition_id has no DB-level ON
+    // DELETE CASCADE, so this verifies the repository performs the cascade itself, in a transaction,
+    // rather than leaving orphaned rows or failing on the FK.
+    FormDefinition saved = FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+    FormFieldRepository.save(newField(saved.getId(), "full_name", "Full Name"));
+    FormFieldRepository.save(newField(saved.getId(), "email", "Email"));
+    assertEquals(2, DB.selectCountFrom("form_fields"), "test setup: both fields must save");
+
+    boolean removed = FormDefinitionRepository.remove(saved);
+
+    assertTrue(removed);
+    assertTrue(FormFieldRepository.findAllByFormDefinitionId(saved.getId()).isEmpty(),
+        "deleting the form definition must also remove its fields");
+    assertEquals(0, DB.selectCountFrom("form_fields"));
+  }
+
+  @Test
+  void removeOfOneFormDoesNotAffectAnotherFormsFields() {
+    FormDefinition contactUs = FormDefinitionRepository.save(newDefinition("contact-us", "Contact Us"));
+    FormDefinition volunteer = FormDefinitionRepository.save(newDefinition("volunteer-signup", "Volunteer Signup"));
+    FormFieldRepository.save(newField(contactUs.getId(), "email", "Email"));
+    FormFieldRepository.save(newField(volunteer.getId(), "email", "Email"));
+
+    FormDefinitionRepository.remove(contactUs);
+
+    assertEquals(1, FormFieldRepository.findAllByFormDefinitionId(volunteer.getId()).size(),
+        "the other form's fields must survive");
+  }
+
+  private static FormDefinition newDefinition(String uniqueId, String name) {
+    FormDefinition definition = new FormDefinition();
+    definition.setUniqueId(uniqueId);
+    definition.setName(name);
+    definition.setTitle(name);
+    definition.setCreatedBy(userId);
+    definition.setModifiedBy(userId);
+    return definition;
+  }
+
+  private static FormField newField(long formDefinitionId, String name, String label) {
+    FormField field = new FormField();
+    field.setFormDefinitionId(formDefinitionId);
+    field.setName(name);
+    field.setLabel(label);
+    field.setType("text");
+    return field;
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // Mirrors NEW_10010__new_cms.sql's `form_definitions`/`form_fields` tables.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS form_fields CASCADE");
+      statement.execute("DROP TABLE IF EXISTS form_definitions CASCADE");
+      statement.execute("DROP TABLE IF EXISTS users CASCADE");
+      statement.execute("CREATE TABLE users ("
+          + "user_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "username VARCHAR(255) UNIQUE NOT NULL, "
+          + "password VARCHAR(255) NOT NULL)");
+      statement.execute("CREATE TABLE form_definitions ("
+          + "form_definition_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "title VARCHAR(255), "
+          + "subtitle VARCHAR(255), "
+          + "button_name VARCHAR(100), "
+          + "success_title VARCHAR(255), "
+          + "success_message TEXT, "
+          + "email_to VARCHAR(512), "
+          + "use_captcha BOOLEAN DEFAULT FALSE, "
+          + "check_for_spam BOOLEAN DEFAULT TRUE, "
+          + "enabled BOOLEAN DEFAULT TRUE, "
+          + "created_by BIGINT REFERENCES users(user_id), "
+          + "modified_by BIGINT REFERENCES users(user_id), "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+      statement.execute("CREATE TABLE form_fields ("
+          + "form_field_id BIGSERIAL PRIMARY KEY, "
+          + "form_definition_id BIGINT NOT NULL REFERENCES form_definitions(form_definition_id), "
+          + "field_order INTEGER DEFAULT 100, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "label VARCHAR(255) NOT NULL, "
+          + "field_type VARCHAR(30) DEFAULT 'text', "
+          + "required BOOLEAN DEFAULT FALSE, "
+          + "placeholder VARCHAR(255), "
+          + "default_value VARCHAR(255), "
+          + "options TEXT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the form_definitions/form_fields/users schema", se);
+    }
+  }
+
+  private static long insertUser(String uniqueId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO users (unique_id, username, password) VALUES (?, ?, ?) RETURNING user_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      pst.setString(3, "not-a-real-hash");
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert test user", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormFieldRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormFieldRepositoryTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link FormFieldRepository} against a real PostgreSQL instance (issue #409), including
+ * that drag-and-drop reordering persists and that the select/checkbox options round-trip through
+ * their delimited-string storage.
+ *
+ * @author SimIS Inc.
+ */
+class FormFieldRepositoryTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+  private static long formDefinitionId;
+  private static long otherFormDefinitionId;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(), "Docker is not available - skipping FormFieldRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE form_fields, form_definitions RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset form_definitions/form_fields tables", se);
+    }
+    formDefinitionId = insertFormDefinition("contact-us");
+    otherFormDefinitionId = insertFormDefinition("volunteer-signup");
+  }
+
+  @Test
+  void saveInsertsANewField() {
+    FormField field = newField(formDefinitionId, "full_name", "Full Name", "text");
+
+    FormField saved = FormFieldRepository.save(field);
+
+    assertNotNull(saved);
+    assertTrue(saved.getId() > -1);
+    assertEquals("full_name", saved.getName());
+  }
+
+  @Test
+  void aFieldSavedWithoutAnExplicitOrderGetsTheColumnDefaultSoItSortsToTheEnd() {
+    // FormField's fieldOrder defaults to -1 (issue #409's domain-model addition); the repository
+    // must omit the column on insert rather than binding that sentinel as NULL, so Postgres'
+    // "field_order INTEGER DEFAULT 100" actually applies.
+    FormField saved = FormFieldRepository.save(newField(formDefinitionId, "full_name", "Full Name", "text"));
+
+    FormField reloaded = FormFieldRepository.findById(saved.getId());
+
+    assertEquals(100, reloaded.getFieldOrder());
+  }
+
+  @Test
+  void findAllByFormDefinitionIdOrdersByFieldOrder() {
+    FormField third = FormFieldRepository.save(newField(formDefinitionId, "c", "C", "text"));
+    FormField first = FormFieldRepository.save(newField(formDefinitionId, "a", "A", "text"));
+    FormField second = FormFieldRepository.save(newField(formDefinitionId, "b", "B", "text"));
+    reorder(first, 10);
+    reorder(second, 20);
+    reorder(third, 30);
+
+    List<FormField> fields = FormFieldRepository.findAllByFormDefinitionId(formDefinitionId);
+
+    assertEquals(List.of("a", "b", "c"), fields.stream().map(FormField::getName).toList());
+  }
+
+  @Test
+  void findAllByFormDefinitionIdScopesToThatFormOnly() {
+    FormFieldRepository.save(newField(formDefinitionId, "email", "Email", "email"));
+    FormFieldRepository.save(newField(otherFormDefinitionId, "email", "Email", "email"));
+
+    List<FormField> fields = FormFieldRepository.findAllByFormDefinitionId(formDefinitionId);
+
+    assertEquals(1, fields.size());
+    assertTrue(fields.stream().allMatch(f -> f.getFormDefinitionId() == formDefinitionId));
+  }
+
+  @Test
+  void reorderFieldsPersistsTheNewOrder() {
+    FormField a = FormFieldRepository.save(newField(formDefinitionId, "a", "A", "text"));
+    FormField b = FormFieldRepository.save(newField(formDefinitionId, "b", "B", "text"));
+    FormField c = FormFieldRepository.save(newField(formDefinitionId, "c", "C", "text"));
+    // Insert order is a, b, c (all default field_order 100) -- reorder to c, a, b as a drag-and-drop
+    // action would submit (issue #409's hidden "fieldOrder" comma-joined id list).
+    boolean reordered = FormFieldRepository.reorderFields(formDefinitionId,
+        List.of(c.getId(), a.getId(), b.getId()));
+
+    assertTrue(reordered);
+    List<FormField> fields = FormFieldRepository.findAllByFormDefinitionId(formDefinitionId);
+    assertEquals(List.of("c", "a", "b"), fields.stream().map(FormField::getName).toList(),
+        "field_order must persist and be reflected by a fresh findAllByFormDefinitionId query");
+  }
+
+  @Test
+  void reorderFieldsIsStableAcrossASecondReorder() {
+    // Reordering twice, verifying the second reorder's result rather than assuming the first one
+    // "stuck" -- guards against a reorder that appears to work once but leaves stale field_order
+    // values that only happen to look right after a single pass.
+    FormField a = FormFieldRepository.save(newField(formDefinitionId, "a", "A", "text"));
+    FormField b = FormFieldRepository.save(newField(formDefinitionId, "b", "B", "text"));
+    FormFieldRepository.reorderFields(formDefinitionId, List.of(a.getId(), b.getId()));
+
+    FormFieldRepository.reorderFields(formDefinitionId, List.of(b.getId(), a.getId()));
+
+    List<FormField> fields = FormFieldRepository.findAllByFormDefinitionId(formDefinitionId);
+    assertEquals(List.of("b", "a"), fields.stream().map(FormField::getName).toList());
+  }
+
+  @Test
+  void reorderFieldsSkipsAnIdBelongingToAnotherForm() {
+    // A malicious or stale request could submit a field id from a different form; reorderFields
+    // must not let that id escape its own form's scope by writing a field_order for it under this
+    // formDefinitionId's reorder call.
+    FormField ownField = FormFieldRepository.save(newField(formDefinitionId, "email", "Email", "email"));
+    FormField otherFormsField = FormFieldRepository.save(newField(otherFormDefinitionId, "email", "Email", "email"));
+
+    boolean result = FormFieldRepository.reorderFields(formDefinitionId,
+        List.of(otherFormsField.getId(), ownField.getId()));
+
+    assertTrue(result);
+    FormField reloadedOtherField = FormFieldRepository.findById(otherFormsField.getId());
+    assertEquals(otherFormDefinitionId, reloadedOtherField.getFormDefinitionId(),
+        "the other form's field must not be reassigned or reordered by this call");
+    assertEquals(1, FormFieldRepository.findAllByFormDefinitionId(formDefinitionId).size());
+  }
+
+  @Test
+  void reorderFieldsWithNoMatchingIdsReturnsTrueWithoutChangingOrder() {
+    FormField a = FormFieldRepository.save(newField(otherFormDefinitionId, "a", "A", "text"));
+
+    // Every id in the list belongs to a different form than formDefinitionId, so nothing should move.
+    boolean result = FormFieldRepository.reorderFields(formDefinitionId, List.of(a.getId()));
+
+    assertTrue(result);
+    FormField reloaded = FormFieldRepository.findById(a.getId());
+    assertEquals(100, reloaded.getFieldOrder(), "an id outside the target form must be left untouched");
+  }
+
+  @Test
+  void reorderFieldsWithAnEmptyListReturnsFalse() {
+    assertFalse(FormFieldRepository.reorderFields(formDefinitionId, List.of()));
+  }
+
+  @Test
+  void getNextFieldOrderStartsAtOneForAFormWithNoFields() {
+    assertEquals(1, FormFieldRepository.getNextFieldOrder(formDefinitionId));
+  }
+
+  @Test
+  void getNextFieldOrderReturnsOneMoreThanTheCurrentMax() {
+    FormField field = FormFieldRepository.save(newField(formDefinitionId, "a", "A", "text"));
+    reorder(field, 30);
+
+    assertEquals(31, FormFieldRepository.getNextFieldOrder(formDefinitionId));
+  }
+
+  @Test
+  void getNextFieldOrderIsScopedToItsOwnForm() {
+    FormField field = FormFieldRepository.save(newField(otherFormDefinitionId, "a", "A", "text"));
+    reorder(field, 500);
+
+    // A high field_order on a different form must not influence this form's next value
+    assertEquals(1, FormFieldRepository.getNextFieldOrder(formDefinitionId));
+  }
+
+  @Test
+  void twoFieldsAddedWithoutAnInterveningReorderGetDistinctFieldOrders() {
+    // Reproduces issue #409's field_order duplicate-value gap: SaveFormFieldCommand calls
+    // getNextFieldOrder() and sets it on every newly-created field, so two consecutive adds -- with
+    // no drag-and-drop reorder between them -- must not both land on the column's DEFAULT 100.
+    FormField first = newField(formDefinitionId, "a", "A", "text");
+    first.setFieldOrder(FormFieldRepository.getNextFieldOrder(formDefinitionId));
+    FormField savedFirst = FormFieldRepository.save(first);
+
+    FormField second = newField(formDefinitionId, "b", "B", "text");
+    second.setFieldOrder(FormFieldRepository.getNextFieldOrder(formDefinitionId));
+    FormField savedSecond = FormFieldRepository.save(second);
+
+    assertTrue(savedSecond.getFieldOrder() > savedFirst.getFieldOrder(),
+        "a second field added without an intervening reorder must not collide with the first field's order");
+    assertEquals(List.of("a", "b"),
+        FormFieldRepository.findAllByFormDefinitionId(formDefinitionId).stream().map(FormField::getName).toList());
+  }
+
+  @Test
+  void optionsRoundTripThroughTheDelimitedStringColumn() {
+    Map<String, String> options = new LinkedHashMap<>();
+    options.put("red", "Red");
+    options.put("blue", "Blue");
+    FormField field = newField(formDefinitionId, "favorite_color", "Favorite Color", "select");
+    field.setListOfOptions(options);
+
+    FormField saved = FormFieldRepository.save(field);
+    FormField reloaded = FormFieldRepository.findById(saved.getId());
+
+    assertEquals(options, reloaded.getListOfOptions());
+  }
+
+  @Test
+  void aFieldWithNoOptionsReloadsWithANullOptionsMap() {
+    FormField saved = FormFieldRepository.save(newField(formDefinitionId, "full_name", "Full Name", "text"));
+
+    FormField reloaded = FormFieldRepository.findById(saved.getId());
+
+    assertNull(reloaded.getListOfOptions());
+  }
+
+  @Test
+  void updateChangesTheStoredValuesInPlace() {
+    FormField saved = FormFieldRepository.save(newField(formDefinitionId, "full_name", "Full Name", "text"));
+
+    saved.setLabel("Legal Name");
+    saved.setRequired(true);
+    saved.setPlaceholder("e.g. Jane Doe");
+    FormFieldRepository.save(saved);
+
+    assertEquals(1, DB.selectCountFrom("form_fields"), "an update must not insert a second row");
+    FormField reloaded = FormFieldRepository.findById(saved.getId());
+    assertEquals("Legal Name", reloaded.getLabel());
+    assertTrue(reloaded.isRequired());
+    assertEquals("e.g. Jane Doe", reloaded.getPlaceholder());
+  }
+
+  @Test
+  void removeDeletesOnlyThatField() {
+    FormField keep = FormFieldRepository.save(newField(formDefinitionId, "email", "Email", "email"));
+    FormField remove = FormFieldRepository.save(newField(formDefinitionId, "phone", "Phone", "text"));
+
+    boolean removed = FormFieldRepository.remove(remove);
+
+    assertTrue(removed);
+    assertNull(FormFieldRepository.findById(remove.getId()));
+    assertNotNull(FormFieldRepository.findById(keep.getId()));
+  }
+
+  private static void reorder(FormField field, int order) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "UPDATE form_fields SET field_order = ? WHERE form_field_id = ?")) {
+      pst.setInt(1, order);
+      pst.setLong(2, field.getId());
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not set up field_order for test", se);
+    }
+  }
+
+  private static FormField newField(long formDefinitionId, String name, String label, String type) {
+    FormField field = new FormField();
+    field.setFormDefinitionId(formDefinitionId);
+    field.setName(name);
+    field.setLabel(label);
+    field.setType(type);
+    return field;
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // Mirrors NEW_10010__new_cms.sql's `form_definitions`/`form_fields` tables.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS form_fields CASCADE");
+      statement.execute("DROP TABLE IF EXISTS form_definitions CASCADE");
+      statement.execute("CREATE TABLE form_definitions ("
+          + "form_definition_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "title VARCHAR(255), "
+          + "subtitle VARCHAR(255), "
+          + "button_name VARCHAR(100), "
+          + "success_title VARCHAR(255), "
+          + "success_message TEXT, "
+          + "email_to VARCHAR(512), "
+          + "use_captcha BOOLEAN DEFAULT FALSE, "
+          + "check_for_spam BOOLEAN DEFAULT TRUE, "
+          + "enabled BOOLEAN DEFAULT TRUE, "
+          + "created_by BIGINT, "
+          + "modified_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+      statement.execute("CREATE TABLE form_fields ("
+          + "form_field_id BIGSERIAL PRIMARY KEY, "
+          + "form_definition_id BIGINT NOT NULL REFERENCES form_definitions(form_definition_id), "
+          + "field_order INTEGER DEFAULT 100, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "label VARCHAR(255) NOT NULL, "
+          + "field_type VARCHAR(30) DEFAULT 'text', "
+          + "required BOOLEAN DEFAULT FALSE, "
+          + "placeholder VARCHAR(255), "
+          + "default_value VARCHAR(255), "
+          + "options TEXT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the form_definitions/form_fields schema", se);
+    }
+  }
+
+  private static long insertFormDefinition(String uniqueId) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO form_definitions (unique_id, name) VALUES (?, ?) RETURNING form_definition_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert test form definition", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidgetTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS Inc.
+ */
+class FormDefinitionFormWidgetTest extends WidgetBase {
+
+  @Test
+  void executeLoadsAnExistingFormById() {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(5L);
+    contactUs.setName("Contact Us");
+
+    addQueryParameter(widgetContext, "formDefinitionId", "5");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(contactUs);
+
+      WidgetContext result = new FormDefinitionFormWidget().execute(widgetContext);
+
+      Assertions.assertEquals(FormDefinitionFormWidget.JSP, result.getJsp());
+      FormDefinition requestBean = (FormDefinition) request.getAttribute("formDefinition");
+      Assertions.assertEquals(5L, requestBean.getId());
+      Assertions.assertEquals("Contact Us", requestBean.getName());
+    }
+  }
+
+  @Test
+  void executeWithNoIdFallsBackToABlankBean() {
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(-1L)).thenReturn(null);
+
+      WidgetContext result = new FormDefinitionFormWidget().execute(widgetContext);
+
+      FormDefinition requestBean = (FormDefinition) request.getAttribute("formDefinition");
+      Assertions.assertNotNull(requestBean);
+      Assertions.assertEquals(-1L, requestBean.getId());
+    }
+  }
+
+  @Test
+  void postSavesANewFormAndRedirectsToItsEditor() throws InvocationTargetException, IllegalAccessException {
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "name", "Contact Us");
+    addQueryParameter(widgetContext, "title", "Get in touch");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findByUniqueId(any())).thenReturn(null);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.save(any())).thenAnswer(invocation -> {
+        FormDefinition savedRecord = invocation.getArgument(0);
+        savedRecord.setId(9L);
+        return savedRecord;
+      });
+
+      WidgetContext result = new FormDefinitionFormWidget().post(widgetContext);
+
+      Assertions.assertEquals("Form was saved", result.getSuccessMessage());
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=9", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postWithABlankNameFailsValidationAndDoesNotSave() throws InvocationTargetException, IllegalAccessException {
+    addQueryParameter(widgetContext, "id", "-1");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      WidgetContext result = new FormDefinitionFormWidget().post(widgetContext);
+
+      Assertions.assertNotNull(result.getErrorMessage());
+      Assertions.assertNull(result.getRedirect());
+      formDefinitionRepository.verify(() -> FormDefinitionRepository.save(any()), never());
+    }
+  }
+
+  /**
+   * Guards against reintroducing the createdBy-on-edit bug this codebase has already hit once in a
+   * sibling command (mailing lists) -- editing an existing form must not overwrite createdBy with
+   * whoever happens to be saving right now.
+   */
+  @Test
+  void postOnAnExistingFormPreservesTheOriginalCreatedBy() throws InvocationTargetException, IllegalAccessException {
+    FormDefinition existing = new FormDefinition();
+    existing.setId(5L);
+    existing.setUniqueId("contact-us");
+    existing.setName("Contact Us");
+    existing.setCreatedBy(42L);
+
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "name", "Contact Us");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(existing);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      // The logged-in test user (see WidgetBase#login) is id 1, which must not clobber createdBy=42
+      new FormDefinitionFormWidget().post(widgetContext);
+
+      Assertions.assertEquals(42L, existing.getCreatedBy());
+      Assertions.assertEquals(1L, existing.getModifiedBy());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldFormWidgetTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS Inc.
+ */
+class FormFieldFormWidgetTest extends WidgetBase {
+
+  @Test
+  void executeLoadsAnExistingFieldAndFormatsItsOptionsForEditing() {
+    FormField colorField = new FormField();
+    colorField.setId(10L);
+    colorField.setFormDefinitionId(1L);
+    colorField.setLabel("Favorite Color");
+    Map<String, String> options = new LinkedHashMap<>();
+    options.put("red", "Red");
+    options.put("blue", "Blue");
+    colorField.setListOfOptions(options);
+
+    addQueryParameter(widgetContext, "fieldId", "10");
+
+    try (MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formFieldRepository.when(() -> FormFieldRepository.findById(10L)).thenReturn(colorField);
+
+      WidgetContext result = new FormFieldFormWidget().execute(widgetContext);
+
+      Assertions.assertEquals(FormFieldFormWidget.JSP, result.getJsp());
+      Assertions.assertEquals(colorField, request.getAttribute("field"));
+      Assertions.assertEquals("red=Red,blue=Blue", request.getAttribute("optionsText"));
+    }
+  }
+
+  @Test
+  void executeWithNoFieldIdFallsBackToABlankFieldForTheGivenForm() {
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+
+    try (MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formFieldRepository.when(() -> FormFieldRepository.findById(-1L)).thenReturn(null);
+
+      WidgetContext result = new FormFieldFormWidget().execute(widgetContext);
+
+      FormField field = (FormField) request.getAttribute("field");
+      Assertions.assertEquals(-1L, field.getId());
+      Assertions.assertEquals(1L, field.getFormDefinitionId());
+      Assertions.assertNull(request.getAttribute("optionsText"));
+    }
+  }
+
+  @Test
+  void postSavesANewFieldParsingItsOptionsAndRedirectsToTheFormEditor()
+      throws InvocationTargetException, IllegalAccessException {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+    addQueryParameter(widgetContext, "label", "Favorite Color");
+    addQueryParameter(widgetContext, "type", "select");
+    addQueryParameter(widgetContext, "options", "red=Red, blue=Blue");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(invocation -> {
+        FormField savedRecord = invocation.getArgument(0);
+        savedRecord.setId(20L);
+        return savedRecord;
+      });
+
+      WidgetContext result = new FormFieldFormWidget().post(widgetContext);
+
+      Assertions.assertEquals("Field was saved", result.getSuccessMessage());
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=1", result.getRedirect());
+      formFieldRepository.verify(() -> FormFieldRepository.save(org.mockito.ArgumentMatchers.argThat(field -> "Red".equals(field.getListOfOptions().get("red"))
+          && "Blue".equals(field.getListOfOptions().get("blue")))));
+    }
+  }
+
+  @Test
+  void postWithABlankLabelFailsValidationAndDoesNotSave() throws InvocationTargetException, IllegalAccessException {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+
+      WidgetContext result = new FormFieldFormWidget().post(widgetContext);
+
+      Assertions.assertNotNull(result.getErrorMessage());
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=1", result.getRedirect());
+      formFieldRepository.verify(() -> FormFieldRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void postWithAnUnrecognizedFieldTypeFailsValidationAndDoesNotSave() throws InvocationTargetException, IllegalAccessException {
+    // form-field-form.jsp's "Type" select only ever submits text/email/textarea/select/checkbox/date
+    // -- this simulates a tampered or stale request submitting something else, which
+    // NEW_10010__new_cms.sql's field_type column comment promises is "validated in application code".
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+    addQueryParameter(widgetContext, "label", "Favorite Color");
+    addQueryParameter(widgetContext, "type", "not-a-real-type");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+
+      WidgetContext result = new FormFieldFormWidget().post(widgetContext);
+
+      Assertions.assertNotNull(result.getErrorMessage());
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=1", result.getRedirect());
+      formFieldRepository.verify(() -> FormFieldRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void postSavesANewFieldWithTheRepositorysNextFieldOrder() throws InvocationTargetException, IllegalAccessException {
+    // Reproduces issue #409's field_order duplicate-value gap at the widget level: a brand new
+    // field must get FormFieldRepository's own next-order value explicitly set on it, rather than
+    // being left for the field_order column's own DEFAULT 100 to (collision-prone-ly) apply.
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+
+    addQueryParameter(widgetContext, "id", "-1");
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+    addQueryParameter(widgetContext, "label", "Favorite Color");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+      formFieldRepository.when(() -> FormFieldRepository.getNextFieldOrder(1L)).thenReturn(21);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      new FormFieldFormWidget().post(widgetContext);
+
+      formFieldRepository.verify(() -> FormFieldRepository.save(
+          org.mockito.ArgumentMatchers.argThat(field -> field.getFieldOrder() == 21)));
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormFieldsListWidgetTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS Inc.
+ */
+class FormFieldsListWidgetTest extends WidgetBase {
+
+  @Test
+  void executeLoadsTheFormAndItsFields() {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+    contactUs.setName("Contact Us");
+
+    List<FormField> fieldList = new ArrayList<>();
+    FormField email = new FormField();
+    email.setId(10L);
+    fieldList.add(email);
+
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(1L)).thenReturn(fieldList);
+
+      WidgetContext result = new FormFieldsListWidget().execute(widgetContext);
+
+      Assertions.assertEquals(FormFieldsListWidget.JSP, result.getJsp());
+      Assertions.assertEquals(contactUs, request.getAttribute("formDefinition"));
+      Assertions.assertEquals(fieldList, request.getAttribute("fieldList"));
+    }
+  }
+
+  @Test
+  void executeWithAnUnknownFormRedirectsToTheFormsList() {
+    addQueryParameter(widgetContext, "formDefinitionId", "404");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(404L)).thenReturn(null);
+
+      WidgetContext result = new FormFieldsListWidget().execute(widgetContext);
+
+      Assertions.assertEquals("/admin/forms", result.getRedirect());
+      Assertions.assertNotNull(result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void postParsesTheCommaJoinedFieldOrderAndPersistsIt() throws InvocationTargetException, IllegalAccessException {
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+    addQueryParameter(widgetContext, "fieldOrder", "30,10,20");
+
+    try (MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      WidgetContext result = new FormFieldsListWidget().post(widgetContext);
+
+      formFieldRepository.verify(() -> FormFieldRepository.reorderFields(1L, Arrays.asList(30L, 10L, 20L)));
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=1", result.getRedirect());
+    }
+  }
+
+  @Test
+  void postWithABlankFieldOrderDoesNotCallReorder() throws InvocationTargetException, IllegalAccessException {
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+
+    try (MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      new FormFieldsListWidget().post(widgetContext);
+
+      formFieldRepository.verify(() -> FormFieldRepository.reorderFields(eq(1L), org.mockito.ArgumentMatchers.any()), never());
+    }
+  }
+
+  @Test
+  void deleteRemovesTheFieldAndRedirectsBackToItsForm() {
+    FormField email = new FormField();
+    email.setId(10L);
+    email.setFormDefinitionId(1L);
+
+    addQueryParameter(widgetContext, "fieldId", "10");
+
+    try (MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formFieldRepository.when(() -> FormFieldRepository.findById(10L)).thenReturn(email);
+      formFieldRepository.when(() -> FormFieldRepository.remove(email)).thenReturn(true);
+
+      WidgetContext result = new FormFieldsListWidget().delete(widgetContext);
+
+      Assertions.assertEquals("Field deleted", result.getSuccessMessage());
+      Assertions.assertEquals("/admin/forms-editor?formDefinitionId=1", result.getRedirect());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormsListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormsListWidgetTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.cms;
+
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * @author SimIS Inc.
+ */
+class FormsListWidgetTest extends WidgetBase {
+
+  @Test
+  void executeListsFormsWithFieldCounts() {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+    contactUs.setName("Contact Us");
+    List<FormDefinition> formDefinitionList = new ArrayList<>();
+    formDefinitionList.add(contactUs);
+
+    List<FormField> fieldList = new ArrayList<>();
+    fieldList.add(new FormField());
+    fieldList.add(new FormField());
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(FormDefinitionRepository::findAll).thenReturn(formDefinitionList);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(1L)).thenReturn(fieldList);
+
+      WidgetContext result = new FormsListWidget().execute(widgetContext);
+
+      Assertions.assertEquals(FormsListWidget.JSP, result.getJsp());
+      List<FormDefinition> requestList = (List) request.getAttribute("formDefinitionList");
+      Assertions.assertEquals(1, requestList.size());
+      Map<Long, Integer> fieldCountMap = (Map) request.getAttribute("fieldCountMap");
+      Assertions.assertEquals(2, fieldCountMap.get(1L));
+    }
+  }
+
+  @Test
+  void deleteRemovesTheFormAndItsFields() {
+    FormDefinition contactUs = new FormDefinition();
+    contactUs.setId(1L);
+    contactUs.setName("Contact Us");
+
+    addQueryParameter(widgetContext, "formDefinitionId", "1");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(1L)).thenReturn(contactUs);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.remove(contactUs)).thenReturn(true);
+
+      WidgetContext result = new FormsListWidget().delete(widgetContext);
+
+      Assertions.assertEquals("Form deleted", result.getSuccessMessage());
+      Assertions.assertEquals("/admin/forms", result.getRedirect());
+      formDefinitionRepository.verify(() -> FormDefinitionRepository.remove(contactUs));
+    }
+  }
+
+  @Test
+  void deleteOfAMissingFormSetsAnErrorInsteadOfThrowing() {
+    addQueryParameter(widgetContext, "formDefinitionId", "99");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(99L)).thenReturn(null);
+
+      WidgetContext result = new FormsListWidget().delete(widgetContext);
+
+      Assertions.assertEquals("Form not found", result.getErrorMessage());
+      Assertions.assertEquals("/admin/forms", result.getRedirect());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/FormWidgetDatabaseFormIntegrationTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/FormWidgetDatabaseFormIntegrationTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.cms.FunnelEventCommand;
+import com.simisinc.platform.domain.model.cms.FormData;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataSource;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDataSpecification;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * End-to-end verification of {@link FormWidget}'s database-backed field configuration (issue
+ * #409), against a real PostgreSQL instance, exercising {@link FormDefinitionRepository} and
+ * {@link FormFieldRepository} exactly as the {@code formId} preference does, then the same
+ * {@link FormDataRepository#save} path an XML-defined form already uses -- proving requirement #5
+ * ("submissions land in the existing form_data table, in the same shape as an XML-defined form's
+ * submission") with an actual round trip rather than a mocked assertion.
+ *
+ * <p>
+ * {@link FormWidgetTest} covers the XML-preference path (unmodified by this feature) and the
+ * formId-not-set backward-compatibility guarantee at the unit level with mocks; this class covers
+ * the formId-set path against real data. It is skipped automatically when Docker is not available.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+class FormWidgetDatabaseFormIntegrationTest extends WidgetBase {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  private long formDefinitionId;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping FormWidget database-form integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTablesAndSeedForm() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE form_data, form_fields, form_definitions RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset form_definitions/form_fields/form_data tables", se);
+    }
+
+    // Seed a form definition with the same shape as FormWidgetTest#initCommonPreferences()'s XML
+    // fields, via the real repositories (not raw SQL), so this test also exercises the same save
+    // path an admin's /admin/forms editor would use.
+    FormDefinition formDefinition = new FormDefinition();
+    formDefinition.setUniqueId("db-contact");
+    formDefinition.setName("Database Contact Form");
+    formDefinition = FormDefinitionRepository.save(formDefinition);
+    formDefinitionId = formDefinition.getId();
+
+    saveField("name", "Your first and last name", "text", true, 10);
+    saveField("organization", "Name of your organization", "text", false, 20);
+    saveField("email", "Your email address", "email", true, 30);
+    saveField("comments", "How Can We Help?", "textarea", true, 40);
+  }
+
+  @Test
+  void executeRendersTheDatabaseDefinedFieldsInFieldOrder() {
+    preferences.put("formId", String.valueOf(formDefinitionId));
+
+    try (MockedStatic<com.simisinc.platform.application.RateLimitCommand> rateLimitCommand =
+        mockStatic(com.simisinc.platform.application.RateLimitCommand.class)) {
+      rateLimitCommand.when(() -> com.simisinc.platform.application.RateLimitCommand.isIpAllowedRightNow(any(), org.mockito.ArgumentMatchers.anyBoolean()))
+          .thenReturn(true);
+
+      FormWidget widget = new FormWidget();
+      widget.execute(widgetContext);
+
+      assertEquals(FormWidget.JSP, widgetContext.getJsp());
+
+      @SuppressWarnings("unchecked")
+      List<FormField> formFieldList = (List<FormField>) widgetContext.getRequest().getAttribute("formFieldList");
+      assertEquals(4, formFieldList.size(), "all 4 database fields should be rendered");
+
+      // field_order (10, 20, 30, 40) must drive rendering order, exactly like FormFieldRepository's
+      // own findAllByFormDefinitionId ordering guarantee
+      assertEquals("name", formFieldList.get(0).getName());
+      assertEquals("Your first and last name", formFieldList.get(0).getLabel());
+      assertTrue(formFieldList.get(0).isRequired());
+
+      assertEquals("organization", formFieldList.get(1).getName());
+      assertTrue(!formFieldList.get(1).isRequired());
+
+      assertEquals("email", formFieldList.get(2).getName());
+      assertEquals("email", formFieldList.get(2).getType());
+      assertTrue(formFieldList.get(2).isRequired());
+
+      assertEquals("comments", formFieldList.get(3).getName());
+      assertEquals("textarea", formFieldList.get(3).getType());
+      assertTrue(formFieldList.get(3).isRequired());
+    }
+  }
+
+  @Test
+  void postPersistsADatabaseDefinedSubmissionToFormDataInTheSameShapeAsAnXmlForm() {
+    preferences.put("formId", String.valueOf(formDefinitionId));
+    preferences.put("formUniqueId", "db-contact");
+    preferences.put("checkForSpam", "false");
+
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "name", "First Last");
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "organization", "Acme Inc");
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "email", "email@example.com");
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "comments", "These are my comments.");
+
+    try (MockedStatic<WorkflowManager> workflowManagerMockedStatic = mockStatic(WorkflowManager.class);
+        MockedStatic<FunnelEventCommand> funnelEventCommand = mockStatic(FunnelEventCommand.class)) {
+
+      FormWidget widget = new FormWidget();
+      WidgetContext result = widget.post(widgetContext);
+
+      assertNull(result, "a successful submission redirects (post() returns null)");
+      assertNull(widgetContext.getWarningMessage());
+      assertNull(widgetContext.getErrorMessage());
+      workflowManagerMockedStatic.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()));
+      funnelEventCommand.verify(() -> FunnelEventCommand.recordContactFormSubmitted(eq("db-contact"), any()));
+    }
+
+    // Re-read the row through FormDataRepository -- the exact same repository/table an XML-defined
+    // form's submission is stored in (issue #409 requirement: no parallel storage mechanism).
+    FormDataSpecification spec = new FormDataSpecification();
+    spec.setFormUniqueId("db-contact");
+    List<FormData> saved = FormDataRepository.findAll(spec, new DataConstraints());
+    assertEquals(1, saved.size(), "exactly one form_data row should have been written");
+
+    FormData formData = saved.get(0);
+    assertEquals("db-contact", formData.getFormUniqueId());
+    List<FormField> savedFields = formData.getFormFieldList();
+    assertEquals(4, savedFields.size(), "field_values must round-trip all 4 submitted fields");
+
+    FormField name = findByName(savedFields, "name");
+    assertEquals("Your first and last name", name.getLabel());
+    assertEquals("First Last", name.getUserValue());
+
+    FormField email = findByName(savedFields, "email");
+    assertEquals("email", email.getType());
+    assertEquals("email@example.com", email.getUserValue());
+
+    FormField comments = findByName(savedFields, "comments");
+    assertEquals("textarea", comments.getType());
+    assertEquals("These are my comments.", comments.getUserValue());
+  }
+
+  @Test
+  void postRejectsAMissingRequiredDatabaseDefinedFieldJustLikeAnXmlField() {
+    preferences.put("formId", String.valueOf(formDefinitionId));
+    preferences.put("formUniqueId", "db-contact");
+    preferences.put("checkForSpam", "false");
+
+    // "comments" is required in the seeded form definition and is left blank here
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "name", "First Last");
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "email", "email@example.com");
+
+    FormWidget widget = new FormWidget();
+    WidgetContext result = widget.post(widgetContext);
+
+    assertEquals(widgetContext, result, "a validation failure redisplays the form (post() returns the context)");
+    assertEquals("How Can We Help? is required", widgetContext.getWarningMessage());
+
+    assertEquals(0, FormDataRepository.countTotalSubmissions(), "an invalid submission must not be saved");
+  }
+
+  private static FormField findByName(List<FormField> fields, String name) {
+    return fields.stream().filter(f -> name.equals(f.getName())).findFirst()
+        .orElseThrow(() -> new AssertionError("No field named " + name + " in " + fields));
+  }
+
+  private void saveField(String name, String label, String type, boolean required, int fieldOrder) {
+    FormField field = new FormField();
+    field.setFormDefinitionId(formDefinitionId);
+    field.setName(name);
+    field.setLabel(label);
+    field.setType(type);
+    field.setRequired(required);
+    field.setFieldOrder(fieldOrder);
+    FormFieldRepository.save(field);
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // Mirrors NEW_10010__new_cms.sql's form_definitions/form_fields/form_data tables (a focused
+    // subset of form_data -- see FormDataRepositoryTest for the same trimming rationale).
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS form_data CASCADE");
+      statement.execute("DROP TABLE IF EXISTS form_fields CASCADE");
+      statement.execute("DROP TABLE IF EXISTS form_definitions CASCADE");
+      statement.execute("CREATE TABLE form_definitions ("
+          + "form_definition_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "title VARCHAR(255), "
+          + "subtitle VARCHAR(255), "
+          + "button_name VARCHAR(100), "
+          + "success_title VARCHAR(255), "
+          + "success_message TEXT, "
+          + "email_to VARCHAR(512), "
+          + "use_captcha BOOLEAN DEFAULT FALSE, "
+          + "check_for_spam BOOLEAN DEFAULT TRUE, "
+          + "enabled BOOLEAN DEFAULT TRUE, "
+          + "created_by BIGINT, "
+          + "modified_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+      statement.execute("CREATE TABLE form_fields ("
+          + "form_field_id BIGSERIAL PRIMARY KEY, "
+          + "form_definition_id BIGINT NOT NULL REFERENCES form_definitions(form_definition_id), "
+          + "field_order INTEGER DEFAULT 100, "
+          + "name VARCHAR(255) NOT NULL, "
+          + "label VARCHAR(255) NOT NULL, "
+          + "field_type VARCHAR(30) DEFAULT 'text', "
+          + "required BOOLEAN DEFAULT FALSE, "
+          + "placeholder VARCHAR(255), "
+          + "default_value VARCHAR(255), "
+          + "options TEXT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+      statement.execute("CREATE TABLE form_data ("
+          + "form_data_id BIGSERIAL PRIMARY KEY, "
+          + "form_unique_id VARCHAR(255), "
+          + "field_values JSONB, "
+          + "ip_address VARCHAR(200), "
+          + "created_by BIGINT, "
+          + "modified_by BIGINT, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "modified TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "claimed TIMESTAMP(3) DEFAULT NULL, "
+          + "claimed_by BIGINT, "
+          + "dismissed TIMESTAMP(3) DEFAULT NULL, "
+          + "url VARCHAR(512), "
+          + "query_params VARCHAR(512), "
+          + "flagged_as_spam BOOLEAN DEFAULT FALSE, "
+          + "session_id VARCHAR(255), "
+          + "dismissed_by BIGINT, "
+          + "processed TIMESTAMP(3) DEFAULT NULL, "
+          + "processed_by BIGINT, "
+          + "processed_system VARCHAR(255))");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the form_definitions/form_fields/form_data schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/FormWidgetFormDefinitionSettingsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/FormWidgetFormDefinitionSettingsTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.FormCommand;
+import com.simisinc.platform.application.cms.FunnelEventCommand;
+import com.simisinc.platform.domain.events.cms.FormSubmittedEvent;
+import com.simisinc.platform.domain.model.cms.FormData;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Verifies that a database-backed form's own settings (issue #409 follow-up) -- enabled,
+ * useCaptcha, checkForSpam, emailTo, title, subtitle, buttonName, successTitle, successMessage --
+ * actually take effect once {@code formId} is configured, rather than the widget placement's XML
+ * preferences silently continuing to be the only thing that matters. Uses mockStatic on the
+ * repositories (like {@code FormFieldFormWidgetTest}), so it needs no real database -- {@link
+ * FormWidgetDatabaseFormIntegrationTest} covers the same {@code formId} path end-to-end against real
+ * Postgres.
+ *
+ * @author SimIS Inc.
+ */
+class FormWidgetFormDefinitionSettingsTest extends WidgetBase {
+
+  @Test
+  void executeReturnsNullWhenTheDatabaseBackedFormIsDisabledForAnAnonymousVisitor() {
+    preferences.put("formId", "5");
+    FormDefinition disabled = new FormDefinition();
+    disabled.setId(5L);
+    disabled.setEnabled(false);
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(disabled);
+
+      WidgetContext result = new FormWidget().execute(widgetContext);
+
+      Assertions.assertNull(result, "a disabled database-backed form must not render for the public");
+    }
+  }
+
+  @Test
+  void executeStillRendersADisabledDatabaseBackedFormForAnAdmin() {
+    preferences.put("formId", "5");
+    setRoles(widgetContext, ADMIN);
+    FormDefinition disabled = new FormDefinition();
+    disabled.setId(5L);
+    disabled.setEnabled(false);
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(disabled);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(List.of(field));
+
+      WidgetContext result = new FormWidget().execute(widgetContext);
+
+      Assertions.assertNotNull(result, "an admin must still be able to preview a disabled form");
+      Assertions.assertEquals(FormWidget.JSP, result.getJsp());
+    }
+  }
+
+  @Test
+  void postRejectsASubmissionToADisabledDatabaseBackedForm() {
+    preferences.put("formId", "5");
+    FormDefinition disabled = new FormDefinition();
+    disabled.setId(5L);
+    disabled.setEnabled(false);
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(disabled);
+
+      WidgetContext result = new FormWidget().post(widgetContext);
+
+      Assertions.assertNull(result, "a direct POST to a disabled database-backed form must not be accepted");
+    }
+  }
+
+  @Test
+  void executeReturnsNullWhenFormIdIsSetButTheFormDefinitionIsNotFound() {
+    preferences.put("formId", "99");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(99L)).thenReturn(null);
+
+      WidgetContext result = new FormWidget().execute(widgetContext);
+
+      Assertions.assertNull(result, "a stale/bad formId must hard-fail, not silently fall back to the XML fields preference");
+    }
+  }
+
+  @Test
+  void executeUsesTheFormDefinitionsOwnUseCaptchaSettingInsteadOfTheWidgetPreference() {
+    preferences.put("formId", "7");
+    preferences.put("useCaptcha", "false");
+    FormDefinition form = new FormDefinition();
+    form.setId(7L);
+    form.setEnabled(true);
+    form.setUseCaptcha(true);
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class);
+        MockedStatic<LoadSitePropertyCommand> property = mockStatic(LoadSitePropertyCommand.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(7L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(7L)).thenReturn(List.of(field));
+      property.when(() -> LoadSitePropertyCommand.loadByName(any())).thenReturn(null);
+
+      new FormWidget().execute(widgetContext);
+
+      Assertions.assertEquals("true", request.getAttribute("useCaptcha"),
+          "the form definition's own useCaptcha=true must win even though the widget preference says false");
+    }
+  }
+
+  @Test
+  void postSkipsSpamCheckingWhenTheFormDefinitionsCheckForSpamIsFalseEvenIfTheWidgetPreferenceSaysTrue() {
+    preferences.put("formId", "9");
+    preferences.put("checkForSpam", "true");
+    FormDefinition form = new FormDefinition();
+    form.setId(9L);
+    form.setEnabled(true);
+    form.setCheckForSpam(false);
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "name", "First Last");
+
+    // post()'s rate limiter only applies to anonymous submitters, and WidgetBase logs a user in by
+    // default, so RateLimitCommand is never reached here -- no need to mock it.
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class);
+        MockedStatic<FormCommand> formCommand = mockStatic(FormCommand.class);
+        MockedStatic<FormDataRepository> formDataRepository = mockStatic(FormDataRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<FunnelEventCommand> funnelEventCommand = mockStatic(FunnelEventCommand.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(9L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(9L)).thenReturn(List.of(field));
+      formDataRepository.when(() -> FormDataRepository.save(any())).thenReturn(new FormData());
+
+      WidgetContext result = new FormWidget().post(widgetContext);
+
+      Assertions.assertNull(result, "a successful submission redirects (post() returns null)");
+      formCommand.verify(() -> FormCommand.checkNotificationRules(any()), never());
+    }
+  }
+
+  @Test
+  void postUsesTheFormDefinitionsOwnEmailToWhenNotifyingRatherThanTheWidgetPreference() {
+    preferences.put("formId", "11");
+    preferences.put("emailTo", "widget-preference@example.com");
+    FormDefinition form = new FormDefinition();
+    form.setId(11L);
+    form.setEnabled(true);
+    form.setCheckForSpam(false);
+    form.setEmailTo("form-definition@example.com");
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "name", "First Last");
+
+    // post()'s rate limiter only applies to anonymous submitters, and WidgetBase logs a user in by
+    // default, so RateLimitCommand is never reached here -- no need to mock it.
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class);
+        MockedStatic<FormDataRepository> formDataRepository = mockStatic(FormDataRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<FunnelEventCommand> funnelEventCommand = mockStatic(FunnelEventCommand.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(11L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(11L)).thenReturn(List.of(field));
+      formDataRepository.when(() -> FormDataRepository.save(any())).thenReturn(new FormData());
+
+      new FormWidget().post(widgetContext);
+
+      ArgumentCaptor<FormSubmittedEvent> eventCaptor = ArgumentCaptor.forClass(FormSubmittedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      Assertions.assertEquals("form-definition@example.com", eventCaptor.getValue().getEmailAddressesTo());
+    }
+  }
+
+  @Test
+  void executeUsesTheFormDefinitionsOwnTitleAndSubtitleInsteadOfTheWidgetPreferences() {
+    preferences.put("formId", "13");
+    preferences.put("title", "Widget Preference Title");
+    preferences.put("subtitle", "Widget Preference Subtitle");
+    FormDefinition form = new FormDefinition();
+    form.setId(13L);
+    form.setEnabled(true);
+    form.setTitle("Form Definition Title");
+    form.setSubtitle("Form Definition Subtitle");
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(13L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(13L)).thenReturn(List.of(field));
+
+      new FormWidget().execute(widgetContext);
+
+      Assertions.assertEquals("Form Definition Title", request.getAttribute("title"),
+          "the form definition's own title must win over the widget preference");
+      Assertions.assertEquals("Form Definition Subtitle", request.getAttribute("subtitle"),
+          "the form definition's own subtitle must win over the widget preference");
+    }
+  }
+
+  @Test
+  void executeUsesTheFormDefinitionsOwnButtonNameInsteadOfTheWidgetPreference() {
+    preferences.put("formId", "14");
+    preferences.put("buttonName", "Widget Preference Button");
+    FormDefinition form = new FormDefinition();
+    form.setId(14L);
+    form.setEnabled(true);
+    form.setButtonName("Send It");
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(14L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(14L)).thenReturn(List.of(field));
+
+      new FormWidget().execute(widgetContext);
+
+      Assertions.assertEquals("Send It", request.getAttribute("buttonName"),
+          "the form definition's own button label must win over the widget preference");
+    }
+  }
+
+  @Test
+  void executeFallsBackToTheDefaultButtonNameWhenTheFormDefinitionsButtonNameIsBlank() {
+    preferences.put("formId", "15");
+    FormDefinition form = new FormDefinition();
+    form.setId(15L);
+    form.setEnabled(true);
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(15L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(15L)).thenReturn(List.of(field));
+
+      new FormWidget().execute(widgetContext);
+
+      Assertions.assertEquals("Submit", request.getAttribute("buttonName"),
+          "an admin who left the form definition's button label blank should still get the same default the XML-preference path always applied");
+    }
+  }
+
+  @Test
+  void executeUsesTheFormDefinitionsOwnSuccessTitleAndMessageOnTheSuccessPage() {
+    preferences.put("formId", "16");
+    preferences.put("successTitle", "Widget Preference Success Title");
+    preferences.put("successMessage", "Widget preference success message");
+    FormDefinition form = new FormDefinition();
+    form.setId(16L);
+    form.setEnabled(true);
+    form.setSuccessTitle("Thanks!");
+    form.setSuccessMessage("We'll be in touch soon.");
+    widgetContext.addSharedRequestValue(widgetContext.getUniqueId() + "formWidgetSuccess", "true");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(16L)).thenReturn(form);
+
+      WidgetContext result = new FormWidget().execute(widgetContext);
+
+      Assertions.assertEquals(FormWidget.SUCCESS_JSP, result.getJsp());
+      Assertions.assertEquals("Thanks!", request.getAttribute("successTitle"),
+          "the form definition's own success title must win over the widget preference");
+      Assertions.assertEquals("We'll be in touch soon.", request.getAttribute("successMessage"),
+          "the form definition's own success message must win over the widget preference");
+    }
+  }
+
+  @Test
+  void executeFallsBackToTheDefaultSuccessMessageWhenTheFormDefinitionsSuccessMessageIsBlank() {
+    preferences.put("formId", "17");
+    FormDefinition form = new FormDefinition();
+    form.setId(17L);
+    form.setEnabled(true);
+    widgetContext.addSharedRequestValue(widgetContext.getUniqueId() + "formWidgetSuccess", "true");
+
+    try (MockedStatic<RateLimitCommand> rateLimitCommand = mockStatic(RateLimitCommand.class);
+        MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      rateLimitCommand.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), anyBoolean())).thenReturn(true);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(17L)).thenReturn(form);
+
+      new FormWidget().execute(widgetContext);
+
+      Assertions.assertNull(request.getAttribute("successTitle"),
+          "a blank form definition success title has no default to fall back to, matching the XML-preference path's plain get()");
+      Assertions.assertEquals("Your information has been submitted.", request.getAttribute("successMessage"),
+          "a blank form definition success message should still get the same default the XML-preference path always applied");
+    }
+  }
+
+  @Test
+  void postUsesTheFormDefinitionsOwnUniqueIdInsteadOfTheWidgetPreference() {
+    preferences.put("formId", "21");
+    preferences.put("formUniqueId", "widget-preference-slug");
+    FormDefinition form = new FormDefinition();
+    form.setId(21L);
+    form.setEnabled(true);
+    form.setUniqueId("form-definition-slug");
+    form.setCheckForSpam(false);
+    FormField field = new FormField();
+    field.setName("name");
+    field.setLabel("Name");
+
+    addQueryParameter(widgetContext, widgetContext.getUniqueId() + "name", "First Last");
+
+    // post()'s rate limiter only applies to anonymous submitters, and WidgetBase logs a user in by
+    // default, so RateLimitCommand is never reached here -- no need to mock it.
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class);
+        MockedStatic<FormDataRepository> formDataRepository = mockStatic(FormDataRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<FunnelEventCommand> funnelEventCommand = mockStatic(FunnelEventCommand.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(21L)).thenReturn(form);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(21L)).thenReturn(List.of(field));
+      formDataRepository.when(() -> FormDataRepository.save(any())).thenReturn(new FormData());
+
+      new FormWidget().post(widgetContext);
+
+      ArgumentCaptor<FormData> formDataCaptor = ArgumentCaptor.forClass(FormData.class);
+      formDataRepository.verify(() -> FormDataRepository.save(formDataCaptor.capture()));
+      Assertions.assertEquals("form-definition-slug", formDataCaptor.getValue().getFormUniqueId(),
+          "form_data must be keyed by the form definition's own collision-checked uniqueId, not a "
+              + "hand-typed widget preference that could collide with an unrelated form");
+      funnelEventCommand.verify(() -> FunnelEventCommand.recordContactFormSubmitted(eq("form-definition-slug"), any()));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #409. Adds `/admin/forms`, a database-backed form builder so content editors can define a form's fields, CAPTCHA/spam settings, and notification address entirely from the admin UI instead of hand-editing a widget's XML `<fields>` preference.

- Field types: text, email, textarea, select (dropdown), checkbox, date
- Per-form settings: title/subtitle/button label, success title/message, CAPTCHA, spam check, email-to address, enabled
- `FormWidget` resolves a database-backed `FormDefinition` when a page's form widget has `formId` configured; falls back to the existing XML-configured behavior otherwise, so existing forms are unaffected
- A disabled form now returns nothing for both the display and submit path unless the caller is `admin`/`community-manager`, matching the existing `WikiWidget`/`BlogPostWidget` disabled-content pattern

**Note on migration versioning:** this branch's `UPGRADE_20260804.1004__form_definitions.sql` was renamed to `UPGRADE_20260804.1005__form_definitions.sql` -- the `.1004` slot is already claimed by #408's in-flight redirect-management migration (PR #981), and Flyway requires unique version numbers across whatever eventually lands on `main` together.

## Test plan

- [x] Full `ant ci-test` — clean
- [x] `check-unescaped-el.py --strict` — clean
- [x] `check-xml-well-formed.py --strict` — clean (72/72)
- [x] `ant package` — clean
- [x] Live Docker verification:
  - Created a form via `/admin/forms`, set `emailTo` and unchecked `useCaptcha` — confirmed persisted (`use_captcha=false`, `check_for_spam=true`, `email_to` set) and confirmed no CAPTCHA renders on the live form
  - Added a checkbox field — confirmed it renders as real `<input type="checkbox">` elements (a checkbox group sharing one field name), not a dropdown
  - Toggled the form's "Enabled?" off — confirmed a logged-out visitor gets nothing from that widget (page has zero renderable widgets), while an admin/privileged session still sees and can edit it