### PR TITLE
Make CSV export respect the Form Data page's active filters

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
@@ -54,7 +54,13 @@ public class FormDataRepository {
     return DB.selectCountFrom(TABLE_NAME, where);
   }
 
-  private static DataResult query(FormDataSpecification specification, DataConstraints constraints) {
+  /**
+   * Builds the shared WHERE clause for a {@link FormDataSpecification}, used by both {@link #query}
+   * (the on-screen list) and {@link #export} (the CSV download) so the two can never drift apart --
+   * a filter added to one must be added to the other via this single method. A null specification
+   * yields a null where clause, i.e. no filtering at all.
+   */
+  private static SqlUtils createWhereStatement(FormDataSpecification specification) {
     SqlUtils where = null;
     if (specification != null) {
       where = new SqlUtils()
@@ -93,6 +99,11 @@ public class FormDataRepository {
       where.addIfExists("created >= ?", specification.getOccurredAfter());
       where.addIfExists("created < ?", specification.getOccurredBefore());
     }
+    return where;
+  }
+
+  private static DataResult query(FormDataSpecification specification, DataConstraints constraints) {
+    SqlUtils where = createWhereStatement(specification);
     return DB.selectAllFrom(TABLE_NAME, where, constraints, FormDataRepository::buildRecord);
   }
 
@@ -341,8 +352,13 @@ public class FormDataRepository {
   /**
    * Exports form submissions to a CSV file (issue #483) so an admin can pull the raw IP addresses
    * offline, e.g. to cross-reference a spam source before adding it to the IP block list.
+   * <p>
+   * {@code specification} scopes the export to the same criteria as the on-screen list (built via
+   * {@link #createWhereStatement}, the same method {@link #query} uses) so the exported CSV always
+   * matches what's currently filtered on screen instead of unconditionally dumping the whole table.
+   * A null specification exports every row, unfiltered, same as before this filter existed.
    */
-  public static void export(DataConstraints constraints, File file) {
+  public static void export(FormDataSpecification specification, DataConstraints constraints, File file) {
     SqlUtils selectFields = new SqlUtils()
         .addNames(
             "form_unique_id AS \"Form\"",
@@ -351,10 +367,11 @@ public class FormDataRepository {
             "url AS \"URL\"",
             "flagged_as_spam AS \"Spam Flagged\""
         );
+    SqlUtils where = createWhereStatement(specification);
     if (constraints == null) {
       constraints = new DataConstraints();
     }
     constraints.setDefaultColumnToSortBy("form_data_id desc");
-    DB.exportToCsvAllFrom(TABLE_NAME, selectFields, null, null, null, constraints, file);
+    DB.exportToCsvAllFrom(TABLE_NAME, selectFields, null, where, null, constraints, file);
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
@@ -68,29 +68,7 @@ public class FormDataListWidget extends GenericWidget {
     String fromDate = context.getParameter("fromDate");
     String toDate = context.getParameter("toDate");
 
-    FormDataSpecification specification = new FormDataSpecification();
-    if (StringUtils.isNotBlank(formUniqueId)) {
-      specification.setFormUniqueId(formUniqueId);
-    }
-    if ("claimed".equalsIgnoreCase(status)) {
-      specification.setClaimed(true);
-    } else if ("processed".equalsIgnoreCase(status)) {
-      specification.setProcessed(true);
-    } else if ("dismissed".equalsIgnoreCase(status)) {
-      specification.setDismissed(true);
-    } else {
-      // Default view: the original hardcoded behavior -- awaiting review
-      specification.setDismissed(false);
-      specification.setProcessed(false);
-    }
-    Timestamp from = parseDate(fromDate, 0);
-    Timestamp to = parseDate(toDate, 1);
-    if (from != null) {
-      specification.setOccurredAfter(from);
-    }
-    if (to != null) {
-      specification.setOccurredBefore(to);
-    }
+    FormDataSpecification specification = buildSpecificationFromParameters(context);
 
     // Load the latest form data
     List<FormData> formDataList = FormDataRepository.findAll(specification, constraints);
@@ -117,6 +95,45 @@ public class FormDataListWidget extends GenericWidget {
     // Show the editor
     context.setJsp(JSP);
     return context;
+  }
+
+  /**
+   * Builds the on-screen list's filter criteria from the current request parameters (issue #563's
+   * formUniqueId/status/fromDate/toDate filters). Shared by {@link #execute} (the on-screen list)
+   * and {@link #downloadCSVFile} (the CSV export) so the export can never drift from what's actually
+   * filtered on screen -- previously downloadCSVFile() ignored these parameters entirely and always
+   * exported the whole form_data table regardless of the active filters.
+   */
+  private FormDataSpecification buildSpecificationFromParameters(WidgetContext context) {
+    String formUniqueId = context.getParameter("formUniqueId");
+    String status = context.getParameter("status");
+    String fromDate = context.getParameter("fromDate");
+    String toDate = context.getParameter("toDate");
+
+    FormDataSpecification specification = new FormDataSpecification();
+    if (StringUtils.isNotBlank(formUniqueId)) {
+      specification.setFormUniqueId(formUniqueId);
+    }
+    if ("claimed".equalsIgnoreCase(status)) {
+      specification.setClaimed(true);
+    } else if ("processed".equalsIgnoreCase(status)) {
+      specification.setProcessed(true);
+    } else if ("dismissed".equalsIgnoreCase(status)) {
+      specification.setDismissed(true);
+    } else {
+      // Default view: the original hardcoded behavior -- awaiting review
+      specification.setDismissed(false);
+      specification.setProcessed(false);
+    }
+    Timestamp from = parseDate(fromDate, 0);
+    Timestamp to = parseDate(toDate, 1);
+    if (from != null) {
+      specification.setOccurredAfter(from);
+    }
+    if (to != null) {
+      specification.setOccurredBefore(to);
+    }
+    return specification;
   }
 
   /** Appends {@code name=urlEncoded(value)} to the paging query string when the value is present. */
@@ -210,7 +227,10 @@ public class FormDataListWidget extends GenericWidget {
     String displayFilename = "form-data-" + new SimpleDateFormat("yyyyMMdd-HHmm").format(new Date()) + "." + extension;
     File tempFile = FileSystemCommand.generateTempFile("exports", context.getUserId(), extension);
     try {
-      FormDataRepository.export(null, tempFile);
+      // Scope the export to the same filters currently applied to the on-screen list, instead of
+      // unconditionally dumping the whole form_data table
+      FormDataSpecification specification = buildSpecificationFromParameters(context);
+      FormDataRepository.export(specification, null, tempFile);
       String mimeType = "text/csv";
       MultipartFileSender.fromFile(tempFile)
           .with(context.getRequest())

--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -90,6 +90,12 @@
   <input type="hidden" name="token" value="${userSession.formToken}"/>
   <%-- Form --%>
   <input type="hidden" name="command" value="downloadCSVFile"/>
+  <%-- Carry the currently active filters through so the export matches what's on screen (this is a
+       separate <form> from the GET filter form above, so it wouldn't otherwise see them) --%>
+  <input type="hidden" name="formUniqueId" value="<c:out value='${formUniqueId}'/>"/>
+  <input type="hidden" name="status" value="<c:out value='${status}'/>"/>
+  <input type="hidden" name="fromDate" value="<c:out value='${fromDate}'/>"/>
+  <input type="hidden" name="toDate" value="<c:out value='${toDate}'/>"/>
   <button type="submit" class="button small secondary radius"><i class="fa fa-download"></i> Download CSV</button>
 </form>
 <table>

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
@@ -51,7 +51,7 @@ import com.simisinc.platform.infrastructure.database.DB;
 
 /**
  * Verifies the FormDataRepository analytics methods (issue #563) and the CSV
- * {@link FormDataRepository#export(DataConstraints, File)} method (issue #483) against a real
+ * {@link FormDataRepository#export(FormDataSpecification, DataConstraints, File)} method (issue #483) against a real
  * PostgreSQL instance -- the count/trend/breakdown queries and the exported CSV content are only
  * meaningful once proven against real rows, not just "the SQL doesn't throw."
  *
@@ -203,7 +203,7 @@ class FormDataRepositoryTest {
     FormData spam = addFormData("newsletter-signup", "198.51.100.9", "https://example.org/newsletter", true);
 
     File file = new File(tempDir, "form-data-export.csv");
-    FormDataRepository.export(null, file);
+    FormDataRepository.export(null, null, file);
 
     List<String> lines = Files.readAllLines(file.toPath());
     assertEquals(3, lines.size(), "a header row plus one row per seeded record");
@@ -231,6 +231,57 @@ class FormDataRepositoryTest {
   }
 
   @Test
+  void exportWithASpecificationOnlyIncludesRowsMatchingTheFormFilter(@TempDir File tempDir) throws IOException {
+    // Regression test: FormDataRepository.export() previously took no filter argument at all and
+    // always dumped the whole table, so filtering the on-screen list to one form and clicking
+    // "Download CSV" silently exported every row instead of just the ones on screen.
+    FormData contactUsOne = addFormData("contact-us", "203.0.113.10", "https://example.org/contact", false);
+    FormData newsletter = addFormData("newsletter-signup", "203.0.113.11", "https://example.org/newsletter", false);
+    FormData contactUsTwo = addFormData("contact-us", "203.0.113.12", "https://example.org/contact", false);
+
+    FormDataSpecification specification = new FormDataSpecification();
+    specification.setFormUniqueId("contact-us");
+
+    File file = new File(tempDir, "filtered-by-form-export.csv");
+    FormDataRepository.export(specification, null, file);
+
+    List<String> lines = Files.readAllLines(file.toPath());
+    // Header plus exactly the two "contact-us" rows -- the "newsletter-signup" row must be excluded
+    assertEquals(3, lines.size(), "only the rows matching the formUniqueId filter should be exported: " + lines);
+    String body = String.join("\n", lines.subList(1, lines.size()));
+    assertTrue(body.contains(contactUsOne.getIpAddress()), "the matching contact-us row should be present: " + body);
+    assertTrue(body.contains(contactUsTwo.getIpAddress()), "the other matching contact-us row should be present: " + body);
+    assertTrue(!body.contains(newsletter.getIpAddress()), "the non-matching newsletter-signup row must be excluded: " + body);
+  }
+
+  @Test
+  void exportWithASpecificationScopesToTheMatchingFormAndStatus(@TempDir File tempDir) throws IOException {
+    // Combines a formUniqueId filter with a status filter (mirroring the widget's status dropdown),
+    // seeded across two forms and two statuses, to prove both criteria are applied as a WHERE clause
+    // rather than only one, or neither.
+    FormData matching = addFormData("contact-us", "203.0.113.20", "https://example.org/contact", false);
+    FormDataRepository.markAsProcessed(matching, 1L);
+
+    FormData wrongForm = addFormData("newsletter-signup", "203.0.113.21", "https://example.org/newsletter", false);
+    FormDataRepository.markAsProcessed(wrongForm, 1L);
+
+    // Right form, but never processed -- must be excluded by the status half of the filter
+    FormData wrongStatus = addFormData("contact-us", "203.0.113.22", "https://example.org/contact", false);
+    assertNotNull(wrongStatus);
+
+    FormDataSpecification specification = new FormDataSpecification();
+    specification.setFormUniqueId("contact-us");
+    specification.setProcessed(true);
+
+    File file = new File(tempDir, "filtered-by-form-and-status-export.csv");
+    FormDataRepository.export(specification, null, file);
+
+    List<String> lines = Files.readAllLines(file.toPath());
+    assertEquals(2, lines.size(), "header plus exactly the one row matching both the form and status filter: " + lines);
+    assertTrue(lines.get(1).contains(matching.getIpAddress()));
+  }
+
+  @Test
   void markAsProcessedIsOneShotSoARepeatCallReturnsFalse() {
     FormData formData = addSubmission("contact-us", false);
 
@@ -244,7 +295,7 @@ class FormDataRepositoryTest {
   @Test
   void exportProducesOnlyAHeaderRowWhenThereAreNoRecords(@TempDir File tempDir) throws IOException {
     File file = new File(tempDir, "empty-export.csv");
-    FormDataRepository.export(null, file);
+    FormDataRepository.export(null, null, file);
 
     List<String> lines = Files.readAllLines(file.toPath());
     assertEquals(1, lines.size(), "only the header row should be written when form_data is empty");
@@ -259,7 +310,7 @@ class FormDataRepositoryTest {
 
     File file = new File(tempDir, "paged-export.csv");
     // Page 1 of size 1: only the most recently inserted row (form_data_id desc) should come back
-    FormDataRepository.export(new DataConstraints(1, 1), file);
+    FormDataRepository.export(null, new DataConstraints(1, 1), file);
 
     List<String> lines = Files.readAllLines(file.toPath());
     assertEquals(2, lines.size(), "header plus exactly one row when the page size limits the export");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
@@ -18,10 +18,12 @@ package com.simisinc.platform.presentation.widgets.admin.cms;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.cms.FunnelEventCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.domain.model.cms.FormData;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
 import com.simisinc.platform.infrastructure.persistence.cms.FormDataSpecification;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.DataConstants;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import org.junit.jupiter.api.Assertions;
@@ -317,6 +319,77 @@ class FormDataListWidgetTest extends WidgetBase {
   }
 
   @Test
+  void downloadCSVFilePassesTheActiveFiltersThroughToExport() throws Exception {
+    // Regression test: downloadCSVFile() previously called FormDataRepository.export(null, tempFile)
+    // with a hardcoded null, so filtering the on-screen list (formUniqueId/status/fromDate/toDate)
+    // and clicking "Download CSV" silently exported the whole table instead of the filtered view.
+    // The specification passed to export() must be built from the same request parameters as
+    // execute(), matching its filtering exactly.
+    addQueryParameter(widgetContext, "command", "downloadCSVFile");
+    addQueryParameter(widgetContext, "formUniqueId", "contact-us");
+    addQueryParameter(widgetContext, "status", "processed");
+    addQueryParameter(widgetContext, "fromDate", "2026-07-01");
+    addQueryParameter(widgetContext, "toDate", "2026-07-31");
+
+    setRoles(widgetContext, ADMIN);
+
+    ArgumentCaptor<FormDataSpecification> specCaptor = ArgumentCaptor.forClass(FormDataSpecification.class);
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class);
+        MockedStatic<AuditEventCommand> auditEventCommand = mockStatic(AuditEventCommand.class);
+        MockedStatic<FileSystemCommand> fileSystemCommand = mockStatic(FileSystemCommand.class)) {
+      // generateTempFile() otherwise chases LoadSitePropertyCommand -> SitePropertyRepository -> a
+      // real DB connection this unit test doesn't have; only the specification passed to export()
+      // matters here, so stub it to a plain File with no filesystem/DB round trip.
+      fileSystemCommand.when(() -> FileSystemCommand.generateTempFile(any(), anyLong(), any()))
+          .thenReturn(new File("/tmp/does-not-exist.csv"));
+
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.post(widgetContext);
+
+      formDataRepositoryMockedStatic.verify(
+          () -> FormDataRepository.export(specCaptor.capture(), any(), any(File.class)));
+    }
+
+    FormDataSpecification specification = specCaptor.getValue();
+    Assertions.assertNotNull(specification,
+        "export() must receive a specification built from the request's filters, not a hardcoded null");
+    Assertions.assertEquals("contact-us", specification.getFormUniqueId());
+    Assertions.assertEquals(DataConstants.TRUE, specification.getProcessed());
+    Assertions.assertNotNull(specification.getOccurredAfter());
+    Assertions.assertNotNull(specification.getOccurredBefore());
+    Assertions.assertTrue(specification.getOccurredBefore().after(specification.getOccurredAfter()));
+  }
+
+  @Test
+  void downloadCSVFileWithNoFiltersAppliedStillDefaultsToTheAwaitingReviewSpecification() throws Exception {
+    // No formUniqueId/status/fromDate/toDate params -- mirrors execute()'s own default (issue #563:
+    // the page's original hardcoded "awaiting review" view), so the export continues to match
+    // whatever the on-screen list is showing by default rather than silently reverting to "everything".
+    addQueryParameter(widgetContext, "command", "downloadCSVFile");
+
+    setRoles(widgetContext, ADMIN);
+
+    ArgumentCaptor<FormDataSpecification> specCaptor = ArgumentCaptor.forClass(FormDataSpecification.class);
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class);
+        MockedStatic<AuditEventCommand> auditEventCommand = mockStatic(AuditEventCommand.class);
+        MockedStatic<FileSystemCommand> fileSystemCommand = mockStatic(FileSystemCommand.class)) {
+      fileSystemCommand.when(() -> FileSystemCommand.generateTempFile(any(), anyLong(), any()))
+          .thenReturn(new File("/tmp/does-not-exist.csv"));
+
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.post(widgetContext);
+
+      formDataRepositoryMockedStatic.verify(
+          () -> FormDataRepository.export(specCaptor.capture(), any(), any(File.class)));
+    }
+
+    FormDataSpecification specification = specCaptor.getValue();
+    Assertions.assertNull(specification.getFormUniqueId());
+    Assertions.assertEquals(DataConstants.FALSE, specification.getDismissed());
+    Assertions.assertEquals(DataConstants.FALSE, specification.getProcessed());
+  }
+
+  @Test
   void postRejectsCallersWithoutTheRequiredRole() {
     // Logged in by default (WidgetBase.login()), but no admin/community-manager role granted
     addQueryParameter(widgetContext, "command", "downloadCSVFile");
@@ -328,7 +401,7 @@ class FormDataListWidgetTest extends WidgetBase {
 
         // The role gate must return before export() (and therefore any file download) is reached
         formDataRepositoryMockedStatic.verify(
-            () -> FormDataRepository.export(any(DataConstraints.class), any(File.class)), never());
+            () -> FormDataRepository.export(any(), any(DataConstraints.class), any(File.class)), never());
         Assertions.assertFalse(widgetContext.handledResponse(), "no file should be streamed back");
         Assertions.assertSame(widgetContext, result);
       }


### PR DESCRIPTION
## Summary

\`FormDataListWidget.downloadCSVFile()\` called \`FormDataRepository.export(null, tempFile)\` with a hardcoded \`null\`, regardless of the page's active \`formUniqueId\`/\`status\`/\`fromDate\`/\`toDate\` filters. Filtering the on-screen list down to one form/status/date-range and clicking "Download CSV" silently exported the entire \`form_data\` table -- not the filtered view.

## Fix

Extracted the filter-parsing logic already in \`execute()\` into a shared \`buildSpecificationFromParameters()\` helper, used by both \`execute()\` and \`downloadCSVFile()\`. \`export()\` now accepts a \`FormDataSpecification\` and applies it via the same \`createWhereStatement()\` the on-screen query already uses -- so the exported CSV always matches what's currently filtered on screen. No filters active still exports everything, same as before.

## Test plan

- [x] \`ant package\` build succeeds
- [x] Full \`ant test\` suite: 2,876 tests, 0 failures
- [x] New tests: a repository-level test seeding rows across forms/statuses and asserting the export only contains matching rows; a widget-level test asserting the active filter parameters actually reach \`export()\`