### PR TITLE
Surface undated pure-draft pages/posts/events on the editorial calendar

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepository.java
@@ -90,11 +90,17 @@ public class BlogPostRepository {
           where.add("(end_date IS NULL OR end_date >= NOW())");
         }
       }
-      // issue #426 (editorial calendar): mirrors CalendarEventRepository's identical
-      // startingDateRange/endingDateRange OR-across-two-columns shape, applied to start_date/
-      // end_date -- BlogPost has no publishAt/expiresAt columns, so start_date/end_date are this
-      // entity's real scheduling-equivalent fields (see BlogPostSpecification's field comment).
-      if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
+      // issue #996 (editorial calendar "Drafts with no dates" feed): a post with neither
+      // scheduling field set has no anchor date, so this replaces the date-range filter below
+      // entirely rather than combining with it -- EditorialCalendarAjax never sets both on the
+      // same specification.
+      if (specification.isUndatedOnly()) {
+        where.add("start_date IS NULL AND end_date IS NULL");
+      } else if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
+        // issue #426 (editorial calendar): mirrors CalendarEventRepository's identical
+        // startingDateRange/endingDateRange OR-across-two-columns shape, applied to start_date/
+        // end_date -- BlogPost has no publishAt/expiresAt columns, so start_date/end_date are this
+        // entity's real scheduling-equivalent fields (see BlogPostSpecification's field comment).
         where.add("((start_date >= ? AND start_date < ?) OR (end_date >= ? AND end_date < ?))",
             new Timestamp[]{specification.getStartingDateRange(), specification.getEndingDateRange(),
                 specification.getStartingDateRange(), specification.getEndingDateRange()});

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostSpecification.java
@@ -46,6 +46,11 @@ public class BlogPostSpecification {
   // startingDateRange/endingDateRange naming exactly.
   private Timestamp startingDateRange = null;
   private Timestamp endingDateRange = null;
+  // issue #996 (editorial calendar "Drafts with no dates" feed): when true, matches a post with
+  // NEITHER scheduling field set (start_date IS NULL AND end_date IS NULL) instead of applying
+  // the startingDateRange/endingDateRange filter above. Mirrors WebPageSpecification's identical
+  // undatedOnly field. Defaults to false so every pre-#996 caller is unaffected.
+  private boolean undatedOnly = false;
   // issue #426: the editorial calendar's author filter. -1 (unset) matches every post, mirroring
   // every other *Specification's -1-means-unset long field.
   private long createdBy = -1L;
@@ -164,6 +169,14 @@ public class BlogPostSpecification {
 
   public void setCreatedBy(long createdBy) {
     this.createdBy = createdBy;
+  }
+
+  public boolean isUndatedOnly() {
+    return undatedOnly;
+  }
+
+  public void setUndatedOnly(boolean undatedOnly) {
+    this.undatedOnly = undatedOnly;
   }
 
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepository.java
@@ -76,7 +76,12 @@ public class CalendarEventRepository {
       } else if (specification.getArchivedOnly() == DataConstants.FALSE) {
         where.add("archived IS NULL");
       }
-      if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
+      // issue #996 (editorial calendar "Drafts with no dates" feed): an event with no startDate
+      // has no anchor date, so this replaces the date-range filter below entirely rather than
+      // combining with it -- EditorialCalendarAjax never sets both on the same specification.
+      if (specification.isUndatedOnly()) {
+        where.add("start_date IS NULL");
+      } else if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
         where.add("((start_date >= ? AND start_date < ?) OR (end_date >= ? AND end_date < ?))",
             new Timestamp[]{specification.getStartingDateRange(), specification.getEndingDateRange(), specification.getStartingDateRange(), specification.getEndingDateRange()});
       } else if (specification.getStartingDateRange() != null) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventSpecification.java
@@ -39,6 +39,13 @@ public class CalendarEventSpecification {
   private Timestamp startingDateRange = null;
   private Timestamp endingDateRange = null;
   private String searchTerm = null;
+  // issue #996 (editorial calendar "Drafts with no dates" feed): when true, matches an event with
+  // no startDate set (start_date IS NULL) instead of applying the startingDateRange/
+  // endingDateRange filter above -- an event's startDate IS the event (see EditorialCalendarAjax's
+  // addEvents javadoc), so that is the only anchor field for this type. Mirrors
+  // WebPageSpecification/BlogPostSpecification's identical undatedOnly field. Defaults to false so
+  // every pre-#996 caller is unaffected.
+  private boolean undatedOnly = false;
   // issue #426 (editorial calendar): the author filter. -1 (unset) matches every event, mirroring
   // this class's own calendarId field and WebPageSpecification/BlogPostSpecification's identical
   // new createdBy field.
@@ -133,5 +140,13 @@ public class CalendarEventSpecification {
 
   public void setCreatedBy(long createdBy) {
     this.createdBy = createdBy;
+  }
+
+  public boolean isUndatedOnly() {
+    return undatedOnly;
+  }
+
+  public void setUndatedOnly(boolean undatedOnly) {
+    this.undatedOnly = undatedOnly;
   }
 }

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepository.java
@@ -69,11 +69,17 @@ public class WebPageRepository {
       } else if (specification.getArchivedOnly() == DataConstants.FALSE) {
         where.add("archived IS NULL");
       }
-      // issue #426 (editorial calendar): mirrors CalendarEventRepository's identical
-      // startingDateRange/endingDateRange OR-across-two-columns shape, applied to publish_at/
-      // expires_at instead of a single occurrence window -- a page matches if EITHER its scheduled
-      // go-live date or its expiration date falls within the requested range.
-      if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
+      // issue #996 (editorial calendar "Drafts with no dates" feed): a page with neither
+      // scheduling field set has no anchor date, so this replaces the date-range filter below
+      // entirely rather than combining with it -- EditorialCalendarAjax never sets both on the
+      // same specification.
+      if (specification.isUndatedOnly()) {
+        where.add("publish_at IS NULL AND expires_at IS NULL");
+      } else if (specification.getStartingDateRange() != null && specification.getEndingDateRange() != null) {
+        // issue #426 (editorial calendar): mirrors CalendarEventRepository's identical
+        // startingDateRange/endingDateRange OR-across-two-columns shape, applied to publish_at/
+        // expires_at instead of a single occurrence window -- a page matches if EITHER its scheduled
+        // go-live date or its expiration date falls within the requested range.
         where.add("((publish_at >= ? AND publish_at < ?) OR (expires_at >= ? AND expires_at < ?))",
             new Timestamp[]{specification.getStartingDateRange(), specification.getEndingDateRange(),
                 specification.getStartingDateRange(), specification.getEndingDateRange()});

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageSpecification.java
@@ -46,6 +46,12 @@ public class WebPageSpecification extends Entity {
   // to publish_at/expires_at instead of a single occurrence window.
   private Timestamp startingDateRange = null;
   private Timestamp endingDateRange = null;
+  // issue #996 (editorial calendar "Drafts with no dates" feed): when true, matches a page with
+  // NEITHER scheduling field set (publish_at IS NULL AND expires_at IS NULL) instead of applying
+  // the startingDateRange/endingDateRange filter above -- a page with no anchor date at all can
+  // never fall inside a date range, so it is otherwise invisible on every calendar view (#996).
+  // Defaults to false so every pre-#996 caller is unaffected.
+  private boolean undatedOnly = false;
   // issue #426: the editorial calendar's author filter. -1 (unset) matches every page, mirroring
   // every other *Specification's -1-means-unset long field (e.g. CalendarEventSpecification.calendarId).
   private long createdBy = -1L;
@@ -166,5 +172,13 @@ public class WebPageSpecification extends Entity {
 
   public void setCreatedBy(long createdBy) {
     this.createdBy = createdBy;
+  }
+
+  public boolean isUndatedOnly() {
+    return undatedOnly;
+  }
+
+  public void setUndatedOnly(boolean undatedOnly) {
+    this.undatedOnly = undatedOnly;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/EditorialCalendarAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/EditorialCalendarAjax.java
@@ -70,6 +70,20 @@ import com.simisinc.platform.presentation.widgets.GenericWidget;
  * StringBuilder JSON assembly (no Jackson) and its start/end date-parsing (ISO8601 or a plain
  * {@code yyyy-MM-dd} fallback) exactly.</p>
  *
+ * <p>Issue #996: a page/post/event with no scheduling date set at all (neither field, for
+ * whichever pair of fields that type uses) has no anchor date and can never appear in the
+ * date-ranged feed above, under any range. Rather than forcing it onto a specific day, a request
+ * with {@code undated=true} short-circuits {@link #execute(WidgetContext)} into a separate code
+ * path ({@link #executeUndated(WidgetContext)}) that returns every such record instead, still
+ * honoring the same type/authorId/status filters and the same {@link #isAuthorized(WidgetContext)}
+ * gate. This stays a single query-param branch on the existing endpoint/class rather than a
+ * second json-services.xml registration, since every entry still needs the exact same
+ * per-type edit-URL and status logic this class already has -- a second class would either
+ * duplicate that logic or need to call back into this one anyway. Each returned entry omits the
+ * "date" key entirely (see {@link #appendEntry}) rather than inventing a placeholder value for a
+ * field that, by definition, does not exist for this content -- callers must not assume "date" is
+ * always present the way the date-ranged feed above guarantees it.</p>
+ *
  * @author SimIS Inc.
  */
 public class EditorialCalendarAjax extends GenericWidget {
@@ -81,6 +95,12 @@ public class EditorialCalendarAjax extends GenericWidget {
     if (!isAuthorized(context)) {
       context.setJson("[]");
       return context;
+    }
+
+    // issue #996: the "Drafts with no dates" feed -- see the class javadoc. Checked before the
+    // start/end requirement below because this path needs no date range at all.
+    if ("true".equalsIgnoreCase(StringUtils.trimToNull(context.getParameter("undated")))) {
+      return executeUndated(context);
     }
 
     String start = context.getParameter("start");
@@ -128,6 +148,34 @@ public class EditorialCalendarAjax extends GenericWidget {
   }
 
   /**
+   * Issue #996: the "Drafts with no dates" feed -- see the class javadoc. Reuses the same
+   * type/authorId/status filter params and the same per-type status/edit-URL logic as the
+   * date-ranged {@link #execute(WidgetContext)} path, but queries each repository with
+   * {@code undatedOnly} instead of a date range, and emits entries with no "date" key.
+   */
+  private WidgetContext executeUndated(WidgetContext context) {
+    String typeFilter = StringUtils.trimToNull(context.getParameter("type"));
+    long authorId = context.getParameterAsLong("authorId", -1);
+    String statusFilter = StringUtils.trimToNull(context.getParameter("status"));
+
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+
+    StringBuilder sb = new StringBuilder();
+    if (typeFilter == null || "page".equalsIgnoreCase(typeFilter)) {
+      addUndatedPages(authorId, statusFilter, now, sb);
+    }
+    if (typeFilter == null || "post".equalsIgnoreCase(typeFilter)) {
+      addUndatedPosts(authorId, statusFilter, now, sb);
+    }
+    if (typeFilter == null || "event".equalsIgnoreCase(typeFilter)) {
+      addUndatedEvents(authorId, statusFilter, now, sb);
+    }
+
+    context.setJson("[" + sb + "]");
+    return context;
+  }
+
+  /**
    * True when the current caller is allowed to see this admin-only feed. See the class-level
    * javadoc -- this is a defensive re-check, not the primary access control (that's the
    * {@code role=} attribute on this service's json-services.xml registration).
@@ -152,7 +200,7 @@ public class EditorialCalendarAjax extends GenericWidget {
     }
     List<WebPage> pageList = WebPageRepository.findAll(specification, null);
     for (WebPage page : pageList) {
-      String editUrl = "/admin/web-page?webPageId=" + page.getId() + "&returnPage=/admin/editorial-calendar";
+      String editUrl = pageEditUrl(page);
       if (page.getPublishAt() != null && inRange(page.getPublishAt(), rangeStart, rangeEnd)) {
         appendEntry(sb, "page-" + page.getId() + "-publish", "Page", page.getTitle(), pageStatus(page, now),
             page.getPublishAt(), editUrl, statusFilter);
@@ -161,6 +209,26 @@ public class EditorialCalendarAjax extends GenericWidget {
         appendEntry(sb, "page-" + page.getId() + "-expire", "Page", page.getTitle(), "Expiring",
             page.getExpiresAt(), editUrl, statusFilter);
       }
+    }
+  }
+
+  /**
+   * Issue #996: the undated-only counterpart to {@link #addPages}. Unlike the date-ranged path,
+   * a page can never emit more than one entry here (there's no "publish" vs "expire" moment to
+   * split on when neither date is set), so the "Expiring" status this class otherwise derives
+   * from a non-null expiresAt never applies -- {@link #pageStatus} covers every remaining case.
+   */
+  private static void addUndatedPages(long authorId, String statusFilter, Timestamp now, StringBuilder sb) {
+    WebPageSpecification specification = new WebPageSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    if (authorId > -1) {
+      specification.setCreatedBy(authorId);
+    }
+    List<WebPage> pageList = WebPageRepository.findAll(specification, null);
+    for (WebPage page : pageList) {
+      appendEntry(sb, "page-" + page.getId(), "Page", page.getTitle(), pageStatus(page, now),
+          null, pageEditUrl(page), statusFilter);
     }
   }
 
@@ -174,6 +242,11 @@ public class EditorialCalendarAjax extends GenericWidget {
       return "Draft";
     }
     return "Published";
+  }
+
+  /** Reuses the exact admin-edit-form URL pattern {@code web-page-list.jsp} already uses. */
+  private static String pageEditUrl(WebPage page) {
+    return "/admin/web-page?webPageId=" + page.getId() + "&returnPage=/admin/editorial-calendar";
   }
 
   // --- Blog posts ---
@@ -191,17 +264,9 @@ public class EditorialCalendarAjax extends GenericWidget {
     if (postList.isEmpty()) {
       return;
     }
-    // Resolve each post's blog for the blog-editor edit URL (mirrors AdminBlogPostListWidget's
-    // blogList lookup, keyed here for O(1) access per post).
-    Map<Long, Blog> blogMap = new HashMap<>();
-    for (Blog blog : BlogRepository.findAll()) {
-      blogMap.put(blog.getId(), blog);
-    }
+    Map<Long, Blog> blogMap = buildBlogMap();
     for (BlogPost post : postList) {
-      Blog blog = blogMap.get(post.getBlogId());
-      String blogUniqueId = blog != null ? blog.getUniqueId() : "";
-      String editUrl = "/blog-editor?blogUniqueId=" + URLEncoder.encode(blogUniqueId, StandardCharsets.UTF_8)
-          + "&blogPostId=" + post.getId() + "&returnPage=/admin/editorial-calendar";
+      String editUrl = postEditUrl(post, blogMap);
       if (post.getStartDate() != null && inRange(post.getStartDate(), rangeStart, rangeEnd)) {
         appendEntry(sb, "post-" + post.getId() + "-publish", "Post", post.getTitle(), postStatus(post, now),
             post.getStartDate(), editUrl, statusFilter);
@@ -210,6 +275,27 @@ public class EditorialCalendarAjax extends GenericWidget {
         appendEntry(sb, "post-" + post.getId() + "-expire", "Post", post.getTitle(), "Expiring",
             post.getEndDate(), editUrl, statusFilter);
       }
+    }
+  }
+
+  /** Issue #996: the undated-only counterpart to {@link #addPosts}, mirroring
+   * {@link #addUndatedPages}'s reasoning -- no split "publish" vs "expire" entry is possible when
+   * neither date is set, so {@link #postStatus} alone determines the single entry emitted. */
+  private static void addUndatedPosts(long authorId, String statusFilter, Timestamp now, StringBuilder sb) {
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    if (authorId > -1) {
+      specification.setCreatedBy(authorId);
+    }
+    List<BlogPost> postList = BlogPostRepository.findAll(specification, null);
+    if (postList.isEmpty()) {
+      return;
+    }
+    Map<Long, Blog> blogMap = buildBlogMap();
+    for (BlogPost post : postList) {
+      appendEntry(sb, "post-" + post.getId(), "Post", post.getTitle(), postStatus(post, now),
+          null, postEditUrl(post, blogMap), statusFilter);
     }
   }
 
@@ -223,6 +309,23 @@ public class EditorialCalendarAjax extends GenericWidget {
       return "Draft";
     }
     return "Published";
+  }
+
+  /** Resolves every blog up front so each post's blog-editor edit URL is an O(1) lookup, mirroring
+   * AdminBlogPostListWidget's blogList lookup. */
+  private static Map<Long, Blog> buildBlogMap() {
+    Map<Long, Blog> blogMap = new HashMap<>();
+    for (Blog blog : BlogRepository.findAll()) {
+      blogMap.put(blog.getId(), blog);
+    }
+    return blogMap;
+  }
+
+  private static String postEditUrl(BlogPost post, Map<Long, Blog> blogMap) {
+    Blog blog = blogMap.get(post.getBlogId());
+    String blogUniqueId = blog != null ? blog.getUniqueId() : "";
+    return "/blog-editor?blogUniqueId=" + URLEncoder.encode(blogUniqueId, StandardCharsets.UTF_8)
+        + "&blogPostId=" + post.getId() + "&returnPage=/admin/editorial-calendar";
   }
 
   // --- Calendar events ---
@@ -241,10 +344,25 @@ public class EditorialCalendarAjax extends GenericWidget {
       // An event's start/end IS the event -- unlike pages/posts there's no separate
       // publish-schedule field to also emit an "Expiring" entry for.
       if (event.getStartDate() != null && inRange(event.getStartDate(), rangeStart, rangeEnd)) {
-        String editUrl = "/admin/calendar-event?calendarEventId=" + event.getId() + "&returnPage=/admin/editorial-calendar";
         appendEntry(sb, "event-" + event.getId(), "Event", event.getTitle(), eventStatus(event, now),
-            event.getStartDate(), editUrl, statusFilter);
+            event.getStartDate(), eventEditUrl(event), statusFilter);
       }
+    }
+  }
+
+  /** Issue #996: the undated-only counterpart to {@link #addEvents}. An event only has one
+   * scheduling field to begin with (startDate), so this is otherwise a direct mirror. */
+  private static void addUndatedEvents(long authorId, String statusFilter, Timestamp now, StringBuilder sb) {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    if (authorId > -1) {
+      specification.setCreatedBy(authorId);
+    }
+    List<CalendarEvent> eventList = CalendarEventRepository.findAll(specification, null);
+    for (CalendarEvent event : eventList) {
+      appendEntry(sb, "event-" + event.getId(), "Event", event.getTitle(), eventStatus(event, now),
+          null, eventEditUrl(event), statusFilter);
     }
   }
 
@@ -260,12 +378,24 @@ public class EditorialCalendarAjax extends GenericWidget {
     return "Published";
   }
 
+  private static String eventEditUrl(CalendarEvent event) {
+    return "/admin/calendar-event?calendarEventId=" + event.getId() + "&returnPage=/admin/editorial-calendar";
+  }
+
   // --- Shared helpers ---
 
   private static boolean inRange(Timestamp value, Timestamp rangeStart, Timestamp rangeEnd) {
     return !value.before(rangeStart) && value.before(rangeEnd);
   }
 
+  /**
+   * Appends one JSON entry to {@code sb}, or nothing at all if {@code statusFilter} is set and
+   * doesn't match {@code status}. {@code date} is nullable (issue #996): the undated-drafts feed
+   * has no date to anchor an entry to, so the "date" key is omitted entirely for those entries
+   * rather than emitting a placeholder value for a field that, by definition, does not exist --
+   * callers of the undated feed must not assume "date" is present the way the date-ranged feed
+   * above guarantees it.
+   */
   private static void appendEntry(StringBuilder sb, String id, String type, String title, String status,
       Timestamp date, String editUrl, String statusFilter) {
     if (statusFilter != null && !statusFilter.equalsIgnoreCase(status)) {
@@ -278,9 +408,11 @@ public class EditorialCalendarAjax extends GenericWidget {
     sb.append("\"id\":\"").append(JsonCommand.toJson(id)).append("\",");
     sb.append("\"type\":\"").append(type).append("\",");
     sb.append("\"title\":\"").append(JsonCommand.toJson(title)).append("\",");
-    sb.append("\"status\":\"").append(status).append("\",");
-    sb.append("\"date\":\"").append(new SimpleDateFormat("yyyy-MM-dd").format(date)).append("\",");
-    sb.append("\"editUrl\":\"").append(JsonCommand.toJson(editUrl)).append("\"");
+    sb.append("\"status\":\"").append(status).append("\"");
+    if (date != null) {
+      sb.append(",\"date\":\"").append(new SimpleDateFormat("yyyy-MM-dd").format(date)).append("\"");
+    }
+    sb.append(",\"editUrl\":\"").append(JsonCommand.toJson(editUrl)).append("\"");
     sb.append("}");
   }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/editorial-calendar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/editorial-calendar.jsp
@@ -67,7 +67,19 @@
     <button type="button" id="editorialCalendarClearFilters" class="button secondary small radius expanded">Clear Filters</button>
   </div>
 </div>
-<div id="editorialCalendar"></div>
+<%-- issue #996: the calendar grid can only ever plot content that has an anchor date -- a pure
+     draft with neither scheduling field set is invisible on it under any date range. This sidebar
+     cell surfaces that content instead, fetched separately from /json/editorialCalendar?undated=true
+     (see the inline script below), reusing the same type/author/status filters above. --%>
+<div class="grid-x grid-margin-x">
+  <div class="cell small-12 large-8">
+    <div id="editorialCalendar"></div>
+  </div>
+  <div class="cell small-12 large-4">
+    <h6>Drafts with no dates</h6>
+    <ul id="editorialCalendarUndatedList" class="no-bullet ec-undated-list"></ul>
+  </div>
+</div>
 <script nonce="${cspNonce}">
   (function () {
     'use strict';
@@ -76,6 +88,7 @@
     var authorFilterEl = document.getElementById('editorialCalendarAuthorFilter');
     var statusFilterEl = document.getElementById('editorialCalendarStatusFilter');
     var clearFiltersEl = document.getElementById('editorialCalendarClearFilters');
+    var undatedListEl = document.getElementById('editorialCalendarUndatedList');
 
     var TYPE_ICONS = {
       page: 'fa-sticky-note',
@@ -115,6 +128,24 @@
       return '${ctx}/json/editorialCalendar?' + params.toString();
     }
 
+    <%-- issue #996: the "Drafts with no dates" sidebar's feed -- same endpoint/filters as
+         buildEventUrl above, minus start/end (this feed has no date range) plus undated=true,
+         which short-circuits EditorialCalendarAjax into the undated-only code path. --%>
+    function buildUndatedUrl() {
+      var params = new URLSearchParams();
+      params.set('undated', 'true');
+      if (typeFilterEl.value) {
+        params.set('type', typeFilterEl.value);
+      }
+      if (authorFilterEl.value) {
+        params.set('authorId', authorFilterEl.value);
+      }
+      if (statusFilterEl.value) {
+        params.set('status', statusFilterEl.value);
+      }
+      return '${ctx}/json/editorialCalendar?' + params.toString();
+    }
+
     function mapEntryToEvent(entry) {
       return {
         id: entry.id,
@@ -130,30 +161,32 @@
       };
     }
 
-    function renderEventContent(arg) {
-      var props = arg.event.extendedProps;
-
+    <%-- Builds the icon + title + status-badge content shared by a calendar-grid entry
+         (renderEventContent below) and a "Drafts with no dates" list entry (renderUndatedEntry
+         below) -- same markup, same TYPE_ICONS/STATUS_LABEL_CLASS/STATUS_ICONS lookups, so the
+         undated list reads as visually consistent with the calendar it sits beside. --%>
+    function buildEntryContent(type, title, status) {
       var wrapper = document.createElement('div');
       wrapper.className = 'ec-event';
 
       var typeIcon = document.createElement('i');
-      typeIcon.className = 'fa fa-fw ' + (TYPE_ICONS[String(props.type).toLowerCase()] || 'fa-file');
+      typeIcon.className = 'fa fa-fw ' + (TYPE_ICONS[String(type).toLowerCase()] || 'fa-file');
       typeIcon.setAttribute('aria-hidden', 'true');
       wrapper.appendChild(typeIcon);
 
       var srType = document.createElement('span');
       srType.className = 'show-for-sr';
-      srType.textContent = props.type + ': ';
+      srType.textContent = type + ': ';
       wrapper.appendChild(srType);
 
       var titleEl = document.createElement('span');
       titleEl.className = 'ec-event-title';
-      titleEl.textContent = arg.event.title;
+      titleEl.textContent = title;
       wrapper.appendChild(titleEl);
 
       var statusEl = document.createElement('span');
-      statusEl.className = 'label ec-status-badge ' + (STATUS_LABEL_CLASS[props.status] || 'secondary');
-      var statusIconClass = STATUS_ICONS[props.status];
+      statusEl.className = 'label ec-status-badge ' + (STATUS_LABEL_CLASS[status] || 'secondary');
+      var statusIconClass = STATUS_ICONS[status];
       if (statusIconClass) {
         var statusIcon = document.createElement('i');
         statusIcon.className = 'fa ' + statusIconClass;
@@ -161,10 +194,64 @@
         statusEl.appendChild(statusIcon);
         statusEl.appendChild(document.createTextNode(' '));
       }
-      statusEl.appendChild(document.createTextNode(props.status));
+      statusEl.appendChild(document.createTextNode(status));
       wrapper.appendChild(statusEl);
 
-      return {domNodes: [wrapper]};
+      return wrapper;
+    }
+
+    function renderEventContent(arg) {
+      var props = arg.event.extendedProps;
+      return {domNodes: [buildEntryContent(props.type, arg.event.title, props.status)]};
+    }
+
+    <%-- issue #996: one "Drafts with no dates" list item -- a plain <a href> (natively focusable
+         and keyboard-operable, unlike the calendar grid's custom-rendered entries, which needed
+         the manual tabindex/keydown handling below) wrapping the same icon/title/badge content a
+         calendar entry renders. --%>
+    function renderUndatedEntry(entry) {
+      var li = document.createElement('li');
+      li.className = 'ec-undated-item';
+
+      var link = document.createElement('a');
+      link.className = 'ec-undated-link';
+      link.href = (entry.editUrl && entry.editUrl.indexOf('/') === 0) ? ('${ctx}' + entry.editUrl) : '#';
+      link.appendChild(buildEntryContent(entry.type, entry.title, entry.status));
+
+      li.appendChild(link);
+      return li;
+    }
+
+    function renderUndatedList(entries) {
+      undatedListEl.innerHTML = '';
+      if (!entries || entries.length === 0) {
+        var emptyEl = document.createElement('li');
+        emptyEl.className = 'ec-undated-empty';
+        emptyEl.textContent = 'Nothing here';
+        undatedListEl.appendChild(emptyEl);
+        return;
+      }
+      entries.forEach(function (entry) {
+        undatedListEl.appendChild(renderUndatedEntry(entry));
+      });
+    }
+
+    function refreshUndatedList() {
+      fetch(buildUndatedUrl(), {credentials: 'same-origin'})
+          .then(function (response) {
+            if (!response.ok) {
+              throw new Error('Request failed: ' + response.status);
+            }
+            return response.json();
+          })
+          .then(renderUndatedList)
+          .catch(function () {
+            undatedListEl.innerHTML = '';
+            var errorEl = document.createElement('li');
+            errorEl.className = 'ec-undated-empty';
+            errorEl.textContent = 'Could not load drafts';
+            undatedListEl.appendChild(errorEl);
+          });
     }
 
     // Opens the edit form for a calendar entry -- shared by mouse click (eventClick) and keyboard
@@ -302,9 +389,14 @@
       });
       calendar.render();
 
+      <%-- issue #996: fetch the undated list once up front, and again on the same filter
+           change/clear events that already refetch the calendar grid, so both stay in sync. --%>
+      refreshUndatedList();
+
       [typeFilterEl, authorFilterEl, statusFilterEl].forEach(function (el) {
         el.addEventListener('change', function () {
           calendar.refetchEvents();
+          refreshUndatedList();
         });
       });
       clearFiltersEl.addEventListener('click', function () {
@@ -312,6 +404,7 @@
         authorFilterEl.value = '';
         statusFilterEl.value = '';
         calendar.refetchEvents();
+        refreshUndatedList();
       });
 
       <%-- Custom keyboard navigation (issue #426): FullCalendar has no built-in per-date keyboard

--- a/src/main/webapp/css/platform-calendar.css
+++ b/src/main/webapp/css/platform-calendar.css
@@ -83,3 +83,40 @@
   border-left: 3px solid #cc4b37;
   background-color: rgba(204, 75, 55, 0.08);
 }
+
+/* "Drafts with no dates" sidebar (issue #996) -- a plain list of undated entries next to the
+   calendar grid, reusing .ec-event/.ec-event-title/.ec-status-badge above for its per-entry
+   content so it reads as visually consistent with a calendar entry. */
+.ec-undated-list {
+  margin: 0;
+  max-height: 100%;
+  overflow-y: auto;
+}
+.ec-undated-item {
+  border-bottom: 1px solid #e6e6e6;
+}
+.ec-undated-item:last-child {
+  border-bottom: 0;
+}
+.ec-undated-link {
+  display: block;
+  padding: 6px 4px;
+  color: inherit;
+  text-decoration: none;
+}
+.ec-undated-link:hover,
+.ec-undated-link:focus {
+  background-color: #f5f5f5;
+}
+.ec-undated-link .ec-event {
+  overflow: visible;
+  white-space: normal;
+}
+.ec-undated-link .ec-event-title {
+  white-space: normal;
+}
+.ec-undated-empty {
+  padding: 6px 4px;
+  color: #767676;
+  font-style: italic;
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/BlogPostRepositoryWhereClauseTest.java
@@ -151,4 +151,54 @@ class BlogPostRepositoryWhereClauseTest {
 
     assertFalse(whereContains(where, "created_by"));
   }
+
+  // --- undatedOnly (issue #996, editorial calendar "Drafts with no dates" feed) ---
+
+  @Test
+  void undatedOnlyTrueAddsTheStartDateAndEndDateIsNullClause() {
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setUndatedOnly(true);
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL AND end_date IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyFalseByDefaultAddsNoUndatedClauseAtAll() {
+    BlogPostSpecification specification = new BlogPostSpecification();
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertFalse(whereContains(where, "start_date IS NULL"));
+    assertFalse(whereContains(where, "end_date IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyTakesPrecedenceOverADateRangeSetOnTheSameSpecification() {
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setUndatedOnly(true);
+    specification.setStartingDateRange(Timestamp.valueOf("2026-08-01 00:00:00"));
+    specification.setEndingDateRange(Timestamp.valueOf("2026-09-01 00:00:00"));
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL AND end_date IS NULL"));
+    assertFalse(whereContains(where, "start_date >= ?"));
+  }
+
+  @Test
+  void undatedOnlyCombinesWithArchivedOnlyAndCreatedByAsAnd() {
+    // Mirrors how EditorialCalendarAjax.addUndatedPosts() actually builds this specification.
+    BlogPostSpecification specification = new BlogPostSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    specification.setCreatedBy(7L);
+
+    SqlUtils where = BlogPostRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL AND end_date IS NULL"));
+    assertTrue(whereContains(where, "archived IS NULL"));
+    assertTrue(whereContains(where, "created_by = ?"));
+  }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/CalendarEventRepositoryWhereClauseTest.java
@@ -133,4 +133,53 @@ class CalendarEventRepositoryWhereClauseTest {
 
     assertFalse(whereContains(where, "created_by"));
   }
+
+  // --- undatedOnly (issue #996, editorial calendar "Drafts with no dates" feed) ---
+
+  @Test
+  void undatedOnlyTrueAddsTheStartDateIsNullClause() {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setUndatedOnly(true);
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyFalseByDefaultAddsNoUndatedClauseAtAll() {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertFalse(whereContains(where, "start_date IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyTakesPrecedenceOverADateRangeSetOnTheSameSpecification() {
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setUndatedOnly(true);
+    specification.setStartingDateRange(Timestamp.valueOf("2026-08-01 00:00:00"));
+    specification.setEndingDateRange(Timestamp.valueOf("2026-09-01 00:00:00"));
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL"));
+    assertFalse(whereContains(where, "start_date >= ?"));
+  }
+
+  @Test
+  void undatedOnlyCombinesWithArchivedOnlyAndCreatedByAsAnd() {
+    // Mirrors how EditorialCalendarAjax.addUndatedEvents() actually builds this specification.
+    CalendarEventSpecification specification = new CalendarEventSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    specification.setCreatedBy(7L);
+
+    SqlUtils where = CalendarEventRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "start_date IS NULL"));
+    assertTrue(whereContains(where, "archived IS NULL"));
+    assertTrue(whereContains(where, "created_by = ?"));
+  }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryWhereClauseTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/WebPageRepositoryWhereClauseTest.java
@@ -150,4 +150,60 @@ class WebPageRepositoryWhereClauseTest {
 
     assertFalse(whereContains(where, "created_by"));
   }
+
+  // --- undatedOnly (issue #996, editorial calendar "Drafts with no dates" feed) ---
+
+  @Test
+  void undatedOnlyTrueAddsThePublishAtAndExpiresAtIsNullClause() {
+    WebPageSpecification specification = new WebPageSpecification();
+    specification.setUndatedOnly(true);
+
+    SqlUtils where = WebPageRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "publish_at IS NULL AND expires_at IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyFalseByDefaultAddsNoUndatedClauseAtAll() {
+    // false is the default -- proves the new filter is purely additive, matching every pre-#996
+    // caller that never touches this field.
+    WebPageSpecification specification = new WebPageSpecification();
+
+    SqlUtils where = WebPageRepository.createWhereStatement(specification);
+
+    assertFalse(whereContains(where, "publish_at IS NULL"));
+    assertFalse(whereContains(where, "expires_at IS NULL"));
+  }
+
+  @Test
+  void undatedOnlyTakesPrecedenceOverADateRangeSetOnTheSameSpecification() {
+    // EditorialCalendarAjax never sets both on the same specification, but the WHERE-building
+    // itself should still resolve unambiguously if it ever happened: the undated-only clause
+    // entirely replaces the date-range clause rather than combining with it.
+    WebPageSpecification specification = new WebPageSpecification();
+    specification.setUndatedOnly(true);
+    specification.setStartingDateRange(Timestamp.valueOf("2026-08-01 00:00:00"));
+    specification.setEndingDateRange(Timestamp.valueOf("2026-09-01 00:00:00"));
+
+    SqlUtils where = WebPageRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "publish_at IS NULL AND expires_at IS NULL"));
+    assertFalse(whereContains(where, "publish_at >= ?"));
+  }
+
+  @Test
+  void undatedOnlyCombinesWithArchivedOnlyAndCreatedByAsAnd() {
+    // Mirrors how EditorialCalendarAjax.addUndatedPages() actually builds this specification --
+    // all three clauses must be present together.
+    WebPageSpecification specification = new WebPageSpecification();
+    specification.setUndatedOnly(true);
+    specification.setArchivedOnly(false);
+    specification.setCreatedBy(7L);
+
+    SqlUtils where = WebPageRepository.createWhereStatement(specification);
+
+    assertTrue(whereContains(where, "publish_at IS NULL AND expires_at IS NULL"));
+    assertTrue(whereContains(where, "archived IS NULL"));
+    assertTrue(whereContains(where, "created_by = ?"));
+  }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/EditorialCalendarAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/EditorialCalendarAjaxTest.java
@@ -43,6 +43,7 @@ import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventReposit
 import com.simisinc.platform.infrastructure.persistence.cms.CalendarEventSpecification;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.WebPageSpecification;
+import com.simisinc.platform.presentation.controller.DataConstants;
 
 /**
  * Verifies {@link EditorialCalendarAjax}'s aggregation across pages/posts/events and its
@@ -465,5 +466,206 @@ class EditorialCalendarAjaxTest extends WidgetBase {
     }
 
     Assertions.assertEquals("[]", widgetContext.getJson());
+  }
+
+  // --- undated drafts (issue #996) ---
+
+  @Test
+  void undatedFeedRequiresAuthorization() {
+    // Mirrors aCallerWithNoRelevantRoleGetsNoData -- the role gate applies to the undated=true
+    // path exactly like the date-ranged path.
+    addQueryParameter(widgetContext, "undated", "true");
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      new EditorialCalendarAjax().execute(widgetContext);
+
+      pages.verifyNoInteractions();
+      posts.verifyNoInteractions();
+      events.verifyNoInteractions();
+    }
+
+    Assertions.assertEquals("[]", widgetContext.getJson());
+  }
+
+  @Test
+  void aPageWithNoDatesAppearsInTheUndatedFeedWithNoDateKey() {
+    // No setDateRange()/start/end at all -- proves the undated path doesn't need (or get
+    // short-circuited by) the missing-start/end guard the date-ranged path has.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+
+    WebPage page = new WebPage();
+    page.setId(50L);
+    page.setTitle("Someday Maybe");
+    page.setDraft(true);
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      pages.when(() -> WebPageRepository.findAll(any(), any())).thenReturn(List.of(page));
+      mockEmptyPostsAndEvents(posts, events);
+
+      new EditorialCalendarAjax().execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertTrue(json.contains("\"type\":\"Page\""), json);
+    Assertions.assertTrue(json.contains("\"status\":\"Draft\""), json);
+    Assertions.assertTrue(json.contains("Someday Maybe"), json);
+    Assertions.assertFalse(json.contains("\"date\":"), "an undated entry must not carry a date key: " + json);
+  }
+
+  @Test
+  void aPostWithNoDatesAppearsInTheUndatedFeed() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+
+    Blog blog = new Blog();
+    blog.setId(5L);
+    blog.setUniqueId("news");
+
+    BlogPost post = new BlogPost();
+    post.setId(51L);
+    post.setBlogId(5L);
+    post.setTitle("Unscheduled Draft Post");
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<BlogRepository> blogs = mockStatic(BlogRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      mockEmptyPagesAndEvents(pages, events);
+      posts.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(List.of(post));
+      blogs.when(BlogRepository::findAll).thenReturn(List.of(blog));
+
+      new EditorialCalendarAjax().execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertTrue(json.contains("\"type\":\"Post\""), json);
+    Assertions.assertTrue(json.contains("\"status\":\"Draft\""), json);
+    Assertions.assertTrue(json.contains("\\/blog-editor?blogUniqueId=news&blogPostId=51&returnPage=\\/admin\\/editorial-calendar"), json);
+    Assertions.assertFalse(json.contains("\"date\":"), json);
+  }
+
+  @Test
+  void anEventWithNoDatesAppearsInTheUndatedFeed() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+
+    CalendarEvent event = new CalendarEvent();
+    event.setId(52L);
+    event.setTitle("Not Yet Scheduled");
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      mockEmptyPagesAndPosts(pages, posts);
+      events.when(() -> CalendarEventRepository.findAll(any(), any())).thenReturn(List.of(event));
+
+      new EditorialCalendarAjax().execute(widgetContext);
+    }
+
+    String json = widgetContext.getJson();
+    Assertions.assertTrue(json.contains("\"type\":\"Event\""), json);
+    Assertions.assertTrue(json.contains("\"status\":\"Draft\""), json);
+    Assertions.assertTrue(json.contains("\\/admin\\/calendar-event?calendarEventId=52&returnPage=\\/admin\\/editorial-calendar"), json);
+    Assertions.assertFalse(json.contains("\"date\":"), json);
+  }
+
+  @Test
+  void typeFilterOfPageSkipsPostsAndEventsInTheUndatedFeed() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+    addQueryParameter(widgetContext, "type", "page");
+
+    WebPage page = new WebPage();
+    page.setId(53L);
+    page.setTitle("Only This Undated Page");
+    page.setDraft(true);
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      pages.when(() -> WebPageRepository.findAll(any(), any())).thenReturn(List.of(page));
+
+      new EditorialCalendarAjax().execute(widgetContext);
+
+      posts.verifyNoInteractions();
+      events.verifyNoInteractions();
+    }
+
+    Assertions.assertTrue(widgetContext.getJson().contains("Only This Undated Page"), widgetContext.getJson());
+  }
+
+  @Test
+  void statusFilterExcludesAnUndatedEntryThatDoesNotMatch() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+    addQueryParameter(widgetContext, "status", "Published");
+
+    WebPage page = new WebPage();
+    page.setId(54L);
+    page.setTitle("Draft Not Published");
+    page.setDraft(true);
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      pages.when(() -> WebPageRepository.findAll(any(), any())).thenReturn(List.of(page));
+      mockEmptyPostsAndEvents(posts, events);
+
+      new EditorialCalendarAjax().execute(widgetContext);
+    }
+
+    Assertions.assertEquals("[]", widgetContext.getJson());
+  }
+
+  @Test
+  void authorIdFilterIsPassedThroughToEveryUndatedSpecification() {
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+    addQueryParameter(widgetContext, "authorId", "7");
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      mockEmptyPagesAndPosts(pages, posts);
+      events.when(() -> CalendarEventRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      new EditorialCalendarAjax().execute(widgetContext);
+
+      pages.verify(() -> WebPageRepository.findAll(
+          argThat((WebPageSpecification s) -> s.isUndatedOnly() && s.getCreatedBy() == 7L), any()));
+      posts.verify(() -> BlogPostRepository.findAll(
+          argThat((BlogPostSpecification s) -> s.isUndatedOnly() && s.getCreatedBy() == 7L), any()));
+      events.verify(() -> CalendarEventRepository.findAll(
+          argThat((CalendarEventSpecification s) -> s.isUndatedOnly() && s.getCreatedBy() == 7L), any()));
+    }
+  }
+
+  @Test
+  void undatedQueriesExcludeArchivedContent() {
+    // Issue #996's coverage requirement: archived undated content must not leak into the "Drafts
+    // with no dates" feed, mirroring the date-ranged path's identical archivedOnly(false) call.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "undated", "true");
+
+    try (MockedStatic<WebPageRepository> pages = mockStatic(WebPageRepository.class);
+        MockedStatic<BlogPostRepository> posts = mockStatic(BlogPostRepository.class);
+        MockedStatic<CalendarEventRepository> events = mockStatic(CalendarEventRepository.class)) {
+      mockEmptyPagesAndPosts(pages, posts);
+      events.when(() -> CalendarEventRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      new EditorialCalendarAjax().execute(widgetContext);
+
+      pages.verify(() -> WebPageRepository.findAll(
+          argThat((WebPageSpecification s) -> s.getArchivedOnly() == DataConstants.FALSE), any()));
+      posts.verify(() -> BlogPostRepository.findAll(
+          argThat((BlogPostSpecification s) -> s.getArchivedOnly() == DataConstants.FALSE), any()));
+      events.verify(() -> CalendarEventRepository.findAll(
+          argThat((CalendarEventSpecification s) -> s.getArchivedOnly() == DataConstants.FALSE), any()));
+    }
   }
 }


### PR DESCRIPTION
Closes #996

Pages/posts/events with no publish/expire date set at all had no anchor date and were invisible on every editorial calendar view, under any date range -- confirmed live during the #426 post-ship deep test pass.

**Design:**
- `undatedOnly` flag added to `WebPageSpecification`/`BlogPostSpecification`/`CalendarEventSpecification`, translated by each repository into "all relevant date columns IS NULL" instead of the existing date-range filter. `archivedOnly(false)` and the optional `createdBy` filter still apply unconditionally alongside it.
- `EditorialCalendarAjax` gains an `undated=true` query-param branch on the *existing* `/json/editorialCalendar` endpoint (same `isAuthorized()` gate, same type/authorId/status filters, same per-type editUrl building) rather than a new endpoint.
- `editorial-calendar.jsp` adds a "Drafts with no dates" section next to the calendar grid, fetched on load and re-fetched on every filter change, with empty-state and fetch-error handling.

**Note on calendar events:** `calendar_events.start_date`/`end_date` are `NOT NULL` in the schema -- an event without a date isn't a coherent concept in this app. The undated branch for events is implemented defensively (parallel structure to pages/posts) but can never match a row in practice; pages and posts are the only content types this actually surfaces.

**Verified:** full `ci-test` build green (61 tests across the 4 changed/new test classes, 0 failures), both static gates (unescaped-EL, XML well-formed) clean. The authorization gate was specifically checked -- `isAuthorized()` runs once at the top of `execute()` before the `undated` branch dispatches, so there's no bypass for this admin-only draft-content feed.