### PR TITLE
Fix click-to-focus on editorial calendar day cells

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/editorial-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/editorial-calendar.jsp
@@ -238,26 +238,32 @@
       });
     }
 
-    function moveDayFocus(calendarEl, deltaDays) {
-      if (!focusedDateISO) {
-        return;
-      }
-      var current = new Date(focusedDateISO + 'T00:00:00');
-      current.setDate(current.getDate() + deltaDays);
-      var targetISO = toISODate(current);
+    // Shared by moveDayFocus (keyboard) and the click handler below (issue #994): moves the
+    // single roving-tabindex stop to targetISO and hands DOM focus to it, if that date is
+    // actually part of the currently rendered grid.
+    function focusDayCell(calendarEl, targetISO) {
       var targetCell = dayCell(calendarEl, targetISO);
       if (!targetCell) {
         // Off the edge of the currently rendered grid -- stop rather than silently paging to a
         // different month/week out from under the user.
         return;
       }
-      var previousCell = dayCell(calendarEl, focusedDateISO);
-      if (previousCell) {
+      var previousCell = focusedDateISO ? dayCell(calendarEl, focusedDateISO) : null;
+      if (previousCell && previousCell !== targetCell) {
         previousCell.setAttribute('tabindex', '-1');
       }
       focusedDateISO = targetISO;
       targetCell.setAttribute('tabindex', '0');
       targetCell.focus();
+    }
+
+    function moveDayFocus(calendarEl, deltaDays) {
+      if (!focusedDateISO) {
+        return;
+      }
+      var current = new Date(focusedDateISO + 'T00:00:00');
+      current.setDate(current.getDate() + deltaDays);
+      focusDayCell(calendarEl, toISODate(current));
     }
 
     document.addEventListener('DOMContentLoaded', function () {
@@ -350,6 +356,27 @@
           default:
             break;
         }
+      });
+
+      <%-- Day-cell click-to-focus (issue #994): the FullCalendar.Calendar init above has no
+           dateClick/select callback, and FullCalendar's own mousedown handling on day-grid cells
+           suppresses the browser's normal click-to-focus behavior -- so clicking a day cell never
+           updated focusedDateISO, never flipped its tabindex to 0, and never received DOM focus,
+           leaving the arrow keys above with nothing to move from until the user tabbed to a cell
+           instead. Delegated the same way as the keydown listener (a plain listener on calendarEl
+           matched against the day-cell selector) rather than FullCalendar's own click callbacks,
+           to stay consistent with this file's hand-rolled roving-tabindex approach. closest() is
+           used (not e.target.matches, unlike the keydown check above) so a click that lands on an
+           event chip inside a cell -- which eventClick/activateEvent already separately opens --
+           still resolves to its containing day cell and moves day-cell focus there too; nothing
+           here calls preventDefault or stops propagation, so eventClick keeps firing normally for
+           chip clicks. --%>
+      calendarEl.addEventListener('click', function (e) {
+        var cell = e.target && e.target.closest && e.target.closest('.fc-daygrid-day[data-date]');
+        if (!cell) {
+          return;
+        }
+        focusDayCell(calendarEl, cell.getAttribute('data-date'));
       });
     });
   })();


### PR DESCRIPTION
Fixes #994

**Root cause**: `editorial-calendar.jsp` implements a hand-rolled roving-tabindex keyboard-navigable date grid for the editorial calendar (FullCalendar 6 has no built-in per-date keyboard navigation). `applyRovingTabindex` sets `tabindex="0"` on exactly one day cell (tracked via the `focusedDateISO` JS variable) on every render, and the `ArrowLeft/Right/Up/Down` keydown handler moves that single stop via `moveDayFocus`. However, the `FullCalendar.Calendar` init has no `dateClick`/`select` callback, and FullCalendar's own mousedown handling on day-grid cells suppresses the browser's normal click-to-focus behavior. So clicking a day cell that wasn't already the tracked cell never updated `focusedDateISO`, never flipped its `tabindex` to `0`, and never received DOM focus -- pressing an arrow key right after a click did nothing (or moved from whatever cell was previously focused), even though Tab-to-the-cell-then-arrow-keys worked correctly.

**Fix**: factored the tabindex-flip-and-focus logic out of `moveDayFocus` into a small shared helper, `focusDayCell(calendarEl, targetISO)`, and added a native `click` listener on `calendarEl` (delegated the same way the existing `keydown` listener is, matching against `.fc-daygrid-day[data-date]`, rather than FullCalendar's own `dateClick`/`select` callbacks, to stay consistent with this file's existing hand-rolled approach). On a matching click it reads the cell's `data-date`, calls `focusDayCell` with it, which flips `tabindex` on the old/new cell, updates `focusedDateISO`, and calls `.focus()` on the clicked cell -- mirroring what `moveDayFocus` already does for keyboard nav.

The click handler uses `closest('.fc-daygrid-day[data-date]')` rather than an exact target match, so a click landing on an event chip inside a cell (rendered by `eventContent`/`eventDidMount`) still resolves to its containing day cell and moves day-cell focus there, in addition to `eventClick`/`activateEvent` separately opening that entry's edit form. Nothing in the new handler calls `preventDefault()` or stops propagation, so `eventClick` keeps firing normally for chip clicks -- the two handlers don't interfere with each other.

**Testing**: `EditorialCalendarWidgetTest.java` only covers server-side widget prep (JSP path, preferences, author list) and doesn't exercise client JS; this repo has no JS test harness (no jest/karma/mocha in `package.json`, no JS `devDependencies` for testing). This is a pure client-side DOM behavior fix with no feasible automated test under this codebase's existing conventions, so none was added. Verified `ant -lib lib/tests ci-test` (BUILD SUCCESSFUL, all tests pass) plus `tools/check-unescaped-el.py --strict` and `tools/check-xml-well-formed.py --strict` both pass clean.