### PR TITLE
Fix GeoIP Location column falling back to the raw IP address

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -131,7 +131,7 @@
             <small>GeoIP Location</small>
           </div>
           <div class="small-8 cell">
-            <small><c:out value="${geoip:location(formData.ipAddress, formData.ipAddress)}"/></small>
+            <small><c:out value="${geoip:location(formData.ipAddress, '--')}"/></small>
           </div>
         </div>
         <c:forEach items="${formData.formFieldList}" var="formField" varStatus="formFieldStatus">


### PR DESCRIPTION
## Summary

\`geoip:location(ip, unknownText)\` shows \`unknownText\` only when the GeoIP lookup fails (localhost, private IPs, or any IP not present in the GeoIP database). Every other call site of this function in the codebase passes a neutral placeholder for that fallback:

- \`allowed-ip-list.jsp\` / \`blocked-ip-list.jsp\`: \`geoip:location(record.ipAddress, " ")\`
- \`email-search-results-list.jsp\` / \`mailing-list-members.jsp\`: \`geoip:location(..., '--')\`

\`form-data-list.jsp\` instead passed \`formData.ipAddress\` as **both** the value to look up and the fallback:

\`\`\`jsp
${geoip:location(formData.ipAddress, formData.ipAddress)}
\`\`\`

So on any lookup failure, the "GeoIP Location" column silently echoes the raw IP address back instead of showing an unresolved-location placeholder -- making the two columns look identical, which is exactly the bug a user spotted while walking through the page.

## Fix

One-line change: pass \`'--'\` as the fallback, matching the convention already used by \`email-search-results-list.jsp\`/\`mailing-list-members.jsp\`.

## Test plan

- [x] \`ant package\` build succeeds
- [x] Full \`ant test\` suite: 2,872 tests, 0 failures (one transient failure on the first run reproduced as clean on a second run -- confirmed unrelated, since this change touches only a JSP template, no Java)