### PR TITLE
Fix: role-checkbox UI doesn't match server-side role-level enforcement

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -75,9 +75,12 @@ public class UserFormWidget extends GenericWidget {
     context.getRequest().setAttribute("user", user);
     context.setPageTitle(user.getFullName());
 
-    // Shows any roles
+    // Shows any roles -- the JSP only offers/enables roles the editor is allowed to grant or revoke
+    // (see highestRoleLevel() below; matches the same request attribute UsersListWidget sets).
     List<Role> roleList = RoleRepository.findAll();
     context.getRequest().setAttribute("roleList", roleList);
+    context.getRequest().setAttribute("actingRoleLevel",
+        highestRoleLevel(context.getUserSession(), roleList != null ? roleList : new ArrayList<>()));
 
     // Show any groups
     List<Group> groupList = GroupRepository.findAll();

--- a/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
@@ -260,7 +260,10 @@
           <div class="small-9 cell">
             <c:forEach items="${roleList}" var="role">
               <c:choose>
-                <c:when test="${role.code eq 'admin' && !userSession.hasRole('admin')}"><%-- --%></c:when>
+                <c:when test="${role.level > actingRoleLevel && !user.hasRole(role.code)}"><%-- above the editor's level, and not already held -- not grantable, omit --%></c:when>
+                <c:when test="${role.level > actingRoleLevel}">
+                  <input id="roleId${role.id}" type="checkbox" name="roleId${role.id}" value="${role.id}" checked disabled/><label for="roleId${role.id}"><c:out value="${role.title}" /> <small class="help-text" style="display:inline;margin-top:0;">(requires a higher role to change)</small></label><br />
+                </c:when>
                 <c:otherwise>
                   <input id="roleId${role.id}" type="checkbox" name="roleId${role.id}" value="${role.id}" <c:if test="${user.hasRole(role.code)}">checked</c:if>/><label for="roleId${role.id}"><c:out value="${role.title}" /></label><br />
                 </c:otherwise>

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -236,7 +236,7 @@
       <select id="bulkRoleId" name="roleId" required>
         <c:forEach items="${roleList}" var="role">
           <c:choose>
-            <c:when test="${role.code eq 'admin' && !userSession.hasRole('admin')}"><%-- not offered --%></c:when>
+            <c:when test="${role.level > actingRoleLevel}"><%-- not offered --%></c:when>
             <c:otherwise>
               <option value="${role.id}"><c:out value="${role.title}" /></option>
             </c:otherwise>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -93,6 +93,39 @@ class UserFormWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeExposesActingRoleLevelForCommunityManager() {
+    // user-form.jsp hides a role checkbox when role.level > actingRoleLevel (and not already held),
+    // and renders it checked+disabled when it is already held -- mirroring users-list.jsp's New User
+    // form. A community-manager (level 90) must not be offered admin (100).
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+
+      new UserFormWidget().execute(widgetContext);
+
+      Assertions.assertEquals(90, widgetContext.getRequest().getAttribute("actingRoleLevel"),
+          "the edit-user form must only be able to offer roles at/below the community-manager's own level");
+    }
+  }
+
+  @Test
+  void executeExposesActingRoleLevelForAdmin() {
+    setRoles(widgetContext, ADMIN);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(new ArrayList<>());
+
+      new UserFormWidget().execute(widgetContext);
+
+      Assertions.assertEquals(100, widgetContext.getRequest().getAttribute("actingRoleLevel"),
+          "an admin must still be offered every role, including admin itself");
+    }
+  }
+
+  @Test
   void postWithoutStepUpShowsReAuthPanel() throws Exception {
     setRoles(widgetContext, ADMIN);
     addQueryParameter(widgetContext, "id", "-1");


### PR DESCRIPTION
## Problem

`SaveUserCommand` (invoked from `UserFormWidget.post()`) already enforces that an editor cannot grant or revoke a role above their own highest role level -- any such attempt is silently no-op'd server-side with only a `LOG.warn`. The edit-user JSP and the bulk-assign role dropdown, however, still gated visibility on a stale hardcoded `role.code eq 'admin' && !userSession.hasRole('admin')` check instead of the actual level comparison, so the UI and the server enforcement disagreed in two ways:

- A role between the editor's level and admin (e.g. a community-manager-level role) was offered as a normal checkbox/dropdown option to editors who could not actually grant it, so submitting silently no-op'd that field with no error.
- Worse: if the edited user already held a role above the editor's level, the checkbox for it rendered as a normal *enabled* control (checked). Unchecking it and saving reported "User was saved," implying the role was removed, while the server silently kept the role in place.

`users-list.jsp`'s "New User" form already handled this correctly via a `role.level > actingRoleLevel` comparison and an `actingRoleLevel` request attribute; the edit-user form (`user-form.jsp`) and the bulk-assign dropdown had not been updated to match.

## Fix

- `UserFormWidget.execute()` now sets the same `actingRoleLevel` request attribute `UsersListWidget` already sets, via the shared `highestRoleLevel()` helper.
- `user-form.jsp`'s role checkboxes now use a three-way branch keyed on `role.level > actingRoleLevel`, mirroring `users-list.jsp`'s existing New User form pattern:
  - Omit the checkbox entirely when the role is above the editor's level and not already held (ungrantable).
  - Render it checked and disabled, with an explanatory label, when it's above the editor's level but already held (so the editor can see it but can't silently drop it).
  - Otherwise render it as a normal enabled checkbox.
- `users-list.jsp`'s bulk-assign role `<select>` gets the identical `role.level > actingRoleLevel` swap in place of the old admin-only check.

`SaveUserCommand` and the level-clamp logic itself are unchanged -- this only brings the JSPs' presented affordances in line with what the server already enforces.

## Testing

- Added `UserFormWidgetTest#executeExposesActingRoleLevelForCommunityManager`: a community-manager (level 90) editor gets `actingRoleLevel` = 90, matching the level that gates which checkboxes `user-form.jsp` will show as enabled/omitted.
- Added `UserFormWidgetTest#executeExposesActingRoleLevelForAdmin`: an admin (level 100) editor still gets `actingRoleLevel` = 100, so every role remains offered.
- `ant -lib lib/war -lib lib/tests clean ci-test` -- full suite compiles and passes.
- `ant -lib lib/war compile-jsp` -- JSP syntax/unescaped-EL gate passes for the touched `user-form.jsp` and `users-list.jsp`.