### PR TITLE
Render form fields of type "date" as a native date input

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cms/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cms/form.jsp
@@ -196,6 +196,13 @@
                 value="true"
                 <c:if test="${formField.userValue eq 'true'}">checked</c:if>>
           </c:when>
+          <c:when test="${formField.type eq 'date'}">
+            <%-- HTML5 date input always submits/echoes yyyy-MM-dd, so userValue round-trips as-is --%>
+            <input type="date"
+                id="${widgetContext.uniqueId}<c:out value="${formField.name}"/>" name="${widgetContext.uniqueId}<c:out value="${formField.name}"/>"
+                <c:if test="${!empty formField.userValue}">value="<c:out value="${formField.userValue}" />"</c:if>
+                <c:if test="${formField.required}">required</c:if>>
+          </c:when>
           <c:otherwise>
             <input type="text"
                 id="${widgetContext.uniqueId}<c:out value="${formField.name}"/>" name="${widgetContext.uniqueId}<c:out value="${formField.name}"/>"


### PR DESCRIPTION
Fixes #993 (re-opened against main now that #409/#988 has merged -- originally opened as lizhsr/simis-cms#44, stacked on the then-unmerged feature/form-builder-409; closing that one in favor of this)

The field-rendering `<c:choose>` block in `form.jsp` had branches for select/textarea/checkbox but no branch for `date`, so a field configured as that type in the /admin/forms builder silently fell through to the plain `<input type="text">` branch -- no date picker, no format hint, no browser-native date validation.

Fix: added the missing `<c:when test="${formField.type eq 'date'}">` branch rendering `<input type="date">`, following the same id/name/required attribute conventions as the sibling branches. HTML5 date inputs always submit/echo `yyyy-MM-dd`, so `formField.userValue` round-trips into the `value` attribute as-is on a validation-failure resubmit.

Verified: full `ci-test` build green (FormWidgetTest 16/0, FormWidgetFormDefinitionSettingsTest 13/0), both static gates clean.