### PR TITLE
Validate required select/checkbox-group form fields client-side

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -95,7 +95,53 @@
       <c:if test="${formField.required}">
         <c:choose>
           <c:when test="${!empty formField.listOfOptions}">
-
+            <c:choose>
+              <c:when test="${formField.type eq 'checkbox'}">
+                var fieldList = document.getElementsByName("${widgetContext.uniqueId}${js:escape(formField.name)}");
+                var errorEl = document.getElementById("error-${widgetContext.uniqueId}${js:escape(formField.name)}");
+                var isChecked = false;
+                for (var i = 0; i < fieldList.length; i++) {
+                  if (fieldList[i].checked) {
+                    isChecked = true;
+                    break;
+                  }
+                }
+                if (!isChecked) {
+                  if (errorEl) {
+                    errorEl.classList.add("show");
+                  }
+                  for (var i = 0; i < fieldList.length; i++) {
+                    fieldList[i].classList.add("form-field-error");
+                    fieldList[i].setAttribute("aria-invalid", "true");
+                  }
+                  hasErrors = true;
+                  if (!firstErrorField && fieldList.length > 0) firstErrorField = fieldList[0];
+                } else if (errorEl) {
+                  errorEl.classList.remove("show");
+                  for (var i = 0; i < fieldList.length; i++) {
+                    fieldList[i].classList.remove("form-field-error");
+                    fieldList[i].setAttribute("aria-invalid", "false");
+                  }
+                }
+              </c:when>
+              <c:otherwise>
+                var field = document.getElementById("${widgetContext.uniqueId}${js:escape(formField.name)}");
+                var errorEl = document.getElementById("error-${widgetContext.uniqueId}${js:escape(formField.name)}");
+                if (field.value.trim() === "") {
+                  if (errorEl) {
+                    errorEl.classList.add("show");
+                  }
+                  field.classList.add("form-field-error");
+                  field.setAttribute("aria-invalid", "true");
+                  hasErrors = true;
+                  if (!firstErrorField) firstErrorField = field;
+                } else if (errorEl) {
+                  errorEl.classList.remove("show");
+                  field.classList.remove("form-field-error");
+                  field.setAttribute("aria-invalid", "false");
+                }
+              </c:otherwise>
+            </c:choose>
           </c:when>
           <c:when test="${formField.type eq 'checkbox'}">
             var field = document.getElementById("${widgetContext.uniqueId}${js:escape(formField.name)}");

--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -253,7 +253,7 @@
         </label>
       </c:otherwise>
     </c:choose>
-    <c:if test="${formField.required && empty formField.listOfOptions}">
+    <c:if test="${formField.required}">
       <p id="error-${widgetContext.uniqueId}<c:out value="${formField.name}"/>" class="error-message" role="alert" aria-live="polite">
         <i class="fa fa-exclamation-circle"></i><c:out value="${formField.label}"/> is required
       </p>


### PR DESCRIPTION
Fixes #995 (re-opened against main now that #409/#988 has merged -- originally opened as lizhsr/simis-cms#43, stacked on the then-unmerged feature/form-builder-409; closing that one in favor of this)

The client-side JS validator (`checkForm${widgetContext.uniqueId}()`) had an empty branch for any required field with `listOfOptions` set -- covering both a required `<select>` dropdown and a required checkbox-group, since both share that specification. A visitor could submit without picking anything and see no inline error, though server-side validation still correctly rejected it.

Fix: filled in the branch to handle both cases -- a select's empty-value check, and a checkbox-group's per-option shared-name lookup (checking if at least one option is checked) -- using the exact same error-display mechanics (classList show/hide, aria-invalid, hasErrors/firstErrorField) the sibling branches already use.

Verified: full `ci-test` build green, both static gates clean, adversarially reviewed against the diff (confirmed scoped to only the validation `<script>` block, no overlap with #993's separate fix to the rendering block in the same file).