### PR TITLE
Add admin "Reset MFA" action for account-lockout recovery

### DIFF
--- a/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
+++ b/src/main/java/com/simisinc/platform/application/login/UserMfaCommand.java
@@ -89,8 +89,9 @@ public class UserMfaCommand {
    * Turns MFA off for a user and clears the stored secret.
    *
    * @param user the user
+   * @return true when the underlying database write succeeded, false if it failed
    */
-  public static void disable(User user) {
-    UserRepository.disableMfa(user);
+  public static boolean disable(User user) {
+    return UserRepository.disableMfa(user) != null;
   }
 }

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -25,6 +25,8 @@ import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
 import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.application.login.UnsuspendAccountCommand;
+import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.events.cms.UnsuspendRequestedEvent;
 import com.simisinc.platform.domain.events.cms.UserAccountRestoredEvent;
 import com.simisinc.platform.domain.events.cms.UserPasswordResetEvent;
@@ -145,6 +147,30 @@ public class UserDetailsWidget extends GenericWidget {
       context.setRedirect("/admin/user-details?userId=" + userId);
       return resetPassword(context, user);
     }
+    if ("resetMfa".equals(action)) {
+      // Clearing another user's MFA enrollment requires step-up, same bar as Reset Password --
+      // and, matching resetPassword's own comment above, is intentionally kept OUT of action()'s
+      // dispatch table so a plain GET/action request can never reach it.
+      String stepUpCredential = context.getParameter("stepUpCredential");
+      if (!StepUpAuthCommand.isValid(context.getUserSession())) {
+        if (StringUtils.isBlank(stepUpCredential)) {
+          context.addSharedRequestValue("stepUpRequired", "true");
+          context.getRequest().setAttribute("user", user);
+          context.setJsp(JSP);
+          return context;
+        }
+        User actingUser = LoadUserCommand.loadUser(context.getUserId());
+        if (!StepUpAuthCommand.verify(context.getUserSession(), actingUser, stepUpCredential)) {
+          context.setErrorMessage("Re-authentication failed. Enter your password or authenticator code.");
+          context.addSharedRequestValue("stepUpRequired", "true");
+          context.getRequest().setAttribute("user", user);
+          context.setJsp(JSP);
+          return context;
+        }
+      }
+      context.setRedirect("/admin/user-details?userId=" + userId);
+      return resetMfa(context, user);
+    }
     if ("approveUnsuspend".equals(action)) {
       // Approving an unsuspend request requires step-up, same bar as Reset Password/Assign Roles --
       // and, matching resetPassword's own comment above, is intentionally kept OUT of action()'s
@@ -189,7 +215,7 @@ public class UserDetailsWidget extends GenericWidget {
       return context;
     }
     // Execute the action
-    // Note: resetPassword is intentionally NOT handled here -- it requires step-up
+    // Note: resetPassword and resetMfa are intentionally NOT handled here -- both require step-up
     // re-authentication (see post()) and must only be reachable through that gated path.
     context.setRedirect("/admin/user-details?userId=" + userId);
     String action = context.getParameter("action");
@@ -223,6 +249,29 @@ public class UserDetailsWidget extends GenericWidget {
     WorkflowManager.triggerWorkflowForEvent(new UserPasswordResetEvent(user, context.getUserSession().getUser()));
 
     context.setSuccessMessage("Password reset instructions have been sent to: " + user.getEmail());
+    return context;
+  }
+
+  private WidgetContext resetMfa(WidgetContext context, User user) {
+    // Not one that outranks the acting admin -- see targetOutranksActor()
+    if (targetOutranksActor(context, user)) {
+      context.setErrorMessage("You cannot reset MFA for an account with a higher role level than your own");
+      return context;
+    }
+    // Capture the target before disable/clear alter its in-memory state
+    String targetId = String.valueOf(user.getId());
+    String targetLabel = user.getEmail();
+
+    // Clear the second factor and any unused recovery codes -- reuses the same commands the
+    // self-service MyMfaSettingsWidget "disable" action calls on the user's own account.
+    UserMfaCommand.disable(user);
+    UserMfaRecoveryCodeCommand.clear(user);
+
+    // Record the admin-initiated MFA reset of another user
+    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.mfa.reset",
+        AuditEventCommand.SUCCESS, "user", targetId, targetLabel, null);
+
+    context.setSuccessMessage("MFA has been reset for: " + targetLabel + ". They must re-enroll from scratch.");
     return context;
   }
 

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -264,14 +264,20 @@ public class UserDetailsWidget extends GenericWidget {
 
     // Clear the second factor and any unused recovery codes -- reuses the same commands the
     // self-service MyMfaSettingsWidget "disable" action calls on the user's own account.
-    UserMfaCommand.disable(user);
+    boolean disabled = UserMfaCommand.disable(user);
     UserMfaRecoveryCodeCommand.clear(user);
 
-    // Record the admin-initiated MFA reset of another user
-    AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.mfa.reset",
-        AuditEventCommand.SUCCESS, "user", targetId, targetLabel, null);
-
-    context.setSuccessMessage("MFA has been reset for: " + targetLabel + ". They must re-enroll from scratch.");
+    // Record the admin-initiated MFA reset of another user, matching deleteAccount()'s pattern of
+    // reflecting the actual DB-write outcome rather than assuming success.
+    if (disabled) {
+      AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.mfa.reset",
+          AuditEventCommand.SUCCESS, "user", targetId, targetLabel, null);
+      context.setSuccessMessage("MFA has been reset for: " + targetLabel + ". They must re-enroll from scratch.");
+    } else {
+      AuditEventCommand.record(context, AuditEventCommand.USER_MANAGEMENT, "user.mfa.reset",
+          AuditEventCommand.FAILURE, "user", targetId, targetLabel, "MFA disable write failed");
+      context.setErrorMessage("MFA reset failed for: " + targetLabel);
+    }
     return context;
   }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -59,6 +59,9 @@
             <li><a href="#" data-open="resetPasswordReveal">Reset Password</a></li>
             <li><a href="#" data-open="suspendAccountReveal">Suspend Account</a></li>
           </c:if>
+          <c:if test="${user.mfaEnabled}">
+            <li><a href="#" data-open="resetMfaReveal">Reset MFA</a></li>
+          </c:if>
           <%-- #492 Phase 3: an elevated-role account can't be reactivated by one admin acting
                alone -- Restore stays a direct one-click action for everyone else. --%>
           <c:if test="${!user.enabled && !isElevatedTarget}">
@@ -428,6 +431,33 @@
       </div>
     </div>
     <input type="submit" class="button warning radius" value="Send Reset Email"/>
+    <button class="button secondary radius" type="button" data-close>Cancel</button>
+  </form>
+  <button class="close-button" data-close aria-label="Close reveal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="reveal" id="resetMfaReveal" role="dialog" aria-modal="true" aria-labelledby="resetMfaRevealTitle"
+     data-reveal data-close-on-click="true">
+  <h4 id="resetMfaRevealTitle">Reset MFA</h4>
+  <p>This immediately clears <strong><c:out value="${user.email}" /></strong>'s second factor and recovery codes.
+    They will need to re-enroll from scratch. Use this to recover an account that has lost its authenticator
+    device and exhausted its recovery codes.</p>
+  <form method="post">
+    <input type="hidden" name="widget" value="${widgetContext.uniqueId}"/>
+    <input type="hidden" name="token" value="${userSession.formToken}"/>
+    <input type="hidden" name="action" value="resetMfa"/>
+    <input type="hidden" name="userId" value="${user.id}"/>
+    <div class="grid-x grid-padding-x">
+      <div class="small-12 cell">
+        <label for="resetMfaStepUpCredential">Your password or authenticator code <span class="required">*</span>
+          <input type="password" id="resetMfaStepUpCredential" name="stepUpCredential" maxlength="255"
+                 placeholder="Password or 6-digit code" required
+                 title="Re-authentication required to reset another user's MFA"/>
+        </label>
+      </div>
+    </div>
+    <input type="submit" class="button warning radius" value="Reset MFA"/>
     <button class="button secondary radius" type="button" data-close>Cancel</button>
   </form>
   <button class="close-button" data-close aria-label="Close reveal" type="button">

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
@@ -33,6 +33,8 @@ import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.LoadUserCommand;
+import com.simisinc.platform.application.login.UserMfaCommand;
+import com.simisinc.platform.application.login.UserMfaRecoveryCodeCommand;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
@@ -61,6 +63,13 @@ import com.simisinc.platform.presentation.controller.WidgetContext;
  * admin-layout.xml), one level below admin (level 100). Without this guard a community-manager could suspend or
  * restore an admin account outright. Mirrors the escalation guard UserFormWidget already applies to role grants
  * (see UserFormWidgetTest).
+ *
+ * resetMfaWithoutStepUpDoesNotResetAndShowsReAuthPanel / resetMfaRefusesWhenTargetOutranksActor /
+ * resetMfaViaPostCallsCommandsAndAudits cover the admin "Reset MFA" lockout-recovery action: it requires a fresh
+ * step-up re-authentication exactly like Reset Password, refuses when the target outranks the acting admin exactly
+ * like Suspend/Restore, and on success clears the target's MFA secret/enabled flag and recovery codes by reusing
+ * the same UserMfaCommand/UserMfaRecoveryCodeCommand calls the self-service "disable" action already makes on the
+ * user's own account (see MyMfaSettingsWidgetTest).
  *
  * @author Elizabeth Houser
  */
@@ -455,6 +464,98 @@ class UserDetailsWidgetTest extends WidgetBase {
       new UserDetailsWidget().post(widgetContext);
 
       userRepo.verify(() -> UserRepository.resetLockout(5L), times(1));
+    }
+  }
+
+  @Test
+  void resetMfaWithoutStepUpDoesNotResetAndShowsReAuthPanel() throws Exception {
+    // No stepUpCredential provided, and the session has no valid step-up token
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetMfa");
+
+    User target = activeUser();
+    target.setMfaEnabled(true);
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      mfa.verify(() -> UserMfaCommand.disable(any()), never());
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(any()), never());
+      audit.verifyNoInteractions();
+      Assertions.assertEquals("true", result.getSharedRequestValue("stepUpRequired"));
+      Assertions.assertEquals(UserDetailsWidget.JSP, result.getJsp());
+      Assertions.assertNull(result.getRedirect());
+    }
+  }
+
+  @Test
+  void resetMfaRefusesWhenTargetOutranksActor() throws Exception {
+    // The target holds admin (level 100), above the acting community-manager (level 90).
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    grantStepUp(widgetContext);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetMfa");
+
+    User target = adminUser();
+    target.setMfaEnabled(true);
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      mfa.verify(() -> UserMfaCommand.disable(any()), never());
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(any()), never());
+      audit.verifyNoInteractions();
+      Assertions.assertEquals("You cannot reset MFA for an account with a higher role level than your own",
+          result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void resetMfaViaPostCallsCommandsAndAudits() throws Exception {
+    setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetMfa");
+
+    // Below the acting admin's level -- not "outranks", the reset must proceed.
+    User target = activeUser();
+    target.setMfaEnabled(true);
+    target.setMfaSecret("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
+    List<Role> held = new ArrayList<>();
+    held.add(role(2, 80, "content-manager", "Content Manager"));
+    target.setRoleList(held);
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      // The second factor and recovery codes are cleared through the same commands the
+      // self-service MyMfaSettingsWidget "disable" action already calls on the user's own account.
+      mfa.verify(() -> UserMfaCommand.disable(target), times(1));
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(target), times(1));
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.USER_MANAGEMENT), eq("user.mfa.reset"),
+          eq(AuditEventCommand.SUCCESS), eq("user"), eq("5"), eq("active@example.com"), any()), times(1));
+      Assertions.assertNotNull(result.getSuccessMessage());
+      Assertions.assertEquals("/admin/user-details?userId=5", result.getRedirect());
     }
   }
 }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
@@ -180,6 +180,29 @@ class UserDetailsWidgetTest extends WidgetBase {
   }
 
   @Test
+  void actionResetMfaIsNotHandledByTheGetActionPath() throws Exception {
+    // MFA reset requires step-up re-authentication (see post()), same bar as Reset Password. The
+    // GET/action() path must never reset MFA directly -- that would bypass step-up entirely,
+    // reachable via a plain GET request carrying the same parameters the UI's POST form uses.
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetMfa");
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(lockedUser());
+
+      new UserDetailsWidget().action(widgetContext);
+
+      mfa.verify(() -> UserMfaCommand.disable(any()), never());
+      recovery.verify(() -> UserMfaRecoveryCodeCommand.clear(any()), never());
+      audit.verifyNoInteractions();
+    }
+  }
+
+  @Test
   void suspendAccountViaPostCallsRepositoryAndAudits() throws Exception {
     setRoles(widgetContext, ADMIN);
     addQueryParameter(widgetContext, "userId", "5");
@@ -545,6 +568,7 @@ class UserDetailsWidgetTest extends WidgetBase {
         MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
       roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      mfa.when(() -> UserMfaCommand.disable(target)).thenReturn(true);
 
       WidgetContext result = new UserDetailsWidget().post(widgetContext);
 
@@ -556,6 +580,41 @@ class UserDetailsWidgetTest extends WidgetBase {
           eq(AuditEventCommand.SUCCESS), eq("user"), eq("5"), eq("active@example.com"), any()), times(1));
       Assertions.assertNotNull(result.getSuccessMessage());
       Assertions.assertEquals("/admin/user-details?userId=5", result.getRedirect());
+    }
+  }
+
+  @Test
+  void resetMfaViaPostRecordsFailureWhenTheMfaDisableWriteFails() throws Exception {
+    // UserMfaCommand.disable() returning false means UserRepository.disableMfa()'s DB write did not
+    // take (see UserRepository#disableMfa returning null on failure) -- resetMfa() must reflect that
+    // instead of unconditionally reporting success, matching deleteAccount()'s if/else pattern.
+    setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "resetMfa");
+
+    User target = activeUser();
+    target.setMfaEnabled(true);
+    target.setMfaSecret("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
+    List<Role> held = new ArrayList<>();
+    held.add(role(2, 80, "content-manager", "Content Manager"));
+    target.setRoleList(held);
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<UserMfaCommand> mfa = mockStatic(UserMfaCommand.class);
+        MockedStatic<UserMfaRecoveryCodeCommand> recovery = mockStatic(UserMfaRecoveryCodeCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      mfa.when(() -> UserMfaCommand.disable(target)).thenReturn(false);
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.USER_MANAGEMENT), eq("user.mfa.reset"),
+          eq(AuditEventCommand.FAILURE), eq("user"), eq("5"), eq("active@example.com"), any()), times(1));
+      Assertions.assertNull(result.getSuccessMessage());
+      Assertions.assertNotNull(result.getErrorMessage());
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a "Reset MFA" action to the admin user-details page so an administrator can clear a locked-out user's second factor without going through a support escalation. An account that has enrolled in TOTP MFA but lost access to its authenticator (device lost, app reinstalled without the recovery codes) previously had no self-service or admin-driven recovery path.

The action:
- Requires step-up re-authentication (the acting admin's own password or authenticator code), matching the existing bar for "Reset Password" -- and, like Reset Password, is only reachable through the step-up-gated `post()` path, never through the plain GET/`action()` dispatch table.
- Refuses to reset MFA for a target account that outranks the acting admin's own role level, matching the existing Suspend/Restore guard.
- Clears the target's second factor and any unused recovery codes via the same `UserMfaCommand`/`UserMfaRecoveryCodeCommand` calls the self-service "disable" action already uses on a user's own account, and requires the user to re-enroll from scratch.
- Records an audit event (`user.mfa.reset`) reflecting the actual outcome of the underlying MFA-disable database write, not an assumed success -- `UserMfaCommand.disable()` now returns whether the write succeeded, and `resetMfa()` records SUCCESS/FAILURE and shows a matching success/error message based on that result, the same pattern `deleteAccount()` already follows elsewhere in the same file.

## Testing

- `ant -lib lib/war -lib lib/tests clean ci-test`: full suite passes, 2866 tests run, 0 failures, 0 errors.
- `ant -lib lib/war compile-jsp`: JSP syntax/EL check passes.
- New/updated coverage in `UserDetailsWidgetTest`:
  - `resetMfaWithoutStepUpDoesNotResetAndShowsReAuthPanel` -- no step-up token or credential shows the re-auth panel and touches neither command.
  - `resetMfaRefusesWhenTargetOutranksActor` -- a lower-privileged admin cannot reset MFA on a higher-role account.
  - `resetMfaViaPostCallsCommandsAndAudits` -- successful reset calls both commands, audits SUCCESS, and shows a success message.
  - `resetMfaViaPostRecordsFailureWhenTheMfaDisableWriteFails` -- when the underlying MFA-disable database write fails, the action now audits FAILURE and shows an error message instead of falsely reporting success.
  - `actionResetMfaIsNotHandledByTheGetActionPath` -- `action=resetMfa` routed through the GET/dispatch-table path (`action()`) is a no-op, matching the existing coverage for `resetPassword` and `approveUnsuspend`.