### PR TITLE
Add CSV export/download for the admin users list

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.File;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,10 +52,9 @@ public class UserRepository {
   private static String TABLE_NAME = "users";
   private static String[] PRIMARY_KEY = new String[]{"user_id"};
 
-  private static DataResult query(UserSpecification specification, DataConstraints constraints) {
-    SqlUtils select = new SqlUtils();
+  /** Shared by {@link #query} and {@link #exportCsv} so the export always honors the same filters as the page. */
+  private static SqlUtils createWhereStatement(UserSpecification specification) {
     SqlUtils where = new SqlUtils();
-    SqlUtils orderBy = new SqlUtils();
     if (specification != null) {
       where.addIfExists("user_id = ?", specification.getId(), -1);
       if (specification.getRoleId() > -1) {
@@ -102,6 +102,13 @@ public class UserRepository {
         }
       }
     }
+    return where;
+  }
+
+  private static DataResult query(UserSpecification specification, DataConstraints constraints) {
+    SqlUtils select = new SqlUtils();
+    SqlUtils where = createWhereStatement(specification);
+    SqlUtils orderBy = new SqlUtils();
     return DB.selectAllFrom(
         TABLE_NAME, select, where, orderBy, constraints, UserRepository::buildRecord);
   }
@@ -174,6 +181,37 @@ public class UserRepository {
     constraints.setDefaultColumnToSortBy("user_id desc");
     DataResult result = query(specification, constraints);
     return (List<User>) result.getRecords();
+  }
+
+  /**
+   * Exports every record matching the filter (unpaginated -- a fresh DataConstraints has no page size) to a
+   * CSV file, honoring the same WHERE clause {@link #query} builds from the specification so the export
+   * always matches whatever filter is applied on the page.
+   *
+   * <p>The column list is an explicit allowlist -- never {@code SELECT *} and never the full-record
+   * {@link #buildRecord} mapper -- so the password hash, MFA TOTP secret, and account-token/reset-token
+   * columns can never end up in the exported file, regardless of what {@link User} gains in the future.
+   * Roles and last-login are correlated subqueries (mirroring the {@code WHERE user_id = users.user_id}
+   * idiom {@link #query} already uses for role/group filters) rather than a plain JOIN, since a plain JOIN
+   * against user_roles or user_logins would multiply a row per role/login for a user with more than one.
+   */
+  public static void exportCsv(UserSpecification specification, File file) {
+    SqlUtils selectFields = new SqlUtils()
+        .addNames(
+            "first_name AS \"First Name\"",
+            "last_name AS \"Last Name\"",
+            "email AS \"Email\"",
+            "username AS \"Username\"",
+            "(SELECT string_agg(lr.title, ', ' ORDER BY lr.level DESC) FROM lookup_role lr " +
+                "JOIN user_roles ur ON ur.role_id = lr.role_id WHERE ur.user_id = users.user_id) AS \"Roles\"",
+            "enabled AS \"Enabled\"",
+            "validated AS \"Validated\"",
+            "created AS \"Created\"",
+            "(SELECT MAX(created) FROM user_logins WHERE user_id = users.user_id) AS \"Last Login\"");
+    SqlUtils where = createWhereStatement(specification);
+    DataConstraints constraints = new DataConstraints();
+    constraints.setDefaultColumnToSortBy("user_id desc");
+    DB.exportToCsvAllFrom(TABLE_NAME, selectFields, null, where, null, constraints, file);
   }
 
   public static List<StatisticsData> findMonthlyUserRegistrations(int monthsLimit) {

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -22,6 +22,7 @@ import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.admin.ProcessUserCSVFileCommand;
 import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.cms.UrlCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
 import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.application.login.UnsuspendAccountCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
@@ -39,6 +40,7 @@ import com.simisinc.platform.infrastructure.persistence.UserSpecification;
 import com.simisinc.platform.infrastructure.persistence.login.UnsuspendRequestRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserLoginRepository;
 import com.simisinc.platform.infrastructure.workflow.WorkflowManager;
+import com.simisinc.platform.presentation.controller.MultipartFileSender;
 import com.simisinc.platform.presentation.controller.RequestConstants;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
@@ -48,8 +50,11 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.security.auth.login.AccountException;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -100,17 +105,10 @@ public class UsersListWidget extends GenericWidget {
     context.getRequest().setAttribute(RequestConstants.RECORD_QUERY, query);
 
     // Determine the filters
-    String statusFilterValue = context.getParameter("statusFilter", STATUS_FILTER_ANY);
-    String statusFilter = STATUS_FILTER_ANY;
-    if (STATUS_FILTER_ACTIVE.equals(statusFilterValue) || STATUS_FILTER_SUSPENDED.equals(statusFilterValue)
-        || STATUS_FILTER_LOCKED.equals(statusFilterValue) || STATUS_FILTER_INACTIVE.equals(statusFilterValue)) {
-      statusFilter = statusFilterValue;
-    }
+    String statusFilter = resolveStatusFilter(context);
     context.getRequest().setAttribute("statusFilter", statusFilter);
 
-    String mfaFilterValue = context.getParameter("mfaFilter", MFA_FILTER_ANY);
-    String mfaFilter = (MFA_FILTER_ENABLED.equals(mfaFilterValue) || MFA_FILTER_DISABLED.equals(mfaFilterValue))
-        ? mfaFilterValue : MFA_FILTER_ANY;
+    String mfaFilter = resolveMfaFilter(context);
     context.getRequest().setAttribute("mfaFilter", mfaFilter);
 
     // "1" is the only supported value today (a simple on/off toggle); the threshold itself comes
@@ -135,35 +133,7 @@ public class UsersListWidget extends GenericWidget {
     context.getRequest().setAttribute(RequestConstants.RECORD_PAGING_URI, pagingUri);
 
     // Determine criteria
-    UserSpecification specification = new UserSpecification();
-    if (StringUtils.isNotBlank(query)) {
-      specification.setMatchesName(query);
-    }
-    // Each status bucket is the same compound condition User.getAccountStatus() derives from, so
-    // the filter always matches what the badge actually shows.
-    if (STATUS_FILTER_ACTIVE.equals(statusFilter)) {
-      specification.setIsEnabled(true);
-      specification.setIsLocked(false);
-      specification.setIsVerified(true);
-    } else if (STATUS_FILTER_SUSPENDED.equals(statusFilter)) {
-      specification.setIsEnabled(false);
-    } else if (STATUS_FILTER_LOCKED.equals(statusFilter)) {
-      specification.setIsEnabled(true);
-      specification.setIsLocked(true);
-    } else if (STATUS_FILTER_INACTIVE.equals(statusFilter)) {
-      specification.setIsEnabled(true);
-      specification.setIsLocked(false);
-      specification.setIsVerified(false);
-    }
-    if (MFA_FILTER_ENABLED.equals(mfaFilter)) {
-      specification.setIsMfaEnabled(true);
-    } else if (MFA_FILTER_DISABLED.equals(mfaFilter)) {
-      specification.setIsMfaEnabled(false);
-    }
-    if (agingPasswordFilter) {
-      int maxAgeDays = UserRepository.resolvePasswordMaxAgeDays(LoadSitePropertyCommand.loadByName("password.maxAgeDays"));
-      specification.setPasswordOlderThanDays(maxAgeDays);
-    }
+    UserSpecification specification = buildSpecification(query, statusFilter, mfaFilter, agingPasswordFilter);
 
     // Load the users
     List<User> userList = UserRepository.findAll(specification, constraints);
@@ -213,6 +183,11 @@ public class UsersListWidget extends GenericWidget {
       return uploadCSVFileAction(context);
     }
 
+    // Download the currently filtered list as a CSV file
+    if ("downloadCSVFile".equals(command)) {
+      return downloadCSVFileAction(context);
+    }
+
     // Bulk actions, selected from /admin/users' checkbox + action-bar UI
     if ("bulkSuspend".equals(command)) {
       return bulkSuspendAction(context);
@@ -242,6 +217,100 @@ public class UsersListWidget extends GenericWidget {
     // Determine the page to return to
     context.setRedirect("/admin/users");
     return context;
+  }
+
+  /**
+   * Streams the currently filtered (unpaginated) user list as a CSV download -- the filter params are the
+   * same query/statusFilter/mfaFilter/agingPasswordFilter the list page's GET uses, resolved with the same
+   * helpers so the export always matches what the admin is currently looking at. The column allowlist that
+   * keeps secrets out of the file lives in {@link UserRepository#exportCsv}, not here.
+   */
+  private WidgetContext downloadCSVFileAction(WidgetContext context) {
+    String query = context.getParameter("query");
+    String statusFilter = resolveStatusFilter(context);
+    String mfaFilter = resolveMfaFilter(context);
+    boolean agingPasswordFilter = "1".equals(context.getParameter("agingPasswordFilter"));
+    UserSpecification specification = buildSpecification(query, statusFilter, mfaFilter, agingPasswordFilter);
+
+    String displayFilename = "users-" + new SimpleDateFormat("yyyyMMdd-HHmm").format(new Date()) + ".csv";
+    File tempFile = FileSystemCommand.generateTempFile("exports", context.getUserId(), "csv");
+    try {
+      UserRepository.exportCsv(specification, tempFile);
+      MultipartFileSender.fromFile(tempFile)
+          .with(context.getRequest())
+          .with(context.getResponse())
+          .withMimeType("text/csv")
+          .withFilename(displayFilename)
+          .serveResource();
+      // Exporting the user list is itself a data-access event worth auditing.
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "user.export", AuditEventCommand.SUCCESS,
+          "user", "filtered", displayFilename, "format=csv");
+    } catch (Exception e) {
+      LOG.error("User export failed", e);
+      AuditEventCommand.record(context, AuditEventCommand.DATA_ACCESS, "user.export", AuditEventCommand.FAILURE,
+          "user", "filtered", displayFilename, "format=csv");
+    } finally {
+      if (tempFile.exists()) {
+        tempFile.delete();
+      }
+    }
+    context.setHandledResponse(true);
+    return context;
+  }
+
+  /** Validates the statusFilter request parameter, defaulting to "any" -- shared by execute() and the CSV export. */
+  private String resolveStatusFilter(WidgetContext context) {
+    String statusFilterValue = context.getParameter("statusFilter", STATUS_FILTER_ANY);
+    if (STATUS_FILTER_ACTIVE.equals(statusFilterValue) || STATUS_FILTER_SUSPENDED.equals(statusFilterValue)
+        || STATUS_FILTER_LOCKED.equals(statusFilterValue) || STATUS_FILTER_INACTIVE.equals(statusFilterValue)) {
+      return statusFilterValue;
+    }
+    return STATUS_FILTER_ANY;
+  }
+
+  /** Validates the mfaFilter request parameter, defaulting to "any" -- shared by execute() and the CSV export. */
+  private String resolveMfaFilter(WidgetContext context) {
+    String mfaFilterValue = context.getParameter("mfaFilter", MFA_FILTER_ANY);
+    return (MFA_FILTER_ENABLED.equals(mfaFilterValue) || MFA_FILTER_DISABLED.equals(mfaFilterValue))
+        ? mfaFilterValue : MFA_FILTER_ANY;
+  }
+
+  /**
+   * Builds the UserSpecification from already-resolved filter values -- shared by execute() (the page's
+   * GET) and downloadCSVFileAction() (the export's POST) so the two can never drift apart.
+   */
+  private UserSpecification buildSpecification(String query, String statusFilter, String mfaFilter,
+      boolean agingPasswordFilter) {
+    UserSpecification specification = new UserSpecification();
+    if (StringUtils.isNotBlank(query)) {
+      specification.setMatchesName(query);
+    }
+    // Each status bucket is the same compound condition User.getAccountStatus() derives from, so
+    // the filter always matches what the badge actually shows.
+    if (STATUS_FILTER_ACTIVE.equals(statusFilter)) {
+      specification.setIsEnabled(true);
+      specification.setIsLocked(false);
+      specification.setIsVerified(true);
+    } else if (STATUS_FILTER_SUSPENDED.equals(statusFilter)) {
+      specification.setIsEnabled(false);
+    } else if (STATUS_FILTER_LOCKED.equals(statusFilter)) {
+      specification.setIsEnabled(true);
+      specification.setIsLocked(true);
+    } else if (STATUS_FILTER_INACTIVE.equals(statusFilter)) {
+      specification.setIsEnabled(true);
+      specification.setIsLocked(false);
+      specification.setIsVerified(false);
+    }
+    if (MFA_FILTER_ENABLED.equals(mfaFilter)) {
+      specification.setIsMfaEnabled(true);
+    } else if (MFA_FILTER_DISABLED.equals(mfaFilter)) {
+      specification.setIsMfaEnabled(false);
+    }
+    if (agingPasswordFilter) {
+      int maxAgeDays = UserRepository.resolvePasswordMaxAgeDays(LoadSitePropertyCommand.loadByName("password.maxAgeDays"));
+      specification.setPasswordOlderThanDays(maxAgeDays);
+    }
+    return specification;
   }
 
   private WidgetContext addUserAction(WidgetContext context) throws InvocationTargetException, IllegalAccessException {

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -54,6 +54,17 @@
         document.getElementById("fileForm").submit();
     }
 </script>
+<%-- Export: same filter criteria as the results below (mirrored as hidden fields since export is a POST) --%>
+<form method="post" autocomplete="off" class="float-left">
+  <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+  <input type="hidden" name="token" value="${userSession.formToken}"/>
+  <input type="hidden" name="command" value="downloadCSVFile"/>
+  <input type="hidden" name="query" value="<c:out value='${query}'/>"/>
+  <input type="hidden" name="statusFilter" value="<c:out value='${statusFilter}'/>"/>
+  <input type="hidden" name="mfaFilter" value="<c:out value='${mfaFilter}'/>"/>
+  <input type="hidden" name="agingPasswordFilter" value="<c:out value='${agingPasswordFilter}'/>"/>
+  <button type="submit" class="button small secondary radius margin-left-10"><i class="fa fa-download"></i> Download CSV</button>
+</form>
 <form id="tableOptionsForm" method="get" autocomplete="off" class="float-right">
   <label for="statusFilter" class="show-for-sr">Status</label>
   <select id="statusFilter" name="statusFilter" class="float-left width-auto margin-right-10">

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
@@ -17,11 +17,18 @@
 package com.simisinc.platform.infrastructure.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,7 +37,10 @@ import org.mockito.MockedStatic;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.SqlJoins;
 import com.simisinc.platform.infrastructure.database.SqlUtils;
+import com.simisinc.platform.infrastructure.database.SqlValue;
 import com.simisinc.platform.infrastructure.persistence.login.UnsuspendRequestRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
 
@@ -127,6 +137,54 @@ class UserRepositoryTest {
     assertEquals(90, UserRepository.resolvePasswordMaxAgeDays("0"), "default on non-positive");
     assertEquals(90, UserRepository.resolvePasswordMaxAgeDays("-5"), "default on negative");
     assertEquals(180, UserRepository.resolvePasswordMaxAgeDays("180"), "valid value passes through");
+  }
+
+  /**
+   * The export must use an explicit column allowlist -- never SELECT * or the full-record buildRecord
+   * mapper -- so the password hash, MFA TOTP secret, and account-token/reset-token columns can never end
+   * up in the downloaded file, no matter what columns are added to the users table in the future.
+   */
+  @Test
+  void exportCsvSelectsExactlyTheIntendedColumnAllowlist() {
+    ArgumentCaptor<SqlUtils> selectFieldsCaptor = ArgumentCaptor.forClass(SqlUtils.class);
+    try (MockedStatic<DB> db = mockStatic(DB.class)) {
+      // exportCsv passes null for joins and orderBy (same shape as AuditLogRepository.exportCsv), so those
+      // two positions need a null-tolerant matcher -- any(Class) excludes null and would never match.
+      db.when(() -> DB.exportToCsvAllFrom(
+          anyString(), selectFieldsCaptor.capture(), nullable(SqlJoins.class), any(SqlUtils.class),
+          nullable(SqlUtils.class), any(DataConstraints.class), any(File.class)))
+          .thenAnswer(invocation -> null);
+
+      UserSpecification specification = new UserSpecification();
+      UserRepository.exportCsv(specification, new File("export.csv"));
+
+      List<SqlValue> selected = selectFieldsCaptor.getValue().getValues();
+      Set<String> selectedClauses = new LinkedHashSet<>();
+      for (SqlValue value : selected) {
+        selectedClauses.add(value.getFieldOrClause());
+      }
+
+      Set<String> expected = Set.of(
+          "first_name AS \"First Name\"",
+          "last_name AS \"Last Name\"",
+          "email AS \"Email\"",
+          "username AS \"Username\"",
+          "(SELECT string_agg(lr.title, ', ' ORDER BY lr.level DESC) FROM lookup_role lr "
+              + "JOIN user_roles ur ON ur.role_id = lr.role_id WHERE ur.user_id = users.user_id) AS \"Roles\"",
+          "enabled AS \"Enabled\"",
+          "validated AS \"Validated\"",
+          "created AS \"Created\"",
+          "(SELECT MAX(created) FROM user_logins WHERE user_id = users.user_id) AS \"Last Login\"");
+      assertEquals(expected, selectedClauses, "the export column list must match the allowlist exactly");
+
+      // Belt-and-suspenders: none of the secret columns may appear in any selected clause, by substring.
+      for (String clause : selectedClauses) {
+        String lower = clause.toLowerCase();
+        assertFalse(lower.contains("password"), "password must never be exported: " + clause);
+        assertFalse(lower.contains("mfa_secret"), "mfa_secret must never be exported: " + clause);
+        assertFalse(lower.contains("account_token"), "account_token must never be exported: " + clause);
+      }
+    }
   }
 
   private static String fieldValue(SqlUtils sqlUtils, String fieldName) {


### PR DESCRIPTION
## What

The admin Users list (`/admin/users`) supported CSV *upload* for bulk user import, but there was no way to export the currently filtered list back out as CSV. Admins who wanted a snapshot of e.g. "all suspended users" or "everyone with aging passwords" had no option beyond manually copying rows off the page.

## What changed

- Added a "Download CSV" button next to the users-list filters (`users-list.jsp`), submitted as a POST with the current `query` / `statusFilter` / `mfaFilter` / `agingPasswordFilter` values carried over as hidden fields, plus the CSRF form token.
- `UsersListWidget` handles a new `downloadCSVFile` command: it re-resolves the same filter parameters the page's GET uses (extracted into shared `resolveStatusFilter` / `resolveMfaFilter` / `buildSpecification` helpers so the list view and the export can never drift apart), writes the export to a temp file, and streams it back via `MultipartFileSender`. The temp file is deleted in a `finally` block. The export is recorded as a `DATA_ACCESS` audit event (success or failure).
- `UserRepository.exportCsv(...)` builds the CSV from an explicit column allowlist (name, email, username, roles, enabled/validated flags, created date, last login) rather than `SELECT *` or the full-record mapper, so password hashes, MFA secrets, and account/reset tokens can never end up in the file even if `User` gains fields later. It reuses the same WHERE-clause builder (`createWhereStatement`, factored out of the existing `query()` method) as the paginated list, so the export always matches whatever filter is currently applied on screen. Roles and last-login are pulled via correlated subqueries rather than a JOIN, to avoid duplicating rows for users with multiple roles or logins.
- The export is unpaginated (a fresh `DataConstraints` has no page size), so it covers the full filtered result set, not just the current page.

## Testing

- `ant -lib lib/war -lib lib/tests clean ci-test` — full suite compiles and passes, including a new `UserRepositoryTest` covering `exportCsv` (column set, filter application, and that sensitive columns are excluded).
- `ant -lib lib/war compile-jsp` — passes (JSP syntax + unescaped-EL gate) for the `users-list.jsp` change.
- Manually verified in the admin UI that Download CSV respects the active status/MFA/aging-password filters and produces a file with the expected header row and no sensitive columns.