### PR TITLE
Add an SEO & AI admin nav section

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/SeoSitemapWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/SeoSitemapWidget.java
@@ -49,6 +49,9 @@ public class SeoSitemapWidget extends GenericWidget {
   static String JSP = "/admin/seo-sitemap.jsp";
 
   public WidgetContext execute(WidgetContext context) {
+    context.getRequest().setAttribute("icon", context.getPreferences().get("icon"));
+    context.getRequest().setAttribute("title", context.getPreferences().get("title"));
+
     List<WebPage> webPageList = WebPageRepository.findAll();
     context.getRequest().setAttribute("webPageList", webPageList);
 

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -532,6 +532,16 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/analytics-retention')}"> class="is-active"</c:if>><a href="${ctx}/admin/analytics-retention"><i class="${font:far()} fa-trash-can fa-fw"></i> <span>Analytics Retention</span></a></li>
             </ul>
           </c:if>
+          <%-- SEO and AI Visibility menu --%>
+          <c:if test="${userSession.hasRole('admin')}">
+            <ul class="vertical menu">
+              <li class="section-title">SEO &amp; AI</li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/seo-overview')}"> class="is-active"</c:if>><a href="${ctx}/admin/seo-overview"><i class="${font:far()} fa-magnifying-glass-chart fa-fw"></i> <span>SEO &amp; AI Visibility</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/seo-sitemap')}"> class="is-active"</c:if>><a href="${ctx}/admin/seo-sitemap"><i class="${font:far()} fa-map fa-fw"></i> <span>SEO Sitemap</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/llms')}"> class="is-active"</c:if>><a href="${ctx}/admin/llms-properties"><i class="${font:far()} fa-file-lines fa-fw"></i> <span>LLM/AI Visibility (llms.txt)</span></a></li>
+              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/robots')}"> class="is-active"</c:if>><a href="${ctx}/admin/robots-properties"><i class="${font:far()} fa-robot fa-fw"></i> <span>Robots &amp; Crawlers</span></a></li>
+            </ul>
+          </c:if>
           <%-- Settings menu --%>
           <c:if test="${userSession.hasRole('admin')}">
             <ul class="vertical menu">
@@ -542,12 +552,8 @@
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/social')}"> class="is-active"</c:if>><a href="${ctx}/admin/social-media-settings"><i class="${font:far()} fa-thumbs-up fa-fw"></i> <span>Social Media</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/configure-analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/configure-analytics"><i class="${font:far()} fa-chart-line fa-fw"></i> <span>Analytics Settings</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/captcha')}"> class="is-active"</c:if>><a href="${ctx}/admin/captcha-properties"><i class="${font:far()} fa-key fa-fw"></i> <span>Captcha Settings</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/robots')}"> class="is-active"</c:if>><a href="${ctx}/admin/robots-properties"><i class="${font:far()} fa-robot fa-fw"></i> <span>Robots &amp; Crawlers</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/security-properties')}"> class="is-active"</c:if>><a href="${ctx}/admin/security-properties"><i class="${font:far()} fa-shield fa-fw"></i> <span>Security</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/feature-flags')}"> class="is-active"</c:if>><a href="${ctx}/admin/feature-flags"><i class="${font:far()} fa-flag fa-fw"></i> <span>Feature Flags</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/seo-overview')}"> class="is-active"</c:if>><a href="${ctx}/admin/seo-overview"><i class="${font:far()} fa-magnifying-glass-chart fa-fw"></i> <span>SEO &amp; AI Visibility</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/seo-sitemap')}"> class="is-active"</c:if>><a href="${ctx}/admin/seo-sitemap"><i class="${font:far()} fa-map fa-fw"></i> <span>SEO Sitemap</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/llms')}"> class="is-active"</c:if>><a href="${ctx}/admin/llms-properties"><i class="${font:far()} fa-file-lines fa-fw"></i> <span>LLM/AI Visibility (llms.txt)</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/bi')}"> class="is-active"</c:if>><a href="${ctx}/admin/bi-properties"><i class="${font:far()} fa-table-columns fa-fw"></i> <span>BI Settings</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/webhook')}"> class="is-active"</c:if>><a href="${ctx}/admin/webhooks"><i class="${font:far()} fa-plug fa-fw"></i> <span>Webhooks</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/integrations')}"> class="is-active"</c:if>><a href="${ctx}/admin/integrations"><i class="${font:far()} fa-puzzle-piece fa-fw"></i> <span>Integrations</span></a></li>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/SeoSitemapWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/SeoSitemapWidgetTest.java
@@ -72,6 +72,8 @@ class SeoSitemapWidgetTest extends WidgetBase {
   void executeListsAllWebPagesAndTheCurrentSitemapStatus() {
     List<WebPage> webPageList = new ArrayList<>();
     webPageList.add(webPage(1L, "/about", "About", true));
+    preferences.put("title", "SEO Sitemap");
+    preferences.put("icon", "fa-map");
 
     try (MockedStatic<WebPageRepository> repository = mockStatic(WebPageRepository.class);
         MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
@@ -83,6 +85,9 @@ class SeoSitemapWidgetTest extends WidgetBase {
       assertEquals("/admin/seo-sitemap.jsp", result.getJsp());
       assertEquals(webPageList, result.getRequest().getAttribute("webPageList"));
       assertEquals(true, result.getRequest().getAttribute("sitemapEnabled"));
+      assertEquals("SEO Sitemap", result.getRequest().getAttribute("title"),
+          "the page heading was configured but never rendered because execute() never set this attribute");
+      assertEquals("fa-map", result.getRequest().getAttribute("icon"));
     }
   }
 


### PR DESCRIPTION
## Summary
- Breaks a new **SEO & AI** section out of the admin nav, sitting between Access and Settings, with (in order): SEO & AI Visibility, SEO Sitemap, LLM/AI Visibility (llms.txt), Robots and Crawlers -- previously scattered inside the general Settings section
- Fixes a real bug found along the way: `SeoSitemapWidget.execute()` never set the `icon`/`title` request attributes that `seo-sitemap.jsp`'s existing (correct) `<h4>` heading markup depends on, so the page has been silently missing its own "SEO Sitemap" title since the widget was first built (issue #622). Same pattern already used by 119 of 122 other admin pages in this codebase.

## Test plan
- [x] Full `ant ci-test` suite: 0 failures
- [x] `compile-jsp` EL/JSP gate: clean
- [x] Live verification in a rehearsal container: new section renders in the right position/order; SEO Sitemap page now shows its title