### PR TITLE
Fix crash on guest auth pages for a not-yet-online site

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -1110,7 +1110,7 @@ public class PageServlet extends HttpServlet {
         // @todo determine if this is needed still (it is, but until all JSP layouts are removed?)
         // Load the main menu
         request.setAttribute(SHOW_MAIN_MENU, "true");
-        List<MenuTab> menuTabList = siteVisibleToUser ? LoadMenuTabsCommand.loadActiveIncludeMenuItemList() : Collections.emptyList();
+        List<MenuTab> menuTabList = siteVisibleToUser ? LoadMenuTabsCommand.loadActiveIncludeMenuItemList() : new ArrayList<>();
         request.setAttribute(MASTER_MENU_TAB_LIST, menuTabList);
 
         // @note this is needed globally

--- a/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
+++ b/src/main/java/com/simisinc/platform/presentation/controller/PageServlet.java
@@ -1110,7 +1110,7 @@ public class PageServlet extends HttpServlet {
         // @todo determine if this is needed still (it is, but until all JSP layouts are removed?)
         // Load the main menu
         request.setAttribute(SHOW_MAIN_MENU, "true");
-        List<MenuTab> menuTabList = siteVisibleToUser ? LoadMenuTabsCommand.loadActiveIncludeMenuItemList() : new ArrayList<>();
+        List<MenuTab> menuTabList = resolveMasterMenuTabList(siteVisibleToUser);
         request.setAttribute(MASTER_MENU_TAB_LIST, menuTabList);
 
         // @note this is needed globally
@@ -1173,6 +1173,16 @@ public class PageServlet extends HttpServlet {
   /** True for the guest-facing auth pages that need header/branding even while site.online is false (issue #1005). */
   static boolean isGuestAuthPage(String pagePath) {
     return "/login".equals(pagePath) || "/register".equals(pagePath) || "/forgot-password".equals(pagePath);
+  }
+
+  /**
+   * Must return a real ArrayList (never Collections.emptyList()) -- layout.jsp's
+   * {@code <jsp:useBean id="masterMenuTabList" class="java.util.ArrayList" scope="request"/>} casts
+   * the existing request attribute to ArrayList instead of instantiating a new one, so any other
+   * List implementation throws a ClassCastException at render time.
+   */
+  static List<MenuTab> resolveMasterMenuTabList(boolean siteVisibleToUser) {
+    return siteVisibleToUser ? LoadMenuTabsCommand.loadActiveIncludeMenuItemList() : new ArrayList<>();
   }
 
   static String generateJsonLdData(PageRenderInfo pageRenderInfo, String siteUrl, String pagePath,

--- a/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/PageServletTest.java
@@ -41,6 +41,7 @@ import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.SocialMediaLink;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.domain.model.cms.FaqQuestion;
+import com.simisinc.platform.domain.model.cms.MenuTab;
 import com.simisinc.platform.domain.model.cms.WebPage;
 import com.simisinc.platform.domain.model.items.Collection;
 import com.simisinc.platform.domain.model.items.Item;
@@ -669,5 +670,16 @@ class PageServletTest {
     // A caller cannot smuggle in a second, conflicting token value via originalQuery.
     assertEquals("/page?a=1&previewToken=abc123",
         PageServlet.buildPreviewLink("/page", "a=1&previewToken=SMUGGLED", "abc123"));
+  }
+
+  @Test
+  void resolveMasterMenuTabListReturnsARealArrayListForAGuestOnAnOfflineSite() {
+    // layout.jsp's <jsp:useBean id="masterMenuTabList" class="java.util.ArrayList" scope="request"/>
+    // casts the request attribute to ArrayList -- Collections.emptyList() is not an ArrayList and
+    // throws a ClassCastException at render time (issue #1005 regression).
+    List<MenuTab> menuTabList = PageServlet.resolveMasterMenuTabList(false);
+
+    assertTrue(menuTabList instanceof ArrayList, "expected an ArrayList, got " + menuTabList.getClass());
+    assertTrue(menuTabList.isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
- `PageServlet`'s guest-auth-page branch (issue #1005, commit 1c0c1b63) assigns `Collections.emptyList()` to the `masterMenuTabList` request attribute
- `layout.jsp`'s `<jsp:useBean id="masterMenuTabList" class="java.util.ArrayList" scope="request"/>` casts that attribute to `ArrayList` -- `Collections.emptyList()` is not an `ArrayList`, so the cast throws
- Net effect: any guest hitting `/login`, `/register`, or `/forgot-password` while `site.online` is `false` (notably a brand-new install's very first login, before an admin flips the site online) gets a `ClassCastException` and a blank, unstyled page instead of the branded form #1005 intended
- Fix: use `new ArrayList<>()` instead -- identical semantics, just the type the JSP cast actually expects

## Test plan
- [x] Full `ant ci-test` suite: 0 failures
- [x] `compile-jsp` EL/JSP gate: clean
- [x] Live verification in a rehearsal container: `/login` on a fresh, not-yet-online install now renders correctly with branding instead of crashing