### PR TITLE
Issue #411 PR3: focal-point admin UI + crop-center logic

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/FocalPointCropCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/FocalPointCropCommand.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import java.awt.Rectangle;
+import java.math.BigDecimal;
+
+/**
+ * Computes a fixed-aspect-ratio crop rectangle centered on an image's focal point (issue #411
+ * PR3), so a server-generated variant keeps the subject in frame instead of a blind center crop.
+ *
+ * <p>
+ * Pure math, no I/O: im4java's {@code crop()}/{@code gravity()} only accept absolute pixels and one
+ * of 9 fixed compass strings, with no percentage/relative concept at that layer, so the conversion
+ * from a stored 0-100 focal-point percentage to the pixel rectangle {@code op.crop(w, h, x, y)}
+ * needs must happen here first, in plain Java, against the original image's own stored dimensions.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+public final class FocalPointCropCommand {
+
+  private FocalPointCropCommand() {
+    // Static utility, not instantiated
+  }
+
+  /**
+   * Computes the largest {@code targetAspectWidth:targetAspectHeight} rectangle that fits inside
+   * the original image, centered on the focal point, clamped so it never runs off-canvas.
+   *
+   * @param originalWidth the original image's width in pixels
+   * @param originalHeight the original image's height in pixels
+   * @param focalXPercent the focal point's horizontal position, 0-100
+   * @param focalYPercent the focal point's vertical position, 0-100
+   * @param targetAspectWidth the crop's target aspect ratio width (e.g. 1 for a square)
+   * @param targetAspectHeight the crop's target aspect ratio height (e.g. 1 for a square)
+   * @return the crop rectangle, always fully contained within the original image's bounds
+   */
+  public static Rectangle computeCropRect(int originalWidth, int originalHeight,
+      BigDecimal focalXPercent, BigDecimal focalYPercent,
+      int targetAspectWidth, int targetAspectHeight) {
+
+    if (originalWidth <= 0 || originalHeight <= 0) {
+      throw new IllegalArgumentException("originalWidth/originalHeight must be positive");
+    }
+    if (targetAspectWidth <= 0 || targetAspectHeight <= 0) {
+      throw new IllegalArgumentException("targetAspectWidth/targetAspectHeight must be positive");
+    }
+
+    // Defensive clamp -- this is a pure function and must not trust its caller blindly, even
+    // though the DB column is already constrained by app-layer validation on write.
+    double fx = clampPercent(focalXPercent);
+    double fy = clampPercent(focalYPercent);
+
+    double originalAspect = (double) originalWidth / originalHeight;
+    double targetAspect = (double) targetAspectWidth / targetAspectHeight;
+
+    int cropWidth;
+    int cropHeight;
+    if (originalAspect > targetAspect) {
+      // Original is relatively wider than the target -- crop the full height, narrow the width.
+      cropHeight = originalHeight;
+      cropWidth = (int) Math.round(originalHeight * targetAspect);
+    } else {
+      // Original is relatively taller than (or exactly as wide as) the target -- crop the full
+      // width, shorten the height.
+      cropWidth = originalWidth;
+      cropHeight = (int) Math.round(originalWidth / targetAspect);
+    }
+    // Defensive clamp: exact arithmetic guarantees these never exceed the original's dimensions in
+    // the branch that computed them, but rounding is what actually ran -- this removes any doubt
+    // and guarantees the crop rectangle always fits inside the original.
+    cropWidth = Math.max(1, Math.min(cropWidth, originalWidth));
+    cropHeight = Math.max(1, Math.min(cropHeight, originalHeight));
+
+    // Where the focal point lands in absolute pixel coordinates on the original.
+    double focalPixelX = fx / 100.0 * originalWidth;
+    double focalPixelY = fy / 100.0 * originalHeight;
+
+    // Center the crop rectangle on the focal pixel...
+    int idealX = (int) Math.round(focalPixelX - cropWidth / 2.0);
+    int idealY = (int) Math.round(focalPixelY - cropHeight / 2.0);
+
+    // ...then clamp the top-left corner so the rectangle never runs off-canvas. Because
+    // cropWidth <= originalWidth and cropHeight <= originalHeight (guaranteed above),
+    // [0, originalWidth - cropWidth] and [0, originalHeight - cropHeight] are always valid,
+    // non-inverted ranges -- a solution always exists, no matter how close the focal point is to
+    // an edge. (Near an edge, the subject ends up as close to the rectangle's center as
+    // geometrically possible, not exactly centered -- there is no way to do better without padding
+    // pixels that don't exist, which a plain crop can't do.)
+    int x = Math.max(0, Math.min(idealX, originalWidth - cropWidth));
+    int y = Math.max(0, Math.min(idealY, originalHeight - cropHeight));
+
+    return new Rectangle(x, y, cropWidth, cropHeight);
+  }
+
+  private static double clampPercent(BigDecimal percent) {
+    if (percent == null) {
+      return 50.0;
+    }
+    return Math.max(0.0, Math.min(100.0, percent.doubleValue()));
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommand.java
@@ -17,6 +17,7 @@
 package com.simisinc.platform.application.cms;
 
 import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,6 +60,11 @@ public class GenerateImageVariantsCommand {
   public static final String THUMBNAIL = "thumbnail";
   public static final String MEDIUM = "medium";
   public static final String LARGE = "large";
+  public static final String SQUARE = "square";
+
+  // A card-thumbnail-ish size; nothing consumes this variant at a specific size yet, so it's an
+  // easy constant to retune once more callers exist.
+  private static final int SQUARE_DIMENSION = 400;
 
   /** Max dimension (the longer side) each variant is resized to fit within, aspect-preserved. */
   private static final Map<String, Integer> VARIANT_MAX_DIMENSION = new LinkedHashMap<>();
@@ -128,26 +134,11 @@ public class GenerateImageVariantsCommand {
 
   private static ImageVariant generateOneVariant(Image image, File originalFile, String variantType, int maxDimension)
       throws Exception {
-    String extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(image.getFilename()));
-    String relativeDir = FilenameUtils.getFullPath(image.getFileServerPath());
-    String baseName = FilenameUtils.getBaseName(image.getFileServerPath());
-    String relativeVariantPath = relativeDir + baseName + "-" + variantType
-        + (extension.isEmpty() ? "" : "." + extension);
-
-    String serverRootPath = FileSystemCommand.getFileServerRootPath();
-    File variantFile = FileSystemCommand.resolveWithinRoot(serverRootPath, relativeVariantPath);
-    if (variantFile == null) {
-      LOG.warn("Could not resolve a safe variant path for image " + image.getId() + " (" + variantType + ")");
+    VariantPath variantPath = resolveVariantPath(image, variantType);
+    if (variantPath == null) {
       return null;
     }
-
-    // Re-check the image row still exists immediately before writing: this job runs
-    // asynchronously off the upload's critical path, so an admin can delete the image while a
-    // variant is still being generated. DeleteImageCommand only knows to clean up variant files
-    // that already had a row at the moment it ran -- writing a file for an image that's already
-    // gone would orphan it with no cleanup path.
-    if (ImageRepository.findById(image.getId()) == null) {
-      LOG.warn("Image was deleted before variant generation completed: " + image.getId() + " (" + variantType + ")");
+    if (!imageStillExists(image, variantType)) {
       return null;
     }
 
@@ -168,21 +159,129 @@ public class GenerateImageVariantsCommand {
     if ("image/gif".equals(image.getFileType())) {
       op.layers("optimize");
     }
-    op.addImage(variantFile.getAbsolutePath());
+    op.addImage(variantPath.file().getAbsolutePath());
     convert.run(op);
 
-    if (!variantFile.isFile() || variantFile.length() <= 0) {
+    return finalizeVariant(image, variantType, variantPath);
+  }
+
+  /**
+   * Generates a square variant cropped around the image's stored focal point (issue #411 PR3),
+   * instead of the aspect-preserving resize {@link #generateVariants} produces. Meant to be called
+   * on demand when an admin sets or changes a focal point ({@code FocalPointVariantJob}), not as
+   * part of the upload-time {@link #generateVariants} sweep -- thumbnail/medium/large are
+   * unaffected by focal point, so regenerating them on a focal-point-only change would be wasted
+   * work.
+   *
+   * @param image a previously-saved image record with its focal point already persisted
+   * @return the generated variant, or {@code null} when the image's format is unsupported, the
+   *         original file is missing, or generation failed
+   */
+  public static ImageVariant generateSquareVariant(Image image) {
+    if (image == null || image.getId() == null || image.getId() == -1) {
+      return null;
+    }
+    if (!SUPPORTED_MIME_TYPES.contains(image.getFileType())) {
+      LOG.debug("Skipping square variant generation for unsupported type: " + image.getFileType());
+      return null;
+    }
+
+    String serverRootPath = FileSystemCommand.getFileServerRootPath();
+    File originalFile = FileSystemCommand.resolveWithinRoot(serverRootPath, image.getFileServerPath());
+    if (originalFile == null || !originalFile.isFile()) {
+      LOG.warn("Original image file not found for square variant generation: " + image.getId());
+      return null;
+    }
+
+    try {
+      return generateOneFocalPointVariant(image, originalFile, SQUARE, 1, 1, SQUARE_DIMENSION);
+    } catch (Exception e) {
+      LOG.error("Could not generate the square variant for image " + image.getId(), e);
+      return null;
+    }
+  }
+
+  private static ImageVariant generateOneFocalPointVariant(Image image, File originalFile, String variantType,
+      int targetAspectWidth, int targetAspectHeight, int maxOutputDimension) throws Exception {
+    VariantPath variantPath = resolveVariantPath(image, variantType);
+    if (variantPath == null) {
+      return null;
+    }
+    if (!imageStillExists(image, variantType)) {
+      return null;
+    }
+
+    Rectangle cropRect = FocalPointCropCommand.computeCropRect(
+        image.getWidth(), image.getHeight(), image.getFocalX(), image.getFocalY(),
+        targetAspectWidth, targetAspectHeight);
+
+    ConvertCmd convert = new ConvertCmd();
+    IMOperation op = new IMOperation();
+    op.addImage(originalFile.getAbsolutePath());
+    if ("image/gif".equals(image.getFileType())) {
+      op.coalesce();
+    }
+    // Crop first -- it's the only operation of the two that changes aspect ratio. Never call
+    // .gravity(...) with a non-default value here: it would change the coordinate origin this
+    // crop's (x,y) is measured from, silently shifting the rectangle FocalPointCropCommand just
+    // computed.
+    op.crop(cropRect.width, cropRect.height, cropRect.x, cropRect.y);
+    // "!" forces the exact final pixel size (removing any rounding slop from the crop step), never
+    // upscaling past what the crop actually contains.
+    int outputDimension = Math.min(maxOutputDimension, cropRect.width);
+    op.resize(outputDimension, outputDimension, "!");
+    if ("image/gif".equals(image.getFileType())) {
+      op.layers("optimize");
+    }
+    op.addImage(variantPath.file().getAbsolutePath());
+    convert.run(op);
+
+    return finalizeVariant(image, variantType, variantPath);
+  }
+
+  private static VariantPath resolveVariantPath(Image image, String variantType) {
+    String extension = FileSystemCommand.cleanExtension(FilenameUtils.getExtension(image.getFilename()));
+    String relativeDir = FilenameUtils.getFullPath(image.getFileServerPath());
+    String baseName = FilenameUtils.getBaseName(image.getFileServerPath());
+    String relativeVariantPath = relativeDir + baseName + "-" + variantType
+        + (extension.isEmpty() ? "" : "." + extension);
+
+    String serverRootPath = FileSystemCommand.getFileServerRootPath();
+    File variantFile = FileSystemCommand.resolveWithinRoot(serverRootPath, relativeVariantPath);
+    if (variantFile == null) {
+      LOG.warn("Could not resolve a safe variant path for image " + image.getId() + " (" + variantType + ")");
+      return null;
+    }
+    return new VariantPath(variantFile, relativeVariantPath);
+  }
+
+  private static boolean imageStillExists(Image image, String variantType) {
+    // Re-check the image row still exists immediately before writing: this job runs
+    // asynchronously off the upload's critical path, so an admin can delete the image while a
+    // variant is still being generated. DeleteImageCommand only knows to clean up variant files
+    // that already had a row at the moment it ran -- writing a file for an image that's already
+    // gone would orphan it with no cleanup path.
+    if (ImageRepository.findById(image.getId()) == null) {
+      LOG.warn("Image was deleted before variant generation completed: " + image.getId() + " (" + variantType + ")");
+      return false;
+    }
+    return true;
+  }
+
+  private static ImageVariant finalizeVariant(Image image, String variantType, VariantPath variantPath)
+      throws IOException {
+    if (!variantPath.file().isFile() || variantPath.file().length() <= 0) {
       LOG.warn("Variant file was not written for image " + image.getId() + " (" + variantType + ")");
       return null;
     }
 
-    Dimension dimension = readDimension(variantFile);
+    Dimension dimension = readDimension(variantPath.file());
 
     ImageVariant record = new ImageVariant();
     record.setImageId(image.getId());
     record.setVariantType(variantType);
-    record.setFileServerPath(relativeVariantPath);
-    record.setFileLength(variantFile.length());
+    record.setFileServerPath(variantPath.relativePath());
+    record.setFileLength(variantPath.file().length());
     record.setFileType(image.getFileType());
     record.setWidth(dimension.width);
     record.setHeight(dimension.height);
@@ -191,5 +290,8 @@ public class GenerateImageVariantsCommand {
 
   private static Dimension readDimension(File imageFile) throws IOException {
     return ImageDimensionCommand.readDimension(imageFile);
+  }
+
+  private record VariantPath(File file, String relativePath) {
   }
 }

--- a/src/main/java/com/simisinc/platform/domain/model/cms/Image.java
+++ b/src/main/java/com/simisinc/platform/domain/model/cms/Image.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.domain.model.cms;
 
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -41,6 +42,8 @@ public class Image extends Entity {
   private String webPath = null;
   private int width = -1;
   private int height = -1;
+  private BigDecimal focalX = new BigDecimal("50.00");
+  private BigDecimal focalY = new BigDecimal("50.00");
 
   public Image() {
   }
@@ -123,6 +126,22 @@ public class Image extends Entity {
 
   public void setHeight(int height) {
     this.height = height;
+  }
+
+  public BigDecimal getFocalX() {
+    return focalX;
+  }
+
+  public void setFocalX(BigDecimal focalX) {
+    this.focalX = focalX;
+  }
+
+  public BigDecimal getFocalY() {
+    return focalY;
+  }
+
+  public void setFocalY(BigDecimal focalY) {
+    this.focalY = focalY;
   }
 
   public String getWebPath() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ImageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/ImageRepository.java
@@ -113,7 +113,9 @@ public class ImageRepository {
         .add("file_length", record.getFileLength())
         .add("file_type", record.getFileType())
         .add("width", record.getWidth())
-        .add("height", record.getHeight());
+        .add("height", record.getHeight())
+        .add("focal_x", record.getFocalX())
+        .add("focal_y", record.getFocalY());
     record.setId(DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY));
     if (record.getId() == -1) {
       LOG.error("An id was not set!");
@@ -124,7 +126,16 @@ public class ImageRepository {
 
   private static Image update(Image record) {
     SqlUtils updateValues = new SqlUtils()
-        .add("processed", record.getProcessed());
+        .add("filename", StringUtils.trimToNull(record.getFilename()))
+        .add("path", StringUtils.trimToNull(record.getFileServerPath()))
+        .add("web_path", StringUtils.trimToNull(record.getWebPath()))
+        .add("file_length", record.getFileLength())
+        .add("file_type", record.getFileType())
+        .add("width", record.getWidth())
+        .add("height", record.getHeight())
+        .add("processed", record.getProcessed())
+        .add("focal_x", record.getFocalX())
+        .add("focal_y", record.getFocalY());
     SqlUtils where = new SqlUtils()
         .add("image_id = ?", record.getId());
     if (DB.update(TABLE_NAME, updateValues, where)) {
@@ -160,6 +171,8 @@ public class ImageRepository {
       record.setWidth(rs.getInt("width"));
       record.setHeight(rs.getInt("height"));
       record.setWebPath(rs.getString("web_path"));
+      record.setFocalX(rs.getBigDecimal("focal_x"));
+      record.setFocalY(rs.getBigDecimal("focal_y"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/FocalPointVariantJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/FocalPointVariantJob.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.cms;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.jobs.lambdas.JobRequest;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+
+import com.simisinc.platform.application.cms.GenerateImageVariantsCommand;
+import com.simisinc.platform.domain.model.cms.Image;
+import com.simisinc.platform.domain.model.cms.ImageVariant;
+import com.simisinc.platform.infrastructure.persistence.cms.ImageRepository;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Regenerates an image's focal-point-dependent square variant in the background, off the admin
+ * request's critical path (issue #411 PR3). Enqueued from {@code AdminImageBrowserWidget} whenever
+ * an admin sets or changes an image's focal point.
+ *
+ * <p>
+ * Deliberately separate from {@code ImageVariantJob}: thumbnail/medium/large are aspect-preserving
+ * resizes unaffected by focal point, so a focal-point-only change only needs the square variant
+ * regenerated, not all four.
+ * </p>
+ *
+ * @author SimIS Inc.
+ */
+@NoArgsConstructor
+public class FocalPointVariantJob implements JobRequest {
+
+  private static final Log LOG = LogFactory.getLog(FocalPointVariantJob.class);
+
+  @Getter
+  @Setter
+  private long imageId = -1;
+
+  public FocalPointVariantJob(long imageId) {
+    this.imageId = imageId;
+  }
+
+  @Override
+  public Class<FocalPointVariantJobRequestHandler> getJobRequestHandler() {
+    return FocalPointVariantJobRequestHandler.class;
+  }
+
+  public static class FocalPointVariantJobRequestHandler implements JobRequestHandler<FocalPointVariantJob> {
+    @Override
+    @Job(name = "Generate focal-point image variant", retries = 1)
+    public void run(FocalPointVariantJob jobRequest) {
+      Image image = ImageRepository.findById(jobRequest.getImageId());
+      if (image == null) {
+        LOG.error("Image not found: " + jobRequest.getImageId());
+        return;
+      }
+
+      ImageVariant variant = GenerateImageVariantsCommand.generateSquareVariant(image);
+      LOG.info((variant != null ? "Generated" : "Skipped") + " the square variant for image " + image.getId());
+      // Deliberately does not touch images.processed here -- that column's documented meaning is
+      // "initial upload processing finished" (see ImageVariantJob), not "some variant was
+      // regenerated." A focal-point change re-triggering this job must not resurrect that
+      // unrelated signal.
+    }
+  }
+}

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidget.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.presentation.widgets.admin.cms;
 
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jobrunr.scheduling.BackgroundJobRequest;
 
 import com.simisinc.platform.application.cms.DeleteImageCommand;
 import com.simisinc.platform.application.cms.ImageUsageCommand;
@@ -35,6 +37,7 @@ import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageVariantRepository;
+import com.simisinc.platform.infrastructure.scheduler.cms.FocalPointVariantJob;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
@@ -200,6 +203,8 @@ public class AdminImageBrowserWidget extends GenericWidget {
     String command = context.getParameter("command");
     if ("bulkDelete".equals(command)) {
       return bulkDeleteAction(context);
+    } else if ("setFocalPoint".equals(command)) {
+      return setFocalPointAction(context);
     }
     return context;
   }
@@ -250,6 +255,65 @@ public class AdminImageBrowserWidget extends GenericWidget {
     }
     context.setRedirect(redirectWithQuery(context));
     return context;
+  }
+
+  /**
+   * Sets an image's focal point (issue #411 PR3, see the focal-point modal in image-browser.jsp)
+   * and enqueues the background job that regenerates its focal-point-dependent square variant.
+   */
+  private WidgetContext setFocalPointAction(WidgetContext context) {
+    long imageId = context.getParameterAsLong("imageId", -1);
+    Image image = imageId > -1 ? ImageRepository.findById(imageId) : null;
+    if (image == null) {
+      context.setErrorMessage("Error. Image was not found.");
+      context.setRedirect(redirectWithQuery(context));
+      return context;
+    }
+
+    BigDecimal focalX = parsePercent(context.getParameter("focalX"));
+    BigDecimal focalY = parsePercent(context.getParameter("focalY"));
+    if (focalX == null || focalY == null) {
+      context.setErrorMessage("Error. The focal point values were not valid.");
+      context.setRedirect(redirectWithQuery(context));
+      return context;
+    }
+
+    image.setFocalX(focalX);
+    image.setFocalY(focalY);
+    boolean saved = ImageRepository.save(image) != null;
+    AuditEventCommand.record(context, AuditEventCommand.CONTENT, "image.setFocalPoint",
+        saved ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
+        "image", String.valueOf(image.getId()), image.getFilename(), null);
+    if (!saved) {
+      context.setErrorMessage("Error. The focal point could not be saved.");
+      context.setRedirect(redirectWithQuery(context));
+      return context;
+    }
+
+    BackgroundJobRequest.enqueue(new FocalPointVariantJob(image.getId()));
+    context.setSuccessMessage("Focal point saved");
+    context.setRedirect(redirectWithQuery(context));
+    return context;
+  }
+
+  /**
+   * Parses a 0-100 focal-point percentage, rejecting anything non-numeric or out of range rather
+   * than trusting the client-side picker's own clamping.
+   */
+  private static BigDecimal parsePercent(String raw) {
+    String trimmed = StringUtils.trimToNull(raw);
+    if (trimmed == null) {
+      return null;
+    }
+    try {
+      BigDecimal value = new BigDecimal(trimmed);
+      if (value.compareTo(BigDecimal.ZERO) < 0 || value.compareTo(new BigDecimal("100")) > 0) {
+        return null;
+      }
+      return value;
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   /**

--- a/src/main/resources/database/install/NEW_10010__new_cms.sql
+++ b/src/main/resources/database/install/NEW_10010__new_cms.sql
@@ -197,7 +197,13 @@ CREATE TABLE images (
   file_type VARCHAR(20),
   width INTEGER NOT NULL,
   height INTEGER NOT NULL,
-  web_path VARCHAR(50) NOT NULL
+  web_path VARCHAR(50) NOT NULL,
+  -- Focal point as a 0-100 percentage of width/height (issue #411 PR3), so a fixed-aspect crop can
+  -- center on the subject instead of blind-center-cropping. NOT NULL with a dead-center default so
+  -- every row is always valid with no null-handling anywhere downstream. See
+  -- UPGRADE_20260804.1901__image_focal_point.sql for existing databases.
+  focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00,
+  focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00
 );
 CREATE INDEX images_created_idx ON images(created);
 CREATE INDEX images_web_path_idx ON images(web_path);

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1901__image_focal_point.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260804.1901__image_focal_point.sql
@@ -1,0 +1,5 @@
+-- Issue #411 PR3: focal point as a 0-100 percentage of width/height, so a fixed-aspect crop can
+-- center on the subject instead of blind-center-cropping. Mirrors the images table change in
+-- NEW_10010__new_cms.sql exactly (install/ and upgrade/ must stay in sync).
+ALTER TABLE images ADD COLUMN IF NOT EXISTS focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00;
+ALTER TABLE images ADD COLUMN IF NOT EXISTS focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00;

--- a/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
@@ -75,6 +75,12 @@
             <small style="color: #999999"><fmt:formatDate pattern="yyyy-MM-dd" value="${image.created}" /></small><br />
             <small><a target="_blank" href="${ctx}/assets/img/${image.url}">Image Link</a></small><br />
             <small><span class="usage-badge label secondary" data-image-id="${image.id}">Checking usage&hellip;</span></small><br />
+            <button type="button" class="setFocalPointBtn button tiny secondary radius margin-top-5"
+                    data-id="${image.id}" data-filename="${fn:escapeXml(image.filename)}"
+                    data-url="${ctx}/assets/img/${image.url}"
+                    data-focal-x="<c:out value="${image.focalX}"/>" data-focal-y="<c:out value="${image.focalY}"/>">
+              <i class="fa fa-crosshairs"></i> Focal Point
+            </button>
             <button type="button" class="deleteImageBtn button tiny alert radius margin-top-5"
                     data-id="${image.id}" data-filename="${fn:escapeXml(image.filename)}">
               <i class="fa fa-remove"></i> Delete
@@ -101,6 +107,42 @@
     <input type="hidden" name="token" value="${userSession.formToken}"/>
     <input type="hidden" name="command" value="bulkDelete"/>
     <input type="submit" class="button alert radius" value="Delete Images"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<%-- Focal point picker (issue #411 PR3) -- lets an admin mark where an image's subject is, so a
+     server-generated square crop can center on it instead of a blind center crop. Populated fresh
+     at open time from the clicked card's data-* attributes, same shared-modal shape as
+     bulkDeleteReveal above. --%>
+<div class="reveal large" id="focalPointReveal" role="dialog" aria-modal="true"
+     aria-labelledby="focalPointRevealTitle" data-reveal data-close-on-click="true">
+  <h4 id="focalPointRevealTitle">Set Focal Point</h4>
+  <p>Click the image where the subject is, so a future square crop keeps it in frame.</p>
+  <div id="focalPointImageWrap" style="position:relative; display:inline-block; max-width:100%;">
+    <img id="focalPointImage" src="" alt="" style="display:block; max-width:100%; height:auto; cursor:crosshair;">
+    <div id="focalPointMarker" style="position:absolute; width:20px; height:20px; margin:-10px 0 0 -10px;
+         border:2px solid #fff; border-radius:50%; box-shadow:0 0 0 1px #000, 0 0 4px rgba(0,0,0,.6);
+         pointer-events:none; left:50%; top:50%;"></div>
+  </div>
+  <div class="grid-x grid-margin-x margin-top-10">
+    <div class="cell small-6">
+      <label>Horizontal <input type="range" id="focalXRange" min="0" max="100" step="1" value="50"></label>
+    </div>
+    <div class="cell small-6">
+      <label>Vertical <input type="range" id="focalYRange" min="0" max="100" step="1" value="50"></label>
+    </div>
+  </div>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="command" value="setFocalPoint"/>
+    <input type="hidden" name="imageId" id="focalPointImageId" value=""/>
+    <input type="hidden" name="focalX" id="focalXInput" value="50"/>
+    <input type="hidden" name="focalY" id="focalYInput" value="50"/>
+    <input type="submit" class="button radius" value="Save Focal Point"/>
     <button class="button secondary radius" type="button" data-close>Cancel</button>
   </form>
   <button class="close-button" data-close aria-label="Close reveal" type="button">
@@ -267,5 +309,52 @@
     }
 
     refresh();
+
+    // Focal point picker
+    var $focalReveal = $('#focalPointReveal');
+    var focalImg = document.getElementById('focalPointImage');
+    var focalMarker = document.getElementById('focalPointMarker');
+    var focalXRange = document.getElementById('focalXRange');
+    var focalYRange = document.getElementById('focalYRange');
+    var focalXInput = document.getElementById('focalXInput');
+    var focalYInput = document.getElementById('focalYInput');
+    var focalImageIdInput = document.getElementById('focalPointImageId');
+
+    function setFocalMarker(px, py) {
+      px = Math.max(0, Math.min(100, px));
+      py = Math.max(0, Math.min(100, py));
+      focalMarker.style.left = px + '%';
+      focalMarker.style.top = py + '%';
+      focalXRange.value = Math.round(px);
+      focalYRange.value = Math.round(py);
+      focalXInput.value = px.toFixed(2);
+      focalYInput.value = py.toFixed(2);
+    }
+
+    document.querySelectorAll('.setFocalPointBtn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        focalImageIdInput.value = btn.getAttribute('data-id');
+        focalImg.src = btn.getAttribute('data-url');
+        setFocalMarker(parseFloat(btn.getAttribute('data-focal-x')) || 50,
+                       parseFloat(btn.getAttribute('data-focal-y')) || 50);
+        $focalReveal.foundation('open');
+      });
+    });
+
+    // getBoundingClientRect() + clientX/clientY, not offsetX/offsetY -- the marker div overlaps
+    // the image, and offsetX/offsetY are relative to whatever element the browser decided was the
+    // actual click target (mitigated by pointer-events:none on the marker regardless, but this is
+    // the more standard, target-independent technique).
+    focalImg.addEventListener('click', function (e) {
+      var rect = focalImg.getBoundingClientRect();
+      setFocalMarker(((e.clientX - rect.left) / rect.width) * 100,
+                     ((e.clientY - rect.top) / rect.height) * 100);
+    });
+
+    [focalXRange, focalYRange].forEach(function (range) {
+      range.addEventListener('input', function () {
+        setFocalMarker(parseFloat(focalXRange.value), parseFloat(focalYRange.value));
+      });
+    });
   })();
 </script>

--- a/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
@@ -334,7 +334,13 @@
     document.querySelectorAll('.setFocalPointBtn').forEach(function (btn) {
       btn.addEventListener('click', function () {
         focalImageIdInput.value = btn.getAttribute('data-id');
-        focalImg.src = btn.getAttribute('data-url');
+        // Image.getUrl() (server-side) always produces webPath + "-" + id + "/" + an
+        // application/x-www-form-urlencoded filename, so this can only ever contain the
+        // characters below; reject anything else before it reaches an HTML-interpreting sink.
+        var dataUrl = btn.getAttribute('data-url');
+        if (/^[\w./%!'()~-]+$/.test(dataUrl)) {
+          focalImg.src = dataUrl;
+        }
         setFocalMarker(parseFloat(btn.getAttribute('data-focal-x')) || 50,
                        parseFloat(btn.getAttribute('data-focal-y')) || 50);
         $focalReveal.foundation('open');

--- a/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
@@ -73,11 +73,11 @@
             <small style="color: #999999">${image.width}x${image.height}</small>
             <small style="color: #999999"><c:out value="${number:suffix(image.fileLength)}"/></small><br />
             <small style="color: #999999"><fmt:formatDate pattern="yyyy-MM-dd" value="${image.created}" /></small><br />
-            <small><a target="_blank" href="${ctx}/assets/img/${image.url}">Image Link</a></small><br />
+            <small><a target="_blank" href="${ctx}/assets/img/${fn:escapeXml(image.url)}">Image Link</a></small><br />
             <small><span class="usage-badge label secondary" data-image-id="${image.id}">Checking usage&hellip;</span></small><br />
             <button type="button" class="setFocalPointBtn button tiny secondary radius margin-top-5"
                     data-id="${image.id}" data-filename="${fn:escapeXml(image.filename)}"
-                    data-url="${ctx}/assets/img/${image.url}"
+                    data-url="${ctx}/assets/img/${fn:escapeXml(image.url)}"
                     data-focal-x="<c:out value="${image.focalX}"/>" data-focal-y="<c:out value="${image.focalY}"/>">
               <i class="fa fa-crosshairs"></i> Focal Point
             </button>

--- a/src/main/webapp/WEB-INF/jsp/ecommerce/product-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/ecommerce/product-browser.jsp
@@ -43,6 +43,17 @@
                 <c:if test="${not empty productImageSrcset}"> srcset="<c:out value="${productImageSrcset}"/>" sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 50vw"</c:if>
                 decoding="async" loading="lazy" /></a>
             </c:when>
+            <c:when test="${!empty product.imageUrl && !empty cardImageClass}">
+              <%-- cardImageClass forces a fixed-aspect CSS crop (object-fit: cover) -- request the
+                   focal-point-aware square variant directly and skip the width-breakpoint srcset
+                   entirely (issue #411 PR3). A srcset's candidates must all be the same crop, only
+                   the resolution may vary; mixing in a differently-cropped square variant would let
+                   the browser silently shift what's visible depending on which candidate a given
+                   viewport resolves to. StreamImageWidget falls back to the original when no square
+                   variant exists yet, so this degrades gracefully for any image without one. --%>
+              <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>?variant=square"
+                decoding="async" loading="lazy" /></a>
+            </c:when>
             <c:when test="${!empty product.imageUrl}">
               <c:set var="productImageSrcset" value="${image:srcsetBatch(product.imageUrl, imageVariantsByImageId)}"/>
               <a href="${ctx}<c:out value="${product.productUrl}"/>"><img alt="product image" src="<c:out value="${product.imageUrl}"/>"

--- a/src/test/java/com/simisinc/platform/application/cms/DeleteImageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/DeleteImageCommandTest.java
@@ -328,7 +328,9 @@ class DeleteImageCommandTest {
           + "file_type VARCHAR(20), "
           + "width INTEGER NOT NULL, "
           + "height INTEGER NOT NULL, "
-          + "web_path VARCHAR(50) NOT NULL)");
+          + "web_path VARCHAR(50) NOT NULL, "
+          + "focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00, "
+          + "focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00)");
       statement.execute("CREATE TABLE image_variants ("
           + "image_variant_id BIGSERIAL PRIMARY KEY, "
           + "image_id BIGINT NOT NULL REFERENCES images(image_id) ON DELETE CASCADE, "

--- a/src/test/java/com/simisinc/platform/application/cms/FocalPointCropCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/FocalPointCropCommandTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.Rectangle;
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+class FocalPointCropCommandTest {
+
+  private static final BigDecimal CENTER = new BigDecimal("50");
+
+  @Test
+  void squareCropOnAWideOriginalCenteredOnAFocalPointInTheMiddleIsHorizontallyCentered() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(1000, 500, CENTER, CENTER, 1, 1);
+    assertEquals(new Rectangle(250, 0, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnAWideOriginalClampsToTheLeftEdgeWhenTheFocalPointIsNearIt() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(1000, 500, new BigDecimal("5"), CENTER, 1, 1);
+    assertEquals(new Rectangle(0, 0, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnAWideOriginalClampsToTheRightEdgeWhenTheFocalPointIsNearIt() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(1000, 500, new BigDecimal("95"), CENTER, 1, 1);
+    assertEquals(new Rectangle(500, 0, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnATallOriginalCenteredOnAFocalPointInTheMiddleIsVerticallyCentered() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(500, 1000, CENTER, CENTER, 1, 1);
+    assertEquals(new Rectangle(0, 250, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnATallOriginalClampsToTheTopEdgeWhenTheFocalPointIsNearIt() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(500, 1000, CENTER, new BigDecimal("5"), 1, 1);
+    assertEquals(new Rectangle(0, 0, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnATallOriginalClampsToTheBottomEdgeWhenTheFocalPointIsNearIt() {
+    Rectangle rect = FocalPointCropCommand.computeCropRect(500, 1000, CENTER, new BigDecimal("95"), 1, 1);
+    assertEquals(new Rectangle(0, 500, 500, 500), rect);
+  }
+
+  @Test
+  void squareCropOnAnAlreadySquareOriginalIsTheFullImageRegardlessOfFocalPoint() {
+    // cropWidth == cropHeight == originalWidth == originalHeight here, so the valid clamp range
+    // collapses to a single point (0,0) no matter where the focal point sits.
+    Rectangle centered = FocalPointCropCommand.computeCropRect(600, 600, CENTER, CENTER, 1, 1);
+    Rectangle cornered = FocalPointCropCommand.computeCropRect(600, 600, new BigDecimal("2"), new BigDecimal("98"), 1, 1);
+
+    assertEquals(new Rectangle(0, 0, 600, 600), centered);
+    assertEquals(new Rectangle(0, 0, 600, 600), cornered);
+  }
+
+  @Test
+  void nonSquareTargetAspectRatioIsSizedAndCenteredCorrectly() {
+    // A 16:9 crop out of a very tall, narrow original: the full width is used (400), height is
+    // 400 * 9/16 = 225 exactly. Centering on the vertical midpoint (focal y = 500 of 1000) puts the
+    // crop's top at 500 - 225/2 = 387.5, which rounds up to 388.
+    Rectangle rect = FocalPointCropCommand.computeCropRect(400, 1000, CENTER, CENTER, 16, 9);
+    assertEquals(new Rectangle(0, 388, 400, 225), rect);
+  }
+
+  @Test
+  void aNullFocalPointDefaultsToDeadCenter() {
+    Rectangle withNull = FocalPointCropCommand.computeCropRect(1000, 500, null, null, 1, 1);
+    Rectangle withExplicitCenter = FocalPointCropCommand.computeCropRect(1000, 500, CENTER, CENTER, 1, 1);
+    assertEquals(withExplicitCenter, withNull);
+  }
+
+  @Test
+  void anOutOfRangeFocalPointIsClampedDefensivelyRatherThanTrustedBlindly() {
+    // computeCropRect is a pure function that must not assume its caller already validated -- even
+    // though the DB column and the admin action both already constrain focal_x/focal_y to [0, 100].
+    Rectangle negative = FocalPointCropCommand.computeCropRect(1000, 500, new BigDecimal("-10"), CENTER, 1, 1);
+    Rectangle atZero = FocalPointCropCommand.computeCropRect(1000, 500, BigDecimal.ZERO, CENTER, 1, 1);
+    Rectangle over100 = FocalPointCropCommand.computeCropRect(1000, 500, new BigDecimal("150"), CENTER, 1, 1);
+    Rectangle at100 = FocalPointCropCommand.computeCropRect(1000, 500, new BigDecimal("100"), CENTER, 1, 1);
+
+    assertEquals(atZero, negative);
+    assertEquals(at100, over100);
+  }
+
+  @Test
+  void rejectsNonPositiveOriginalDimensions() {
+    assertThrows(IllegalArgumentException.class,
+        () -> FocalPointCropCommand.computeCropRect(0, 500, CENTER, CENTER, 1, 1));
+    assertThrows(IllegalArgumentException.class,
+        () -> FocalPointCropCommand.computeCropRect(500, -1, CENTER, CENTER, 1, 1));
+  }
+
+  @Test
+  void rejectsNonPositiveTargetAspectRatio() {
+    assertThrows(IllegalArgumentException.class,
+        () -> FocalPointCropCommand.computeCropRect(500, 500, CENTER, CENTER, 0, 1));
+    assertThrows(IllegalArgumentException.class,
+        () -> FocalPointCropCommand.computeCropRect(500, 500, CENTER, CENTER, 1, -1));
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/GenerateImageVariantsCommandTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mockStatic;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -305,6 +306,73 @@ class GenerateImageVariantsCommandTest {
     assertEquals(600, byType.get("medium").getHeight());
   }
 
+  @Test
+  void generateSquareVariantCropsAroundTheStoredFocalPointAndProducesASquareFile(@TempDir Path tempDir) throws Exception {
+    // A wide 2000x1000 original with a focal point near the right edge -- the exact crop offset is
+    // covered by FocalPointCropCommandTest; this only needs to prove the wiring produces a real,
+    // square, persisted variant using the image's own stored focal point.
+    Image image = insertImageWithRealFile(tempDir, "wide-original.png", 2000, 1000);
+    image.setFocalX(new BigDecimal("90"));
+    image.setFocalY(new BigDecimal("50"));
+    ImageRepository.save(image);
+
+    ImageVariant variant = withStubbedRoot(tempDir, () -> GenerateImageVariantsCommand.generateSquareVariant(image));
+
+    assertEquals("square", variant.getVariantType());
+    assertEquals(400, variant.getWidth());
+    assertEquals(400, variant.getHeight());
+    File variantFile = tempDir.resolve(variant.getFileServerPath()).toFile();
+    assertTrue(variantFile.isFile(), "the cropped file must actually exist on disk");
+    ImageVariant persisted = ImageVariantRepository.findByImageIdAndVariantType(image.getId(), "square");
+    assertEquals(variant.getId(), persisted.getId());
+  }
+
+  @Test
+  void generateSquareVariantReturnsNullForAnUnsupportedFileType(@TempDir Path tempDir) throws Exception {
+    Image image = insertImageWithRealFile(tempDir, "vector.svg", 2000, 1500);
+    image.setFileType("image/svg+xml");
+
+    ImageVariant variant = withStubbedRoot(tempDir, () -> GenerateImageVariantsCommand.generateSquareVariant(image));
+
+    assertNull(variant, "SVG is resolution-independent and must not be rasterized into a square variant");
+  }
+
+  @Test
+  void generateSquareVariantReturnsNullWhenTheOriginalFileIsMissing(@TempDir Path tempDir) throws Exception {
+    Image image = new Image();
+    image.setFilename("gone.png");
+    image.setFileServerPath("images/2026/08/gone.png");
+    image.setCreatedBy(userId);
+    image.setFileLength(1000);
+    image.setFileType("image/png");
+    image.setWidth(2000);
+    image.setHeight(1500);
+    image.setWebPath("20260804120100");
+    Image saved = ImageRepository.save(image);
+
+    ImageVariant variant = withStubbedRoot(tempDir, () -> GenerateImageVariantsCommand.generateSquareVariant(saved));
+
+    assertNull(variant);
+  }
+
+  @Test
+  void generateSquareVariantOnANullOrUnsavedImageReturnsNullWithoutThrowing() {
+    assertNull(GenerateImageVariantsCommand.generateSquareVariant(null));
+    assertNull(GenerateImageVariantsCommand.generateSquareVariant(new Image()));
+  }
+
+  @Test
+  void generateSquareVariantSkipsWritingOnceTheImageRowIsGone(@TempDir Path tempDir) throws Exception {
+    Image image = insertImageWithRealFile(tempDir, "wide-original.png", 2000, 1000);
+    assertTrue(ImageRepository.remove(image), "test setup: could not remove the image row");
+
+    ImageVariant variant = withStubbedRoot(tempDir, () -> GenerateImageVariantsCommand.generateSquareVariant(image));
+
+    assertNull(variant, "must not generate or persist a variant once the image row is gone");
+    File expectedSquareFile = tempDir.resolve("images/2026/08/wide-original-square.png").toFile();
+    assertTrue(!expectedSquareFile.exists(), "must not have written a variant file for a deleted image");
+  }
+
   private static Image insertImageWithRealWebpFile(Path tempDir, String filename, int width, int height)
       throws Exception {
     String relativePath = "images/2026/08/" + filename;
@@ -457,7 +525,9 @@ class GenerateImageVariantsCommandTest {
           + "processed_file_type VARCHAR(20), "
           + "processed_width INTEGER NOT NULL DEFAULT 0, "
           + "processed_height INTEGER NOT NULL DEFAULT 0, "
-          + "web_path VARCHAR(50) NOT NULL)");
+          + "web_path VARCHAR(50) NOT NULL, "
+          + "focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00, "
+          + "focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00)");
       statement.execute("CREATE TABLE image_variants ("
           + "image_variant_id BIGSERIAL PRIMARY KEY, "
           + "image_id BIGINT NOT NULL REFERENCES images(image_id) ON DELETE CASCADE, "

--- a/src/test/java/com/simisinc/platform/application/cms/ImageUsageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ImageUsageCommandTest.java
@@ -223,7 +223,9 @@ class ImageUsageCommandTest {
           + "file_type VARCHAR(20), "
           + "width INTEGER NOT NULL, "
           + "height INTEGER NOT NULL, "
-          + "web_path VARCHAR(50) NOT NULL)");
+          + "web_path VARCHAR(50) NOT NULL, "
+          + "focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00, "
+          + "focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00)");
       // A focused subset of web_pages -- just link + page_image_url, the only columns this scan reads.
       statement.execute("CREATE TABLE web_pages ("
           + "web_page_id BIGSERIAL PRIMARY KEY, "

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ImageRepositorySearchTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ImageRepositorySearchTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -58,6 +59,11 @@ import com.simisinc.platform.infrastructure.database.DataSource;
  * findAll(null, constraints)} path and the search-filtered {@code findAll(specification,
  * constraints)} path, and a page number past the last page must degrade to an empty list rather
  * than error.
+ *
+ * <p>Also verifies the {@code focal_x}/{@code focal_y} columns added for issue #411 PR3: a new
+ * image defaults to a dead-center focal point, and {@link ImageRepository#save} actually persists a
+ * focal-point change on an existing row (previously {@code update()} only ever wrote {@code
+ * processed}).
  *
  * @author SimIS Inc.
  */
@@ -266,6 +272,40 @@ class ImageRepositorySearchTest {
     assertTrue(results.isEmpty());
   }
 
+  @Test
+  void newlySavedImageDefaultsToADeadCenterFocalPoint() {
+    Image saved = ImageRepository.findAll().get(0);
+
+    assertEquals(0, new BigDecimal("50.00").compareTo(saved.getFocalX()),
+        "a freshly-inserted image must default to a dead-center focal point");
+    assertEquals(0, new BigDecimal("50.00").compareTo(saved.getFocalY()));
+  }
+
+  @Test
+  void updatePersistsFocalPointAndOtherMutableFieldsOnAnExistingRecord() {
+    // ImageRepository.update() used to only ever write the `processed` column -- a latent bug
+    // invisible until issue #411 PR3's "set focal point on an existing image" action became the
+    // first caller needing anything else to actually persist on an existing row.
+    Image image = new Image();
+    image.setFilename("focal-point-test.png");
+    image.setFileServerPath("2026/07/focal-point-test.png");
+    image.setCreatedBy(userId);
+    image.setFileLength(2048);
+    image.setFileType("image/png");
+    image.setWidth(200);
+    image.setHeight(200);
+    image.setWebPath("2026/07");
+    Image saved = ImageRepository.save(image);
+
+    saved.setFocalX(new BigDecimal("12.50"));
+    saved.setFocalY(new BigDecimal("87.25"));
+    ImageRepository.save(saved);
+
+    Image reloaded = ImageRepository.findById(saved.getId());
+    assertEquals(0, new BigDecimal("12.50").compareTo(reloaded.getFocalX()));
+    assertEquals(0, new BigDecimal("87.25").compareTo(reloaded.getFocalY()));
+  }
+
   /**
    * Builds paging constraints with an explicit, unique sort column (the primary key) instead of
    * relying on {@code ImageRepository.findAll}'s internal "created DESC" default -- the seed
@@ -314,7 +354,9 @@ class ImageRepositorySearchTest {
           + "file_type VARCHAR(20), "
           + "width INTEGER NOT NULL, "
           + "height INTEGER NOT NULL, "
-          + "web_path VARCHAR(50) NOT NULL)");
+          + "web_path VARCHAR(50) NOT NULL, "
+          + "focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00, "
+          + "focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the images/users schema", se);
     }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ImageVariantRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/ImageVariantRepositoryTest.java
@@ -325,7 +325,9 @@ class ImageVariantRepositoryTest {
           + "processed_file_type VARCHAR(20), "
           + "processed_width INTEGER NOT NULL DEFAULT 0, "
           + "processed_height INTEGER NOT NULL DEFAULT 0, "
-          + "web_path VARCHAR(50) NOT NULL)");
+          + "web_path VARCHAR(50) NOT NULL, "
+          + "focal_x NUMERIC(5,2) NOT NULL DEFAULT 50.00, "
+          + "focal_y NUMERIC(5,2) NOT NULL DEFAULT 50.00)");
       statement.execute("CREATE TABLE image_variants ("
           + "image_variant_id BIGSERIAL PRIMARY KEY, "
           + "image_id BIGINT NOT NULL REFERENCES images(image_id) ON DELETE CASCADE, "

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidgetTest.java
@@ -24,12 +24,15 @@ import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.ImageVariantRepository;
+import com.simisinc.platform.infrastructure.scheduler.cms.FocalPointVariantJob;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,9 +40,11 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -414,5 +419,130 @@ class AdminImageBrowserWidgetTest extends WidgetBase {
       deleteMockedStatic.verifyNoInteractions();
     }
     Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void setFocalPointWithAdminRoleSavesAndEnqueuesTheRegenerationJob() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    setRoles(widgetContext, ADMIN);
+    widgetContext.getParameterMap().put("command", new String[] { "setFocalPoint" });
+    addQueryParameter(widgetContext, "imageId", "42");
+    addQueryParameter(widgetContext, "focalX", "12.5");
+    addQueryParameter(widgetContext, "focalY", "87.25");
+
+    Image image = new Image();
+    image.setId(42L);
+    image.setFilename("hero.png");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class);
+        MockedStatic<AuditEventCommand> auditMockedStatic = mockStatic(AuditEventCommand.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findById(42L)).thenReturn(image);
+      imageRepositoryMockedStatic.when(() -> ImageRepository.save(image)).thenReturn(image);
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.post(widgetContext);
+
+      Assertions.assertEquals(0, new BigDecimal("12.5").compareTo(image.getFocalX()));
+      Assertions.assertEquals(0, new BigDecimal("87.25").compareTo(image.getFocalY()));
+      jobRequest.verify(() -> BackgroundJobRequest.enqueue(argThat((FocalPointVariantJob job) -> job.getImageId() == 42L)));
+      auditMockedStatic.verify(() -> AuditEventCommand.record(any(), any(), eq("image.setFocalPoint"),
+          any(), any(), any(), any(), any()));
+    }
+
+    Assertions.assertEquals("Focal point saved", widgetContext.getSuccessMessage());
+    Assertions.assertEquals("/admin/images", widgetContext.getRedirect());
+  }
+
+  @Test
+  void setFocalPointWithAnUnknownImageIdProducesAnErrorAndDoesNotEnqueue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    setRoles(widgetContext, ADMIN);
+    widgetContext.getParameterMap().put("command", new String[] { "setFocalPoint" });
+    addQueryParameter(widgetContext, "imageId", "999");
+    addQueryParameter(widgetContext, "focalX", "50");
+    addQueryParameter(widgetContext, "focalY", "50");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findById(999L)).thenReturn(null);
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.post(widgetContext);
+
+      jobRequest.verifyNoInteractions();
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.save(any()), never());
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void setFocalPointWithAnOutOfRangeValueProducesAnErrorAndDoesNotSaveOrEnqueue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    setRoles(widgetContext, ADMIN);
+    widgetContext.getParameterMap().put("command", new String[] { "setFocalPoint" });
+    addQueryParameter(widgetContext, "imageId", "42");
+    addQueryParameter(widgetContext, "focalX", "150");
+    addQueryParameter(widgetContext, "focalY", "50");
+
+    Image image = new Image();
+    image.setId(42L);
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findById(42L)).thenReturn(image);
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.post(widgetContext);
+
+      jobRequest.verifyNoInteractions();
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.save(any()), never());
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void setFocalPointWithANonNumericValueProducesAnErrorAndDoesNotSaveOrEnqueue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    setRoles(widgetContext, ADMIN);
+    widgetContext.getParameterMap().put("command", new String[] { "setFocalPoint" });
+    addQueryParameter(widgetContext, "imageId", "42");
+    addQueryParameter(widgetContext, "focalX", "not-a-number");
+    addQueryParameter(widgetContext, "focalY", "50");
+
+    Image image = new Image();
+    image.setId(42L);
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class);
+        MockedStatic<BackgroundJobRequest> jobRequest = mockStatic(BackgroundJobRequest.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findById(42L)).thenReturn(image);
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.post(widgetContext);
+
+      jobRequest.verifyNoInteractions();
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.save(any()), never());
+    }
+
+    Assertions.assertNotNull(widgetContext.getErrorMessage());
+  }
+
+  @Test
+  void setFocalPointWithoutPermissionNeverTouchesTheRepository() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    // Default logged-in test user has no roles at all -- neither admin nor content-manager
+    widgetContext.getParameterMap().put("command", new String[] { "setFocalPoint" });
+    addQueryParameter(widgetContext, "imageId", "42");
+    addQueryParameter(widgetContext, "focalX", "50");
+    addQueryParameter(widgetContext, "focalY", "50");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.post(widgetContext);
+
+      imageRepositoryMockedStatic.verifyNoInteractions();
+    }
   }
 }


### PR DESCRIPTION
## Summary

Third and final PR for issue #411. Lets an admin mark where an image's subject is, so a server-generated square variant can crop around it instead of a blind center crop — the same blind-center-crop pattern (CSS `object-fit: cover`) is already live today via `platform.css`'s opt-in `cardImageClass` utility classes, just with no control over what stays in frame.

**Stacked on #986** (PR2, still open/under review) — this branch edits `product-browser.jsp` lines PR2 already touched, so it's based on PR2's branch rather than `main` to avoid re-litigating that merge. Do not merge until #986 lands.

- Adds `focal_x`/`focal_y` (0-100%, default dead-center) to `images`.
- Fixes `ImageRepository.update()`, which previously only ever wrote the `processed` column — invisible until this PR's "set focal point on an existing image" action became the first caller that needed anything else to persist on an existing row.
- New `FocalPointCropCommand` computes the crop rectangle (percent → pixel against the original's own stored dimensions, since im4java's `crop()`/`gravity()` only take absolute pixels/fixed compass strings — no percentage concept exists at that layer), wired into `GenerateImageVariantsCommand.generateSquareVariant()` and a new `FocalPointVariantJob` that regenerates only that variant on a focal-point change (thumbnail/medium/large are unaffected by focal point, so a full re-run would be wasted work).
- New focal-point picker modal in `admin/image-browser.jsp` (click the image, or nudge with the paired range inputs), posting to a new `setFocalPoint` action on `AdminImageBrowserWidget`. No new vendored JS dependency — a focal point is one click producing one `(x%, y%)`, not a draggable resizable rectangle.
- Wires `product-browser.jsp`'s `cardImageClass`-forced-crop branch to request the square variant instead of the plain original, and drops its width-breakpoint `srcset` on that branch specifically — a `srcset`'s candidates must all share one crop, and mixing in the differently-cropped square variant would let the browser pick either unpredictably depending on viewport.

## Scope note

Research (see linked findings in the issue) found `media-library-panel.jsp`'s 1:1 grid — an earlier candidate for "wire a second consumer" — is actually backed by a completely separate `MediaAsset`/`media_assets` subsystem with no relationship to `Image`/`ImageVariant`, so it's out of scope here; `product-browser.jsp` is the only file pair using the `Image`-backed `cardImageClass` pattern.

## Test plan

- [x] `ant -lib lib/war -lib lib/tests clean ci-test` — full suite green, including new/extended: `FocalPointCropCommandTest` (12 cases — crop-rect math across wide/tall/square originals × center/edge/corner focal points), `GenerateImageVariantsCommandTest` (+5 for `generateSquareVariant`), `ImageRepositorySearchTest` (+2, including the `update()` fix itself), `AdminImageBrowserWidgetTest` (+5 for `setFocalPointAction`, including the enqueue-only-on-success check).
- [x] `ant -lib lib/war compile-jsp` — both edited JSPs translate/compile clean.
- [x] `tools/check-unescaped-el.py --strict` — 0 unallowlisted (new `data-focal-x`/`data-focal-y` attributes wrapped in `<c:out>`).
- [ ] Manual/docker click-through (upload an image, set an off-center focal point, confirm `?variant=square` is requested and visually correct on a `cardImageClass`-configured product list) — not yet run this session; worth doing before merge.