### PR TITLE
Wire Users/Groups admin pages onto the capability-grant system (new users:manage capability)

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UnsuspendRequestsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UnsuspendRequestsWidget.java
@@ -78,7 +78,7 @@ public class UnsuspendRequestsWidget extends GenericWidget {
   }
 
   public WidgetContext post(WidgetContext context) {
-    if (!(context.hasRole("admin") || context.hasRole("community-manager"))) {
+    if (!(context.hasRole("admin") || context.hasRole("community-manager") || context.hasPermission("users:manage"))) {
       return context;
     }
     context.getUserSession().renewFormToken();

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidget.java
@@ -336,11 +336,17 @@ public class UserDetailsWidget extends GenericWidget {
    * True when the target account's highest role level exceeds the acting user's highest role level --
    * mirrors UserFormWidget's role-grant escalation guard so a lower-privileged admin (e.g.
    * community-manager, level 90, who reaches this page via admin-layout.xml's
-   * role="admin,community-manager") cannot suspend or restore an account that outranks them (e.g.
-   * admin, level 100). Both /admin/users and /admin/user-details are open to community-manager, and
-   * this is the only check standing between that role and acting on an admin account.
+   * role="admin,community-manager") cannot suspend, restore, or delete an account that outranks them
+   * (e.g. admin, level 100). Both /admin/users and /admin/user-details are open to community-manager
+   * -- and, as of the users:manage capability, to any user holding only that capability with no
+   * legacy role at all -- and this is the only check standing between that access and acting on an
+   * admin account.
+   * <p>
+   * Package-private (not private): UsersListWidget.bulkSuspendAction() re-checks this identical rule
+   * per selected account so the bulk path can't reach an account the single-account suspendAccount()
+   * below would refuse to touch.
    */
-  private static boolean targetOutranksActor(WidgetContext context, User user) {
+  static boolean targetOutranksActor(WidgetContext context, User user) {
     List<Role> allRoles = RoleRepository.findAll();
     int actingLevel = highestRoleLevel(context.getUserSession(), allRoles);
     int targetLevel = highestRoleLevel(user.getRoleList());
@@ -377,6 +383,13 @@ public class UserDetailsWidget extends GenericWidget {
     // Attempt to delete the account (but not own self)
     if (context.getUserId() == user.getId()) {
       context.setErrorMessage("You cannot delete your own account");
+      return context;
+    }
+    // Nor one that outranks the acting admin -- see targetOutranksActor(). Without this, any user
+    // who can reach this page (including a users:manage capability-only grantee with no admin or
+    // community-manager role) could permanently delete any other account, including an admin's.
+    if (targetOutranksActor(context, user)) {
+      context.setErrorMessage("You cannot delete an account with a higher role level than your own");
       return context;
     }
     // Capture identity before the record is removed

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -348,6 +348,7 @@ public class UsersListWidget extends GenericWidget {
     BulkActor actor = new BulkActor(context);
     int succeeded = 0;
     int skippedSelf = 0;
+    int skippedOutranked = 0;
     int notFound = 0;
     int failed = 0;
     for (Long userId : userIds) {
@@ -360,6 +361,14 @@ public class UsersListWidget extends GenericWidget {
       User user = LoadUserCommand.loadUser(userId);
       if (user == null) {
         ++notFound;
+        continue;
+      }
+      // Nor one that outranks the acting admin -- mirrors the guard UserDetailsWidget's single-
+      // account suspendAccount() already enforces (targetOutranksActor()), so a community-manager,
+      // or a users:manage capability-only grantee with no legacy role, can't use this bulk checkbox
+      // path to suspend an account (e.g. an admin's) the single-user form would refuse to touch.
+      if (UserDetailsWidget.targetOutranksActor(context, user)) {
+        ++skippedOutranked;
         continue;
       }
       User result = UserRepository.suspendAccount(user, reason);
@@ -376,10 +385,10 @@ public class UsersListWidget extends GenericWidget {
     SaveAuditEventCommand.recordAdminEvent(AuditEventCommand.USER_MANAGEMENT, "user.bulk_disable",
         succeeded > 0 ? AuditEventCommand.SUCCESS : AuditEventCommand.FAILURE,
         actor.userId, actor.username, actor.ip, actor.sessionId, "user", null, null,
-        "suspended=" + succeeded + "; skippedSelf=" + skippedSelf + "; notFound=" + notFound
-            + "; failed=" + failed + "; reason=" + reason);
+        "suspended=" + succeeded + "; skippedSelf=" + skippedSelf + "; skippedOutranked=" + skippedOutranked
+            + "; notFound=" + notFound + "; failed=" + failed + "; reason=" + reason);
 
-    setBulkResultMessage(context, "suspended", succeeded, 0, userIds.size(), skippedSelf, notFound, failed);
+    setBulkResultMessage(context, "suspended", succeeded, 0, userIds.size(), skippedSelf, skippedOutranked, notFound, failed);
     context.setRedirect("/admin/users");
     return context;
   }
@@ -530,7 +539,7 @@ public class UsersListWidget extends GenericWidget {
         actor.userId, actor.username, actor.ip, actor.sessionId, "user", null, null,
         "reset=" + succeeded + "; notFound=" + notFound + "; failed=" + failed);
 
-    setBulkResultMessage(context, "sent a password reset email", succeeded, 0, userIds.size(), 0, notFound, failed);
+    setBulkResultMessage(context, "sent a password reset email", succeeded, 0, userIds.size(), 0, 0, notFound, failed);
     context.setRedirect("/admin/users");
     return context;
   }
@@ -615,7 +624,7 @@ public class UsersListWidget extends GenericWidget {
             + "; notFound=" + notFound + "; failed=" + failed);
 
     setBulkResultMessage(context, "granted the " + role.getTitle() + " role", succeeded, alreadyHadRole,
-        userIds.size(), 0, notFound, failed);
+        userIds.size(), 0, 0, notFound, failed);
     context.setRedirect("/admin/users");
     return context;
   }
@@ -696,7 +705,7 @@ public class UsersListWidget extends GenericWidget {
    * in the audit log instead, where every account gets its own event regardless of outcome.
    */
   private void setBulkResultMessage(WidgetContext context, String verb, int succeeded, int alreadyDone,
-      int totalSelected, int skippedSelf, int notFound, int failed) {
+      int totalSelected, int skippedSelf, int skippedOutranked, int notFound, int failed) {
     StringBuilder sb = new StringBuilder();
     sb.append(succeeded).append(" of ").append(totalSelected).append(" selected account")
         .append(totalSelected == 1 ? "" : "s").append(" ").append(verb).append(".");
@@ -705,6 +714,9 @@ public class UsersListWidget extends GenericWidget {
     }
     if (skippedSelf > 0) {
       sb.append(" Skipped: your own account.");
+    }
+    if (skippedOutranked > 0) {
+      sb.append(" Skipped (higher role level than yours): ").append(skippedOutranked).append(".");
     }
     if (notFound > 0) {
       sb.append(" Not found: ").append(notFound).append(".");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidget.java
@@ -198,7 +198,7 @@ public class UsersListWidget extends GenericWidget {
 
   public WidgetContext post(WidgetContext context) throws InvocationTargetException, IllegalAccessException {
     // Permission is required
-    if (!(context.hasRole("admin") || context.hasRole("community-manager"))) {
+    if (!(context.hasRole("admin") || context.hasRole("community-manager") || context.hasPermission("users:manage"))) {
       return context;
     }
 

--- a/src/main/resources/database/install/NEW_10000__new_database.sql
+++ b/src/main/resources/database/install/NEW_10000__new_database.sql
@@ -336,7 +336,11 @@ INSERT INTO capabilities (code, category, description) VALUES
   ('community:manage', 'community', 'Manage mailing lists, users, and community/forum content'),
   ('data:manage', 'data', 'Manage structured data items and collections'),
   ('ecommerce:manage', 'ecommerce', 'Manage products and orders'),
-  ('admin:manage', 'admin', 'Full administrative access to all site settings and configuration');
+  ('admin:manage', 'admin', 'Full administrative access to all site settings and configuration'),
+  -- Added by issue #733's follow-up: a dedicated capability for /admin/users and its sibling
+  -- Users/Groups pages, deliberately separate from admin:manage/community:manage so it can be
+  -- granted without also handing out unrelated admin/community access.
+  ('users:manage', 'users', 'Manage user accounts, user groups, and unsuspend requests');
 
 -- admin: the existing "admin OR X" pattern found at every one of the 191 hasRole() call sites
 -- means admin implicitly has every capability - expressed here as explicit rows so the table
@@ -355,6 +359,13 @@ INSERT INTO role_capabilities (role_id, capability_id)
 SELECT lr.role_id, c.capability_id
 FROM lookup_role lr, capabilities c
 WHERE lr.code = 'community-manager' AND c.code = 'community:manage';
+
+-- No community-manager row for users:manage: that role's existing role="admin,community-manager"
+-- attribute already covers /admin/users, /admin/user-details, /admin/unsuspend-requests, and
+-- /admin/modify-user, but NOT /admin/groups or /admin/group (role="admin" only). Mapping
+-- community-manager to this single capability would silently widen its access to the Groups
+-- pages once capability="users:manage" is added there - out of scope here, since this table is
+-- only meant to describe access that already exists, not grant new access.
 
 INSERT INTO role_capabilities (role_id, capability_id)
 SELECT lr.role_id, c.capability_id

--- a/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1200__users_manage_capability.sql
+++ b/src/main/resources/database/upgrade/2026/UPGRADE_20260805.1200__users_manage_capability.sql
@@ -1,0 +1,24 @@
+-- Adds a dedicated "users:manage" capability for /admin/users and its sibling Users/Groups pages
+-- (/admin/user-details, /admin/unsuspend-requests, /admin/modify-user, /admin/groups,
+-- /admin/group). Issue #733 wired the page-level capability="..." gate onto 3 admin:manage pages
+-- only; the Users/Groups admin surface was left reachable by legacy role="..." alone, with no
+-- hasPermission() path at all. Deliberately its own capability code, not admin:manage or
+-- community:manage, scoped specifically to user-management access rather than bundled with
+-- unrelated features those capabilities also gate.
+INSERT INTO capabilities (code, category, description) VALUES
+  ('users:manage', 'users', 'Manage user accounts, user groups, and unsuspend requests');
+
+-- admin: keep the capabilities table a complete matrix, matching every other capability (#701's
+-- "admin implicitly has every capability" pattern). Not a behavior change - admin already reaches
+-- every one of these pages via its role="admin" attribute regardless of this row.
+INSERT INTO role_capabilities (role_id, capability_id)
+SELECT lr.role_id, c.capability_id
+FROM lookup_role lr, capabilities c
+WHERE lr.code = 'admin' AND c.code = 'users:manage';
+
+-- No community-manager row: that role's existing role="admin,community-manager" attribute
+-- already covers /admin/users, /admin/user-details, /admin/unsuspend-requests, and
+-- /admin/modify-user, but NOT /admin/groups or /admin/group (role="admin" only). Mapping
+-- community-manager to this single capability would silently widen its access to the Groups
+-- pages once capability="users:manage" is added there - this migration only adds a new,
+-- independently grantable capability, it does not change what any existing role can reach.

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -449,20 +449,26 @@
             </c:if>
           </ul>
           <%-- Community menu --%>
-          <c:if test="${userSession.hasRole('admin') || userSession.hasRole('community-manager')}">
+          <%-- Issue #733's follow-up: broadened so a user reachable only via the users:manage
+               capability (no legacy role) can discover the Users/User Groups links, not just hit
+               their URLs directly. The rest of this section's links have nothing to do with
+               users:manage, so they stay nested behind the original role-only check below. --%>
+          <c:if test="${userSession.hasRole('admin') || userSession.hasRole('community-manager') || userSession.hasPermission('users:manage')}">
             <ul class="vertical menu">
               <li class="section-title">Community</li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/community/analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/community/analytics"><i class="${font:far()} fa-chart-line fa-fw"></i> <span>Analytics</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/community/search-analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/community/search-analytics"><i class="${font:far()} fa-search fa-fw"></i> <span>Search Analytics</span></a></li>
-              <c:if test="${userSession.hasRole('admin')}">
-                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/web-vitals')}"> class="is-active"</c:if>><a href="${ctx}/admin/web-vitals"><i class="${font:far()} fa-tachometer-alt fa-fw"></i> <span>Web Vitals</span></a></li>
+              <c:if test="${userSession.hasRole('admin') || userSession.hasRole('community-manager')}">
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/community/analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/community/analytics"><i class="${font:far()} fa-chart-line fa-fw"></i> <span>Analytics</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/community/search-analytics')}"> class="is-active"</c:if>><a href="${ctx}/admin/community/search-analytics"><i class="${font:far()} fa-search fa-fw"></i> <span>Search Analytics</span></a></li>
+                <c:if test="${userSession.hasRole('admin')}">
+                  <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/web-vitals')}"> class="is-active"</c:if>><a href="${ctx}/admin/web-vitals"><i class="${font:far()} fa-tachometer-alt fa-fw"></i> <span>Web Vitals</span></a></li>
+                </c:if>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/forms')}"> class="is-active"</c:if>><a href="${ctx}/admin/forms"><i class="${font:far()} fa-file-lines fa-fw"></i> <span>Form Builder</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/form-')}"> class="is-active"</c:if>><a href="${ctx}/admin/form-data"><i class="${font:far()} fa-list-alt fa-fw"></i> <span>Form Data</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/mailing-list') && !fn:startsWith(pageRenderInfo.name, '/admin/mailing-list-properties')}"> class="is-active"</c:if>><a href="${ctx}/admin/mailing-lists"><i class="${font:far()} fa-envelope fa-fw"></i> <span>Mailing Lists</span></a></li>
+                <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/newsletter-send')}"> class="is-active"</c:if>><a href="${ctx}/admin/newsletter-send"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>Send Newsletter</span></a></li>
               </c:if>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/forms')}"> class="is-active"</c:if>><a href="${ctx}/admin/forms"><i class="${font:far()} fa-file-lines fa-fw"></i> <span>Form Builder</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/form-')}"> class="is-active"</c:if>><a href="${ctx}/admin/form-data"><i class="${font:far()} fa-list-alt fa-fw"></i> <span>Form Data</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/mailing-list') && !fn:startsWith(pageRenderInfo.name, '/admin/mailing-list-properties')}"> class="is-active"</c:if>><a href="${ctx}/admin/mailing-lists"><i class="${font:far()} fa-envelope fa-fw"></i> <span>Mailing Lists</span></a></li>
-              <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/newsletter-send')}"> class="is-active"</c:if>><a href="${ctx}/admin/newsletter-send"><i class="${font:far()} fa-paper-plane fa-fw"></i> <span>Send Newsletter</span></a></li>
               <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/user') || fn:startsWith(pageRenderInfo.name, '/admin/modify-user') || fn:startsWith(pageRenderInfo.name, '/admin/unsuspend-requests')}"> class="is-active"</c:if>><a href="${ctx}/admin/users"><i class="${font:far()} fa-user-circle fa-fw"></i> <span>Users</span></a></li>
-              <c:if test="${userSession.hasRole('admin')}">
+              <c:if test="${userSession.hasRole('admin') || userSession.hasPermission('users:manage')}">
                 <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/group')}"> class="is-active"</c:if>><a href="${ctx}/admin/groups"><i class="${font:far()} fa-users fa-fw"></i> <span>User Groups</span></a></li>
               </c:if>
               <%-- Editorial Calendar (issue #426) is authorized for community-manager too (see
@@ -470,7 +476,7 @@
                    section below is gated to admin/content-manager only. Duplicate just this one
                    link here, guarded so admin/content-manager users -- who already see it in the
                    Content section -- don't see it twice. --%>
-              <c:if test="${!userSession.hasRole('admin') && !userSession.hasRole('content-manager')}">
+              <c:if test="${(userSession.hasRole('admin') || userSession.hasRole('community-manager')) && !userSession.hasRole('admin') && !userSession.hasRole('content-manager')}">
                 <li<c:if test="${fn:startsWith(pageRenderInfo.name, '/admin/editorial-calendar')}"> class="is-active"</c:if>><a href="${ctx}/admin/editorial-calendar"><i class="${font:far()} fa-calendar-check fa-fw"></i> <span>Editorial Calendar</span></a></li>
               </c:if>
             </ul>

--- a/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
+++ b/src/main/webapp/WEB-INF/web-layouts/page/admin-layout.xml
@@ -1239,7 +1239,7 @@
     </section>
   </page>
 
-  <page name="/admin/users" role="admin,community-manager" title="Users">
+  <page name="/admin/users" role="admin,community-manager" capability="users:manage" title="Users">
     <!--<section>-->
       <!--<column class="small-12 cell">-->
         <!--<widget name="breadcrumbs">-->
@@ -1258,7 +1258,7 @@
     </section>
   </page>
 
-  <page name="/admin/user-details{?userId}" role="admin,community-manager" title="User Details">
+  <page name="/admin/user-details{?userId}" role="admin,community-manager" capability="users:manage" title="User Details">
     <section>
       <column class="small-12 cell">
         <widget name="userDetails" />
@@ -1266,7 +1266,7 @@
     </section>
   </page>
 
-  <page name="/admin/unsuspend-requests" role="admin,community-manager" title="Unsuspend Requests">
+  <page name="/admin/unsuspend-requests" role="admin,community-manager" capability="users:manage" title="Unsuspend Requests">
     <section>
       <column class="small-12 cell">
         <widget name="unsuspendRequestsList">
@@ -1276,7 +1276,7 @@
     </section>
   </page>
 
-  <page name="/admin/modify-user{?userId}" role="admin,community-manager" title="Edit User">
+  <page name="/admin/modify-user{?userId}" role="admin,community-manager" capability="users:manage" title="Edit User">
     <section>
       <column class="small-12 cell">
         <widget name="userForm" />
@@ -1284,7 +1284,7 @@
     </section>
   </page>
 
-  <page name="/admin/groups" role="admin" title="User Groups">
+  <page name="/admin/groups" role="admin" capability="users:manage" title="User Groups">
     <!--<section>-->
       <!--<column class="small-12 cell">-->
         <!--<widget name="breadcrumbs">-->
@@ -1308,7 +1308,7 @@
     </section>
   </page>
 
-  <page name="/admin/group{?groupId}" role="admin" title="Edit Group">
+  <page name="/admin/group{?groupId}" role="admin" capability="users:manage" title="Edit Group">
     <section>
       <column class="small-12 cell">
         <widget name="breadcrumbs">

--- a/src/test/java/com/simisinc/platform/domain/model/PermissionSeedEquivalenceTest.java
+++ b/src/test/java/com/simisinc/platform/domain/model/PermissionSeedEquivalenceTest.java
@@ -35,12 +35,17 @@ import org.junit.jupiter.api.Test;
  * silent policy change. If the seed SQL and this test ever diverge, this test is the one that's
  * wrong - keep it in sync with the migration, not the other way around.
  *
+ * users:manage (UPGRADE_20260805.1200__users_manage_capability.sql, #733 follow-up) is a
+ * deliberate exception to that "read model" framing: it's a brand-new, independently grantable
+ * capability, not a restatement of a role's existing access, so only admin is seeded with it -
+ * see communityManagerDoesNotHaveUsersManage below for why community-manager is not.
+ *
  * @author elizabeth houser
  */
 class PermissionSeedEquivalenceTest {
 
   private static final List<String> ALL_CAPABILITIES = Arrays.asList(
-      "content:manage", "community:manage", "data:manage", "ecommerce:manage", "admin:manage");
+      "content:manage", "community:manage", "data:manage", "ecommerce:manage", "admin:manage", "users:manage");
 
   @Test
   void adminHasEveryCapability() {
@@ -56,6 +61,19 @@ class PermissionSeedEquivalenceTest {
   void communityManagerHasCommunityAndContentManage() {
     // The wiki widget's 3-way admin/content-manager/community-manager OR-check means
     // community-manager also needs content:manage's wiki slice - see the migration's comment.
+    assertRoleGrantsExactly("community-manager", List.of("community:manage", "content:manage"));
+  }
+
+  @Test
+  void communityManagerDoesNotHaveUsersManage() {
+    // community-manager's role="admin,community-manager" attribute already covers /admin/users,
+    // /admin/user-details, /admin/unsuspend-requests, and /admin/modify-user directly - but NOT
+    // /admin/groups or /admin/group (role="admin" only). Seeding community-manager with
+    // users:manage here would silently widen its access to the Groups pages once
+    // capability="users:manage" is added there, so it's deliberately left unseeded; already
+    // covered by communityManagerHasCommunityAndContentManage's exact-match assertion above, but
+    // named explicitly here since it's the one deviation from the "just restates hasRole()" story
+    // the other assertions in this file tell.
     assertRoleGrantsExactly("community-manager", List.of("community:manage", "content:manage"));
   }
 

--- a/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/controller/WebComponentCommandTest.java
@@ -461,6 +461,37 @@ class WebComponentCommandTest {
         "the Page-specific overload must read page.getCapabilities(), not just page.getRoles()");
   }
 
+  // --- users:manage (issue #733 follow-up): /admin/users and its sibling Users/Groups pages
+  // (/admin/user-details, /admin/unsuspend-requests, /admin/modify-user, /admin/groups,
+  // /admin/group) previously carried role="..." only, with no capability= attribute at all, so a
+  // user granted users:manage directly -- but holding no admin/community-manager role -- was
+  // 404'd by this same page-level gate before UsersListWidget's own hasPermission() check
+  // (added alongside it) ever ran. ---
+
+  @Test
+  void capabilityOnlySessionCanReachAdminUsersPage() {
+    UserSession userSession = sessionWithCapability("users:manage");
+
+    Page page = new Page("/admin/users", null, null);
+    page.setRoles(List.of("admin", "community-manager"));
+    page.setCapabilities(List.of("users:manage"));
+
+    Assertions.assertTrue(WebComponentCommand.allowsUser(page, userSession),
+        "a user holding users:manage but no legacy role must still reach /admin/users");
+  }
+
+  @Test
+  void sessionWithNeitherRoleNorUsersManageCapabilityCannotReachAdminUsersPage() {
+    UserSession userSession = sessionWithCapability("some-other:capability");
+
+    Page page = new Page("/admin/users", null, null);
+    page.setRoles(List.of("admin", "community-manager"));
+    page.setCapabilities(List.of("users:manage"));
+
+    Assertions.assertFalse(WebComponentCommand.allowsUser(page, userSession),
+        "a user with neither the legacy role nor the users:manage capability must still be denied");
+  }
+
   // PageServlet's page-level access check (the "PAGE NOT ALLOWED" 404 gate, checked once per
   // request before any widget's execute()/post()/delete() runs) calls this exact Page overload.
   // #799/#800 removed several widgets' own redundant in-code hasRole("admin") checks on the theory

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UnsuspendRequestsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UnsuspendRequestsWidgetTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.admin.login;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.login.UnsuspendAccountCommand;
+import com.simisinc.platform.domain.model.Capability;
+import com.simisinc.platform.domain.model.login.UnsuspendRequest;
+import com.simisinc.platform.presentation.controller.AuditEventCommand;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Covers the users:manage permission gate added to {@link UnsuspendRequestsWidget#post} alongside
+ * its existing hasRole("admin")/hasRole("community-manager") check (issue #733 follow-up) - a
+ * user granted the capability directly, with no legacy role at all, must still be able to act on
+ * a pending unsuspend request, and a user with neither must still be denied.
+ *
+ * @author SimIS Inc.
+ */
+class UnsuspendRequestsWidgetTest extends WidgetBase {
+
+  private static UnsuspendRequest deniedRequest() {
+    UnsuspendRequest request = new UnsuspendRequest();
+    request.setId(9L);
+    request.setTargetUserId(5L);
+    request.setTargetEmail("target@example.com");
+    request.setRequestedByEmail("requester@example.com");
+    return request;
+  }
+
+  @Test
+  void capabilityOnlyUserWithUsersManageCanDenyARequest() throws Exception {
+    // No role set at all -- WidgetBase's default session already has an empty role list; the
+    // only thing granting access here is the users:manage capability (issue #733 follow-up).
+    Capability usersManage = new Capability();
+    usersManage.setCode("users:manage");
+    widgetContext.getUserSession().setCapabilityList(List.of(usersManage));
+    addQueryParameter(widgetContext, "command", "deny");
+    addQueryParameter(widgetContext, "requestId", "9");
+    addQueryParameter(widgetContext, "denialReason", "capability-only access check");
+
+    try (MockedStatic<UnsuspendAccountCommand> command = mockStatic(UnsuspendAccountCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      command.when(() -> UnsuspendAccountCommand.deny(9L, widgetContext.getUserId(), "capability-only access check"))
+          .thenReturn(deniedRequest());
+
+      WidgetContext result = new UnsuspendRequestsWidget().post(widgetContext);
+
+      command.verify(() -> UnsuspendAccountCommand.deny(9L, widgetContext.getUserId(), "capability-only access check"),
+          times(1));
+      audit.verify(() -> AuditEventCommand.record(any(WidgetContext.class), anyString(), anyString(), anyString(),
+          anyString(), anyString(), anyString(), anyString()), times(1));
+      assertNull(result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void userWithNeitherRoleNorUsersManageCapabilityCannotReachApprovalActionsAtAll() throws Exception {
+    // WidgetBase's default session has neither a role nor a capability list populated
+    addQueryParameter(widgetContext, "command", "deny");
+    addQueryParameter(widgetContext, "requestId", "9");
+    addQueryParameter(widgetContext, "denialReason", "n/a");
+
+    try (MockedStatic<UnsuspendAccountCommand> command = mockStatic(UnsuspendAccountCommand.class)) {
+      new UnsuspendRequestsWidget().post(widgetContext);
+
+      command.verify(() -> UnsuspendAccountCommand.deny(anyLong(), anyLong(), any()), never());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserDetailsWidgetTest.java
@@ -54,13 +54,14 @@ import com.simisinc.platform.presentation.controller.WidgetContext;
  * (redirect back to the same page, no error, no repository call). These tests call post() directly, the same
  * method a real request now reaches, so they fail if that dispatch gap reopens.
  *
- * communityManagerCannotSuspendAccountThatOutranksThem / communityManagerCannotRestoreAccountThatOutranksThem
- * guard a separate, pre-existing gap (predates issue #358, unrelated to it): suspendAccount()/restoreAccount()
- * only ever checked "is this my own account" -- neither checked the target's role level against the acting
- * admin's, even though both /admin/users and /admin/user-details are reachable by community-manager (level 90,
- * admin-layout.xml), one level below admin (level 100). Without this guard a community-manager could suspend or
- * restore an admin account outright. Mirrors the escalation guard UserFormWidget already applies to role grants
- * (see UserFormWidgetTest).
+ * communityManagerCannotSuspendAccountThatOutranksThem / communityManagerCannotRestoreAccountThatOutranksThem /
+ * communityManagerCannotDeleteAccountThatOutranksThem guard a shared gap: suspendAccount(), restoreAccount(), and
+ * deleteAccount() only ever checked "is this my own account" -- none checked the target's role level against the
+ * acting admin's, even though both /admin/users and /admin/user-details are reachable by community-manager
+ * (level 90, admin-layout.xml) and, as of the users:manage capability, by a user holding only that capability
+ * with no legacy role at all -- one level below admin (level 100). Without this guard, either could suspend,
+ * restore, or permanently delete an admin account outright. Mirrors the escalation guard UserFormWidget already
+ * applies to role grants (see UserFormWidgetTest). deleteAccount() was the last of the three still missing it.
  *
  * @author Elizabeth Houser
  */
@@ -325,12 +326,15 @@ class UserDetailsWidgetTest extends WidgetBase {
     addQueryParameter(widgetContext, "userId", "5");
     addQueryParameter(widgetContext, "action", "deleteAccount");
 
+    // An admin (level 100) acting on a non-elevated target -- not "outranks".
     User target = activeUser();
 
     try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
         MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
         MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
       loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
       userRepo.when(() -> UserRepository.remove(target)).thenReturn(true);
 
       WidgetContext result = new UserDetailsWidget().post(widgetContext);
@@ -338,6 +342,62 @@ class UserDetailsWidgetTest extends WidgetBase {
       userRepo.verify(() -> UserRepository.remove(target), times(1));
       audit.verify(() -> AuditEventCommand.record(any(), eq(AuditEventCommand.USER_MANAGEMENT), eq("user.delete"),
           eq(AuditEventCommand.SUCCESS), eq("user"), eq("5"), eq("active@example.com"), any()), times(1));
+      Assertions.assertEquals("Account deleted", result.getSuccessMessage());
+    }
+  }
+
+  @Test
+  void communityManagerCannotDeleteAccountThatOutranksThem() throws Exception {
+    // Without this guard, any user who can reach this page -- including a community-manager, or,
+    // as of the users:manage capability, a user holding only that capability with no role at all --
+    // could permanently delete an admin account, since deleteAccount()'s only other check is
+    // "not yourself".
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "deleteAccount");
+
+    // The target holds admin (level 100), above the acting community-manager (level 90).
+    User target = adminUser();
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      userRepo.verify(() -> UserRepository.remove(any()), never());
+      audit.verifyNoInteractions();
+      Assertions.assertEquals("You cannot delete an account with a higher role level than your own",
+          result.getErrorMessage());
+    }
+  }
+
+  @Test
+  void communityManagerCanDeleteAccountAtOrBelowTheirOwnLevel() throws Exception {
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    addQueryParameter(widgetContext, "userId", "5");
+    addQueryParameter(widgetContext, "action", "deleteAccount");
+
+    // The target holds community-manager (level 90), at the acting user's own level -- not "outranks".
+    User target = activeUser();
+    List<Role> held = new ArrayList<>();
+    held.add(role(3, 90, "community-manager", "Community Manager"));
+    target.setRoleList(held);
+
+    try (MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      userRepo.when(() -> UserRepository.remove(target)).thenReturn(true);
+
+      WidgetContext result = new UserDetailsWidget().post(widgetContext);
+
+      userRepo.verify(() -> UserRepository.remove(target), times(1));
       Assertions.assertEquals("Account deleted", result.getSuccessMessage());
     }
   }

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetBulkActionsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetBulkActionsTest.java
@@ -55,6 +55,13 @@ import com.simisinc.platform.presentation.controller.WidgetContext;
  * Reset Password / Assign Roles both require a fresh step-up re-authentication once per batch --
  * exactly the same bar the single-user forms already hold each of these actions to.
  *
+ * bulkSuspendSkipsAnAccountThatOutranksTheActorButContinuesTheRestOfTheBatch guards a gap that was
+ * specific to the bulk checkbox path: UserDetailsWidget's single-account suspendAccount() already
+ * refuses to suspend an account with a higher role level than the acting admin's, but
+ * bulkSuspendAction() had no equivalent per-target check, so a community-manager (or a
+ * users:manage capability-only grantee with no legacy role) could reach an admin account through
+ * this path that the single-user form would refuse.
+ *
  * @author SimIS Inc.
  */
 class UsersListWidgetBulkActionsTest extends WidgetBase {
@@ -113,8 +120,11 @@ class UsersListWidgetBulkActionsTest extends WidgetBase {
 
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       loadCmd.when(() -> LoadUserCommand.loadUser(5L)).thenReturn(other);
+      // The target (level 0, no roles) does not outrank the acting admin (level 100).
+      roleRepo.when(RoleRepository::findAll).thenReturn(Arrays.asList(role(1, 100, ADMIN)));
       userRepo.when(() -> UserRepository.suspendAccount(other, "compromised credentials")).thenReturn(other);
 
       WidgetContext result = new UsersListWidget().post(widgetContext);
@@ -132,6 +142,45 @@ class UsersListWidgetBulkActionsTest extends WidgetBase {
       // warning, not a plain success -- matching the same "partial" bucket as a not-found/failed id.
       assertTrue(result.getWarningMessage().contains("1 of 2"));
       assertTrue(result.getWarningMessage().contains("your own account"));
+    }
+  }
+
+  @Test
+  void bulkSuspendSkipsAnAccountThatOutranksTheActorButContinuesTheRestOfTheBatch() throws Exception {
+    // Without this guard, a community-manager (or, as of the users:manage capability, a user
+    // holding only that capability with no legacy role at all) could use this bulk checkbox path
+    // to suspend an admin account -- something the single-account suspendAccount() form on
+    // /admin/user-details already refuses (see UserDetailsWidgetTest).
+    setRoles(widgetContext, COMMUNITY_MANAGER);
+    multiValue("userId", "5", "6");
+    addQueryParameter(widgetContext, "command", "bulkSuspend");
+    addQueryParameter(widgetContext, "reason", "incident response");
+
+    User outranking = userWithId(5L);
+    List<Role> heldByOutranking = new ArrayList<>();
+    heldByOutranking.add(role(1, 100, ADMIN));
+    outranking.setRoleList(heldByOutranking);
+
+    User withinReach = userWithId(6L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(5L)).thenReturn(outranking);
+      loadCmd.when(() -> LoadUserCommand.loadUser(6L)).thenReturn(withinReach);
+      roleRepo.when(RoleRepository::findAll).thenReturn(Arrays.asList(role(2, 90, COMMUNITY_MANAGER), role(1, 100, ADMIN)));
+      userRepo.when(() -> UserRepository.suspendAccount(withinReach, "incident response")).thenReturn(withinReach);
+
+      WidgetContext result = new UsersListWidget().post(widgetContext);
+
+      // The outranking account (admin, level 100) was never touched; the other account (level 0,
+      // below the acting community-manager's level 90) was suspended normally.
+      userRepo.verify(() -> UserRepository.suspendAccount(outranking, "incident response"), never());
+      userRepo.verify(() -> UserRepository.suspendAccount(withinReach, "incident response"), times(1));
+      userRepo.verify(() -> UserRepository.suspendAccount(any(), any()), times(1));
+      assertTrue(result.getWarningMessage().contains("1 of 2"));
+      assertTrue(result.getWarningMessage().contains("Skipped (higher role level than yours): 1"));
     }
   }
 
@@ -409,8 +458,12 @@ class UsersListWidgetBulkActionsTest extends WidgetBase {
 
     try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
         MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
         MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
       loadCmd.when(() -> LoadUserCommand.loadUser(5L)).thenReturn(other);
+      // The acting session holds no role at all (capability-only), so it matches none of these by
+      // hasRole() and resolves to level 0 -- the target (also level 0, no roles) does not outrank it.
+      roleRepo.when(RoleRepository::findAll).thenReturn(Arrays.asList(role(1, 100, ADMIN)));
       userRepo.when(() -> UserRepository.suspendAccount(other, "capability-only access check")).thenReturn(other);
 
       WidgetContext result = new UsersListWidget().post(widgetContext);

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetBulkActionsTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UsersListWidgetBulkActionsTest.java
@@ -38,6 +38,7 @@ import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.audit.SaveAuditEventCommand;
 import com.simisinc.platform.application.login.StepUpAuthCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Capability;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.RoleRepository;
@@ -377,6 +378,51 @@ class UsersListWidgetBulkActionsTest extends WidgetBase {
   @Test
   void nonAdminNonCommunityManagerCannotReachBulkActionsAtAll() throws Exception {
     setRoles(widgetContext, CONTENT_MANAGER);
+    multiValue("userId", "5");
+    addQueryParameter(widgetContext, "command", "bulkSuspend");
+    addQueryParameter(widgetContext, "reason", "n/a");
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class)) {
+      new UsersListWidget().post(widgetContext);
+
+      loadCmd.verifyNoInteractions();
+      userRepo.verify(() -> UserRepository.suspendAccount(any(), any()), never());
+    }
+  }
+
+  // --- users:manage (issue #733 follow-up): the same permission gate this class already covers
+  // for hasRole(), now also reachable via a direct capability grant with no legacy role at all ---
+
+  @Test
+  void capabilityOnlyUserWithUsersManageCanExecuteABulkAction() throws Exception {
+    // No role set at all -- WidgetBase's default session already has an empty role list; the
+    // only thing granting access here is the users:manage capability (issue #733 follow-up).
+    Capability usersManage = new Capability();
+    usersManage.setCode("users:manage");
+    widgetContext.getUserSession().setCapabilityList(List.of(usersManage));
+    multiValue("userId", "5");
+    addQueryParameter(widgetContext, "command", "bulkSuspend");
+    addQueryParameter(widgetContext, "reason", "capability-only access check");
+
+    User other = userWithId(5L);
+
+    try (MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+      loadCmd.when(() -> LoadUserCommand.loadUser(5L)).thenReturn(other);
+      userRepo.when(() -> UserRepository.suspendAccount(other, "capability-only access check")).thenReturn(other);
+
+      WidgetContext result = new UsersListWidget().post(widgetContext);
+
+      userRepo.verify(() -> UserRepository.suspendAccount(other, "capability-only access check"), times(1));
+      assertTrue(result.getSuccessMessage().contains("1 of 1"));
+    }
+  }
+
+  @Test
+  void userWithNeitherRoleNorUsersManageCapabilityCannotReachBulkActionsAtAll() throws Exception {
+    // WidgetBase's default session has neither a role nor a capability list populated
     multiValue("userId", "5");
     addQueryParameter(widgetContext, "command", "bulkSuspend");
     addQueryParameter(widgetContext, "reason", "n/a");


### PR DESCRIPTION
## What

Issue #733 added a page-level `capability="..."` gate and wired it onto 3 `admin:manage` pages (`/admin/role-capabilities`, `/admin/role-capabilities-form`, `/admin/analytics-retention`), but left every other admin page — including the entire Users/Groups admin surface — reachable only through the legacy `role="..."` attribute. A user holding a capability grant but no matching legacy role got 404'd by `PageServlet` before any widget code ran, and `UsersListWidget`/`UnsuspendRequestsWidget` additionally hardcoded their own role-only checks internally with no `hasPermission()` fallback.

## What changed

- Adds a new, dedicated `users:manage` capability (`UPGRADE_20260805.1200`, mirrored in `NEW_10000` for fresh installs) scoped specifically to user management, deliberately separate from `admin:manage`/`community:manage` so it can be granted without handing out unrelated access. Seeded only for the `admin` role (not `community-manager`): `community-manager`'s existing `role="admin,community-manager"` attribute covers 4 of the 6 affected pages but not `/admin/groups` or `/admin/group` (`role="admin"` only), and mapping it to this capability in `role_capabilities` would silently widen its access to the Groups pages.
- Adds `capability="users:manage"` to the 6 affected `<page>` elements in `admin-layout.xml` (`/admin/users`, `/admin/user-details`, `/admin/unsuspend-requests`, `/admin/modify-user`, `/admin/groups`, `/admin/group`), purely additive alongside their existing `role=` attributes. `UserFormWidget`, `UserDetailsWidget`, `GroupsListWidget`, and `GroupFormWidget` have no internal role gate of their own and pick up the new capability automatically once their page carries it, matching how #733 already documented behaves for its 3 pages. `UsersListWidget`'s and `UnsuspendRequestsWidget`'s own hardcoded `hasRole("admin")`/`hasRole("community-manager")` `post()` checks are extended with an OR `hasPermission("users:manage")`.
- Extends `main.jsp`'s admin nav so a capability-only user can discover the Users and User Groups links via navigation rather than only by hitting their URLs directly — the exact class of nav-visibility gap #733 explicitly left unresolved for its own pages. The Community section's other, unrelated links (Analytics, Web Vitals, Form Builder, Mailing Lists, Send Newsletter, Editorial Calendar) stay behind the original role-only check so they remain hidden from a capability-only user.
- The Capability Grants and Role Capabilities admin UIs both already list whatever `CapabilityRepository.findAll()` returns, so `users:manage` becomes selectable there automatically once seeded, with no widget/JSP change required.

## Security hardening included in this PR

Widening the reachable audience for these pages (any `users:manage` grantee, not just `admin`/`community-manager`) surfaced two guards that were missing for actions available on this surface:

- `UserDetailsWidget.deleteAccount()` only checked "not yourself" before permanently removing an account. Unlike `suspendAccount()`/`restoreAccount()` in the same class, it never checked whether the target's role level outranks the acting user's — so any user who could reach `/admin/user-details` could permanently delete an admin account. It now applies the same `targetOutranksActor()` guard as suspend/restore.
- `UsersListWidget.bulkSuspendAction()` had no equivalent per-target check, so the bulk checkbox path on `/admin/users` could suspend an account the single-account form on `/admin/user-details` already refuses to touch. It now re-checks the same guard (exposed package-private on `UserDetailsWidget`) per selected account, and reports a distinct "skipped (higher role level than yours)" count in the result message.

## Testing

- `WebComponentCommandTest`: a capability-only session (`users:manage`, no legacy role) reaches the `/admin/users` page-level gate; a role-less/capability-less session is still denied.
- `UsersListWidgetBulkActionsTest`: the `users:manage` capability path can execute a bulk action; a bulk-suspend selection that includes an account outranking the actor skips that account and continues the rest of the batch.
- `UnsuspendRequestsWidgetTest` (new): equivalent capability-gate coverage for the unsuspend-requests widget.
- `UserDetailsWidgetTest`: adds coverage that a community-manager (or, by extension, a `users:manage` capability-only user) cannot delete an account that outranks them, mirroring the existing suspend/restore coverage.
- `PermissionSeedEquivalenceTest`: extended to prove `admin` has `users:manage` and `community-manager` does not.
- Verified locally with `ant -lib lib/war -lib lib/tests clean ci-test` (full suite green) and `ant -lib lib/war compile-jsp` (JSP syntax/EL gate).