### PR TITLE
Fix createdBy reassigned to editor on calendar event, web page, and blog post edits

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveBlogPostCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveBlogPostCommand.java
@@ -80,9 +80,12 @@ public class SaveBlogPostCommand {
       if (blogPost == null) {
         throw new DataException("The existing record could not be found");
       }
+      // createdBy is set once, below, only for a genuinely new record -- an edit must not
+      // reassign the original creator to whoever happens to be editing it today
     } else {
       LOG.debug("Saving a new record... ");
       blogPost = new BlogPost();
+      blogPost.setCreatedBy(blogPostBean.getCreatedBy());
     }
 
     // Check for events
@@ -107,7 +110,6 @@ public class SaveBlogPostCommand {
     blogPost.setSummary(blogPostBean.getSummary());
     blogPost.setKeywords(blogPostBean.getKeywords());
     blogPost.setImageUrl(blogPostBean.getImageUrl());
-    blogPost.setCreatedBy(blogPostBean.getCreatedBy());
     blogPost.setModifiedBy(blogPostBean.getModifiedBy());
     blogPost.setPublished(blogPostBean.getPublished());
     blogPost.setStartDate(blogPostBean.getStartDate());

--- a/src/main/java/com/simisinc/platform/application/cms/SaveCalendarEventCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveCalendarEventCommand.java
@@ -75,9 +75,12 @@ public class SaveCalendarEventCommand {
       if (calendarEvent == null) {
         throw new DataException("The existing record could not be found");
       }
+      // createdBy is set once, below, only for a genuinely new record -- an edit must not
+      // reassign the original creator to whoever happens to be editing it today
     } else {
       LOG.debug("Saving a new record... ");
       calendarEvent = new CalendarEvent();
+      calendarEvent.setCreatedBy(calendarEventBean.getCreatedBy());
     }
 
     // Check for events
@@ -106,7 +109,6 @@ public class SaveCalendarEventCommand {
     calendarEvent.setImageUrl(calendarEventBean.getImageUrl());
     calendarEvent.setVideoUrl(calendarEventBean.getVideoUrl());
     calendarEvent.setTagsList(calendarEventBean.getTagsList());
-    calendarEvent.setCreatedBy(calendarEventBean.getCreatedBy());
     calendarEvent.setModifiedBy(calendarEventBean.getModifiedBy());
     calendarEvent.setPublished(calendarEventBean.getPublished());
     calendarEvent.setStartDate(calendarEventBean.getStartDate());

--- a/src/main/java/com/simisinc/platform/application/cms/SaveWebPageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveWebPageCommand.java
@@ -115,11 +115,13 @@ public class SaveWebPageCommand {
       if (webPage == null) {
         throw new DataException("The existing record could not be found");
       }
+      // createdBy is set once, below, only for a genuinely new record -- an edit must not
+      // reassign the original creator to whoever happens to be editing it today
     } else {
       LOG.debug("Saving a new record... ");
       webPage = new WebPage();
+      webPage.setCreatedBy(webPageBean.getCreatedBy());
     }
-    webPage.setCreatedBy(webPageBean.getCreatedBy());
     webPage.setModifiedBy(webPageBean.getModifiedBy());
     webPage.setLink(webPageBean.getLink());
     webPage.setRedirectUrl(webPageBean.getRedirectUrl());

--- a/src/test/java/com/simisinc/platform/application/cms/SaveBlogPostCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveBlogPostCommandTest.java
@@ -212,6 +212,66 @@ class SaveBlogPostCommandTest {
     assertEquals("CR-5678", reloaded.getReleaseReference());
   }
 
+  @Test
+  void editingAnExistingPostDoesNotChangeItsOriginalCreatedBy() throws Exception {
+    // createdBy must be set once, at creation -- editing an existing post (e.g. fixing a typo)
+    // must not reassign the original author to whoever happens to be editing it today.
+    long blogId = addBlog();
+
+    BlogPost existing = new BlogPost();
+    existing.setBlogId(blogId);
+    existing.setUniqueId("a-post");
+    existing.setTitle("Original Title");
+    existing.setBody("Original body");
+    existing.setCreatedBy(7); // the original author
+    existing.setModifiedBy(7);
+    BlogPost saved = BlogPostRepository.add(existing);
+    assertNotNull(saved);
+
+    // Mirrors what BlogEditorWidget.post() builds when a different admin edits the post
+    BlogPost editBean = new BlogPost();
+    editBean.setId(saved.getId());
+    editBean.setBlogId(blogId);
+    editBean.setUniqueId("a-post");
+    editBean.setTitle("Original Title, edited");
+    editBean.setBody("Original body, edited");
+    editBean.setCreatedBy(42); // a different user editing it today
+    editBean.setModifiedBy(42);
+
+    // Asserted on the command's own return value, not a reload from BlogPostRepository.findById():
+    // BlogPostRepository.update()'s SQL never includes created_by in the first place (it is
+    // deliberately excluded from that method's SqlUtils, so a DB round-trip can never distinguish
+    // the buggy and fixed command). What this test actually guards is SaveBlogPostCommand's own
+    // in-memory object: with the bug, the object it hands to BlogPostRepository.save() -- and
+    // therefore the object callers/widgets receive back and act on -- carries the editor's id
+    // instead of the original author's, even though the update() SQL happens to make that
+    // particular mistake harmless against the persisted row today.
+    BlogPost result = SaveBlogPostCommand.saveBlogPost(editBean);
+    assertNotNull(result);
+    assertEquals(7L, result.getCreatedBy(), "createdBy must survive an edit by a different user");
+    assertEquals(42L, result.getModifiedBy(), "modifiedBy must still reflect the editor");
+  }
+
+  @Test
+  void newPostGetsCreatedByFromTheSubmitter() throws Exception {
+    long blogId = addBlog();
+
+    BlogPost bean = new BlogPost();
+    bean.setBlogId(blogId);
+    bean.setUniqueId("a-new-post");
+    bean.setTitle("A New Post");
+    bean.setBody("Body");
+    bean.setCreatedBy(42);
+    bean.setModifiedBy(42);
+
+    BlogPost result = SaveBlogPostCommand.saveBlogPost(bean);
+    assertNotNull(result);
+
+    BlogPost reloaded = BlogPostRepository.findById(result.getId());
+    assertNotNull(reloaded);
+    assertEquals(42L, reloaded.getCreatedBy());
+  }
+
   private static boolean isDockerAvailable() {
     try {
       return DockerClientFactory.instance().isDockerAvailable();

--- a/src/test/java/com/simisinc/platform/application/cms/SaveCalendarEventCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveCalendarEventCommandTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.CalendarEvent;
+import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+
+/**
+ * saveCalendarEvent() used to unconditionally overwrite createdBy on every save, including an
+ * edit of an existing record -- so editing a calendar event (e.g. fixing a typo) silently
+ * reassigned its original creator to whoever happened to be editing it that day. modifiedBy is
+ * correctly re-set on every save; createdBy must be set once, only when the record is genuinely
+ * new.
+ *
+ * @author elizabeth houser
+ */
+class SaveCalendarEventCommandTest {
+
+  private static CalendarEvent newEventBean(long calendarId) {
+    CalendarEvent bean = new CalendarEvent();
+    bean.setCalendarId(calendarId);
+    bean.setTitle("Town Hall");
+    Timestamp start = new Timestamp(System.currentTimeMillis());
+    bean.setStartDate(start);
+    bean.setEndDate(start);
+    return bean;
+  }
+
+  @Test
+  void newRecordGetsCreatedByFromTheSubmitter() throws DataException {
+    CalendarEvent bean = newEventBean(1L);
+    bean.setCreatedBy(42L); // the current submitter, per CalendarEventFormWidget.post()
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class)) {
+      repository.when(() -> CalendarEventRepository.findByUniqueId(any(), any())).thenReturn(null);
+      repository.when(() -> CalendarEventRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveCalendarEventCommand.saveCalendarEvent(bean);
+
+      repository.verify(() -> CalendarEventRepository.save(argThat(saved -> saved.getCreatedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void editingAnExistingRecordDoesNotChangeItsOriginalCreatedBy() throws DataException {
+    CalendarEvent existing = new CalendarEvent();
+    existing.setId(1L);
+    existing.setCalendarId(1L);
+    existing.setUniqueId("town-hall");
+    existing.setTitle("Town Hall");
+    existing.setCreatedBy(7L); // the original creator
+    Timestamp start = new Timestamp(System.currentTimeMillis());
+    existing.setStartDate(start);
+    existing.setEndDate(start);
+
+    CalendarEvent bean = newEventBean(1L);
+    bean.setId(1L);
+    bean.setStartDate(start);
+    bean.setEndDate(start);
+    bean.setCreatedBy(42L); // a different user editing it today
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class)) {
+      repository.when(() -> CalendarEventRepository.findById(1L)).thenReturn(existing);
+      repository.when(() -> CalendarEventRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveCalendarEventCommand.saveCalendarEvent(bean);
+
+      repository.verify(() -> CalendarEventRepository.save(argThat(saved -> saved.getCreatedBy() == 7L)));
+    }
+  }
+
+  @Test
+  void editingAnExistingRecordStillUpdatesModifiedBy() throws DataException {
+    // modifiedBy is a different field with different, correct semantics -- must keep working
+    CalendarEvent existing = new CalendarEvent();
+    existing.setId(1L);
+    existing.setCalendarId(1L);
+    existing.setUniqueId("town-hall");
+    existing.setTitle("Town Hall");
+    existing.setCreatedBy(7L);
+    existing.setModifiedBy(7L);
+    Timestamp start = new Timestamp(System.currentTimeMillis());
+    existing.setStartDate(start);
+    existing.setEndDate(start);
+
+    CalendarEvent bean = newEventBean(1L);
+    bean.setId(1L);
+    bean.setStartDate(start);
+    bean.setEndDate(start);
+    bean.setCreatedBy(42L);
+    bean.setModifiedBy(42L);
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class)) {
+      repository.when(() -> CalendarEventRepository.findById(1L)).thenReturn(existing);
+      repository.when(() -> CalendarEventRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      SaveCalendarEventCommand.saveCalendarEvent(bean);
+
+      repository.verify(() -> CalendarEventRepository.save(argThat(saved -> saved.getModifiedBy() == 42L)));
+    }
+  }
+
+  @Test
+  void editingAMissingRecordThrowsBeforeTouchingCreatedBy() {
+    CalendarEvent bean = newEventBean(1L);
+    bean.setId(99L);
+    bean.setCreatedBy(42L);
+
+    try (MockedStatic<CalendarEventRepository> repository = mockStatic(CalendarEventRepository.class)) {
+      repository.when(() -> CalendarEventRepository.findById(99L)).thenReturn(null);
+
+      assertThrows(DataException.class, () -> SaveCalendarEventCommand.saveCalendarEvent(bean));
+
+      repository.verify(() -> CalendarEventRepository.save(any()), never());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/SaveWebPageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveWebPageCommandTest.java
@@ -135,6 +135,35 @@ class SaveWebPageCommandTest {
   }
 
   @Test
+  void editingAnExistingPageDoesNotChangeItsOriginalCreatedBy() throws Exception {
+    // createdBy must be set once, at creation -- editing an existing page (e.g. fixing a typo)
+    // must not reassign the original author to whoever happens to be editing it today.
+    WebPage existing = new WebPage();
+    existing.setId(5L);
+    existing.setLink("/about");
+    existing.setCreatedBy(7L); // the original author
+
+    WebPage bean = newPageBean("/about");
+    bean.setId(5L);
+    bean.setCreatedBy(42L); // a different admin editing it today, per WebPageFormWidget.post()
+
+    WebPage saved = new WebPage();
+    saved.setId(5L);
+    saved.setLink("/about");
+
+    try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
+        MockedStatic<WorkflowManager> workflow = mockStatic(WorkflowManager.class);
+        MockedStatic<PublishEventCachePurgeHandler> purge = mockStatic(PublishEventCachePurgeHandler.class)) {
+      repository.when(() -> WebPageRepository.findById(5L)).thenReturn(existing);
+      repository.when(() -> WebPageRepository.save(any())).thenReturn(saved);
+
+      SaveWebPageCommand.saveWebPage(bean);
+
+      repository.verify(() -> WebPageRepository.save(argThat(page -> page.getCreatedBy() == 7L)));
+    }
+  }
+
+  @Test
   void failedValidationNeverTriggersAPurge() {
     // No link -- SaveWebPageCommand rejects this before WebPageRepository or the purge handler
     // are ever touched.


### PR DESCRIPTION
## Summary

`SaveCalendarEventCommand`, `SaveWebPageCommand`, and `SaveBlogPostCommand` all unconditionally copy `createdBy` from the incoming bean onto the record they save -- including on the update branch. Every widget that saves one of these (`CalendarEventFormWidget`, `CalendarWidget`, `WebPageFormWidget`, `WebPageDesignerWidget`, `WebPageListWidget`'s bulk publish/unpublish, `BlogEditorWidget`) sets that bean's `createdBy` to the current user on every submit, so editing an existing record built the in-memory result with the editor's id in place of the original creator's.

Fix: `createdBy` is now only set in each command's new-record branch, mirroring the same shape already used in `SaveMailingListCommand`. `modifiedBy` is untouched -- it correctly continues to reflect the current user on every save.

**Actual impact, found while verifying this:** `CalendarEventRepository`, `WebPageRepository`, and `BlogPostRepository`'s `update()` methods already exclude `created_by` from their `UPDATE` SQL, so the persisted database column was never actually being overwritten by this bug -- editorial-calendar authorship queries reading directly from that column were not affected. The defect was confined to the in-memory object each command builds and returns from `save()`; nothing currently reads that value back after a save (no widget, no cache). This closes a real, latent correctness gap rather than a live data-integrity or display bug -- worth fixing since it's an easy trap for future code that trusts the returned object, but not something that needed a hotfix.

## Test plan

- Added `SaveCalendarEventCommandTest` (new) and new cases in `SaveWebPageCommandTest`/`SaveBlogPostCommandTest` asserting `createdBy` survives an edit by a different user while `modifiedBy` still updates.
- Verified each new/updated test actually catches the regression: reverted the production fix with the tests in place and confirmed they fail (`SaveCalendarEventCommandTest` and `SaveWebPageCommandTest` catch it via the object passed to `Repository.save()`; `SaveBlogPostCommandTest` needed its assertion changed to check the command's own return value rather than a DB reload, since `BlogPostRepository.update()`'s exclusion of `created_by` means a DB round-trip can't distinguish buggy from fixed here).
- `ant -lib lib/war clean compile` passes cleanly against current `main`.
- Targeted run of the three affected test classes passes.
- Full `ci-test` run hit an apparent Docker/Testcontainers environment hang on an unrelated integration test (`AuditLogChainIntegrationTest`) partway through and had to be killed rather than completing -- not something the change here touches. Flagging in case CI hits the same thing.
