### PR TITLE
Fix: CSV user import overcounts successes on silent save failures

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
@@ -152,11 +152,19 @@ public class ProcessUserCSVFileCommand {
         user.setModifiedBy(context.getUserId());
 
         User saved = SaveUserCommand.saveUser(user);
-        ++userCount;
-        // Record each imported account so a bulk import is individually attributable
-        SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.create",
-            AuditEventCommand.SUCCESS, actorUserId, actorUsername, actorIp, actorSessionId,
-            "user", saved != null ? String.valueOf(saved.getId()) : null, email, "csv-import");
+        if (saved != null) {
+          ++userCount;
+          // Record each imported account so a bulk import is individually attributable
+          SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.create",
+              AuditEventCommand.SUCCESS, actorUserId, actorUsername, actorIp, actorSessionId,
+              "user", String.valueOf(saved.getId()), email, "csv-import");
+        } else {
+          // saveUser() caught a DB-level failure and returned null (see UserRepository.add()); the
+          // row was not persisted, so don't count it and record the failure instead
+          SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.create",
+              AuditEventCommand.FAILURE, actorUserId, actorUsername, actorIp, actorSessionId,
+              "user", null, email, "csv-import: user could not be saved");
+        }
       }
 
     } catch (DataException | AccountException data) {

--- a/src/test/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommandTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.application.cms.SaveFilePartCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.infrastructure.persistence.GroupRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+/**
+ * Proves ProcessUserCSVFileCommand.processCSV() only counts (and records a "success" audit event for)
+ * CSV rows that SaveUserCommand.saveUser() actually persisted. A row where saveUser() returns null --
+ * a caught DB-level failure inside UserRepository.add() -- must not inflate the "N users added" total
+ * reported back to the admin, and must be recorded as a failure instead, mirroring the null-check
+ * UsersListWidget#addUserAction already applies to the same saveUser() call (issue behind PR for
+ * over-counted CSV import success).
+ */
+class ProcessUserCSVFileCommandTest extends WidgetBase {
+
+  private Path csvFile;
+
+  @AfterEach
+  void cleanup() throws Exception {
+    if (csvFile != null) {
+      Files.deleteIfExists(csvFile);
+    }
+  }
+
+  @Test
+  void aRowWhereSaveUserReturnsNullIsNotCountedAndIsRecordedAsAFailure() throws Exception {
+    setRoles(widgetContext, ADMIN);
+
+    csvFile = Files.createTempFile("user-import", ".csv");
+    Files.write(csvFile, ("Email,First Name,Last Name\n" +
+        "ok@example.com,Ok,User\n" +
+        "broken@example.com,Broken,User\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+
+    FileItem fileItemBean = new FileItem();
+    fileItemBean.setFileServerPath("uploads/user-import.csv");
+
+    Group allUsersGroup = new Group();
+    allUsersGroup.setId(1L);
+    allUsersGroup.setName("All Users");
+
+    User savedOkUser = new User();
+    savedOkUser.setId(42L);
+    savedOkUser.setEmail("ok@example.com");
+
+    try (MockedStatic<SaveFilePartCommand> saveFilePart = mockStatic(SaveFilePartCommand.class);
+        MockedStatic<FileSystemCommand> fileSystem = mockStatic(FileSystemCommand.class);
+        MockedStatic<GroupRepository> groupRepository = mockStatic(GroupRepository.class);
+        MockedStatic<UserRepository> userRepository = mockStatic(UserRepository.class);
+        MockedStatic<SaveUserCommand> saveUserCommand = mockStatic(SaveUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+
+      saveFilePart.when(() -> SaveFilePartCommand.saveFile(widgetContext)).thenReturn(fileItemBean);
+      fileSystem.when(FileSystemCommand::getFileServerRootPath).thenReturn("/tmp/");
+      fileSystem.when(() -> FileSystemCommand.resolveWithinRoot(anyString(), anyString()))
+          .thenReturn(csvFile.toFile());
+      groupRepository.when(() -> GroupRepository.findByName("All Users")).thenReturn(allUsersGroup);
+      userRepository.when(() -> UserRepository.findByUsername(anyString())).thenReturn(null);
+
+      // Simulate SaveUserCommand.saveUser() returning null for one row, as it does on a caught
+      // DB-level failure inside UserRepository.add() -- the other row persists normally
+      saveUserCommand.when(() -> SaveUserCommand.saveUser(any(User.class))).thenAnswer(invocation -> {
+        User candidate = invocation.getArgument(0);
+        if ("broken@example.com".equals(candidate.getEmail())) {
+          return null;
+        }
+        return savedOkUser;
+      });
+
+      int userCount = ProcessUserCSVFileCommand.processCSV(widgetContext);
+
+      Assertions.assertEquals(1, userCount, "Only the row that actually persisted should be counted");
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq(AuditEventCommand.USER_MANAGEMENT),
+          eq("user.create"), eq(AuditEventCommand.SUCCESS), eq(1L), any(), any(), any(),
+          eq("user"), eq("42"), eq("ok@example.com"), anyString()), times(1));
+
+      audit.verify(() -> SaveAuditEventCommand.recordAdminEvent(eq(AuditEventCommand.USER_MANAGEMENT),
+          eq("user.create"), eq(AuditEventCommand.FAILURE), eq(1L), any(), any(), any(),
+          eq("user"), eq(null), eq("broken@example.com"), anyString()), times(1));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`ProcessUserCSVFileCommand` incremented the imported-user success counter and logged a `SUCCESS` audit event for every row it processed, even when `SaveUserCommand.saveUser()` returned `null`. `UserRepository.add()` returns `null` (rather than throwing) when a row fails to persist at the database level, so those rows were silently swallowed: the admin-facing import summary reported them as successful, no failure was recorded anywhere, and the subsequent audit-event call used `saved.getId()`, which would have thrown a `NullPointerException` had that code path actually been exercised with a failed save.

## What changed

In `ProcessUserCSVFileCommand.java`, the per-row handling after `SaveUserCommand.saveUser()` now branches on whether the save actually succeeded:

- If `saved != null`, the row counts toward `userCount` and a `SUCCESS` audit event is recorded, as before (now safely using `saved.getId()` directly).
- If `saved == null`, the row is not counted, and a `FAILURE` audit event is recorded instead so the failed import is attributable and visible in the audit trail rather than silently dropped.

This keeps the reported success count accurate and gives admins a way to see which rows in a CSV import actually failed to persist.

## Testing

- Added `ProcessUserCSVFileCommandTest` covering the success-count and audit-event behavior for both the normal-save and null-save (silent failure) paths.
- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite compiles and passes.
- `ant -lib lib/war compile-jsp` — not applicable (no JSP files touched), but run for completeness; passes.