### PR TITLE
Fix: hide Capability Grants link from roles that can't use it

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -49,7 +49,9 @@
 </script>
 <div style="margin-top: 6px;background-color:<c:out value="${themePropertyMap['theme.body.backgroundColor']}" />;">
   <div class="button-container float-right">
-    <a class="button small radius float-right" href="${ctx}/admin/capability-grants?userId=${user.id}">Capability Grants</a>
+    <c:if test="${userSession.hasRole('admin')}">
+      <a class="button small radius float-right" href="${ctx}/admin/capability-grants?userId=${user.id}">Capability Grants</a>
+    </c:if>
     <a class="button small radius float-right" href="${ctx}/admin/modify-user?userId=${user.id}">Modify User</a>
     <ul class="dropdown menu" style="padding-right: 15px;" data-dropdown-menu>
       <li>


### PR DESCRIPTION
## What was wrong

The "Capability Grants" button on the User Details page (`admin/user-details.jsp`) was rendered unconditionally for anyone who could reach that page. But `/admin/capability-grants` is gated `role="admin"` in `admin-layout.xml`, and its widget additionally requires the `admin:manage` capability.

User Details is also reachable by community-managers (not just admins), so those users saw a "Capability Grants" button they could never actually use. Clicking it produced a bare, unexplained 404 instead of any indication that the page requires admin access.

## What changed

Wrapped the button in a `${userSession.hasRole('admin')}` check — the same guard idiom already used elsewhere in this JSP set — so the link only renders for users who can actually follow it. Non-admin users viewing User Details no longer see a dead link.

This is a single-file, one-defect change: `src/main/webapp/WEB-INF/jsp/admin/user-details.jsp`.

## Testing

- `ant -lib lib/war -lib lib/tests clean ci-test` — full build and test suite, all passing.
- `ant -lib lib/war compile-jsp` — JSP syntax/unescaped-EL gate, passing (this PR touches a `.jsp`).
- Adversarial code review of the diff reported no findings.