### PR TITLE
Add double opt-in confirmation to mailing list signups

### DIFF
--- a/docs/mailing-lists.md
+++ b/docs/mailing-lists.md
@@ -1,0 +1,115 @@
+# Mailing Lists
+
+**Audience:** Site administrators, community managers, DevOps
+**Goal:** Explain what the Mailing Lists feature does, how signups become sends, what to configure before going live on Azure, and what to monitor.
+
+## Overview
+
+```
+Visitor submits an email (footer form / ajax widget / checkout opt-in)
+  → SaveEmailCommand validates + GeoIP-enriches + upserts an `emails` row
+    → MailingListMemberRepository.addEmailToList() creates/reactivates a
+      `mailing_list_members` row, PENDING confirmation (double opt-in)
+        → MailingListConfirmationCommand fires a domain event
+          → jeasy-flows "mailing-list-member-confirmation-requested" playbook
+            → confirm-subscription.html emailed via SMTP (EmailTask)
+              → visitor clicks the link → MailingListConfirmSubscriptionWidget
+                → member.confirmed set, is_valid = true, member is now ACTIVE
+
+Admin CSV import / admin manual "Add Email" on /admin/mailing-list-members
+  → same SaveEmailCommand path, but BYPASSES confirmation (admin attests consent)
+    → member is ACTIVE immediately
+
+Active members
+  → ZeroBounce classifies deliverability (emails.validation_status)
+    → confirmed-bad addresses auto-quarantined (archived, is_valid = false)
+  → NewsletterSendCommand enqueues a send (mailing_list_sent, per recipient)
+    → NewsletterQueueJob sends via SMTP, OR MailChimpCommand hands the whole
+      send off to MailChimp as a Campaign instead
+  → recipient can click a one-click unsubscribe link (unsubscribe_token) at
+    any time, no login required
+```
+
+## Data Model
+
+| Table | Key columns | Purpose |
+|---|---|---|
+| `emails` | `email`, `first_name`/`last_name`/`organization`, `ip_address` + GeoIP fields, `subscribed`/`unsubscribed`, `validation_status`/`validation_sub_status`/`validated_at` (ZeroBounce), `last_order`/`number_of_orders`/`total_spent` | One row per address, shared across mailing lists **and** ecommerce customers |
+| `mailing_lists` | `name`, `title`, `member_count`, `show_online`, `enabled` | A list a visitor can subscribe to; `member_count` is a display-only counter (never decremented on unsubscribe, see `countDistinctSubscribers()`'s own comment) |
+| `mailing_list_members` | `list_id`, `email_id`, `is_valid`, `unsubscribed`/`unsubscribed_by`/`unsubscribe_reason`, `quarantined`/`quarantine_reason`, `unsubscribe_token`, `confirmed`/`confirm_token`/`confirm_token_expires` | One row per (list, email) membership. `is_valid = false` means either genuinely unsubscribed, quarantined, or **pending double opt-in confirmation** — the admin member table's status filter distinguishes these (Active / Pending Confirmation / Unsubscribed / Quarantined) |
+| `mailing_list_history` / `mailing_list_sent` | `service`, `subject`, `mailchimp_campaign_id`; per-recipient `status` (queued/sent/failed) | One send "batch" (history) and its per-recipient delivery rows (sent) |
+
+## Signup Paths
+
+| Path | Widget/Command | Requires confirmation? |
+|---|---|---|
+| Footer/newsletter signup form | `EmailSubscribeWidget` | **Yes** |
+| Ajax inline signup (same form, JS variant) | `EmailSubscribeAjax` | **Yes** |
+| Checkout "subscribe to newsletter" checkbox | `PlaceOrderWidget` | **Yes** |
+| CSV bulk import | `ProcessEmailCSVFileCommand` → `/admin/mailing-list-members` upload | No — admin is attesting consent already exists |
+| Admin manual "Add Email" | `MailingListMembersWidget`'s add-email action | No — same reasoning as CSV import |
+
+All five converge on `SaveEmailCommand`. The three public self-service paths call `saveEmailRequiringConfirmation(...)`; CSV import and the admin manual-add form call the original `saveEmail(...)` overloads unchanged. A pending (unconfirmed) row is `is_valid = false` with a live `confirm_token`, expiring after a configurable number of days (`mailing-list.confirmation.expiryDays`, default 7) — an expired or already-used token behaves exactly like an unknown one on `/confirm-subscription`, matching `UserRepository`'s account-token precedent.
+
+**Reactivation is also gated.** If someone previously unsubscribed and signs up again through a public path, they get a *fresh* confirmation email rather than being silently reactivated — this closes the loophole an earlier issue on this same page found (unbounded reactivation without re-consent). A **quarantined** address is never reactivated by any signup path, public or admin — only deliberate admin review clears a quarantine.
+
+## Deliverability: ZeroBounce + Quarantine
+
+If `mailing-list.zerobounce.apiKey` is configured, a background job periodically classifies subscriber emails via ZeroBounce's verification API into `emails.validation_status`. Any membership linked to a confirmed-bad status (`invalid`, `spamtrap`, `abuse`, `do_not_mail`) is automatically **quarantined** — archived (`is_valid = false`, `quarantined` timestamp set) but never deleted, and never touched by `unsubscribed` logic since quarantine is a distinct reason a membership stopped being active. `catch_all`/`unknown` statuses deliberately do **not** trigger quarantine, since ZeroBounce itself isn't calling those bad, just unresolved.
+
+A dashboard tile tracks the quarantine rate against a configurable alert threshold (`mailing-list.quarantine.alertThresholdPercent`, default 10%) — if this spikes, it usually means either a compromised signup form (bot traffic feeding garbage addresses) or a genuine list-hygiene problem worth investigating before it drags down sender reputation.
+
+## Sending: Direct SMTP vs. MailChimp
+
+The app has **two independent send mechanisms**, chosen per list/send at `/admin/newsletter-send`:
+
+1. **Direct SMTP** (`NewsletterSendCommand` → `NewsletterQueueJob`) — enqueues one row per active, valid member into `mailing_list_sent`, then sends each individually via `EmailCommand.prepareNewEmail()` (Apache Commons `ImageHtmlEmail`) using the site's configured `mail.host_name`/`mail.port`/`mail.username`/`mail.password`/`mail.ssl` properties — i.e., a raw SMTP relay you provide.
+2. **MailChimp Campaign** (`MailChimpCommand`) — hands the whole send off to MailChimp's Campaigns API instead, using `mailing-list.mailchimp.apiKey`/`mailing-list.mailchimp.listId`. MailChimp also has its own separate sync path that pushes members into a MailChimp audience independent of sending a campaign through it.
+
+The confirm-subscription and unsubscribe emails (transactional, one-off) always go through the direct-SMTP path via the same `jeasy-flows` workflow-YAML mechanism the rest of the app's transactional email uses (`WEB-INF/workflows/*.yml` + `EmailTask`) — they are not affected by which mechanism a list's *newsletter* sends use.
+
+## Azure Deployment Guidance
+
+**Outbound SMTP port 25 is blocked** on Azure App Service and (for most subscription types) VMs — this affects the direct-SMTP send path above regardless of list size. Configure `mail.port` to **587** (authenticated submission) against your SMTP provider; port 25 will silently fail or hang depending on the provider. This is confirmed current Microsoft Learn guidance (last updated July 2026) — see [Troubleshoot Outbound SMTP Connectivity in Azure](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-network/troubleshoot-outbound-smtp-connectivity).
+
+**Raw SMTP relay is fine for transactional volume (unsubscribe/confirm emails, order confirmations) but risky for bulk newsletter sends.** Sending hundreds/thousands of marketing emails through a generic SMTP relay with no reputation management tends toward the spam folder over time, independent of Azure specifically. For real newsletter volume, prefer either:
+
+- **MailChimp** (already integrated, `MailChimpCommand`) — reputation management, deliverability tooling, and campaign analytics are MailChimp's job, not yours.
+- **A dedicated ESP as the SMTP relay target** instead of a generic mailbox provider — swap `mail.host_name`/`mail.username`/`mail.password` to point at the ESP's SMTP endpoint; no code change needed since the send path is already relay-agnostic. Reasonable options with Java-integrable REST APIs if you outgrow raw SMTP entirely: **Amazon SES** (cheapest at volume, but starts in a sandbox limited to 200 msgs/24h/verified-recipients-only until you request production access), **SendGrid**, **Postmark** (explicitly separates transactional vs. broadcast traffic into different IP pools — don't run newsletter blasts through a "transactional" stream if you adopt it), **Brevo/Sendinblue** (free tier includes both transactional + marketing, closest like-for-like MailChimp swap), **Mailgun**.
+- **Azure Communication Services (ACS) Email** — a native Azure option explicitly positioned for bulk/marketing (not transactional-only), with its own SPF/DKIM/ARC, bounce/open/click analytics, and suppression-list handling, and its own 587 relay as one of the documented port-25 workarounds. Worth evaluating if you want to stay entirely within Azure's ecosystem rather than adding a third-party vendor.
+
+**Captcha egress**: `EmailSubscribeWidget`/`EmailSubscribeAjax` validate reCAPTCHA/Turnstile server-side (`CaptchaCommand`) on every public signup. If the app runs behind VNet integration with restricted egress (NAT Gateway, firewall), explicitly allow-list the captcha provider's verification endpoint (`www.google.com`/`recaptcha.net` for reCAPTCHA, `challenges.cloudflare.com` for Turnstile) — a blocked verification call fails closed (signup rejected), which is safe but will look like "the signup form is broken" if nobody remembers to open the egress rule.
+
+**IP/domain reputation**: a dedicated sending IP only pays off above roughly 100k emails/month of consistent volume; below that, a reputable shared pool (the default for SES/SendGrid/Mailgun/Brevo/ACS) is easier to maintain. Warm up any new sending domain or IP gradually — start with your most-engaged segment and ramp volume over days/weeks — regardless of which provider you choose.
+
+## Monitoring & What To Watch
+
+| Signal | Where | What it means |
+|---|---|---|
+| Quarantine rate spike | Mailing Lists dashboard tile, `mailing-list.quarantine.alertThresholdPercent` | Bot signups or a genuine hygiene problem |
+| Rising "Pending Confirmation" count that never converts | `/admin/mailing-list-members?status=pending` | Confirmation emails aren't being delivered/opened — check SMTP relay health first |
+| `mailing_list_sent.status = 'failed'` rows | `NewsletterQueueJob` per-recipient tracking | Individual send failures during a newsletter blast — check `error_message` |
+| Bounce/complaint feedback | Provider-side (MailChimp dashboard, or SES/SendGrid/etc. webhooks if you adopt one) | Not currently surfaced inside SimIS CMS for the direct-SMTP path — this is an external tool you'd check on the provider's own dashboard |
+| Rate-limit rejections on signup | Not currently persisted for mailing-list signups specifically (unlike Form Data's `FormSubmissionFailureRepository`) | A burst of legitimate-looking but rejected signups wouldn't show up anywhere today — a gap worth knowing about if signup volume seems lower than expected |
+
+## Best Practices
+
+- **Never bypass confirmation on a public-facing path.** The bypass exists only for CSV import and admin manual-add, both of which assume the admin already has a legal basis for the address. Anything reachable by an anonymous visitor should always go through `saveEmailRequiringConfirmation(...)`.
+- **Keep the confirm-link expiry short enough to matter, long enough to be usable.** 7 days (the default) balances "don't let a stale token linger forever" against "don't punish someone who signs up on a Friday and checks email Monday."
+- **Don't manually flip `is_valid = true` in the database** to "fix" a stuck pending signup — that skips consent entirely. Either wait for them to click the link, or re-trigger a fresh signup.
+- **Route confirmation/unsubscribe email through a reliable relay before you route newsletter blasts through it.** If the transactional path is unreliable, double opt-in itself becomes the deliverability bottleneck (nobody can confirm if the email never arrives).
+- **Check the quarantine dashboard before every large send**, not just periodically — a spike right before a scheduled campaign is a strong signal something (a scraper, a compromised form) fed the list garbage addresses recently.
+
+## Newsletter / Blog Post Notifications
+
+Publishing a blog post can optionally trigger a "Notify subscribers" email to a chosen mailing list (configured per-post in the blog editor) — this reuses the same `NewsletterSendCommand`/`NewsletterQueueJob` mechanism above, templated via `newsletter-blog-post.html`. A blog can also be permanently associated with a specific mailing list, which both defaults that picker and lets a blog-scoped signup CTA (`EmailSubscribeWidget`'s `blogUniqueId` preference) subscribe visitors directly to the right list from the blog's own page.
+
+---
+
+**See Also:**
+- `SaveEmailCommand.java` / `MailingListMemberRepository.java` — signup + confirmation logic
+- `MailChimpCommand.java` / `NewsletterSendCommand.java` / `NewsletterQueueJob.java` — send mechanisms
+- `MailingListConfirmSubscriptionWidget.java` / `NewsletterUnsubscribeWidget.java` — public token-based landing pages
+- `WEB-INF/workflows/mailinglists-workflows.yml` — confirmation email playbook
+- [Troubleshoot Outbound SMTP Connectivity in Azure](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-network/troubleshoot-outbound-smtp-connectivity)
+- [Azure Communication Services Email overview](https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/email-overview)

--- a/src/main/java/com/simisinc/platform/application/mailinglists/MailingListConfirmationCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/MailingListConfirmationCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberConfirmationRequestedEvent;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+
+/**
+ * Sends the confirm-subscription email for a pending double opt-in membership. Mirrors
+ * ForgotPasswordWidget/AccountValidationWidget's shape: the actual send happens through the
+ * workflow engine's "mailing-list-member-confirmation-requested" playbook (see
+ * mailinglists-workflows.yml), not synchronously here -- this command only builds the link and
+ * fires the event.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListConfirmationCommand {
+
+  public static void sendConfirmationEmail(MailingListMember member, MailingList mailingList) {
+    if (member == null || mailingList == null || member.getConfirmToken() == null) {
+      return;
+    }
+    String siteUrl = LoadSitePropertyCommand.loadByName("site.url");
+    String confirmUrl = siteUrl + "/confirm-subscription?token=" + UrlCommand.encodeUri(member.getConfirmToken());
+    WorkflowManager.triggerWorkflowForEvent(new MailingListMemberConfirmationRequestedEvent(member, mailingList, confirmUrl));
+  }
+}

--- a/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/MailingListMemberCommand.java
@@ -46,6 +46,15 @@ public class MailingListMemberCommand {
 
   private static Log LOG = LogFactory.getLog(MailingListMemberCommand.class);
 
+  /**
+   * A logged-in user's self-service "subscribe me" toggle (e.g. My Email Preferences), called
+   * with the account's own email address. Deliberately calls the immediate-activation {@link
+   * SaveEmailCommand#saveEmail(Email, MailingList)} rather than {@code
+   * saveEmailRequiringConfirmation(...)} -- unlike the public signup paths, the address here is
+   * always the caller's own account email, already proven via account validation at registration
+   * time (see AccountValidationWidget), so a second confirmation step would add friction with no
+   * consent benefit. A third trusted bypass, alongside CSV import and admin manual-add.
+   */
   public static void subscribe(MailingList mailingList, User user, UserSession userSession) throws DataException {
 
     if (mailingList == null) {

--- a/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
+++ b/src/main/java/com/simisinc/platform/application/mailinglists/SaveEmailCommand.java
@@ -22,8 +22,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.sql.Timestamp;
+
 import com.sanctionco.jmail.JMail;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.maps.GeoIPCommand;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
@@ -52,6 +55,44 @@ public class SaveEmailCommand {
   }
 
   public static Email saveEmail(Email emailBean, String mailingListName) throws DataException {
+    return saveEmail(emailBean, resolveMailingList(mailingListName));
+  }
+
+  public static Email saveEmail(Email emailBean, MailingList mailingList) throws DataException {
+    return saveEmail(emailBean, List.of(mailingList));
+  }
+
+  /** Subscribes to every list in mailingLists (issue #598 -- a signup can choose more than one).
+   *  Trusted paths only (CSV import, admin manual-add) -- activates immediately, with no
+   *  confirmation step. Public self-service signup paths must call {@link
+   *  #saveEmailRequiringConfirmation(Email, List)} instead. */
+  public static Email saveEmail(Email emailBean, List<MailingList> mailingLists) throws DataException {
+    return saveEmail(emailBean, mailingLists, false);
+  }
+
+  public static Email saveEmailRequiringConfirmation(Email emailBean) throws DataException {
+    return saveEmailRequiringConfirmation(emailBean, (String) null);
+  }
+
+  public static Email saveEmailRequiringConfirmation(Email emailBean, String mailingListName) throws DataException {
+    return saveEmailRequiringConfirmation(emailBean, resolveMailingList(mailingListName));
+  }
+
+  public static Email saveEmailRequiringConfirmation(Email emailBean, MailingList mailingList) throws DataException {
+    return saveEmailRequiringConfirmation(emailBean, List.of(mailingList));
+  }
+
+  /**
+   * Double opt-in: for public self-service signup paths (the newsletter form, its ajax variant,
+   * and the checkout newsletter checkbox), a new or reactivated membership is left pending until
+   * the address owner clicks the link {@link MailingListConfirmationCommand} emails them, instead
+   * of activating immediately on nothing but a typed-in address.
+   */
+  public static Email saveEmailRequiringConfirmation(Email emailBean, List<MailingList> mailingLists) throws DataException {
+    return saveEmail(emailBean, mailingLists, true);
+  }
+
+  private static MailingList resolveMailingList(String mailingListName) {
     if (mailingListName == null) {
       mailingListName = "Newsletter";
     }
@@ -64,15 +105,11 @@ public class SaveEmailCommand {
       mailingList.setEnabled(true);
       mailingList = MailingListRepository.save(mailingList);
     }
-    return saveEmail(emailBean, mailingList);
+    return mailingList;
   }
 
-  public static Email saveEmail(Email emailBean, MailingList mailingList) throws DataException {
-    return saveEmail(emailBean, List.of(mailingList));
-  }
-
-  /** Subscribes to every list in mailingLists (issue #598 -- a signup can choose more than one). */
-  public static Email saveEmail(Email emailBean, List<MailingList> mailingLists) throws DataException {
+  private static Email saveEmail(Email emailBean, List<MailingList> mailingLists, boolean requiresConfirmation)
+      throws DataException {
     if (mailingLists == null || mailingLists.isEmpty()) {
       throw new DataException("Please choose at least one list to subscribe to");
     }
@@ -119,9 +156,31 @@ public class SaveEmailCommand {
     // #810 fix), so on the duplicate-email/update branch above, email.getCreatedBy() would still
     // be whoever originally created that address, not who is submitting this request
     User actingUser = emailBean.getCreatedBy() > -1 ? UserRepository.findByUserId(emailBean.getCreatedBy()) : null;
+
+    // Resolve once for the whole signup, not per-list -- every list in a multi-list signup shares
+    // one confirm-link expiry rather than drifting by milliseconds between addEmailToList() calls.
+    Timestamp confirmTokenExpires = null;
+    if (requiresConfirmation) {
+      int expiryDays = MailingListMemberRepository.resolveConfirmationExpiryDays(
+          LoadSitePropertyCommand.loadByName("mailing-list.confirmation.expiryDays"));
+      confirmTokenExpires = new Timestamp(System.currentTimeMillis() + expiryDays * 86_400_000L);
+    }
+
     for (MailingList mailingList : mailingLists) {
       MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
-          mailingList);
+          mailingList, requiresConfirmation, confirmTokenExpires);
+      if (result != null && result.requiresConfirmation()) {
+        // Double opt-in: don't sync to a third-party list or fire the created/updated lifecycle
+        // yet -- the real lifecycle event fires once the recipient actually confirms (see the
+        // confirm-subscription widget). Only send the email when a fresh token was actually
+        // minted (confirmationEmailNeeded) -- addEmailToList() reuses a still-live token instead
+        // of reissuing one on a resubmit, so repeatedly submitting the same address doesn't
+        // resend a real outbound email on every request.
+        if (result.confirmationEmailNeeded()) {
+          MailingListConfirmationCommand.sendConfirmationEmail(result.getMember(), mailingList);
+        }
+        continue;
+      }
       MailingListMemberCommand.triggerEmailSubscriptionProcess(email, mailingList, true);
       if (result != null && result.getMember() != null) {
         // issue #452: webhook/workflow event for the mailing-list-member lifecycle. A "not

--- a/src/main/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommand.java
+++ b/src/main/java/com/simisinc/platform/application/webhooks/BuildWebhookPayloadCommand.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberConfirmationRequestedEvent;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberDeletedEvent;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
@@ -171,6 +172,8 @@ public class BuildWebhookPayloadCommand {
     } else if (event instanceof MailingListMemberDeletedEvent mailingListMemberDeletedEvent) {
       putMailingListMember(data, mailingListMemberDeletedEvent.getMember(), mailingListMemberDeletedEvent.getMailingList());
       data.put("user", userSummary(mailingListMemberDeletedEvent.getUser()));
+    } else if (event instanceof MailingListMemberConfirmationRequestedEvent confirmationRequestedEvent) {
+      putMailingListMember(data, confirmationRequestedEvent.getMember(), confirmationRequestedEvent.getMailingList());
     } else {
       LOG.warn("No webhook payload mapping for event type: " + event.getClass().getName()
           + " -- delivering with an empty data object rather than failing the dispatch");

--- a/src/main/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommand.java
+++ b/src/main/java/com/simisinc/platform/application/webhooks/WebhookEventTypeCommand.java
@@ -76,7 +76,8 @@ public class WebhookEventTypeCommand {
       new WebhookEventType("user-account-restored", "User account restored"),
       new WebhookEventType("mailing-list-member-created", "Mailing list member subscribed"),
       new WebhookEventType("mailing-list-member-updated", "Mailing list member subscription changed"),
-      new WebhookEventType("mailing-list-member-deleted", "Mailing list member removed"))));
+      new WebhookEventType("mailing-list-member-deleted", "Mailing list member removed"),
+      new WebhookEventType("mailing-list-member-confirmation-requested", "Mailing list member confirmation requested"))));
 
   private WebhookEventTypeCommand() {
     // Static utility, not instantiated

--- a/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberConfirmationRequestedEvent.java
+++ b/src/main/java/com/simisinc/platform/domain/events/mailinglists/MailingListMemberConfirmationRequestedEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.domain.events.mailinglists;
+
+import com.simisinc.platform.domain.events.Event;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+
+/**
+ * Fired when a public signup path (double opt-in) creates or reactivates a mailing list
+ * membership that is pending confirmation, so the confirm-subscription email can be sent.
+ * Deliberately distinct from {@link MailingListMemberCreatedEvent}/{@link
+ * MailingListMemberUpdatedEvent} -- those represent an actually-active membership change and must
+ * not fire (nor sync to a third-party list) until the address owner actually confirms.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListMemberConfirmationRequestedEvent extends Event {
+
+  public static final String ID = "mailing-list-member-confirmation-requested";
+
+  private final MailingListMember member;
+  private final MailingList mailingList;
+  private final String confirmUrl;
+
+  public MailingListMemberConfirmationRequestedEvent(MailingListMember member, MailingList mailingList, String confirmUrl) {
+    this.member = member;
+    this.mailingList = mailingList;
+    this.confirmUrl = confirmUrl;
+  }
+
+  @Override
+  public String getDomainEventType() {
+    return ID;
+  }
+
+  public MailingListMember getMember() {
+    return member;
+  }
+
+  public MailingList getMailingList() {
+    return mailingList;
+  }
+
+  public String getConfirmUrl() {
+    return confirmUrl;
+  }
+}

--- a/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
+++ b/src/main/java/com/simisinc/platform/domain/model/mailinglists/MailingListMember.java
@@ -44,6 +44,12 @@ public class MailingListMember extends Entity {
   private Timestamp quarantined = null;
   private String quarantineReason = null;
   private String unsubscribeToken = null;
+  /** When the address owner clicked the confirm-subscription link (double opt-in). NULL means
+   *  still pending, or this membership bypassed confirmation entirely (CSV import, admin
+   *  manual-add). */
+  private Timestamp confirmed = null;
+  private String confirmToken = null;
+  private Timestamp confirmTokenExpires = null;
 
   /** Only populated by queries that join to emails -- not a mailing_list_members column. */
   private String emailAddress = null;
@@ -177,6 +183,30 @@ public class MailingListMember extends Entity {
 
   public void setUnsubscribeToken(String unsubscribeToken) {
     this.unsubscribeToken = unsubscribeToken;
+  }
+
+  public Timestamp getConfirmed() {
+    return confirmed;
+  }
+
+  public void setConfirmed(Timestamp confirmed) {
+    this.confirmed = confirmed;
+  }
+
+  public String getConfirmToken() {
+    return confirmToken;
+  }
+
+  public void setConfirmToken(String confirmToken) {
+    this.confirmToken = confirmToken;
+  }
+
+  public Timestamp getConfirmTokenExpires() {
+    return confirmTokenExpires;
+  }
+
+  public void setConfirmTokenExpires(Timestamp confirmTokenExpires) {
+    this.confirmTokenExpires = confirmTokenExpires;
   }
 
   public String getEmailAddress() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -59,6 +59,7 @@ public class MailingListMemberRepository {
   private static final String QUARANTINE_TRIGGER_STATUSES_SQL = "('invalid', 'spamtrap', 'abuse', 'do_not_mail')";
 
   private static final int DEFAULT_QUARANTINE_ALERT_THRESHOLD_PERCENT = 10;
+  private static final int DEFAULT_CONFIRMATION_EXPIRY_DAYS = 7;
 
   /** Whether {@link #addEmailToList} inserted a new member row or reactivated an existing one
    *  (issue #452 -- the caller needs this to fire a created vs. updated lifecycle event), plus the
@@ -70,11 +71,33 @@ public class MailingListMemberRepository {
   public static final class AddToListResult {
     private final boolean created;
     private final boolean previouslyUnsubscribed;
+    private final boolean requiresConfirmation;
+    private final boolean confirmationEmailNeeded;
     private final MailingListMember member;
 
     public AddToListResult(boolean created, boolean previouslyUnsubscribed, MailingListMember member) {
+      this(created, previouslyUnsubscribed, false, false, member);
+    }
+
+    /** @param requiresConfirmation true when this call left the membership pending double
+     *  opt-in confirmation instead of activating it -- see {@link #addEmailToList(Email,
+     *  MailingList, boolean, Timestamp)}. */
+    public AddToListResult(boolean created, boolean previouslyUnsubscribed, boolean requiresConfirmation,
+        MailingListMember member) {
+      this(created, previouslyUnsubscribed, requiresConfirmation, requiresConfirmation, member);
+    }
+
+    /** @param confirmationEmailNeeded true only when this call actually minted a fresh
+     *  confirm_token (a brand-new pending row, or an existing one whose prior token had expired
+     *  or never existed) -- false when an already-live, unexpired token was reused instead. This
+     *  is what stops a resubmitted address from getting a fresh "please confirm" email on every
+     *  request; see the "requiresConfirmation" branch of {@link #addEmailToList}. */
+    public AddToListResult(boolean created, boolean previouslyUnsubscribed, boolean requiresConfirmation,
+        boolean confirmationEmailNeeded, MailingListMember member) {
       this.created = created;
       this.previouslyUnsubscribed = previouslyUnsubscribed;
+      this.requiresConfirmation = requiresConfirmation;
+      this.confirmationEmailNeeded = confirmationEmailNeeded;
       this.member = member;
     }
 
@@ -86,12 +109,37 @@ public class MailingListMemberRepository {
       return previouslyUnsubscribed;
     }
 
+    public boolean requiresConfirmation() {
+      return requiresConfirmation;
+    }
+
+    public boolean confirmationEmailNeeded() {
+      return confirmationEmailNeeded;
+    }
+
     public MailingListMember getMember() {
       return member;
     }
   }
 
   public static AddToListResult addEmailToList(Email email, MailingList mailingList) {
+    return addEmailToList(email, mailingList, false, null);
+  }
+
+  /**
+   * @param requiresConfirmation Double opt-in: public-facing signup paths must not activate a new
+   *     membership, or reactivate a previously-unsubscribed one, until the address owner proves
+   *     control by clicking the link {@link com.simisinc.platform.application.mailinglists.MailingListConfirmationCommand}
+   *     emails them. Trusted paths -- CSV import, admin manual-add -- pass false and get the
+   *     pre-existing immediate-activation behavior. Ignored (may be null) when false.
+   * @param confirmTokenExpires when the freshly-issued confirm_token stops being honored by
+   *     {@link #findByConfirmToken}; the caller resolves this from the configurable
+   *     mailing-list.confirmation.expiryDays site property (see {@link
+   *     #resolveConfirmationExpiryDays}) so every list in a single multi-list signup shares one
+   *     expiry rather than drifting by milliseconds between DB calls.
+   */
+  public static AddToListResult addEmailToList(Email email, MailingList mailingList, boolean requiresConfirmation,
+      Timestamp confirmTokenExpires) {
     // Capture prior state before mutating, so the caller can tell a genuine reactivation (was
     // unsubscribed) from a harmless re-add of an already-active member (issue #452)
     MailingListMember existingBefore = findByListAndEmail(mailingList.getId(), email.getId());
@@ -101,6 +149,10 @@ public class MailingListMemberRepository {
     // do_not_mail). That decision must not be silently reversed just because the same address
     // resubscribes -- via the public signup form, a MailChimp sync, or a replayed subscription job.
     boolean previouslyQuarantined = existingBefore != null && StringUtils.isNotBlank(existingBefore.getQuarantineReason());
+    // Already a confirmed, active member -- a duplicate signup is a harmless no-op, not a fresh
+    // consent event, so it never needs to (re)confirm or re-notify.
+    boolean alreadyActiveMember = existingBefore != null && existingBefore.getIsValid() && !previouslyUnsubscribed
+        && !previouslyQuarantined;
 
     // Determine if the email is already listed
     SqlUtils insertValues = new SqlUtils()
@@ -108,8 +160,14 @@ public class MailingListMemberRepository {
         .add("email_id", email.getId())
         .addIfExists("created_by", email.getCreatedBy(), -1)
         .addIfExists("modified_by", email.getCreatedBy(), -1);
+    if (requiresConfirmation) {
+      applyPendingConfirmation(insertValues, confirmTokenExpires);
+    } else {
+      insertValues.add("is_valid", true);
+    }
     long memberId = DB.insertInto(TABLE_NAME, insertValues, PRIMARY_KEY);
     boolean created = memberId > -1;
+    boolean confirmationEmailNeeded = created && requiresConfirmation;
     if (created) {
       // New member - Update the related count
       String set = "member_count = member_count + 1";
@@ -124,19 +182,68 @@ public class MailingListMemberRepository {
       SaveAuditEventCommand.recordAdminEvent("configuration", "mailing_list.reactivation_blocked", "success",
           -1L, "system", null, null, "mailing_list_members", String.valueOf(existingBefore.getId()),
           existingBefore.getEmailAddress(), "quarantine_reason=" + existingBefore.getQuarantineReason());
+    } else if (alreadyActiveMember && requiresConfirmation) {
+      // Nothing to do -- re-adding an already-confirmed, already-active member through a
+      // confirmation-requiring path must not re-issue a token or re-send a confirmation email.
+      // (requiresConfirmation=false falls through to the unconditional "make active" branch
+      // below, exactly as it did before double opt-in existed -- a harmless no-op update.)
+    } else if (requiresConfirmation) {
+      // Existing but inactive (unsubscribed, or a stale never-confirmed pending signup) row being
+      // re-added through a path that requires confirmation. Deliberately does NOT touch
+      // unsubscribed/is_valid here -- only confirmByToken() does that, once they click.
+      //
+      // If a still-live (unexpired) token is already outstanding, reuse it instead of minting a
+      // new one and sending another email -- without this, resubmitting the same address (the
+      // public form has no login/ownership check) would re-send a real outbound email on every
+      // single request, an unthrottled spam/mail-bomb primitive against an arbitrary address.
+      // Capping to one send per still-valid token means the worst case is exactly what every
+      // double opt-in system already accepts as normal: one confirmation email per address per
+      // confirm-link lifetime, however many times someone resubmits it.
+      boolean hasLiveToken = existingBefore != null && StringUtils.isNotBlank(existingBefore.getConfirmToken())
+          && existingBefore.getConfirmTokenExpires() != null
+          && existingBefore.getConfirmTokenExpires().after(new Timestamp(System.currentTimeMillis()));
+      if (!hasLiveToken) {
+        SqlUtils updateValues = new SqlUtils()
+            .add("modified", new Timestamp(System.currentTimeMillis()))
+            .addIfExists("modified_by", email.getModifiedBy(), -1);
+        applyPendingConfirmation(updateValues, confirmTokenExpires);
+        SqlUtils where = new SqlUtils()
+            .add("list_id = ?", mailingList.getId())
+            .add("email_id = ?", email.getId());
+        DB.update(TABLE_NAME, updateValues, where);
+        confirmationEmailNeeded = true;
+      }
     } else {
-      // Make sure email is set to subscribed
+      // Make sure email is set to subscribed. Also clears confirm_token/confirm_token_expires --
+      // without this, a member who had an outstanding double opt-in confirmation pending (via a
+      // public signup) and was then separately activated through a trusted path (CSV import,
+      // admin manual-add) would keep a live, clickable confirm link after already being fully
+      // active: clicking it would re-run confirmByToken() and fire a duplicate
+      // MailingListMemberCreatedEvent, and the admin member list would mislabel them "Pending
+      // Confirmation" indefinitely (see the "pending" status filter below, which relies on
+      // confirm_token being cleared the moment a member is genuinely active).
       SqlUtils updateValues = new SqlUtils()
           .add("unsubscribed", (Timestamp) null)
           .add("modified", new Timestamp(System.currentTimeMillis()))
           .addIfExists("modified_by", email.getModifiedBy(), -1)
-          .add("is_valid", true);
+          .add("is_valid", true)
+          .add("confirm_token", (String) null)
+          .add("confirm_token_expires", (Timestamp) null);
       SqlUtils where = new SqlUtils()
           .add("list_id = ?", mailingList.getId())
           .add("email_id = ?", email.getId());
       DB.update(TABLE_NAME, updateValues, where);
     }
-    return new AddToListResult(created, previouslyUnsubscribed, findByListAndEmail(mailingList.getId(), email.getId()));
+    boolean pendingConfirmation = requiresConfirmation && !alreadyActiveMember && !previouslyQuarantined;
+    return new AddToListResult(created, previouslyUnsubscribed, pendingConfirmation, confirmationEmailNeeded,
+        findByListAndEmail(mailingList.getId(), email.getId()));
+  }
+
+  private static SqlUtils applyPendingConfirmation(SqlUtils values, Timestamp confirmTokenExpires) {
+    return values
+        .add("is_valid", false)
+        .add("confirm_token", UUID.randomUUID().toString())
+        .add("confirm_token_expires", confirmTokenExpires);
   }
 
   public static void remove(Email email, MailingList mailingList) {
@@ -256,6 +363,67 @@ public class MailingListMemberRepository {
     DB.update(TABLE_NAME, updateValues, where);
   }
 
+  /** Looks up a pending member by their confirm-subscription link token, only while it hasn't
+   *  expired -- an expired token must behave exactly like an unknown one, matching
+   *  UserRepository.findByAccountToken's expiry-checked-in-SQL precedent. */
+  public static MailingListMember findByConfirmToken(String token) {
+    if (StringUtils.isBlank(token)) {
+      return null;
+    }
+    SqlUtils select = new SqlUtils().addNames("emails.email AS email_address");
+    SqlJoins joins = new SqlJoins().add(JOIN);
+    SqlUtils where = new SqlUtils()
+        .add("mailing_list_members.confirm_token = ?", token)
+        .add("(mailing_list_members.confirm_token_expires IS NULL OR mailing_list_members.confirm_token_expires > NOW())");
+    return (MailingListMember) DB.selectRecordFrom(TABLE_NAME, select, joins, where,
+        MailingListMemberRepository::buildRecordWithEmail);
+  }
+
+  /**
+   * Activates a pending membership once the address owner proves control by clicking the
+   * confirm-subscription link (double opt-in). Single-use: clears the token so a re-clicked link
+   * lands on a graceful already-confirmed state instead of erroring, mirroring
+   * unsubscribeByToken()'s shape. Also clears unsubscribed -- a reconfirmed resubscribe is no
+   * longer unsubscribed, whether this was a brand-new signup (already NULL) or a returning
+   * subscriber re-proving consent after having left.
+   */
+  public static void confirmByToken(MailingListMember member) {
+    Timestamp now = new Timestamp(System.currentTimeMillis());
+    SqlUtils updateValues = new SqlUtils()
+        .add("confirmed", now)
+        .add("is_valid", true)
+        .add("unsubscribed", (Timestamp) null)
+        .add("modified", now)
+        .add("confirm_token", (String) null)
+        .add("confirm_token_expires", (Timestamp) null);
+    SqlUtils where = new SqlUtils().add("member_id = ?", member.getId());
+    DB.update(TABLE_NAME, updateValues, where);
+  }
+
+  /**
+   * Parses the configurable mailing-list.confirmation.expiryDays site property, falling back to
+   * the default on a blank/unparseable value and clamping to a sane range -- mirrors
+   * resolveQuarantineAlertThresholdPercent's exact shape.
+   */
+  public static int resolveConfirmationExpiryDays(String value) {
+    if (StringUtils.isBlank(value)) {
+      return DEFAULT_CONFIRMATION_EXPIRY_DAYS;
+    }
+    int days;
+    try {
+      days = Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return DEFAULT_CONFIRMATION_EXPIRY_DAYS;
+    }
+    if (days < 1) {
+      return 1;
+    }
+    if (days > 90) {
+      return 90;
+    }
+    return days;
+  }
+
   private static MailingListMember buildRecordWithEmail(ResultSet rs) {
     try {
       MailingListMember record = new MailingListMember();
@@ -274,6 +442,9 @@ public class MailingListMemberRepository {
       record.setQuarantined(rs.getTimestamp("quarantined"));
       record.setQuarantineReason(rs.getString("quarantine_reason"));
       record.setUnsubscribeToken(rs.getString("unsubscribe_token"));
+      record.setConfirmed(rs.getTimestamp("confirmed"));
+      record.setConfirmToken(rs.getString("confirm_token"));
+      record.setConfirmTokenExpires(rs.getTimestamp("confirm_token_expires"));
       record.setEmailAddress(rs.getString("email_address"));
       return record;
     } catch (SQLException se) {
@@ -333,10 +504,26 @@ public class MailingListMemberRepository {
       if ("quarantined".equals(specification.getStatus())) {
         where.add("mailing_list_members.quarantined IS NOT NULL");
       } else if ("unsubscribed".equals(specification.getStatus())) {
+        // Excludes a row that's unsubscribed but has a live reconfirmation token outstanding --
+        // that's a "pending" row (see below), not a durably-unsubscribed one.
         where.add("mailing_list_members.unsubscribed IS NOT NULL");
+        where.add("mailing_list_members.confirm_token IS NULL");
+      } else if ("pending".equals(specification.getStatus())) {
+        // Awaiting double opt-in confirmation -- a live (not-yet-consumed) confirm_token is what
+        // distinguishes this from a CSV-imported/admin-added member, which never gets a
+        // confirm_token at all (addEmailToList's trusted-path branch always clears it), and from
+        // a durably-quarantined/unsubscribed member. Deliberately does NOT require
+        // unsubscribed IS NULL -- a previously-unsubscribed member re-signing up on a
+        // confirmation-required path keeps their unsubscribed timestamp until they actually
+        // reconfirm (see addEmailToList), so that row must still surface here.
+        where.add("mailing_list_members.quarantined IS NULL");
+        where.add("mailing_list_members.confirm_token IS NOT NULL");
       } else if ("active".equals(specification.getStatus())) {
+        // is_valid = true (not just quarantined/unsubscribed both NULL) so a pending-confirmation
+        // row -- introduced by double opt-in -- doesn't misclassify as active; see "pending" above.
         where.add("mailing_list_members.quarantined IS NULL");
         where.add("mailing_list_members.unsubscribed IS NULL");
+        where.add("mailing_list_members.is_valid = ?", true);
       }
     }
     if (constraints == null) {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepository.java
@@ -16,6 +16,7 @@
 
 package com.simisinc.platform.infrastructure.persistence.mailinglists;
 
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
 import com.simisinc.platform.domain.model.mailinglists.Email;
@@ -95,6 +96,11 @@ public class MailingListMemberRepository {
     // unsubscribed) from a harmless re-add of an already-active member (issue #452)
     MailingListMember existingBefore = findByListAndEmail(mailingList.getId(), email.getId());
     boolean previouslyUnsubscribed = existingBefore != null && existingBefore.getUnsubscribed() != null;
+    // A non-null quarantine_reason means quarantineFlaggedMembers() (issue #564) previously
+    // archived this membership for a confirmed-bad deliverability status (spamtrap/invalid/abuse/
+    // do_not_mail). That decision must not be silently reversed just because the same address
+    // resubscribes -- via the public signup form, a MailChimp sync, or a replayed subscription job.
+    boolean previouslyQuarantined = existingBefore != null && StringUtils.isNotBlank(existingBefore.getQuarantineReason());
 
     // Determine if the email is already listed
     SqlUtils insertValues = new SqlUtils()
@@ -109,6 +115,15 @@ public class MailingListMemberRepository {
       String set = "member_count = member_count + 1";
       SqlUtils where = new SqlUtils().add("list_id = ?", mailingList.getId());
       DB.update("mailing_lists", set, where);
+    } else if (previouslyQuarantined) {
+      // Blocked reactivation: leave is_valid=false and the quarantined/quarantine_reason columns
+      // untouched. A quarantined address only becomes eligible for sends again through deliberate
+      // admin review (the member-management table, issue #763), never automatically on resubscribe.
+      LOG.warn("Blocked reactivation of a quarantined mailing list member: listId=" + mailingList.getId() +
+          ", emailId=" + email.getId() + ", quarantineReason=" + existingBefore.getQuarantineReason());
+      SaveAuditEventCommand.recordAdminEvent("configuration", "mailing_list.reactivation_blocked", "success",
+          -1L, "system", null, null, "mailing_list_members", String.valueOf(existingBefore.getId()),
+          existingBefore.getEmailAddress(), "quarantine_reason=" + existingBefore.getQuarantineReason());
     } else {
       // Make sure email is set to subscribed
       SqlUtils updateValues = new SqlUtils()

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberSpecification.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberSpecification.java
@@ -27,7 +27,7 @@ public class MailingListMemberSpecification {
   private long mailingListId = -1;
   private String matchesEmail = null;
   private String matchesName = null;
-  /** One of "quarantined" / "unsubscribed" / "active", or null/blank for no status filter. */
+  /** One of "quarantined" / "unsubscribed" / "pending" / "active", or null/blank for no status filter. */
   private String status = null;
 
   public MailingListMemberSpecification() {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjax.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjax.java
@@ -117,9 +117,9 @@ public class EmailSubscribeAjax extends GenericWidget {
     // Save the record
     try {
       if (selectedLists != null) {
-        SaveEmailCommand.saveEmail(emailBean, selectedLists);
+        SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, selectedLists);
       } else {
-        SaveEmailCommand.saveEmail(emailBean);
+        SaveEmailCommand.saveEmailRequiringConfirmation(emailBean);
       }
       // Manage the related cookie
       context.getUserSession().setShowSiteNewsletterSignup(false);

--- a/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/PlaceOrderWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/ecommerce/PlaceOrderWidget.java
@@ -230,7 +230,7 @@ public class PlaceOrderWidget extends GenericWidget {
           emailBean.setCreatedBy(context.getUserId());
           emailBean.setModifiedBy(context.getUserId());
         }
-        SaveEmailCommand.saveEmail(emailBean);
+        SaveEmailCommand.saveEmailRequiringConfirmation(emailBean);
       }
 
     } catch (AccountException ae) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/EmailSubscribeWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/EmailSubscribeWidget.java
@@ -77,7 +77,8 @@ public class EmailSubscribeWidget extends GenericWidget {
     if ("true".equals(isSuccess)) {
       context.getRequest().setAttribute("successTitle", context.getPreferences().get("successTitle"));
       context.getRequest().setAttribute("successMessage",
-          context.getPreferences().getOrDefault("successMessage", "You are now subscribed"));
+          context.getPreferences().getOrDefault("successMessage",
+              "Almost done! Check your email to confirm your subscription."));
       context.setJsp(SUCCESS_JSP);
       return context;
     }
@@ -194,9 +195,9 @@ public class EmailSubscribeWidget extends GenericWidget {
           // The blog's association was removed between this form rendering and being submitted
           throw new DataException("Sorry, this signup isn't available right now.");
         }
-        SaveEmailCommand.saveEmail(emailBean, mailingList);
+        SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, mailingList);
       } else {
-        SaveEmailCommand.saveEmail(emailBean, mailingListName);
+        SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, mailingListName);
       }
     } catch (DataException e) {
       context.setWarningMessage(e.getMessage());

--- a/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListConfirmSubscriptionWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListConfirmSubscriptionWidget.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.mailinglists.MailingListMemberCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+import com.simisinc.platform.presentation.widgets.GenericWidget;
+
+/**
+ * Anonymous, no-login-required double opt-in confirmation link. Modeled on
+ * NewsletterUnsubscribeWidget: the mutation happens directly on GET, no form/POST required, since
+ * confirming needs no additional input from the visitor. The token itself is the authorization; a
+ * missing, invalid, or expired token gets the same graceful "not found" page rather than an
+ * error, so a re-clicked email link never looks broken.
+ *
+ * @author SimIS Inc.
+ */
+public class MailingListConfirmSubscriptionWidget extends GenericWidget {
+
+  static final long serialVersionUID = -8484048371911908894L;
+
+  static String JSP = "/mailinglists/confirm-subscription.jsp";
+  static String NOT_FOUND_JSP = "/mailinglists/confirm-subscription-not-found.jsp";
+  static String RATE_LIMITED_JSP = "/cms/error-rate-limited.jsp";
+
+  public WidgetContext execute(WidgetContext context) {
+
+    // The token is a guessable-length concern only in aggregate (brute force); rate limit the
+    // same way NewsletterUnsubscribeWidget rate limits its own anonymous, token-adjacent surface.
+    if (!RateLimitCommand.isIpAllowedRightNow(context.getRequest().getRemoteAddr(), false)) {
+      context.setJsp(RATE_LIMITED_JSP);
+      return context;
+    }
+
+    String token = context.getParameter("token");
+    if (StringUtils.isBlank(token)) {
+      context.setJsp(NOT_FOUND_JSP);
+      return context;
+    }
+
+    MailingListMember member = MailingListMemberRepository.findByConfirmToken(token);
+    if (member == null) {
+      RateLimitCommand.isIpAllowedRightNow(context.getRequest().getRemoteAddr(), true);
+      context.setJsp(NOT_FOUND_JSP);
+      return context;
+    }
+
+    MailingList mailingList = MailingListRepository.findById(member.getListId());
+    if (mailingList == null) {
+      context.setJsp(NOT_FOUND_JSP);
+      return context;
+    }
+    context.getRequest().setAttribute("mailingList", mailingList);
+
+    if (member.getConfirmed() == null) {
+      // A live confirm_token only ever exists on a pending row (see addEmailToList) -- distinguish
+      // a fresh signup from a returning subscriber reconfirming after having unsubscribed, so the
+      // right lifecycle event fires. This is the moment the membership actually becomes active, so
+      // this is when that event fires -- not back when the pending row was first inserted.
+      boolean wasReactivation = member.getUnsubscribed() != null;
+      MailingListMemberRepository.confirmByToken(member);
+
+      Email email = EmailRepository.findById(member.getEmailId());
+      MailingListMemberCommand.triggerEmailSubscriptionProcess(email, mailingList, true);
+
+      MailingListMember confirmedMember = MailingListMemberRepository.findByListAndEmail(mailingList.getId(),
+          member.getEmailId());
+      if (confirmedMember != null) {
+        if (wasReactivation) {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberUpdatedEvent(confirmedMember, mailingList, null, "resubscribed", false));
+        } else {
+          WorkflowManager.triggerWorkflowForEvent(
+              new MailingListMemberCreatedEvent(confirmedMember, mailingList, null));
+        }
+      }
+    }
+
+    context.setJsp(JSP);
+    return context;
+  }
+}

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -149,6 +149,7 @@ INSERT INTO site_properties (property_order, property_label, property_name, prop
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (22, 'MailChimp List Id', 'mailing-list.mailchimp.listId', '', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (24, 'ZeroBounce API Key', 'mailing-list.zerobounce.apiKey', '', 'text');
 INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (26, 'Mailing List Quarantine Alert Threshold (%)', 'mailing-list.quarantine.alertThresholdPercent', '10', 'text');
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type) VALUES (27, 'Mailing List Confirmation Link Expiry (days)', 'mailing-list.confirmation.expiryDays', '7', 'text');
 
 -- Search
 

--- a/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
+++ b/src/main/resources/database/install/NEW_10070__new_mailing_lists.sql
@@ -93,7 +93,10 @@ CREATE TABLE mailing_list_members (
   is_valid BOOLEAN DEFAULT true,
   quarantined TIMESTAMP(3),
   quarantine_reason VARCHAR(50),
-  unsubscribe_token VARCHAR(255)
+  unsubscribe_token VARCHAR(255),
+  confirmed TIMESTAMP(3),
+  confirm_token VARCHAR(255),
+  confirm_token_expires TIMESTAMP(3)
 );
 CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id);
 CREATE INDEX mail_lis_mem_lid_idx ON mailing_list_members(list_id);
@@ -101,6 +104,7 @@ CREATE INDEX mail_lis_mem_eid_idx ON mailing_list_members(email_id);
 CREATE INDEX mail_lis_mem_quarantined_idx ON mailing_list_members(quarantined);
 CREATE INDEX mail_lis_mem_val_idx ON mailing_list_members(is_valid);
 CREATE UNIQUE INDEX mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token);
+CREATE UNIQUE INDEX mail_lis_mem_confirm_tok_idx ON mailing_list_members(confirm_token);
 
 CREATE TABLE mailing_list_history (
   history_id BIGSERIAL PRIMARY KEY,

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1600__mailing_list_double_optin.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1600__mailing_list_double_optin.sql
@@ -1,0 +1,24 @@
+-- Double opt-in for mailing list signups: no path today confirms that the address owner actually
+-- requested the subscription -- the public signup form, the ajax signup endpoint, and the
+-- checkout newsletter checkbox all activate a membership immediately on nothing but a bare
+-- typed-in address, with no verification step at all.
+--
+-- confirmed:              when the address owner clicked the confirm link. NULL means still
+--                          pending (or the membership bypassed confirmation entirely, e.g. CSV
+--                          import / admin manual-add -- see MailingListConfirmationCommand).
+-- confirm_token:           single-use link token, mirroring unsubscribe_token's shape. Cleared on
+--                          confirmation (MailingListMemberRepository.confirmByToken()).
+-- confirm_token_expires:   matches UserRepository.account_token_expires' expiry-checked-in-SQL
+--                          pattern (see findByConfirmToken()) so a stale link stops working
+--                          instead of remaining valid forever.
+ALTER TABLE mailing_list_members ADD COLUMN IF NOT EXISTS confirmed TIMESTAMP(3);
+ALTER TABLE mailing_list_members ADD COLUMN IF NOT EXISTS confirm_token VARCHAR(255);
+ALTER TABLE mailing_list_members ADD COLUMN IF NOT EXISTS confirm_token_expires TIMESTAMP(3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS mail_lis_mem_confirm_tok_idx ON mailing_list_members(confirm_token);
+
+-- Configurable confirm-link expiry, matching the mailing-list.quarantine.alertThresholdPercent /
+-- formData.failureRetentionDays configurable-default precedent.
+INSERT INTO site_properties (property_order, property_label, property_name, property_value, property_type)
+VALUES (27, 'Mailing List Confirmation Link Expiry (days)', 'mailing-list.confirmation.expiryDays', '7', 'text')
+ON CONFLICT (property_name) DO NOTHING;

--- a/src/main/webapp/WEB-INF/email-templates/mailinglists/confirm-subscription.html
+++ b/src/main/webapp/WEB-INF/email-templates/mailinglists/confirm-subscription.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title></title>
+  <style type="text/css">
+    /* Client Specific Styles */
+    body,
+    table,
+    td,
+    a {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table,
+    td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+    }
+    /* Reset Styles */
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      max-width: 100%;
+    }
+    table {
+      border-collapse: collapse !important;
+    }
+    body {
+      height: 100% !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+    /* iOS Links */
+    a[x-apple-data-detectors] {
+      color: inherit !important;
+      text-decoration: none !important;
+      font-size: inherit !important;
+      font-family: inherit !important;
+      font-weight: inherit !important;
+      line-height: inherit !important;
+    }
+    /* Mobile Styles */
+    @media screen and (max-width: 600px) {
+      .mobile-wrapper {
+        width: 95% !important;
+        max-width: 95% !important;
+      }
+      .mobile-padding {
+        padding-left: 3% !important;
+        padding-right: 3% !important;
+      }
+    }
+    /* Android Center Fix */
+    div[style*="margin: 16px 0;"] {
+      margin: 0 !important;
+    }
+    /* Styles */
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-weight: 600;
+      color: #333333;
+      line-height: 1.5;
+      margin: 0 0 20px 0;
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+    }
+    h1 {
+      font-size: 22px;
+    }
+    h2 {
+      font-size: 18px;
+    }
+    h3 {
+      font-size: 16px;
+    }
+    h4,
+    h5,
+    h6 {
+      font-size: 14px;
+    }
+    p {
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+      font-size: 16px;
+      line-height: 1.5;
+      margin: 0 0 20px 0;
+      color: #868e96;
+    }
+    a {
+      color: #329af0;
+      text-decoration: underline;
+    }
+    ul li,
+    ol li {
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+      font-size: 16px;
+      line-height: 1.5;
+      color: #868e96;
+    }
+    a.web-button {
+      font-size: 20px;
+      font-weight: 600;
+      font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      color: #f8f9fa;
+      display: inline-block;
+      border: 1px solid #1c7cd6;
+      padding: 16px 48px;
+      border-radius: 4px;
+      text-decoration: none;
+      background-color: #1c7cd6;
+    }
+  </style>
+</head>
+<body th:inline="text" style="margin: 0 !important; padding: 0; !important background-color: #f8f9fa !important; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; color: #495057;" bgcolor="#f8f9fa">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td align="center" height="100%" valign="top" width="100%" bgcolor="#f8f9fa" style="padding: 25px 15px 25px 15px;" class="mobile-padding">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="mobile-wrapper" style="max-width:700px">
+        <tr>
+          <td align="center" valign="top" style="padding: 0; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+            <table cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                <td align="center" bgcolor="#ffffff" style="border-radius: 8px; padding: 40px;" class="mobile-padding">
+                  <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                    <tr>
+                      <td align="center" valign="top" style="padding: 10px 50px 40px 50px;">
+                        <div th:if="${site.logo != null}">
+                          <img src="logo.png" th:src="${site.logo}" width="300" style="max-width:430px !important; max-height:150px !important;" alt="Site Name" th:alt="${site.name}" />
+                        </div>
+                        <div th:if="${site.logo == null}">
+                          <h1 style="margin: 0; text-align:center; color: #333333; font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; font-size: 22px; line-height: 1.5;"><span th:text="${site.name}">Site Name</span></h1>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="template-content" style="font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; padding: 0;">
+                        <p style="color: #333333; font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; font-size: 18px; line-height: 1.5; margin: 0;" align="center">Please confirm you'd like to subscribe to <span th:text="${mailingList.title}">this mailing list</span>:</p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <div style="text-align: center !important" align="center"><a class="web-button" target="_blank" href="https://example.com/confirm-subscription" th:href="${confirmUrl}" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #1c7cd6; border: 1px solid #1c7cd6; border-radius: 4px; color: #f8f9fa; display: inline-block; font-family: 'Proxima Nova Soft', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 20px; font-weight: 600; padding: 16px 48px; text-decoration: none; margin: 50px 0 20px">Confirm Subscription</a></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="template-content" style="font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif !important; padding: 0;">
+                        <p style="color: #868e96; font-size: 14px; line-height: 1.5; margin: 0;" align="center">If you didn't request this, you can safely ignore this email.</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" height="100%" valign="top" width="100%" bgcolor="#f8f9fa" style="padding: 25px 15px 50px 15px;" class="mobile-padding">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="80%" class="mobile-wrapper">
+        <tr>
+          <td align="center" valign="top" style="padding: 0 0 5px 0; font-family: 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #868e96;">
+            <p style="font-size: 14px; line-height: 20px; color: #868e96;">
+              [[${site.name}]]<th:block th:if="${site.state != null}"><br></th:block>
+              <th:block th:if="${site.addressLine1 != null}">[[${site.addressLine1}]],</th:block>
+              <th:block th:if="${site.city != null}">[[${site.city}]],</th:block>
+              <th:block th:if="${site.state != null}">[[${site.state}]]</th:block>
+              <th:block th:if="${site.postalCode != null}">[[${site.postalCode}]]</th:block>
+              <th:block th:if="${site.country != null}">[[${site.country}]]</th:block>
+            </p>
+            <p style="font-size: 14px; line-height: 20px; color: #868e96;">
+              <a href="https://example.com/contact" th:href="${site.contactUsUrl}" style="color: #adb5bd;" target="_blank">Contact Us</a>
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/mailing-list-members.jsp
@@ -71,6 +71,7 @@
       <select id="memberStatus" name="status">
         <option value="">All statuses</option>
         <option value="active"<c:if test="${status eq 'active'}"> selected</c:if>>Active</option>
+        <option value="pending"<c:if test="${status eq 'pending'}"> selected</c:if>>Pending Confirmation</option>
         <option value="unsubscribed"<c:if test="${status eq 'unsubscribed'}"> selected</c:if>>Unsubscribed</option>
         <option value="quarantined"<c:if test="${status eq 'quarantined'}"> selected</c:if>>Quarantined</option>
       </select>
@@ -108,6 +109,12 @@
         <c:choose>
           <c:when test="${!empty member.quarantined}">
             <span class="label alert" title="Quarantined: <c:out value="${member.quarantineReason}"/>">Quarantined</span>
+          </c:when>
+          <c:when test="${!empty member.confirmToken}">
+            <%-- Checked before "unsubscribed" -- a previously-unsubscribed member re-signing up
+                 keeps their old unsubscribed timestamp until they actually reconfirm, so a live
+                 confirm_token here means a genuine pending reconfirmation, not a stale unsubscribe. --%>
+            <span class="label secondary" title="Sent a confirmation email, not yet clicked">Pending Confirmation</span>
           </c:when>
           <c:when test="${!empty member.unsubscribed}">
             <span class="label warning">Unsubscribed</span>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/confirm-subscription-not-found.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/confirm-subscription-not-found.jsp
@@ -1,0 +1,27 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<h4>This confirmation link is no longer valid</h4>
+<p>
+  It may have already been used, or it may have expired. If you still want to subscribe, please
+  sign up again from the site to get a fresh confirmation email.
+</p>
+<p>
+  <a href="${ctx}/" class="button primary radius">Visit Home Page <i class="fa fa-angle-right"></i></a>
+  <a href="${ctx}/contact-us" class="button secondary radius">Contact Us <i class="fa fa-angle-right"></i></a>
+</p>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/confirm-subscription.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/confirm-subscription.jsp
@@ -1,0 +1,34 @@
+<%--
+  ~ Copyright 2026 SimIS Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<jsp:useBean id="userSession" class="com.simisinc.platform.presentation.controller.UserSession" scope="session"/>
+<jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
+<div class="callout success">
+  <h4>Subscription confirmed</h4>
+  <p>
+    <c:choose>
+      <c:when test="${not empty mailingList.title}">
+        You're all set. You'll now receive emails from <c:out value="${mailingList.title}"/>.
+      </c:when>
+      <c:otherwise>
+        You're all set. Thanks for confirming your subscription.
+      </c:otherwise>
+    </c:choose>
+  </p>
+</div>
+<p>
+  <a href="${ctx}/" class="button primary radius">Visit Home Page <i class="fa fa-angle-right"></i></a>
+</p>

--- a/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mailinglists/email-subscribe-inline-form.jsp
@@ -69,7 +69,7 @@
                     (data.message ? data.message : "Please re-enter your email address using a proper format.");
                 return;
             }
-            document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Thanks for signing up for <c:out value="${js:escape(sitePropertyMap['site.name'])}"/> emails";
+            document.getElementById('emailHelpText${widgetContext.uniqueId}').innerHTML = "Almost done! Check your email to confirm your subscription to <c:out value="${js:escape(sitePropertyMap['site.name'])}"/> emails";
         });
     }
     <c:choose>

--- a/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/cms-layout.xml
@@ -179,6 +179,14 @@
     </section>
   </page>
 
+  <page name="/confirm-subscription" title="Confirm Subscription">
+    <section class="align-center">
+      <column class="small-12 medium-6 cell">
+        <widget name="mailingListConfirmSubscription" class="callout box radius" />
+      </column>
+    </section>
+  </page>
+
   <page name="/forgot-password" role="guest,admin,content-manager" title="Forgot Password" class="platform-dialog">
     <section id="platform-forgot-password" class="align-center">
       <column class="small-12 medium-7 large-5 cell">

--- a/src/main/webapp/WEB-INF/widgets/widget-library.xml
+++ b/src/main/webapp/WEB-INF/widgets/widget-library.xml
@@ -210,6 +210,7 @@
   <widget name="mailingListMembers" class="com.simisinc.platform.presentation.widgets.mailinglists.MailingListMembersWidget" />
   <widget name="newsletterSend" class="com.simisinc.platform.presentation.widgets.admin.NewsletterSendWidget" />
   <widget name="newsletterUnsubscribe" class="com.simisinc.platform.presentation.widgets.mailinglists.NewsletterUnsubscribeWidget" />
+  <widget name="mailingListConfirmSubscription" class="com.simisinc.platform.presentation.widgets.mailinglists.MailingListConfirmSubscriptionWidget" />
   <widget name="folderList" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderListWidget" />
   <widget name="folderDetails" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderDetailsWidget" />
   <widget name="folderForm" class="com.simisinc.platform.presentation.widgets.admin.cms.FolderFormWidget" />

--- a/src/main/webapp/WEB-INF/workflows/mailinglists-workflows.yml
+++ b/src/main/webapp/WEB-INF/workflows/mailinglists-workflows.yml
@@ -1,0 +1,13 @@
+# Mailing List Workflows
+---
+
+- id: mailing-list-member-confirmation-requested
+  vars:
+    member: '{{ event.member }}'
+    mailingList: '{{ event.mailingList }}'
+    confirmUrl: '{{ event.confirmUrl }}'
+  workflow:
+    - email:
+      to-email: '{{ member.emailAddress }}'
+      subject: '{{ site.name }} - Please confirm your subscription'
+      template: 'mailinglists/confirm-subscription'

--- a/src/test/java/com/simisinc/platform/application/email/EmailTemplateTests.java
+++ b/src/test/java/com/simisinc/platform/application/email/EmailTemplateTests.java
@@ -179,6 +179,11 @@ class EmailTemplateTests {
       ctx.setVariable("blogPost", blogPost);
       ctx.setVariable("blogPostUrl", "http://site.example.com/blog/a-post");
       ctx.setVariable("unsubscribeUrl", "http://site.example.com/unsubscribe?token=TEST");
+      // Double opt-in confirmation email
+      Map<String, String> mailingList = new HashMap<>();
+      mailingList.put("title", "Newsletter");
+      ctx.setVariable("mailingList", mailingList);
+      ctx.setVariable("confirmUrl", "http://site.example.com/confirm-subscription?token=TEST");
     }
 
     String html = templateEngine.process(template, ctx);

--- a/src/test/java/com/simisinc/platform/application/mailinglists/MailingListConfirmationCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/MailingListConfirmationCommandTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.mailinglists;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberConfirmationRequestedEvent;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MailingListConfirmationCommandTest {
+
+  @Test
+  void sendConfirmationEmailBuildsTheLinkFromTheSiteUrlAndTheMembersToken() {
+    MailingListMember member = new MailingListMember();
+    member.setId(1L);
+    member.setConfirmToken("tok-123");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(3L);
+
+    try (MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("site.url")).thenReturn("https://example.org");
+
+      MailingListConfirmationCommand.sendConfirmationEmail(member, mailingList);
+
+      ArgumentCaptor<MailingListMemberConfirmationRequestedEvent> captor = ArgumentCaptor
+          .forClass(MailingListMemberConfirmationRequestedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(captor.capture()));
+      assertEquals(member, captor.getValue().getMember());
+      assertEquals(mailingList, captor.getValue().getMailingList());
+      assertTrue(captor.getValue().getConfirmUrl().startsWith("https://example.org/confirm-subscription?token="));
+      assertTrue(captor.getValue().getConfirmUrl().endsWith("tok-123"));
+    }
+  }
+
+  @Test
+  void sendConfirmationEmailDoesNothingWhenTheMemberHasNoToken() {
+    MailingListMember member = new MailingListMember();
+    member.setId(1L);
+    MailingList mailingList = new MailingList();
+    mailingList.setId(3L);
+
+    try (MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      MailingListConfirmationCommand.sendConfirmationEmail(member, mailingList);
+
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/mailinglists/SaveEmailCommandTest.java
@@ -19,6 +19,7 @@ package com.simisinc.platform.application.mailinglists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -32,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.maps.GeoIPCommand;
 import com.simisinc.platform.domain.events.Event;
 import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
@@ -101,8 +103,8 @@ class SaveEmailCommandTest {
 
       assertEquals(saved, result);
       emailRepo.verify(() -> EmailRepository.add(emailBean), times(1));
-      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, lists.get(0)));
-      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, lists.get(1)));
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, lists.get(0), false, null));
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, lists.get(1), false, null));
       memberCommand.verify(() -> MailingListMemberCommand.triggerEmailSubscriptionProcess(saved, lists.get(0), true));
       memberCommand.verify(() -> MailingListMemberCommand.triggerEmailSubscriptionProcess(saved, lists.get(1), true));
     }
@@ -129,9 +131,9 @@ class SaveEmailCommandTest {
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listA))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listA, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, memberA));
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listB))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, listB, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, memberB));
 
       SaveEmailCommand.saveEmail(emailBean, List.of(listA, listB));
@@ -172,7 +174,8 @@ class SaveEmailCommandTest {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(null); // duplicate -> update branch
       emailRepo.when(() -> EmailRepository.findByEmailAddress("subscriber@example.com"))
           .thenReturn(existingWithADifferentOriginalCreator);
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(existingWithADifferentOriginalCreator, mailingList))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(existingWithADifferentOriginalCreator,
+          mailingList, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, member));
       com.simisinc.platform.domain.model.User admin42 = new com.simisinc.platform.domain.model.User();
       admin42.setId(42L);
@@ -204,8 +207,8 @@ class SaveEmailCommandTest {
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
 
-      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, mailingList), times(1));
-      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(any(), any()), times(1));
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(saved, mailingList, false, null), times(1));
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(any(), any(), anyBoolean(), any()), times(1));
     }
   }
 
@@ -225,7 +228,7 @@ class SaveEmailCommandTest {
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, member));
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
@@ -255,7 +258,7 @@ class SaveEmailCommandTest {
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(false, true, member));
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
@@ -291,7 +294,7 @@ class SaveEmailCommandTest {
         MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
         MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
       emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
-      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList))
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(saved, mailingList, false, null))
           .thenReturn(new MailingListMemberRepository.AddToListResult(false, false, member));
 
       SaveEmailCommand.saveEmail(emailBean, mailingList);
@@ -340,7 +343,102 @@ class SaveEmailCommandTest {
 
       assertEquals(existing, result);
       emailRepo.verify(() -> EmailRepository.update(emailBean));
-      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(existing, lists.get(0)));
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(existing, lists.get(0), false, null));
+    }
+  }
+
+  @Test
+  void requiringConfirmationPassesTrueAndAResolvedExpiryToAddEmailToList() throws DataException {
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember pendingMember = new MailingListMember();
+    pendingMember.setId(10L);
+    pendingMember.setEmailAddress("subscriber@example.com");
+    pendingMember.setConfirmToken("a-token");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<MailingListConfirmationCommand> confirmationCommand = mockStatic(MailingListConfirmationCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("mailing-list.confirmation.expiryDays")).thenReturn("7");
+      memberRepo.when(() -> MailingListMemberRepository.resolveConfirmationExpiryDays("7")).thenReturn(7);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(eq(saved), eq(mailingList), eq(true), any()))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, true, pendingMember));
+
+      SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, mailingList);
+
+      memberRepo.verify(() -> MailingListMemberRepository.addEmailToList(eq(saved), eq(mailingList), eq(true), any()));
+    }
+  }
+
+  @Test
+  void aPendingConfirmationResultSendsTheConfirmationEmailInsteadOfFiringTheCreatedEvent() throws DataException {
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember pendingMember = new MailingListMember();
+    pendingMember.setId(10L);
+    pendingMember.setEmailAddress("subscriber@example.com");
+    pendingMember.setConfirmToken("a-token");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<MailingListConfirmationCommand> confirmationCommand = mockStatic(MailingListConfirmationCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(eq(saved), eq(mailingList), eq(true), any()))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(true, false, true, pendingMember));
+
+      SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, mailingList);
+
+      confirmationCommand.verify(
+          () -> MailingListConfirmationCommand.sendConfirmationEmail(pendingMember, mailingList));
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+      memberCommand.verify(
+          () -> MailingListMemberCommand.triggerEmailSubscriptionProcess(any(), any(), anyBoolean()), never());
+    }
+  }
+
+  @Test
+  void aPendingResultThatDoesNotNeedANewConfirmationEmailDoesNotSendOne() throws DataException {
+    // addEmailToList() reuses a still-live token instead of reissuing one on a resubmit --
+    // requiresConfirmation() stays true (still not active) but confirmationEmailNeeded() is
+    // false. Resending here on every resubmit would be an unthrottled mail-bomb primitive.
+    Email emailBean = email("subscriber@example.com");
+    Email saved = email("subscriber@example.com");
+    saved.setId(5L);
+    MailingList mailingList = mailingList(1L, "News");
+    MailingListMember pendingMember = new MailingListMember();
+    pendingMember.setId(10L);
+    pendingMember.setEmailAddress("subscriber@example.com");
+    pendingMember.setConfirmToken("still-live-token");
+
+    try (MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberRepository> memberRepo = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<MailingListConfirmationCommand> confirmationCommand = mockStatic(MailingListConfirmationCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<GeoIPCommand> geoIp = mockStatic(GeoIPCommand.class)) {
+      emailRepo.when(() -> EmailRepository.add(emailBean)).thenReturn(saved);
+      memberRepo.when(() -> MailingListMemberRepository.addEmailToList(eq(saved), eq(mailingList), eq(true), any()))
+          .thenReturn(new MailingListMemberRepository.AddToListResult(false, false, true, false, pendingMember));
+
+      SaveEmailCommand.saveEmailRequiringConfirmation(emailBean, mailingList);
+
+      confirmationCommand.verify(() -> MailingListConfirmationCommand.sendConfirmationEmail(any(), any()), never());
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+      memberCommand.verify(
+          () -> MailingListMemberCommand.triggerEmailSubscriptionProcess(any(), any(), anyBoolean()), never());
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
@@ -44,6 +44,7 @@ import org.testcontainers.utility.DockerImageName;
 import com.simisinc.platform.domain.model.dashboard.StatisticsData;
 import com.simisinc.platform.domain.model.mailinglists.Email;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
 import com.simisinc.platform.infrastructure.database.DB;
 import com.simisinc.platform.infrastructure.database.DataSource;
 
@@ -322,6 +323,287 @@ class MailingListMemberRepositoryQueryTest {
   }
 
   @Test
+  void addEmailToListRequiringConfirmationLeavesANewMemberPendingWithAToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("new@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    assertTrue(result.isCreated());
+    assertTrue(result.requiresConfirmation(), "a brand-new signup through a confirmation-requiring path must be reported as pending");
+    assertNotNull(result.getMember());
+    assertTrue(!result.getMember().getIsValid(), "a pending member must not be active yet");
+    assertNull(result.getMember().getConfirmed());
+    assertNotNull(result.getMember().getConfirmToken());
+    assertEquals(expires, result.getMember().getConfirmTokenExpires());
+  }
+
+  @Test
+  void addEmailToListRequiringConfirmationReissuesATokenForAPreviouslyUnsubscribedMember() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("returning@example.com");
+    seedMembership(listId, emailId, false, "2026-07-01 00:00:00"); // previously unsubscribed
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    assertTrue(!result.isCreated(), "the row already existed");
+    assertTrue(result.requiresConfirmation());
+    assertNotNull(result.getMember().getConfirmToken());
+    assertNotNull(result.getMember().getUnsubscribed(),
+        "must not silently clear unsubscribed until the address owner actually reconfirms");
+    assertTrue(!result.getMember().getIsValid());
+  }
+
+  @Test
+  void addEmailToListRequiringConfirmationDoesNotReissueATokenForAnAlreadyActiveMember() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("already-subscribed@example.com");
+    seedMembership(listId, emailId, true, null); // already active, never unsubscribed
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    assertTrue(!result.requiresConfirmation(),
+        "a duplicate signup from an already-active member must not be sent a fresh confirmation email");
+    assertNull(result.getMember().getConfirmToken());
+    assertTrue(result.getMember().getIsValid());
+  }
+
+  @Test
+  void addEmailToListRequiringConfirmationDoesNotReactivateAQuarantinedMember() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("spamtrap@example.com");
+    seedQuarantinedMembership(listId, emailId, "spamtrap");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    assertTrue(!result.requiresConfirmation());
+    assertNull(result.getMember().getConfirmToken());
+    assertNotNull(result.getMember().getQuarantined(), "the quarantine must not be cleared or reconfirmed around");
+  }
+
+  @Test
+  void findByConfirmTokenReturnsAPendingMemberByItsLiveToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("pending@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+    MailingListMemberRepository.AddToListResult created = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+    String token = created.getMember().getConfirmToken();
+
+    MailingListMember found = MailingListMemberRepository.findByConfirmToken(token);
+
+    assertNotNull(found);
+    assertEquals("pending@example.com", found.getEmailAddress());
+  }
+
+  @Test
+  void findByConfirmTokenReturnsNullForAnExpiredToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("expired@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp alreadyExpired = new Timestamp(System.currentTimeMillis() - 1000L);
+    MailingListMemberRepository.AddToListResult created = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, alreadyExpired);
+    String token = created.getMember().getConfirmToken();
+
+    assertNull(MailingListMemberRepository.findByConfirmToken(token),
+        "an expired confirm link must behave exactly like an unknown one");
+  }
+
+  @Test
+  void confirmByTokenActivatesThePendingMemberAndClearsTheToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("confirming@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+    MailingListMemberRepository.AddToListResult created = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    MailingListMemberRepository.confirmByToken(created.getMember());
+
+    MailingListMember confirmed = MailingListMemberRepository.findByListAndEmail(listId, emailId);
+    assertTrue(confirmed.getIsValid());
+    assertNotNull(confirmed.getConfirmed());
+    assertNull(confirmed.getConfirmToken(), "the token must be single-use");
+    assertNull(MailingListMemberRepository.findByConfirmToken(created.getMember().getConfirmToken()),
+        "a re-clicked link must no longer resolve to anything");
+  }
+
+  @Test
+  void resolveConfirmationExpiryDaysFallsBackToTheDefaultOnABlankOrBadValue() {
+    assertEquals(7, MailingListMemberRepository.resolveConfirmationExpiryDays(null));
+    assertEquals(7, MailingListMemberRepository.resolveConfirmationExpiryDays(""));
+    assertEquals(7, MailingListMemberRepository.resolveConfirmationExpiryDays("not-a-number"));
+    assertEquals(14, MailingListMemberRepository.resolveConfirmationExpiryDays("14"));
+    assertEquals(1, MailingListMemberRepository.resolveConfirmationExpiryDays("0"), "clamps below the floor");
+    assertEquals(90, MailingListMemberRepository.resolveConfirmationExpiryDays("9999"), "clamps above the ceiling");
+  }
+
+  @Test
+  void findAllPendingStatusExcludesActiveAndTrustedBypassMembers() throws SQLException {
+    long listId = seedList("List A");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    // A pending double opt-in signup
+    Email pendingEmail = new Email();
+    pendingEmail.setId(seedEmail("pending@example.com"));
+    MailingListMemberRepository.addEmailToList(pendingEmail, mailingList, true, expires);
+
+    // An immediately-active CSV/admin-add member (requiresConfirmation=false) -- must NOT show as pending
+    seedMembership(listId, seedEmail("csv-imported@example.com"), true, null);
+
+    MailingListMemberSpecification pendingSpec = new MailingListMemberSpecification();
+    pendingSpec.setMailingListId(listId);
+    pendingSpec.setStatus("pending");
+    List<MailingListMember> pending = MailingListMemberRepository.findAll(pendingSpec, null);
+    assertEquals(1, pending.size());
+    assertEquals("pending@example.com", pending.get(0).getEmailAddress());
+
+    MailingListMemberSpecification activeSpec = new MailingListMemberSpecification();
+    activeSpec.setMailingListId(listId);
+    activeSpec.setStatus("active");
+    List<MailingListMember> active = MailingListMemberRepository.findAll(activeSpec, null);
+    assertEquals(1, active.size(), "a pending (is_valid=false) member must not show up under 'active'");
+    assertEquals("csv-imported@example.com", active.get(0).getEmailAddress());
+  }
+
+  @Test
+  void addEmailToListRequiringConfirmationDoesNotReissueALiveToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("resubmit@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    MailingListMemberRepository.AddToListResult first = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+    assertTrue(first.confirmationEmailNeeded());
+    String firstToken = first.getMember().getConfirmToken();
+
+    MailingListMemberRepository.AddToListResult second = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires);
+
+    assertTrue(!second.confirmationEmailNeeded(),
+        "resubmitting the same address while a confirm link is still live must not send another email -- "
+            + "otherwise this is an unthrottled mail-bomb primitive against an arbitrary address");
+    assertEquals(firstToken, second.getMember().getConfirmToken(), "the existing live token must be reused, not replaced");
+  }
+
+  @Test
+  void addEmailToListRequiringConfirmationReissuesAfterTheOldTokenExpired() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("expired-resubmit@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+
+    MailingListMemberRepository.AddToListResult first = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, new Timestamp(System.currentTimeMillis() - 1000L)); // already expired
+    String firstToken = first.getMember().getConfirmToken();
+
+    MailingListMemberRepository.AddToListResult second = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L));
+
+    assertTrue(second.confirmationEmailNeeded(), "an expired token must be replaced, not silently treated as still live");
+    assertTrue(!firstToken.equals(second.getMember().getConfirmToken()));
+  }
+
+  @Test
+  void addEmailToListWithoutConfirmationClearsALeftoverPendingToken() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("csv-overtakes-pending@example.com");
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+    MailingListMemberRepository.AddToListResult pending = MailingListMemberRepository.addEmailToList(email,
+        mailingList, true, expires); // public signup, awaiting confirmation
+    String oldToken = pending.getMember().getConfirmToken();
+
+    // Before the visitor clicks the link, an admin CSV-imports/manually-adds the same address
+    MailingListMemberRepository.AddToListResult activated = MailingListMemberRepository.addEmailToList(email,
+        mailingList, false, null);
+
+    assertTrue(activated.getMember().getIsValid());
+    assertNull(activated.getMember().getConfirmToken(),
+        "a leftover confirm_token must be cleared once the member is force-activated by a trusted path, or the "
+            + "old link stays clickable and re-fires a duplicate created/webhook event later, and the admin UI "
+            + "mislabels an active member as still pending");
+    assertNull(activated.getMember().getConfirmTokenExpires());
+    assertNull(MailingListMemberRepository.findByConfirmToken(oldToken),
+        "the old link must no longer resolve to anything once the member is force-activated");
+  }
+
+  @Test
+  void findAllPendingStatusIncludesAReactivationStyleSignupAndExcludesItFromUnsubscribed() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("reactivating@example.com");
+    seedMembership(listId, emailId, false, "2026-07-01 00:00:00"); // previously unsubscribed
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+    Timestamp expires = new Timestamp(System.currentTimeMillis() + 7L * 86_400_000L);
+
+    // Re-signs up on a confirmation-required path -- unsubscribed stays set until they reconfirm
+    MailingListMemberRepository.addEmailToList(email, mailingList, true, expires);
+
+    MailingListMemberSpecification pendingSpec = new MailingListMemberSpecification();
+    pendingSpec.setMailingListId(listId);
+    pendingSpec.setStatus("pending");
+    List<MailingListMember> pending = MailingListMemberRepository.findAll(pendingSpec, null);
+    assertEquals(1, pending.size(),
+        "a previously-unsubscribed member re-signing up must show as pending, not be invisible to admins auditing "
+            + "outstanding confirmations");
+
+    MailingListMemberSpecification unsubSpec = new MailingListMemberSpecification();
+    unsubSpec.setMailingListId(listId);
+    unsubSpec.setStatus("unsubscribed");
+    List<MailingListMember> unsub = MailingListMemberRepository.findAll(unsubSpec, null);
+    assertEquals(0, unsub.size(), "must not also show under 'unsubscribed' while a reconfirmation is outstanding");
+  }
+
+  @Test
   void findLastClassifiedAtReturnsNullWhenNoSubscriberHasBeenClassified() throws SQLException {
     long list = seedList("List A");
     seedMembership(list, seedEmail("unchecked@example.com"), true, null);
@@ -437,7 +719,10 @@ class MailingListMemberRepositoryQueryTest {
           + "unsubscribe_token VARCHAR(255), "
           + "is_valid BOOLEAN DEFAULT true, "
           + "quarantined TIMESTAMP(3), "
-          + "quarantine_reason VARCHAR(50))");
+          + "quarantine_reason VARCHAR(50), "
+          + "confirmed TIMESTAMP(3), "
+          + "confirm_token VARCHAR(255), "
+          + "confirm_token_expires TIMESTAMP(3))");
       statement.execute("CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the mailing list metrics test schema", se);

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/MailingListMemberRepositoryQueryTest.java
@@ -298,6 +298,30 @@ class MailingListMemberRepositoryQueryTest {
   }
 
   @Test
+  void addEmailToListDoesNotReactivateAQuarantinedMember() throws SQLException {
+    long listId = seedList("List A");
+    long emailId = seedEmail("spamtrap@example.com");
+    seedQuarantinedMembership(listId, emailId, "spamtrap"); // e.g. quarantineFlaggedMembers() (issue #564)
+    MailingList mailingList = new MailingList();
+    mailingList.setId(listId);
+    Email email = new Email();
+    email.setId(emailId);
+
+    MailingListMemberRepository.AddToListResult result = MailingListMemberRepository.addEmailToList(email,
+        mailingList);
+
+    assertTrue(!result.isCreated(), "the row already existed");
+    assertNotNull(result.getMember());
+    assertTrue(!result.getMember().getIsValid(),
+        "a quarantined address must not be silently reactivated by a resubscribe -- it must go through "
+            + "deliberate admin review first");
+    assertNotNull(result.getMember().getQuarantined(),
+        "the quarantine timestamp must not be cleared by a resubscribe");
+    assertEquals("spamtrap", result.getMember().getQuarantineReason(),
+        "the quarantine reason must not be cleared by a resubscribe");
+  }
+
+  @Test
   void findLastClassifiedAtReturnsNullWhenNoSubscriberHasBeenClassified() throws SQLException {
     long list = seedList("List A");
     seedMembership(list, seedEmail("unchecked@example.com"), true, null);
@@ -362,6 +386,18 @@ class MailingListMemberRepositoryQueryTest {
       String unsubscribedSql = unsubscribed == null ? "NULL" : "'" + unsubscribed + "'";
       statement.execute("INSERT INTO mailing_list_members (list_id, email_id, is_valid, unsubscribed) VALUES ("
           + listId + ", " + emailId + ", " + isValid + ", " + unsubscribedSql + ")");
+    }
+  }
+
+  /** A membership already archived by {@code quarantineFlaggedMembers()} -- is_valid=false, quarantined
+   *  timestamp set, quarantine_reason set, and (as that job does) unsubscribed left NULL since quarantine
+   *  is a distinct reason a membership stopped being active, not a person choosing to leave. */
+  private void seedQuarantinedMembership(long listId, long emailId, String quarantineReason) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("INSERT INTO mailing_list_members "
+          + "(list_id, email_id, is_valid, unsubscribed, quarantined, quarantine_reason) VALUES ("
+          + listId + ", " + emailId + ", false, NULL, CURRENT_TIMESTAMP, '" + quarantineReason + "')");
     }
   }
 

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/mailinglists/NewsletterSendQueueRepositoryTest.java
@@ -456,7 +456,10 @@ class NewsletterSendQueueRepositoryTest {
           + "is_valid BOOLEAN DEFAULT true, "
           + "quarantined TIMESTAMP(3), "
           + "quarantine_reason VARCHAR(50), "
-          + "unsubscribe_token VARCHAR(255))");
+          + "unsubscribe_token VARCHAR(255), "
+          + "confirmed TIMESTAMP(3), "
+          + "confirm_token VARCHAR(255), "
+          + "confirm_token_expires TIMESTAMP(3))");
       statement.execute("CREATE UNIQUE INDEX mail_lis_mem_uniq_idx ON mailing_list_members(list_id, email_id)");
       statement.execute("CREATE UNIQUE INDEX mail_lis_mem_unsub_tok_idx ON mailing_list_members(unsubscribe_token)");
       statement.execute("CREATE TABLE mailing_list_history ("

--- a/src/test/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjaxTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/ecommerce/EmailSubscribeAjaxTest.java
@@ -70,13 +70,13 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
       listRepo.when(MailingListRepository::findOnlineLists).thenReturn(null);
-      saveEmail.when(() -> SaveEmailCommand.saveEmail(any())).thenReturn(new Email());
+      saveEmail.when(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any())).thenReturn(new Email());
 
       new EmailSubscribeAjax().execute(widgetContext);
 
       Assertions.assertEquals("{\"status\":\"0\"}", widgetContext.getJson());
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()));
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), anyList()), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any()));
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), anyList()), never());
     }
   }
 
@@ -93,7 +93,7 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       String json = widgetContext.getJson();
       Assertions.assertTrue(json.contains("\"status\":\"1\""), json);
       Assertions.assertTrue(json.contains("verify you're human"), json);
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any()), never());
     }
   }
 
@@ -112,7 +112,7 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       String json = widgetContext.getJson();
       Assertions.assertTrue(json.contains("\"status\":\"1\""), json);
       Assertions.assertTrue(json.contains(RateLimitCommand.INVALID_ATTEMPTS), json);
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any()), never());
     }
   }
 
@@ -163,12 +163,12 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
       listRepo.when(MailingListRepository::findOnlineLists).thenReturn(onlineLists);
-      saveEmail.when(() -> SaveEmailCommand.saveEmail(any(), anyList())).thenReturn(new Email());
+      saveEmail.when(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), anyList())).thenReturn(new Email());
 
       new EmailSubscribeAjax().execute(widgetContext);
 
       Assertions.assertEquals("{\"status\":\"0\"}", widgetContext.getJson());
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), eq(List.of(onlineLists.get(1)))));
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), eq(List.of(onlineLists.get(1)))));
     }
   }
 
@@ -193,8 +193,8 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       String json = widgetContext.getJson();
       Assertions.assertTrue(json.contains("\"status\":\"1\""), json);
       Assertions.assertTrue(json.contains("choose at least one list"), json);
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), anyList()), never());
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any()), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), anyList()), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any()), never());
     }
   }
 
@@ -240,12 +240,12 @@ class EmailSubscribeAjaxTest extends WidgetBase {
       captcha.when(() -> CaptchaCommand.validateRequest(any())).thenReturn(true);
       rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
       listRepo.when(MailingListRepository::findOnlineLists).thenReturn(onlineLists);
-      saveEmail.when(() -> SaveEmailCommand.saveEmail(any(), anyList())).thenReturn(new Email());
+      saveEmail.when(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), anyList())).thenReturn(new Email());
 
       new EmailSubscribeAjax().execute(widgetContext);
 
       Assertions.assertEquals("{\"status\":\"0\"}", widgetContext.getJson());
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), eq(onlineLists)));
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), eq(onlineLists)));
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/EmailSubscribeWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/EmailSubscribeWidgetTest.java
@@ -128,8 +128,8 @@ class EmailSubscribeWidgetTest extends WidgetBase {
 
       new EmailSubscribeWidget().post(widgetContext);
 
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), eq(mailingList)));
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), any(String.class)), never());
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), eq(mailingList)));
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), any(String.class)), never());
     }
   }
 
@@ -164,7 +164,7 @@ class EmailSubscribeWidgetTest extends WidgetBase {
 
       new EmailSubscribeWidget().post(widgetContext);
 
-      saveEmail.verify(() -> SaveEmailCommand.saveEmail(any(), eq("Newsletter")));
+      saveEmail.verify(() -> SaveEmailCommand.saveEmailRequiringConfirmation(any(), eq("Newsletter")));
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListConfirmSubscriptionWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/mailinglists/MailingListConfirmSubscriptionWidgetTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.mailinglists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.RateLimitCommand;
+import com.simisinc.platform.application.mailinglists.MailingListMemberCommand;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberCreatedEvent;
+import com.simisinc.platform.domain.events.mailinglists.MailingListMemberUpdatedEvent;
+import com.simisinc.platform.domain.model.mailinglists.Email;
+import com.simisinc.platform.domain.model.mailinglists.MailingList;
+import com.simisinc.platform.domain.model.mailinglists.MailingListMember;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.EmailRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListMemberRepository;
+import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingListRepository;
+import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+class MailingListConfirmSubscriptionWidgetTest extends WidgetBase {
+
+  private static MailingListMember pendingMember(boolean previouslyUnsubscribed) {
+    MailingListMember member = new MailingListMember();
+    member.setId(1L);
+    member.setListId(3L);
+    member.setEmailId(4L);
+    member.setEmailAddress("subscriber@example.com");
+    member.setConfirmToken("tok-123");
+    if (previouslyUnsubscribed) {
+      member.setUnsubscribed(new Timestamp(System.currentTimeMillis()));
+    }
+    return member;
+  }
+
+  private static MailingList mailingList() {
+    MailingList mailingList = new MailingList();
+    mailingList.setId(3L);
+    mailingList.setName("Newsletter");
+    return mailingList;
+  }
+
+  private static Email email() {
+    Email email = new Email();
+    email.setId(4L);
+    email.setEmail("subscriber@example.com");
+    return email;
+  }
+
+  @Test
+  void executeConfirmsANewSignupAndFiresACreatedEvent() {
+    MailingListMember member = pendingMember(false);
+    MailingListMember confirmedMember = pendingMember(false);
+    confirmedMember.setConfirmed(new Timestamp(System.currentTimeMillis()));
+    confirmedMember.setConfirmToken(null);
+    MailingList mailingList = mailingList();
+    Email email = email(); // Email has no equals() override -- reuse one instance for stub + verify
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByConfirmToken("tok-123")).thenReturn(member);
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList);
+      emailRepo.when(() -> EmailRepository.findById(4L)).thenReturn(email);
+      repository.when(() -> MailingListMemberRepository.findByListAndEmail(3L, 4L)).thenReturn(confirmedMember);
+
+      WidgetContext result = new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/confirm-subscription.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.confirmByToken(member));
+      memberCommand.verify(() -> MailingListMemberCommand.triggerEmailSubscriptionProcess(email, mailingList, true));
+
+      ArgumentCaptor<MailingListMemberCreatedEvent> eventCaptor = ArgumentCaptor
+          .forClass(MailingListMemberCreatedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals(confirmedMember, eventCaptor.getValue().getMember());
+      assertEquals(mailingList, eventCaptor.getValue().getMailingList());
+    }
+  }
+
+  @Test
+  void executeConfirmsAReactivationAndFiresAResubscribedEventNotACreatedEvent() {
+    MailingListMember member = pendingMember(true);
+    MailingListMember confirmedMember = pendingMember(true);
+    confirmedMember.setUnsubscribed(null);
+    confirmedMember.setConfirmed(new Timestamp(System.currentTimeMillis()));
+    confirmedMember.setConfirmToken(null);
+    MailingList mailingList = mailingList();
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<EmailRepository> emailRepo = mockStatic(EmailRepository.class);
+        MockedStatic<MailingListMemberCommand> memberCommand = mockStatic(MailingListMemberCommand.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByConfirmToken("tok-123")).thenReturn(member);
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList);
+      emailRepo.when(() -> EmailRepository.findById(4L)).thenReturn(email());
+      repository.when(() -> MailingListMemberRepository.findByListAndEmail(3L, 4L)).thenReturn(confirmedMember);
+
+      new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      ArgumentCaptor<MailingListMemberUpdatedEvent> eventCaptor = ArgumentCaptor
+          .forClass(MailingListMemberUpdatedEvent.class);
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(eventCaptor.capture()));
+      assertEquals("resubscribed", eventCaptor.getValue().getChangeType());
+    }
+  }
+
+  @Test
+  void executeDoesNotReconfirmAnAlreadyConfirmedMember() {
+    MailingListMember alreadyConfirmed = pendingMember(false);
+    alreadyConfirmed.setConfirmed(new Timestamp(System.currentTimeMillis()));
+    MailingList mailingList = mailingList();
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class);
+        MockedStatic<MailingListRepository> mailingListRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<WorkflowManager> workflowManager = mockStatic(WorkflowManager.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByConfirmToken("tok-123")).thenReturn(alreadyConfirmed);
+      mailingListRepo.when(() -> MailingListRepository.findById(3L)).thenReturn(mailingList);
+
+      WidgetContext result = new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/confirm-subscription.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.confirmByToken(any()), never());
+      workflowManager.verify(() -> WorkflowManager.triggerWorkflowForEvent(any()), never());
+    }
+  }
+
+  @Test
+  void executeShowsNotFoundForAnUnknownOrExpiredToken() {
+    addQueryParameter(widgetContext, "token", "does-not-exist");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(true))).thenReturn(true);
+      repository.when(() -> MailingListMemberRepository.findByConfirmToken("does-not-exist")).thenReturn(null);
+
+      WidgetContext result = new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/confirm-subscription-not-found.jsp", result.getJsp());
+    }
+  }
+
+  @Test
+  void executeShowsNotFoundForAMissingToken() {
+    // No "token" param at all
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(true);
+
+      WidgetContext result = new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      assertEquals("/mailinglists/confirm-subscription-not-found.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.findByConfirmToken(any()), never());
+    }
+  }
+
+  @Test
+  void executeShowsRateLimitedPageWhenThrottled() {
+    addQueryParameter(widgetContext, "token", "tok-123");
+
+    try (MockedStatic<RateLimitCommand> rateLimit = mockStatic(RateLimitCommand.class);
+        MockedStatic<MailingListMemberRepository> repository = mockStatic(MailingListMemberRepository.class)) {
+      rateLimit.when(() -> RateLimitCommand.isIpAllowedRightNow(any(), eq(false))).thenReturn(false);
+
+      WidgetContext result = new MailingListConfirmSubscriptionWidget().execute(widgetContext);
+
+      assertEquals("/cms/error-rate-limited.jsp", result.getJsp());
+      repository.verify(() -> MailingListMemberRepository.findByConfirmToken(any()), never());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Public self-service signup paths (footer form, its ajax variant, checkout newsletter checkbox) no longer activate a membership immediately on a bare typed-in address -- a new or reactivated signup from one of these paths is left pending until the recipient clicks a confirmation link emailed to them.
- CSV import and the admin's manual "Add Email" form on `/admin/mailing-list-members` continue to activate immediately, unchanged -- an admin using either is attesting consent was already obtained elsewhere.
- The logged-in "My Email Preferences" self-service subscribe checkbox also continues to activate immediately (documented, no behavior change) -- it only ever uses the account's own already-validated email, so a second confirmation adds friction with no consent benefit.
- New admin "Pending Confirmation" status filter/badge on `/admin/mailing-list-members`.
- New configurable `mailing-list.confirmation.expiryDays` site property (default 7 days).

## Security/correctness fixes from pre-ship review
This PR went through an adversarial multi-agent review before opening. 9 findings came back, all independently verified as real; 6 distinct root causes are fixed here:
- **Unthrottled resend (high)**: resubmitting the same address while a confirm link is still outstanding no longer re-issues a token or re-sends an email. Previously this was an unthrottled way to spam an arbitrary third-party address with confirmation emails -- most acutely on the checkout newsletter checkbox, which has no captcha or rate-limiting at all.
- **Leftover token on trusted activation (high)**: a CSV import/admin-add that activates a member who already had a pending public-signup confirmation now clears the stale token. Previously the old link stayed live, and clicking it later would re-fire a duplicate "member created" lifecycle/webhook event and permanently mislabel an already-active member as "Pending Confirmation" in the admin UI.
- **"Pending" filter blind spot (medium)**: a previously-unsubscribed member who re-signs up (keeping their `unsubscribed` timestamp until they actually reconfirm) now correctly shows under the new "Pending Confirmation" filter/badge instead of being miscategorized as plain "Unsubscribed".
- **Undocumented 4th bypass path (low)**: `MailingListMemberCommand.subscribe()` (the logged-in preferences-page checkbox) wasn't migrated and wasn't in the documented bypass list -- now documented as an intentional 3rd trusted path alongside CSV import and admin manual-add.

## Test plan
- [x] Full suite: 2898 tests, 0 failures (`ant ci-test`)
- [x] `ant package` clean build, JSP/unescaped-EL gate passes
- [x] New repository-level tests cover: token reuse on resubmit, token reissue after expiry, token clearing on trusted-path activation, "pending" status filter including reactivation-style signups and excluding them from "unsubscribed"
- [x] New widget/command tests for the confirm-subscription landing page and the confirmation email trigger
- [ ] Live Docker verification (not yet done for this PR)

## Notes for reviewers
- Stacked on the not-yet-merged #1018 (quarantine reactivation loophole fix) -- this branch is based on that PR's branch, so the diff includes its commit too.
- Deliberately does **not** include a bulk-deletion retention job for unconfirmed pending signups past the 7-day expiry window -- only token-expiry *enforcement* at confirm-time is in scope here (an expired token behaves like an unknown one). Bulk cleanup of stale pending rows is flagged as a separate follow-up, analogous to the mailing-list-member/history/sent tables' existing lack of retention.