### PR TITLE
Make the reserved from_path denylist case-insensitive

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveWebRedirectCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveWebRedirectCommand.java
@@ -194,8 +194,13 @@ public class SaveWebRedirectCommand {
   }
 
   private static boolean isReservedFromPath(String fromPath) {
+    // Case-insensitive: RESERVED_FROM_PATH_PREFIXES are all lowercase literals, but a from_path of
+    // "/ADMIN" or "/Login" would otherwise sail past this check while still reading as a plausible
+    // shadow of the real (case-sensitive, but visually identical) route -- a phishing/confusion
+    // vector even though it can't literally intercept the real route's requests (issue #992).
+    String normalized = fromPath.toLowerCase();
     for (String reserved : RESERVED_FROM_PATH_PREFIXES) {
-      if (fromPath.equals(reserved) || fromPath.startsWith(reserved + "/")) {
+      if (normalized.equals(reserved) || normalized.startsWith(reserved + "/")) {
         return true;
       }
     }

--- a/src/test/java/com/simisinc/platform/application/cms/SaveWebRedirectCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveWebRedirectCommandTest.java
@@ -310,6 +310,45 @@ class SaveWebRedirectCommandTest {
     }
   }
 
+  // --- Reserved-path check is case-insensitive (issue #992: "/ADMIN", "/Login", etc. sailed past
+  // a naive case-sensitive comparison against the all-lowercase RESERVED_FROM_PATH_PREFIXES) ---
+
+  @Test
+  void anUppercaseAdminConsolePathAsTheFromPathIsRejected() {
+    WebRedirect bean = bean(-1L, "/ADMIN/web-redirects", "/target", 301, true);
+    try (MockedStatic<WebRedirectRepository> repository = mockStatic(WebRedirectRepository.class)) {
+      DataException e = assertThrows(DataException.class, () -> SaveWebRedirectCommand.save(bean));
+      assertTrue(e.getMessage().contains("reserved system path"));
+      repository.verify(() -> WebRedirectRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void aMixedCaseLoginPathAsTheFromPathIsRejected() {
+    WebRedirect bean = bean(-1L, "/Login", "https://evil.example.com/harvest", 301, true);
+    try (MockedStatic<WebRedirectRepository> repository = mockStatic(WebRedirectRepository.class)) {
+      DataException e = assertThrows(DataException.class, () -> SaveWebRedirectCommand.save(bean));
+      assertTrue(e.getMessage().contains("reserved system path"));
+      repository.verify(() -> WebRedirectRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void aPathThatMerelyStartsWithAReservedWordInMixedCaseIsNotTreatedAsReserved() throws DataException {
+    // Same "shares a prefix but isn't the reserved path itself" guard as the lowercase case above,
+    // now exercised in mixed case to prove the new toLowerCase() normalization didn't loosen the
+    // startsWith(reserved + "/") boundary check.
+    WebRedirect bean = bean(-1L, "/AdminCustomers", "/target", 301, true);
+    try (MockedStatic<WebRedirectRepository> repository = mockStatic(WebRedirectRepository.class)) {
+      repository.when(() -> WebRedirectRepository.findByFromPath("/AdminCustomers")).thenReturn(null);
+      repository.when(() -> WebRedirectRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      WebRedirect saved = SaveWebRedirectCommand.save(bean);
+
+      assertEquals("/AdminCustomers", saved.getFromPath());
+    }
+  }
+
   // --- Redirect loop detection (issue #408 review: only a direct self-loop was rejected, so a
   // two-record cycle -- A -> B, B -> A -- passed validation and sent browsers into an infinite
   // series of redirects) ---


### PR DESCRIPTION
Fixes #992

`isReservedFromPath()` in `SaveWebRedirectCommand.java` compared the submitted `from_path` directly against `RESERVED_FROM_PATH_PREFIXES` (all lowercase literals: `/admin`, `/login`, `/api`, etc.), so a from_path of `/ADMIN`, `/Login`, or `/API/x` sailed past the check and could be saved as a live redirect. It can't literally shadow the real route (HTTP paths are case-sensitive at the servlet-container level too), but it reads as a plausible impersonation of a protected path -- a phishing/confusion vector an admin or content-manager could create without realizing it.

Fix: normalize the input to lowercase before comparing, leaving the array and all other behavior untouched.

Added 3 tests: an uppercase `/ADMIN` path is rejected, a mixed-case `/Login` path is rejected, and a mixed-case path that merely shares a reserved prefix (`/AdminCustomers`) is still correctly accepted -- proving the case-insensitivity fix didn't loosen the existing `startsWith(reserved + "/")` boundary check.