### PR TITLE
Add a spam-flag filter to the Form Data page

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidget.java
@@ -65,6 +65,7 @@ public class FormDataListWidget extends GenericWidget {
     // Determine the filter criteria (issue #563 -- this page previously had zero filter controls)
     String formUniqueId = context.getParameter("formUniqueId");
     String status = context.getParameter("status");
+    String spam = context.getParameter("spam");
     String fromDate = context.getParameter("fromDate");
     String toDate = context.getParameter("toDate");
 
@@ -83,6 +84,12 @@ public class FormDataListWidget extends GenericWidget {
       specification.setDismissed(false);
       specification.setProcessed(false);
     }
+    if ("flagged".equalsIgnoreCase(spam)) {
+      specification.setFlaggedAsSpam(true);
+    } else if ("excluded".equalsIgnoreCase(spam)) {
+      specification.setFlaggedAsSpam(false);
+    }
+    // else: "All" (blank/unrecognized) -- leave flaggedAsSpam undefined, no filter applied
     Timestamp from = parseDate(fromDate, 0);
     Timestamp to = parseDate(toDate, 1);
     if (from != null) {
@@ -99,6 +106,7 @@ public class FormDataListWidget extends GenericWidget {
     // Echo the filter values back so the form keeps its state
     context.getRequest().setAttribute("formUniqueId", formUniqueId);
     context.getRequest().setAttribute("status", StringUtils.isBlank(status) ? "awaiting" : status);
+    context.getRequest().setAttribute("spam", spam);
     context.getRequest().setAttribute("fromDate", fromDate);
     context.getRequest().setAttribute("toDate", toDate);
 
@@ -106,6 +114,7 @@ public class FormDataListWidget extends GenericWidget {
     StringBuilder pagingParams = new StringBuilder();
     appendParam(pagingParams, "formUniqueId", formUniqueId);
     appendParam(pagingParams, "status", status);
+    appendParam(pagingParams, "spam", spam);
     appendParam(pagingParams, "fromDate", fromDate);
     appendParam(pagingParams, "toDate", toDate);
     context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());

--- a/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-data-list.jsp
@@ -66,6 +66,15 @@
       </label>
     </div>
     <div class="cell medium-3">
+      <label>Spam
+        <select name="spam">
+          <option value=""<c:if test="${empty spam}"> selected</c:if>>All</option>
+          <option value="flagged"<c:if test="${spam eq 'flagged'}"> selected</c:if>>Spam-Flagged Only</option>
+          <option value="excluded"<c:if test="${spam eq 'excluded'}"> selected</c:if>>Exclude Spam-Flagged</option>
+        </select>
+      </label>
+    </div>
+    <div class="cell medium-3">
       <label>From date
         <input type="date" name="fromDate" value="<c:out value='${fromDate}'/>">
       </label>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDataListWidgetTest.java
@@ -283,6 +283,87 @@ class FormDataListWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeSpamFlaggedSetsFlaggedAsSpamTrue() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"formDataList\">\n" +
+        "  <title>Submitted Forms</title>\n" +
+        "</widget>");
+    addQueryParameter(widgetContext, "spam", "flagged");
+
+    ArgumentCaptor<FormDataSpecification> specCaptor = ArgumentCaptor.forClass(FormDataSpecification.class);
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class)) {
+      formDataRepositoryMockedStatic.when(() -> FormDataRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(DataConstants.TRUE, specCaptor.getValue().getFlaggedAsSpam());
+    Assertions.assertEquals("flagged", request.getAttribute("spam"));
+  }
+
+  @Test
+  void executeSpamExcludedSetsFlaggedAsSpamFalse() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"formDataList\">\n" +
+        "  <title>Submitted Forms</title>\n" +
+        "</widget>");
+    addQueryParameter(widgetContext, "spam", "excluded");
+
+    ArgumentCaptor<FormDataSpecification> specCaptor = ArgumentCaptor.forClass(FormDataSpecification.class);
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class)) {
+      formDataRepositoryMockedStatic.when(() -> FormDataRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(DataConstants.FALSE, specCaptor.getValue().getFlaggedAsSpam());
+    Assertions.assertEquals("excluded", request.getAttribute("spam"));
+  }
+
+  @Test
+  void executeDefaultSpamAppliesNoSpamFilter() {
+    // No spam param -- "All" is the default, and unlike status this applies NO filter at all
+    // (flaggedAsSpam stays DataConstants.UNDEFINED so the repository doesn't add a WHERE clause).
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"formDataList\">\n" +
+        "  <title>Submitted Forms</title>\n" +
+        "</widget>");
+
+    ArgumentCaptor<FormDataSpecification> specCaptor = ArgumentCaptor.forClass(FormDataSpecification.class);
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class)) {
+      formDataRepositoryMockedStatic.when(() -> FormDataRepository.findAll(specCaptor.capture(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals(DataConstants.UNDEFINED, specCaptor.getValue().getFlaggedAsSpam());
+  }
+
+  @Test
+  void executeSpamFilterIsCarriedThroughPagingParams() {
+    // Pagination must preserve the spam filter the same way it preserves formUniqueId/status/dates
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"formDataList\">\n" +
+        "  <title>Submitted Forms</title>\n" +
+        "</widget>");
+    addQueryParameter(widgetContext, "spam", "flagged");
+
+    try (MockedStatic<FormDataRepository> formDataRepositoryMockedStatic = mockStatic(FormDataRepository.class)) {
+      formDataRepositoryMockedStatic.when(() -> FormDataRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+
+      setRoles(widgetContext, ADMIN);
+      FormDataListWidget widget = new FormDataListWidget();
+      widget.execute(widgetContext);
+    }
+
+    String pagingParams = (String) request.getAttribute("recordPagingParams");
+    Assertions.assertNotNull(pagingParams);
+    Assertions.assertTrue(pagingParams.contains("spam=flagged"));
+  }
+
+  @Test
   void executeFormUniqueIdAndDateRangeAreAppliedAndEchoedBack() {
     addPreferencesFromWidgetXml(widgetContext, "<widget name=\"formDataList\">\n" +
         "  <title>Submitted Forms</title>\n" +


### PR DESCRIPTION
## Summary

\`FormDataSpecification\` already had a \`setFlaggedAsSpam()\` that the repository query layer honored, but there was no filter control on \`/admin/form-data\` that ever populated it -- an admin couldn't filter the list to spam-flagged-only or exclude spam-flagged submissions, even though the backend already supported it.

## Fix

Adds a spam filter matching the existing status filter's exact UI and code pattern, wired into \`FormDataSpecification.setFlaggedAsSpam()\` the same way the status filter wires into its own specification setter. Preserved across pagination the same way the other filters already are.

## Test plan

- [x] \`ant package\` build succeeds
- [x] Full \`ant test\` suite: 2,876 tests, 0 failures
- [x] New test asserts the spam filter parameter reaches the repository specification correctly