### PR TITLE
Fix jQuery syntax error on bare href="#" anchor clicks

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -793,13 +793,19 @@
         <%-- // Add a smooth scroll for anchors --%>
         $(document).on('click', 'a[href^="#"]', function (event) {
           event.preventDefault();
+          <%-- Bare href="#" links (e.g. admin action icons using onclick="return confirmPostAction(...)")
+               have no target to scroll to; $("#") throws a jQuery selector syntax error --%>
+          var hash = $.attr(this, 'href');
+          if (!hash || hash === '#') {
+            return;
+          }
           if ($("#platform-small-menu").is(":visible")) {
             $('html, body').animate({
-              scrollTop: $($.attr(this, 'href')).offset().top - $("#platform-small-menu").height() - 20
+              scrollTop: $(hash).offset().top - $("#platform-small-menu").height() - 20
             }, 500);
           } else {
             $('html, body').animate({
-              scrollTop: $($.attr(this, 'href')).offset().top - $("#platform-menu").height() - 20
+              scrollTop: $(hash).offset().top - $("#platform-menu").height() - 20
             }, 500);
           }
         });


### PR DESCRIPTION
## Summary
- The global smooth-scroll click handler in `main.jsp` (`$(document).on('click', 'a[href^="#"]', ...)`) passes the anchor's raw `href` attribute straight into a jQuery selector via `$($.attr(this, 'href'))`.
- For anchors whose `href` is exactly `"#"` — the standard admin action-icon pattern (`href="#" onclick="return confirmPostAction(...)"`) used throughout the admin (Blocked IP list, Users, Mailing Lists, etc.) — this becomes `$("#")`, which jQuery rejects with `Syntax error, unrecognized expression: #`.
- The error doesn't block the inline `onclick`-driven action itself (it runs and returns before the delegated handler bubbles up and throws), but it fires on every click of any such link site-wide, spamming the browser console.
- Fix: guard the hash lookup so a missing or bare `"#"` href is a no-op, before doing the `$(hash)` lookup. `event.preventDefault()` still runs unconditionally so there's no change to the existing prevented-default behavior.

## Test plan
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `ant -lib lib/war package`, confirmed the fix bytes are present in the built WAR
- [x] Local `docker compose` rehearsal: logged in as admin, added a test entry to `/admin/blocked-ip-list`, clicked its delete (`×`) icon (`href="#" onclick="return confirmPostAction(...)"`) with the browser console open — no error thrown (previously threw `Syntax error, unrecognized expression: #` on every such click)
- [x] Programmatically verified in-page: triggering a click on a real `href="#"` anchor throws no error; a genuine `href="#some-id"` anchor still smooth-scrolls correctly (unaffected regression check)