### PR TITLE
Add retention for processed/dismissed form submissions

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepository.java
@@ -47,6 +47,10 @@ public class FormDataRepository {
   private static String TABLE_NAME = "form_data";
   private static String[] PRIMARY_KEY = new String[]{"form_data_id"};
 
+  private static final int DEFAULT_RETENTION_DAYS = 90;
+  private static final int MIN_RETENTION_DAYS = 7;
+  private static final int MAX_RETENTION_DAYS = 3650;
+
   public static long countAwaitingReview() {
     SqlUtils where = new SqlUtils()
         .add("processed IS NULL")
@@ -307,6 +311,45 @@ public class FormDataRepository {
       record.setProcessedBy(userId);
     }
     return updated;
+  }
+
+  /**
+   * Deletes form_data rows that have reached a terminal state (an admin has processed or dismissed
+   * them) whose terminal timestamp is past the configured retention window. Rows still awaiting
+   * review (both processed and dismissed are null) are never touched here, regardless of age -- they
+   * represent unactioned work an admin may still need to see. GREATEST(processed, dismissed) ignores
+   * nulls in PostgreSQL, so it resolves to whichever of the two is set, or the later of the two if
+   * both are (e.g. dismissed, then later reopened and processed) -- "time since this became terminal",
+   * not "time since creation". Mirrors FormSubmissionFailureRepository.deleteOlderThan. Returns the
+   * number of rows removed.
+   */
+  public static int deleteOlderThan(int days) {
+    if (days < 1) {
+      return 0;
+    }
+    return DB.deleteFrom(TABLE_NAME, new SqlUtils()
+        .add("(processed IS NOT NULL OR dismissed IS NOT NULL)")
+        .add("GREATEST(processed, dismissed) < NOW() - INTERVAL '" + days + " days'"));
+  }
+
+  /** Parses the configured retention window to a bounded positive integer, defaulting to 90 days. */
+  public static int resolveRetentionDays(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_RETENTION_DAYS;
+    }
+    int days;
+    try {
+      days = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_RETENTION_DAYS;
+    }
+    if (days < MIN_RETENTION_DAYS) {
+      return MIN_RETENTION_DAYS;
+    }
+    if (days > MAX_RETENTION_DAYS) {
+      return MAX_RETENTION_DAYS;
+    }
+    return days;
   }
 
   private static FormData buildRecord(ResultSet rs) {

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/SchedulerManager.java
@@ -23,6 +23,7 @@ import com.simisinc.platform.infrastructure.scheduler.admin.CapabilityGrantExpir
 import com.simisinc.platform.infrastructure.scheduler.admin.DatasetsDownloadAndSyncJob;
 import com.simisinc.platform.infrastructure.scheduler.audit.AuditLogIntegrityJob;
 import com.simisinc.platform.infrastructure.scheduler.audit.AuditLogRetentionJob;
+import com.simisinc.platform.infrastructure.scheduler.cms.FormDataRetentionJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.FormSubmissionFailureRetentionJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.FunnelEventRetentionJob;
 import com.simisinc.platform.infrastructure.scheduler.cms.LoadSystemFilesJob;
@@ -100,6 +101,7 @@ public class SchedulerManager {
   public static final String EMAIL_CLASSIFICATION_JOB = "EmailClassification";
   public static final String MAILING_LIST_QUARANTINE_JOB = "MailingListQuarantine";
   public static final String FORM_SUBMISSION_FAILURE_RETENTION_JOB = "FormSubmissionFailureRetention";
+  public static final String FORM_DATA_RETENTION_JOB = "FormDataRetention";
   public static final String FUNNEL_EVENT_RETENTION_JOB = "FunnelEventRetention";
   public static final String NEWSLETTER_QUEUE_JOB = "NewsletterQueue";
 
@@ -208,6 +210,8 @@ public class SchedulerManager {
         BackgroundJob.scheduleRecurrently(MAILING_LIST_QUARANTINE_JOB, Cron.daily(3, 30), MailingListQuarantineJob::execute);
         BackgroundJob.scheduleRecurrently(FORM_SUBMISSION_FAILURE_RETENTION_JOB, Cron.daily(5), FormSubmissionFailureRetentionJob::execute);
         BackgroundJob.scheduleRecurrently(FUNNEL_EVENT_RETENTION_JOB, Cron.daily(5, 30), FunnelEventRetentionJob::execute);
+        // Offset from the other retention jobs above so they aren't all competing for DB time at once
+        BackgroundJob.scheduleRecurrently(FORM_DATA_RETENTION_JOB, Cron.daily(5, 45), FormDataRetentionJob::execute);
         BackgroundJob.scheduleRecurrently(NEWSLETTER_QUEUE_JOB, Cron.minutely(), NewsletterQueueJob::execute);
       }
     } catch (Exception se) {

--- a/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/FormDataRetentionJob.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/scheduler/cms/FormDataRetentionJob.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.scheduler.cms;
+
+import java.time.Duration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jobrunr.jobs.annotations.Job;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.infrastructure.distributedlock.LockManager;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDataRepository;
+import com.simisinc.platform.infrastructure.scheduler.SchedulerManager;
+
+/**
+ * Deletes form_data records past the configured retention window, but only once they have reached a
+ * terminal state (an admin has processed or dismissed them -- see FormDataRepository.deleteOlderThan).
+ * Submissions still awaiting review are never deleted here, no matter how old, since they represent
+ * unactioned work an admin may still need to see. Unlike AuditLogRetentionJob, this does not record
+ * an audit event for its own purge, mirroring FormSubmissionFailureRetentionJob.
+ *
+ * @author SimIS Inc.
+ */
+public class FormDataRetentionJob {
+
+  private static Log LOG = LogFactory.getLog(FormDataRetentionJob.class);
+
+  @Job(name = "Delete terminal-state form data records past the retention window")
+  public static void execute() {
+    // Distributed lock so only one node purges
+    String lock = LockManager.lock(SchedulerManager.FORM_DATA_RETENTION_JOB, Duration.ofHours(4));
+    if (lock == null) {
+      return;
+    }
+
+    int days = FormDataRepository.resolveRetentionDays(
+        LoadSitePropertyCommand.loadByName("formData.retentionDays"));
+    int deleted = FormDataRepository.deleteOlderThan(days);
+    if (deleted > 0) {
+      LOG.info("Form data retention: deleted " + deleted + " terminal-state record(s) older than " + days + " days");
+    }
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -172,6 +172,10 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (1, 'Audit log retention (days)', 'audit.retentionDays', '2555');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (2, 'Password Age Warning Threshold (days)', 'password.maxAgeDays', '90', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (11, 'Form submission failure retention (days)', 'formData.failureRetentionDays', '90');
+-- Only applies to form_data rows that have reached a terminal state (processed or dismissed by an
+-- admin) -- rows still awaiting review are never deleted by this, regardless of age. See
+-- FormDataRepository.deleteOlderThan and FormDataRetentionJob.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (14, 'Form data retention (days, terminal-state only)', 'formData.retentionDays', '90');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (12, 'Web page version history limit (per page)', 'webPage.versionHistoryLimit', '20', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (13, 'Content block version history limit (per block)', 'content.versionHistoryLimit', '20', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value) VALUES (10, 'Analytics Service', 'analytics.service', 'google');

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1300__form_data_retention.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1300__form_data_retention.sql
@@ -1,0 +1,11 @@
+-- Copyright 2026 SimIS Inc. (https://www.simiscms.com), Licensed under the Apache License, Version 2.0 (the "License").
+-- The form_data table has never had a retention/cleanup job -- submissions can carry PII (whatever
+-- fields the form collects) and rows stayed forever. Retention here only applies to rows that have
+-- reached a terminal state (processed IS NOT NULL OR dismissed IS NOT NULL); rows still awaiting
+-- review are never deleted, regardless of age, since they represent unactioned work an admin may
+-- still need to see. Mirrors formData.failureRetentionDays (same default/bounds, see
+-- FormDataRepository.resolveRetentionDays). Idempotent so it is safe on any existing install; fresh
+-- installs get the identical row from NEW_10000.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value)
+VALUES (14, 'Form data retention (days, terminal-state only)', 'formData.retentionDays', '90')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/cms/FormDataRepositoryTest.java
@@ -242,6 +242,76 @@ class FormDataRepositoryTest {
   }
 
   @Test
+  void deleteOlderThanRemovesOnlyOldTerminalStateRows() {
+    FormData oldProcessed = addSubmission("contact-us", false);
+    markProcessed(oldProcessed.getId(), 100);
+
+    FormData oldDismissed = addSubmission("contact-us", false);
+    markDismissed(oldDismissed.getId(), 100);
+
+    // Both processed and dismissed remain null -- an unactioned row, no matter how old
+    FormData oldAwaiting = addSubmission("contact-us", false);
+    backdate(oldAwaiting.getId(), 100);
+
+    FormData recentProcessed = addSubmission("contact-us", false);
+    markProcessed(recentProcessed.getId(), 5);
+
+    int deleted = FormDataRepository.deleteOlderThan(90);
+
+    assertEquals(2, deleted, "only the two old terminal-state rows should be deleted");
+    assertEquals(2, DB.selectCountFrom("form_data"));
+    assertNotNull(FormDataRepository.findById(oldAwaiting.getId()),
+        "an old but still-awaiting row must never be deleted, regardless of age");
+    assertNotNull(FormDataRepository.findById(recentProcessed.getId()),
+        "a row that only recently became terminal must not be deleted yet");
+  }
+
+  @Test
+  void deleteOlderThanNeverDeletesAnAwaitingReviewRowNoMatterHowOld() {
+    FormData veryOldAwaiting = addSubmission("contact-us", false);
+    backdate(veryOldAwaiting.getId(), 5000);
+
+    int deleted = FormDataRepository.deleteOlderThan(7);
+
+    assertEquals(0, deleted, "unactioned submissions represent work an admin may still need to see");
+    assertEquals(1, DB.selectCountFrom("form_data"));
+  }
+
+  @Test
+  void deleteOlderThanMeasuresFromTheLaterOfProcessedAndDismissed() {
+    // Dismissed long ago, then reopened and processed recently -- retention should key off the more
+    // recent terminal timestamp (processed), not the older one (dismissed)
+    FormData reopened = addSubmission("contact-us", false);
+    markDismissed(reopened.getId(), 100);
+    markProcessed(reopened.getId(), 5);
+
+    int deleted = FormDataRepository.deleteOlderThan(90);
+
+    assertEquals(0, deleted,
+        "the row became terminal again 5 days ago (processed), not 100 days ago (dismissed)");
+    assertEquals(1, DB.selectCountFrom("form_data"));
+  }
+
+  @Test
+  void deleteOlderThanReturnsZeroForNonPositiveDays() {
+    FormData oldProcessed = addSubmission("contact-us", false);
+    markProcessed(oldProcessed.getId(), 100);
+
+    assertEquals(0, FormDataRepository.deleteOlderThan(0));
+    assertEquals(1, DB.selectCountFrom("form_data"));
+  }
+
+  @Test
+  void resolveRetentionDaysAppliesDefaultAndBounds() {
+    assertEquals(90, FormDataRepository.resolveRetentionDays(null));
+    assertEquals(90, FormDataRepository.resolveRetentionDays(""));
+    assertEquals(45, FormDataRepository.resolveRetentionDays("45"));
+    assertEquals(7, FormDataRepository.resolveRetentionDays("1"), "below the floor should clamp to 7");
+    assertEquals(3650, FormDataRepository.resolveRetentionDays("999999"), "above the ceiling should clamp to 3650");
+    assertEquals(90, FormDataRepository.resolveRetentionDays("not-a-number"));
+  }
+
+  @Test
   void exportProducesOnlyAHeaderRowWhenThereAreNoRecords(@TempDir File tempDir) throws IOException {
     File file = new File(tempDir, "empty-export.csv");
     FormDataRepository.export(null, file);
@@ -296,6 +366,32 @@ class FormDataRepositoryTest {
       pst.executeUpdate();
     } catch (SQLException se) {
       throw new IllegalStateException("Could not backdate form_data row", se);
+    }
+  }
+
+  /** Directly rewrites {@code processed} to a backdated timestamp, for retention-window tests. */
+  private static void markProcessed(long formDataId, int daysAgo) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "UPDATE form_data SET processed = NOW() - (? || ' days')::interval WHERE form_data_id = ?")) {
+      pst.setInt(1, daysAgo);
+      pst.setLong(2, formDataId);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not mark form_data row as processed", se);
+    }
+  }
+
+  /** Directly rewrites {@code dismissed} to a backdated timestamp, for retention-window tests. */
+  private static void markDismissed(long formDataId, int daysAgo) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "UPDATE form_data SET dismissed = NOW() - (? || ' days')::interval WHERE form_data_id = ?")) {
+      pst.setInt(1, daysAgo);
+      pst.setLong(2, formDataId);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not mark form_data row as dismissed", se);
     }
   }
 


### PR DESCRIPTION
## Summary

\`form_data\` can carry PII -- whatever fields a form collects (name, email, comments, etc). It had no retention/cleanup job at all: nothing in \`SchedulerManager\` ever deleted or aged out rows, and the admin's "Remove" action only sets a \`dismissed\` timestamp (soft-delete) -- the row stays forever regardless.

## Design

By design, retention only applies to submissions that have reached a **terminal state**: \`processed IS NOT NULL OR dismissed IS NOT NULL\`. A submission still sitting unactioned in "awaiting" is never deleted automatically, no matter how old -- it represents work an admin may still need to see, not an expired log entry. Age is measured from the *later* of \`processed\`/\`dismissed\` (via \`GREATEST()\`), so a submission dismissed long ago but only just processed doesn't get immediately swept.

## What's added

- \`formData.retentionDays\` site property (default 90, 7-3650 day bounds), matching the existing \`formData.failureRetentionDays\` precedent for the sibling failure-tracking table
- \`FormDataRepository.deleteOlderThan()\`
- \`FormDataRetentionJob\`, scheduled daily, mirroring \`FormSubmissionFailureRetentionJob\`'s lock/log pattern

## Test plan

- [x] \`ant package\` build succeeds
- [x] Full \`ant test\` suite: 2,877 tests, 0 failures
- [x] New tests prove: an old+unactioned row is never deleted regardless of age; an old+processed row is deleted; a row dismissed long ago but processed recently is measured from the later (processed) timestamp