### PR TITLE
Fix: N+1 queries on admin users list (role + last-login lookups)

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/RoleRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/RoleRepository.java
@@ -25,9 +25,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Persists and retrieves role objects
@@ -83,6 +89,52 @@ public class RoleRepository {
       return (List<Role>) result.getRecords();
     }
     return null;
+  }
+
+  /**
+   * Batch form of {@link #findAllByUserId} for a widget rendering many users on one page (e.g.
+   * /admin/users) -- one query instead of one-per-row. Modeled on the IN-list pattern in
+   * {@code ImageVariantRepository#findByImageIds}, but plain JDBC rather than {@code DB.selectAllFrom}:
+   * the roles returned here come from a join against {@code user_roles}, and {@link #buildRecord}
+   * (reused as-is) maps a {@code lookup_role} row to a {@link Role} that has no {@code userId} field
+   * of its own, so the owning user id has to be read off the result set separately, per row, to know
+   * which map entry each role belongs to.
+   */
+  public static Map<Long, List<Role>> findAllByUserIds(Collection<Long> userIds) {
+    Map<Long, List<Role>> roleListByUserId = new LinkedHashMap<>();
+    if (userIds == null || userIds.isEmpty()) {
+      return roleListByUserId;
+    }
+    StringBuilder placeholders = new StringBuilder();
+    for (int i = 0; i < userIds.size(); i++) {
+      if (i > 0) {
+        placeholders.append(",");
+      }
+      placeholders.append("?");
+    }
+    String sql = "SELECT lookup_role.role_id, lookup_role.level, lookup_role.code, lookup_role.title, "
+        + "user_roles.user_id AS ur_user_id "
+        + "FROM lookup_role "
+        + "JOIN user_roles ON user_roles.role_id = lookup_role.role_id "
+        + "WHERE user_roles.user_id IN (" + placeholders + ") "
+        + "ORDER BY user_roles.user_id, lookup_role.role_id";
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(sql)) {
+      int fieldIdx = 1;
+      for (Long userId : userIds) {
+        pst.setLong(fieldIdx++, userId);
+      }
+      try (ResultSet rs = pst.executeQuery()) {
+        while (rs.next()) {
+          Role role = buildRecord(rs);
+          long userId = rs.getLong("ur_user_id");
+          roleListByUserId.computeIfAbsent(userId, k -> new ArrayList<>()).add(role);
+        }
+      }
+    } catch (SQLException se) {
+      LOG.error("findAllByUserIds SQLException: " + se.getMessage());
+    }
+    return roleListByUserId;
   }
 
   public static List<Role> findAll() {

--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserLoginRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/login/UserLoginRepository.java
@@ -27,7 +27,10 @@ import org.apache.commons.logging.LogFactory;
 import java.sql.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Persists and retrieves user login objects
@@ -73,6 +76,50 @@ public class UserLoginRepository {
       return (UserLogin) result.getRecords().get(0);
     }
     return null;
+  }
+
+  /**
+   * Batch form of {@link #queryLastLogin} for a widget rendering many users on one page (e.g.
+   * /admin/users) -- one query instead of one-per-row. {@code DISTINCT ON} is Postgres-specific, but
+   * this class already relies on Postgres-only SQL elsewhere ({@link #findUniqueDailyLogins},
+   * {@link #findUniqueMonthlyLogins} use {@code DATE_TRUNC}/{@code generate_series}), so it's
+   * consistent with precedent rather than a new dependency. {@code DISTINCT ON (user_id) ... ORDER BY
+   * user_id, created DESC} keeps just the most recent {@code user_logins} row per user_id in a single
+   * pass, restricted to the requested ids via an IN-list mirroring
+   * {@code ImageVariantRepository#findByImageIds}.
+   */
+  public static Map<Long, UserLogin> queryLastLogins(Collection<Long> userIds) {
+    Map<Long, UserLogin> lastLoginByUserId = new LinkedHashMap<>();
+    if (userIds == null || userIds.isEmpty()) {
+      return lastLoginByUserId;
+    }
+    StringBuilder placeholders = new StringBuilder();
+    for (int i = 0; i < userIds.size(); i++) {
+      if (i > 0) {
+        placeholders.append(",");
+      }
+      placeholders.append("?");
+    }
+    String sql = "SELECT DISTINCT ON (user_id) login_id, source, user_id, ip_address, user_agent, created "
+        + "FROM " + TABLE_NAME + " "
+        + "WHERE user_id IN (" + placeholders + ") "
+        + "ORDER BY user_id, created DESC";
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(sql)) {
+      int fieldIdx = 1;
+      for (Long userId : userIds) {
+        pst.setLong(fieldIdx++, userId);
+      }
+      try (ResultSet rs = pst.executeQuery()) {
+        while (rs.next()) {
+          UserLogin login = buildRecord(rs);
+          lastLoginByUserId.put(login.getUserId(), login);
+        }
+      }
+    } catch (SQLException se) {
+      LOG.error("queryLastLogins SQLException: " + se.getMessage());
+    }
+    return lastLoginByUserId;
   }
 
   public static long queryTodaysLoginCount(long userId) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -31,6 +31,7 @@ import com.simisinc.platform.domain.events.cms.UserPasswordResetEvent;
 import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserLogin;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
@@ -51,6 +52,7 @@ import javax.security.auth.login.AccountException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Description
@@ -165,11 +167,20 @@ public class UsersListWidget extends GenericWidget {
       specification.setPasswordOlderThanDays(maxAgeDays);
     }
 
-    // Load the users
+    // Load the users, then batch-load their roles and last-login in one query each rather than
+    // one query per row (a page of 20 users previously issued 41 round trips: 1 + 20 + 20).
     List<User> userList = UserRepository.findAll(specification, constraints);
-    for (User user : userList) {
-      user.setRoleList(RoleRepository.findAllByUserId(user.getId()));
-      user.setLastLogin(UserLoginRepository.queryLastLogin(user.getId()));
+    if (!userList.isEmpty()) {
+      List<Long> userIds = new ArrayList<>();
+      for (User user : userList) {
+        userIds.add(user.getId());
+      }
+      Map<Long, List<Role>> roleListByUserId = RoleRepository.findAllByUserIds(userIds);
+      Map<Long, UserLogin> lastLoginByUserId = UserLoginRepository.queryLastLogins(userIds);
+      for (User user : userList) {
+        user.setRoleList(roleListByUserId.get(user.getId()));
+        user.setLastLogin(lastLoginByUserId.get(user.getId()));
+      }
     }
     context.getRequest().setAttribute("userList", userList);
 

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/RoleRepositoryFindAllByUserIdsTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/RoleRepositoryFindAllByUserIdsTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.Role;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link RoleRepository#findAllByUserIds} against a real PostgreSQL instance -- the batch
+ * form added for /admin/users (UsersListWidget) so a page of users issues one role query instead of
+ * one per row. Modeled on {@code ImageVariantRepositoryTest}'s Testcontainers convention.
+ *
+ * @author SimIS Inc.
+ */
+class RoleRepositoryFindAllByUserIdsTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(), "Docker is not available - skipping RoleRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE user_roles, lookup_role, users RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset users/lookup_role/user_roles tables", se);
+    }
+  }
+
+  @Test
+  void findAllByUserIdsGroupsRolesByUserIdAcrossMultipleUsers() throws SQLException {
+    long user1 = insertUser("user-one");
+    long user2 = insertUser("user-two");
+    long user3 = insertUser("user-three"); // no roles -- must not appear in the returned map at all
+    long editorRole = insertRole(70, "content-editor", "Content Editor");
+    long managerRole = insertRole(80, "content-manager", "Content Manager");
+    assignRole(user1, editorRole);
+    assignRole(user1, managerRole);
+    assignRole(user2, editorRole);
+
+    Map<Long, List<Role>> rolesByUserId = RoleRepository.findAllByUserIds(List.of(user1, user2, user3));
+
+    assertEquals(2, rolesByUserId.get(user1).size());
+    assertTrue(rolesByUserId.get(user1).stream().map(Role::getCode)
+        .toList().containsAll(List.of("content-editor", "content-manager")));
+    assertEquals(1, rolesByUserId.get(user2).size());
+    assertEquals("content-editor", rolesByUserId.get(user2).get(0).getCode());
+    assertNull(rolesByUserId.get(user3), "a user with zero roles must not get an empty-list entry");
+  }
+
+  @Test
+  void findAllByUserIdsOnlyReturnsRolesForTheRequestedIds() throws SQLException {
+    long requested = insertUser("requested");
+    long notRequested = insertUser("not-requested");
+    long adminRole = insertRole(100, "admin", "System Administrator");
+    assignRole(requested, adminRole);
+    assignRole(notRequested, adminRole);
+
+    Map<Long, List<Role>> rolesByUserId = RoleRepository.findAllByUserIds(List.of(requested));
+
+    assertEquals(1, rolesByUserId.size(), "a user id outside the requested set must not leak into the result");
+    assertTrue(rolesByUserId.containsKey(requested));
+  }
+
+  @Test
+  void findAllByUserIdsReturnsAnEmptyMapForNullOrEmptyInputWithoutQuerying() {
+    assertTrue(RoleRepository.findAllByUserIds(null).isEmpty());
+    assertTrue(RoleRepository.findAllByUserIds(List.of()).isEmpty());
+  }
+
+  private static long insertUser(String uniqueId) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO users (unique_id, username, password) VALUES (?, ?, ?) RETURNING user_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      pst.setString(3, "not-a-real-hash");
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static long insertRole(int level, String code, String title) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO lookup_role (level, code, title) VALUES (?, ?, ?) RETURNING role_id")) {
+      pst.setInt(1, level);
+      pst.setString(2, code);
+      pst.setString(3, title);
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static void assignRole(long userId, long roleId) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)")) {
+      pst.setLong(1, userId);
+      pst.setLong(2, roleId);
+      pst.executeUpdate();
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // Mirrors NEW_10000__new_database.sql's `users`/`lookup_role`/`user_roles` tables, trimmed to
+    // just the columns findAllByUserIds' join and buildRecord() touch.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS user_roles CASCADE");
+      statement.execute("DROP TABLE IF EXISTS lookup_role CASCADE");
+      statement.execute("DROP TABLE IF EXISTS users CASCADE");
+      statement.execute("CREATE TABLE users ("
+          + "user_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "username VARCHAR(255) UNIQUE NOT NULL, "
+          + "password VARCHAR(255) NOT NULL)");
+      statement.execute("CREATE TABLE lookup_role ("
+          + "role_id SERIAL PRIMARY KEY, "
+          + "level INTEGER NOT NULL, "
+          + "code VARCHAR(20), "
+          + "title VARCHAR(100), "
+          + "oauth_path VARCHAR(255))");
+      statement.execute("CREATE TABLE user_roles ("
+          + "user_role_id BIGSERIAL PRIMARY KEY, "
+          + "user_id BIGINT REFERENCES users(user_id) NOT NULL, "
+          + "role_id BIGINT REFERENCES lookup_role(role_id) NOT NULL, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP)");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the users/lookup_role/user_roles schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/login/UserLoginRepositoryQueryLastLoginsTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/login/UserLoginRepositoryQueryLastLoginsTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.infrastructure.persistence.login;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.simisinc.platform.domain.model.login.UserLogin;
+import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataSource;
+
+/**
+ * Verifies {@link UserLoginRepository#queryLastLogins} against a real PostgreSQL instance -- the
+ * batch form added for /admin/users (UsersListWidget) so a page of users issues one last-login query
+ * instead of one per row. Exercises the Postgres-specific {@code DISTINCT ON (user_id) ... ORDER BY
+ * user_id, created DESC} this method relies on to keep only the most recent row per user in a single
+ * pass. Modeled on {@code ImageVariantRepositoryTest}'s Testcontainers convention.
+ *
+ * @author SimIS Inc.
+ */
+class UserLoginRepositoryQueryLastLoginsTest {
+
+  private static final String DEFAULT_IMAGE = "postgres:15-alpine";
+  private static final int POSTGRES_PORT = 5432;
+  private static final String DB_NAME = "simis_cms_test";
+  private static final String DB_USER = "simis";
+  private static final String DB_PASSWORD = "simis";
+
+  private static GenericContainer<?> postgres;
+
+  @BeforeAll
+  static void startDatabase() {
+    Assumptions.assumeTrue(isDockerAvailable(),
+        "Docker is not available - skipping UserLoginRepository integration test");
+
+    postgres = new GenericContainer<>(DockerImageName.parse(resolveImage()))
+        .withEnv("POSTGRES_USER", DB_USER)
+        .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
+        .withEnv("POSTGRES_DB", DB_NAME)
+        .withExposedPorts(POSTGRES_PORT)
+        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+            .withStartupTimeout(Duration.ofSeconds(120)));
+    try {
+      postgres.start();
+    } catch (Throwable t) {
+      Assumptions.abort("Unable to start PostgreSQL test container: " + t.getMessage());
+    }
+
+    String jdbcUrl = "jdbc:postgresql://" + postgres.getHost() + ":" + postgres.getMappedPort(POSTGRES_PORT)
+        + "/" + DB_NAME;
+    Properties properties = new Properties();
+    properties.setProperty("jdbcUrl", jdbcUrl);
+    properties.setProperty("username", DB_USER);
+    properties.setProperty("password", DB_PASSWORD);
+    DataSource.init(properties);
+
+    createSchema();
+  }
+
+  @AfterAll
+  static void stopDatabase() {
+    try {
+      DataSource.shutdown();
+    } catch (Exception e) {
+      // Never initialized when Docker is unavailable
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @BeforeEach
+  void resetTables() {
+    if (postgres == null || !postgres.isRunning()) {
+      return;
+    }
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("TRUNCATE TABLE user_logins, users RESTART IDENTITY CASCADE");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not reset users/user_logins tables", se);
+    }
+  }
+
+  @Test
+  void queryLastLoginsReturnsOnlyTheMostRecentLoginPerUser() throws SQLException {
+    long user1 = insertUser("user-one");
+    long user2 = insertUser("user-two");
+    long user3 = insertUser("user-three"); // never logged in -- must not appear in the returned map at all
+    Instant now = Instant.now();
+    insertLogin(user1, Timestamp.from(now.minusSeconds(3600)), "1.1.1.1");
+    insertLogin(user1, Timestamp.from(now), "9.9.9.9"); // the most recent for user1
+    insertLogin(user2, Timestamp.from(now.minusSeconds(60)), "2.2.2.2");
+
+    Map<Long, UserLogin> lastLoginByUserId = UserLoginRepository.queryLastLogins(List.of(user1, user2, user3));
+
+    assertEquals("9.9.9.9", lastLoginByUserId.get(user1).getIpAddress(),
+        "must keep the most recent row per user, not an arbitrary one");
+    assertEquals("2.2.2.2", lastLoginByUserId.get(user2).getIpAddress());
+    assertTrue(!lastLoginByUserId.containsKey(user3), "a user with zero logins must not get a map entry");
+  }
+
+  @Test
+  void queryLastLoginsOnlyReturnsLoginsForTheRequestedIds() throws SQLException {
+    long requested = insertUser("requested");
+    long notRequested = insertUser("not-requested");
+    insertLogin(requested, new Timestamp(System.currentTimeMillis()), "1.1.1.1");
+    insertLogin(notRequested, new Timestamp(System.currentTimeMillis()), "2.2.2.2");
+
+    Map<Long, UserLogin> lastLoginByUserId = UserLoginRepository.queryLastLogins(List.of(requested));
+
+    assertEquals(1, lastLoginByUserId.size(), "a user id outside the requested set must not leak into the result");
+    assertTrue(lastLoginByUserId.containsKey(requested));
+  }
+
+  @Test
+  void queryLastLoginsReturnsAnEmptyMapForNullOrEmptyInputWithoutQuerying() {
+    assertTrue(UserLoginRepository.queryLastLogins(null).isEmpty());
+    assertTrue(UserLoginRepository.queryLastLogins(List.of()).isEmpty());
+  }
+
+  private static long insertUser(String uniqueId) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO users (unique_id, username, password) VALUES (?, ?, ?) RETURNING user_id")) {
+      pst.setString(1, uniqueId);
+      pst.setString(2, uniqueId);
+      pst.setString(3, "not-a-real-hash");
+      try (ResultSet rs = pst.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static void insertLogin(long userId, Timestamp created, String ipAddress) throws SQLException {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO user_logins (user_id, ip_address, user_agent, created) VALUES (?, ?, ?, ?)")) {
+      pst.setLong(1, userId);
+      pst.setString(2, ipAddress);
+      pst.setString(3, "test-agent");
+      pst.setTimestamp(4, created);
+      pst.executeUpdate();
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private static String resolveImage() {
+    String image = System.getenv("TEST_POSTGRES_IMAGE");
+    return (image != null && !image.isBlank()) ? image : DEFAULT_IMAGE;
+  }
+
+  private static void createSchema() {
+    // Mirrors NEW_10000__new_database.sql's `users`/`user_logins` tables, trimmed to just the
+    // columns queryLastLogins' query and buildRecord() touch.
+    try (Connection connection = DB.getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS user_logins CASCADE");
+      statement.execute("DROP TABLE IF EXISTS users CASCADE");
+      statement.execute("CREATE TABLE users ("
+          + "user_id BIGSERIAL PRIMARY KEY, "
+          + "unique_id VARCHAR(255) UNIQUE NOT NULL, "
+          + "username VARCHAR(255) UNIQUE NOT NULL, "
+          + "password VARCHAR(255) NOT NULL)");
+      statement.execute("CREATE TABLE user_logins ("
+          + "login_id BIGSERIAL PRIMARY KEY, "
+          + "user_id BIGINT REFERENCES users(user_id) NOT NULL, "
+          + "ip_address VARCHAR(200) NOT NULL, "
+          + "user_agent VARCHAR(255) NOT NULL, "
+          + "created TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "
+          + "session_id VARCHAR(255), "
+          + "source VARCHAR(50))");
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not create the users/user_logins schema", se);
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetTest.java
@@ -20,11 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +40,7 @@ import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.UserLogin;
 import com.simisinc.platform.infrastructure.database.DataConstraints;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
@@ -264,6 +267,82 @@ class UsersListWidgetTest extends WidgetBase {
       saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
       Assertions.assertTrue(captor.getValue().getRoleList().isEmpty(),
           "a session whose role code isn't in the authoritative role list must fail closed and grant nothing");
+    }
+  }
+
+  /**
+   * execute() used to load each row's roles and last-login with one {@code RoleRepository.findAllByUserId}
+   * and one {@code UserLoginRepository.queryLastLogin} call per user (N+1). It now batches both into a
+   * single {@code findAllByUserIds}/{@code queryLastLogins} call and assigns per-row from the returned
+   * maps -- this confirms the page still renders each user's own roles and last-login correctly from
+   * that batched data, and that the old per-row methods are no longer called at all.
+   */
+  @Test
+  void executeAssignsRolesAndLastLoginFromTheBatchedMapsRatherThanPerRowQueries() {
+    setRoles(widgetContext, ADMIN);
+
+    User user1 = new User();
+    user1.setId(1L);
+    User user2 = new User();
+    user2.setId(2L);
+    User user3 = new User();
+    user3.setId(3L); // no roles, no login -- must end up with null roleList/lastLogin, not a crash
+
+    Role editorRole = role(1, 70, "content-editor", "Content Editor");
+    UserLogin user1Login = new UserLogin();
+    user1Login.setUserId(1L);
+    UserLogin user2Login = new UserLogin();
+    user2Login.setUserId(2L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> loginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<UnsuspendRequestRepository> requestRepo = mockStatic(UnsuspendRequestRepository.class)) {
+      userRepo.when(() -> UserRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(List.of(user1, user2, user3));
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      roleRepo.when(() -> RoleRepository.findAllByUserIds(List.of(1L, 2L, 3L)))
+          .thenReturn(Map.of(1L, List.of(editorRole)));
+      loginRepo.when(() -> UserLoginRepository.queryLastLogins(List.of(1L, 2L, 3L)))
+          .thenReturn(Map.of(1L, user1Login, 2L, user2Login));
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      requestRepo.when(UnsuspendRequestRepository::countPending).thenReturn(0L);
+
+      new UsersListWidget().execute(widgetContext);
+
+      assertEquals(List.of(editorRole), user1.getRoleList());
+      assertEquals(user1Login, user1.getLastLogin());
+      Assertions.assertNull(user2.getRoleList(), "user2 has no assigned role -- must be null, not a missing-key crash");
+      assertEquals(user2Login, user2.getLastLogin());
+      Assertions.assertNull(user3.getRoleList());
+      Assertions.assertNull(user3.getLastLogin());
+
+      // The whole point of the batching: never fall back to a per-row call.
+      roleRepo.verify(() -> RoleRepository.findAllByUserId(anyLong()), never());
+      loginRepo.verify(() -> UserLoginRepository.queryLastLogin(anyLong()), never());
+    }
+  }
+
+  @Test
+  void executeNeverCallsTheBatchRepositoriesWhenThePageHasNoUsers() {
+    setRoles(widgetContext, ADMIN);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserLoginRepository> loginRepo = mockStatic(UserLoginRepository.class);
+        MockedStatic<UnsuspendRequestRepository> requestRepo = mockStatic(UnsuspendRequestRepository.class)) {
+      userRepo.when(() -> UserRepository.findAll(any(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+      requestRepo.when(UnsuspendRequestRepository::countPending).thenReturn(0L);
+
+      new UsersListWidget().execute(widgetContext);
+
+      roleRepo.verify(() -> RoleRepository.findAllByUserIds(any()), never());
+      loginRepo.verify(() -> UserLoginRepository.queryLastLogins(any()), never());
     }
   }
 


### PR DESCRIPTION
## Problem

`UsersListWidget.execute()` (backing `/admin/users`) looped over every user returned for the current page and issued a separate `RoleRepository.findAllByUserId()` call and a separate `UserLoginRepository.queryLastLogin()` call for each one. A page of 20 users therefore cost 41 database round trips: 1 to fetch the page of users, 20 for roles, 20 for last-login lookups. This scales linearly with page size and gets worse as admins increase the page size or as the user table grows.

## Change

- Added `RoleRepository.findAllByUserIds(Collection<Long>)`, which joins `lookup_role` to `user_roles` with a single `IN (...)` query and returns a `Map<Long, List<Role>>` keyed by user id. The row-mapped `Role` has no `userId` field to group by, so the owning user id is read off the result set separately per row.
- Added `UserLoginRepository.queryLastLogins(Collection<Long>)`, which uses Postgres's `DISTINCT ON (user_id) ... ORDER BY user_id, created DESC` to keep only the most recent login per user in one pass, returning a `Map<Long, UserLogin>`. This mirrors the `DISTINCT ON`-free but still Postgres-specific `DATE_TRUNC`/`generate_series` usage already elsewhere in that class, so it isn't introducing a new database dependency. Both new methods follow the IN-list batch pattern already used by `ImageVariantRepository.findByImageIds()`.
- `UsersListWidget.execute()` now collects the page's user ids, makes one batch call to each new method, and assigns each user's `roleList`/`lastLogin` from the returned maps instead of querying per row. A user with no roles or no logins simply gets no map entry (null), matching the prior per-row behavior of "not found" returning null/empty.

## Testing

- `RoleRepositoryFindAllByUserIdsTest` and `UserLoginRepositoryQueryLastLoginsTest` (new, Testcontainers/Postgres): verify roles/logins are correctly grouped by user id, that ids outside the requested set never leak into the result, and that a null/empty input returns an empty map without querying.
- `UsersListWidgetTest` (extended): verifies `execute()` assigns each user's roles and last-login from the batched maps, that a user with no roles/no login ends up with a null field rather than a crash, and that the old per-row `findAllByUserId`/`queryLastLogin` methods are never called (via Mockito `never()`). Also verifies neither batch method is called when the page has no users.
- Ran the full build/verify sequence: `ant -lib lib/war -lib lib/tests clean ci-test` (full suite) and `ant -lib lib/war compile-jsp` (JSP gate, no JSPs touched by this change) -- both passing before this PR was opened.