### PR TITLE
Fix: admin users list decrypts TOTP secrets it never displays

### DIFF
--- a/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/simisinc/platform/infrastructure/persistence/UserRepository.java
@@ -102,8 +102,15 @@ public class UserRepository {
         }
       }
     }
+    // Uses buildSummaryRecord rather than buildRecord: list-style queries (the /admin/users list,
+    // the editorial-calendar author dropdown, the user lookup autocomplete) never read
+    // User#getMfaSecret(), only the separate mfa_enabled boolean, so there is no reason to pay for
+    // a SecretCryptoCommand.decrypt() call (and its ERROR log on a misconfigured CMS_SECRET_KEY)
+    // on every MFA-enabled row of every list render. Single-record lookups (findByUserId,
+    // findByUsername, etc., used by login/MFA-verification flows that do need the plaintext seed)
+    // still go through buildRecord via DB.selectRecordFrom.
     return DB.selectAllFrom(
-        TABLE_NAME, select, where, orderBy, constraints, UserRepository::buildRecord);
+        TABLE_NAME, select, where, orderBy, constraints, UserRepository::buildSummaryRecord);
   }
 
   public static User findByUniqueId(String uniqueId) {
@@ -639,46 +646,73 @@ public class UserRepository {
     return false;
   }
 
+  /**
+   * The full row mapper, used by single-record lookups (by id, username, email, account token,
+   * etc.) where a caller may legitimately need the plaintext TOTP seed -- e.g. login/MFA
+   * verification. Decrypts mfa_secret on every call.
+   */
   private static User buildRecord(ResultSet rs) {
     try {
-      User record = new User();
-      record.setId(rs.getLong("user_id"));
-      record.setUniqueId(rs.getString("unique_id"));
-      record.setFirstName(rs.getString("first_name"));
-      record.setLastName(rs.getString("last_name"));
-      record.setOrganization(rs.getString("organization"));
-      record.setNickname(rs.getString("nickname"));
-      record.setEmail(rs.getString("email"));
-      record.setUsername(rs.getString("username"));
-      record.setPassword(rs.getString("password"));
-      record.setEnabled(rs.getBoolean("enabled"));
-      record.setCreated(rs.getTimestamp("created"));
-      record.setModified(rs.getTimestamp("modified"));
-      record.setAccountToken(rs.getString("account_token"));
-      record.setAccountTokenExpires(rs.getTimestamp("account_token_expires"));
-      record.setValidated(rs.getTimestamp("validated"));
-      record.setCreatedBy(rs.getLong("created_by"));
-      record.setModifiedBy(rs.getLong("modified_by"));
-      record.setTitle(rs.getString("title"));
-      record.setDepartment(rs.getString("department"));
-      record.setTimeZone(rs.getString("timezone"));
-      record.setCity(rs.getString("city"));
-      record.setState(rs.getString("state"));
-      record.setCountry(rs.getString("country"));
-      record.setPostalCode(rs.getString("postal_code"));
-      record.setLatitude(rs.getDouble("latitude"));
-      record.setLongitude(rs.getDouble("longitude"));
+      User record = buildSummaryFields(rs);
       // Decrypt the at-rest TOTP seed so callers always see plaintext (legacy plaintext passes through unchanged)
       record.setMfaSecret(SecretCryptoCommand.decrypt(rs.getString("mfa_secret")));
-      record.setMfaEnabled(rs.getBoolean("mfa_enabled"));
-      record.setFailedAttemptCount(rs.getInt("failed_attempt_count"));
-      record.setLockedUntil(rs.getTimestamp("locked_until"));
-      record.setLastPasswordChangedAt(rs.getTimestamp("last_password_changed_at"));
-      record.setSuspensionReason(rs.getString("suspension_reason"));
       return record;
     } catch (SQLException se) {
       LOG.error("buildRecord", se);
       return null;
     }
+  }
+
+  /**
+   * The row mapper used by list-style/multi-record queries (query(), i.e. findAll() and its
+   * callers such as the /admin/users list, the editorial-calendar author dropdown, and the user
+   * lookup autocomplete). None of those read User#getMfaSecret() -- only the separate mfa_enabled
+   * boolean -- so this skips the SecretCryptoCommand.decrypt() call that buildRecord() pays on
+   * every MFA-enabled row. mfaSecret is left null on the returned records.
+   */
+  private static User buildSummaryRecord(ResultSet rs) {
+    try {
+      return buildSummaryFields(rs);
+    } catch (SQLException se) {
+      LOG.error("buildSummaryRecord", se);
+      return null;
+    }
+  }
+
+  /** Populates every User field shared by buildRecord() and buildSummaryRecord() except mfaSecret. */
+  private static User buildSummaryFields(ResultSet rs) throws SQLException {
+    User record = new User();
+    record.setId(rs.getLong("user_id"));
+    record.setUniqueId(rs.getString("unique_id"));
+    record.setFirstName(rs.getString("first_name"));
+    record.setLastName(rs.getString("last_name"));
+    record.setOrganization(rs.getString("organization"));
+    record.setNickname(rs.getString("nickname"));
+    record.setEmail(rs.getString("email"));
+    record.setUsername(rs.getString("username"));
+    record.setPassword(rs.getString("password"));
+    record.setEnabled(rs.getBoolean("enabled"));
+    record.setCreated(rs.getTimestamp("created"));
+    record.setModified(rs.getTimestamp("modified"));
+    record.setAccountToken(rs.getString("account_token"));
+    record.setAccountTokenExpires(rs.getTimestamp("account_token_expires"));
+    record.setValidated(rs.getTimestamp("validated"));
+    record.setCreatedBy(rs.getLong("created_by"));
+    record.setModifiedBy(rs.getLong("modified_by"));
+    record.setTitle(rs.getString("title"));
+    record.setDepartment(rs.getString("department"));
+    record.setTimeZone(rs.getString("timezone"));
+    record.setCity(rs.getString("city"));
+    record.setState(rs.getString("state"));
+    record.setCountry(rs.getString("country"));
+    record.setPostalCode(rs.getString("postal_code"));
+    record.setLatitude(rs.getDouble("latitude"));
+    record.setLongitude(rs.getDouble("longitude"));
+    record.setMfaEnabled(rs.getBoolean("mfa_enabled"));
+    record.setFailedAttemptCount(rs.getInt("failed_attempt_count"));
+    record.setLockedUntil(rs.getTimestamp("locked_until"));
+    record.setLastPasswordChangedAt(rs.getTimestamp("last_password_changed_at"));
+    record.setSuspensionReason(rs.getString("suspension_reason"));
+    return record;
   }
 }

--- a/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
+++ b/src/test/java/com/simisinc/platform/infrastructure/persistence/UserRepositoryTest.java
@@ -17,27 +17,40 @@
 package com.simisinc.platform.infrastructure.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import com.simisinc.platform.application.SecretCryptoCommand;
+import com.simisinc.platform.domain.model.Entity;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.cache.CacheManager;
 import com.simisinc.platform.infrastructure.database.DB;
+import com.simisinc.platform.infrastructure.database.DataConstraints;
+import com.simisinc.platform.infrastructure.database.DataResult;
 import com.simisinc.platform.infrastructure.database.SqlUtils;
 import com.simisinc.platform.infrastructure.persistence.login.UnsuspendRequestRepository;
 import com.simisinc.platform.infrastructure.persistence.login.UserTokenRepository;
 
 /**
- * Covers the security-relevant cleanup that runs when a user's password changes: alongside
- * revoking user tokens, the cached plaintext credentials must be invalidated, or the old
- * password keeps authenticating via AuthenticateLoginCommand's credentials cache.
+ * Covers UserRepository behavior that is easy to silently regress: the security-relevant cleanup
+ * that runs when a user's password changes (alongside revoking user tokens, the cached plaintext
+ * credentials must be invalidated, or the old password keeps authenticating via
+ * AuthenticateLoginCommand's credentials cache), and the split between the list-serving row
+ * mapper (must not decrypt the TOTP secret) and the single-record row mapper (must).
  *
  * @author Liz Houser
  * @created 7/23/2026
@@ -116,6 +129,58 @@ class UserRepositoryTest {
       UserRepository.restoreAccount(user);
 
       assertEquals(null, fieldValue(valuesCaptor.getValue(), "suspension_reason"));
+    }
+  }
+
+  /**
+   * findAll() (used by the /admin/users list, the editorial-calendar author dropdown, and the
+   * user lookup autocomplete) must map rows with the lighter-weight summary mapper: it should
+   * never touch SecretCryptoCommand.decrypt(), and the resulting User's mfaSecret must stay null,
+   * even though the underlying row has an encrypted secret present.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  void findAllDoesNotDecryptTheMfaSecret() throws SQLException {
+    ArgumentCaptor<Function<ResultSet, Entity>> mapperCaptor = ArgumentCaptor.forClass(Function.class);
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<SecretCryptoCommand> crypto = mockStatic(SecretCryptoCommand.class)) {
+      db.when(() -> DB.selectAllFrom(anyString(), any(SqlUtils.class), any(SqlUtils.class), any(SqlUtils.class),
+          any(DataConstraints.class), mapperCaptor.capture())).thenReturn(new DataResult());
+
+      UserRepository.findAll(new UserSpecification(), new DataConstraints());
+
+      ResultSet rs = mock(ResultSet.class);
+      when(rs.getString("mfa_secret")).thenReturn("enc:should-not-be-read");
+      User mapped = (User) mapperCaptor.getValue().apply(rs);
+
+      assertNull(mapped.getMfaSecret(), "the list-serving row mapper must not populate mfaSecret");
+      crypto.verify(() -> SecretCryptoCommand.decrypt(anyString()), never());
+    }
+  }
+
+  /**
+   * A single-record lookup (e.g. findByUserId, used by login/MFA-verification flows) must keep
+   * decrypting the TOTP seed via the full row mapper -- this is the counterpart to
+   * findAllDoesNotDecryptTheMfaSecret(), confirming the split didn't regress the path that
+   * actually needs the plaintext secret.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  void findByUserIdStillDecryptsTheMfaSecret() throws SQLException {
+    ArgumentCaptor<Function<ResultSet, Entity>> mapperCaptor = ArgumentCaptor.forClass(Function.class);
+    try (MockedStatic<DB> db = mockStatic(DB.class);
+        MockedStatic<SecretCryptoCommand> crypto = mockStatic(SecretCryptoCommand.class)) {
+      db.when(() -> DB.selectRecordFrom(anyString(), any(SqlUtils.class), mapperCaptor.capture()))
+          .thenReturn(null);
+      crypto.when(() -> SecretCryptoCommand.decrypt("enc:real-secret")).thenReturn("JBSWY3DPEHPK3PXP");
+
+      UserRepository.findByUserId(42L);
+
+      ResultSet rs = mock(ResultSet.class);
+      when(rs.getString("mfa_secret")).thenReturn("enc:real-secret");
+      User mapped = (User) mapperCaptor.getValue().apply(rs);
+
+      assertEquals("JBSWY3DPEHPK3PXP", mapped.getMfaSecret());
     }
   }
 


### PR DESCRIPTION
## Problem

`UserRepository.findAll()` -- the query behind the `/admin/users` list, the editorial-calendar author dropdown, and the user lookup autocomplete -- mapped every row with `buildRecord()`, the same mapper used by single-record lookups. `buildRecord()` calls `SecretCryptoCommand.decrypt()` on the stored `mfa_secret` for every row.

None of those list-style callers ever read `User#getMfaSecret()` -- they only display the separate `mfa_enabled` boolean. So every MFA-enabled row in every list render paid for a decrypt call whose result is thrown away, and on a misconfigured `CMS_SECRET_KEY` each of those also logs an ERROR line.

## Change

Split the row mapper in `UserRepository`:

- `buildSummaryRecord()` -- new, used by `findAll()` (list-style/multi-record queries). Populates every `User` field except `mfaSecret`, which is left null.
- `buildRecord()` -- unchanged behavior, still used by single-record lookups (`findByUserId`, `findByUsername`, `findByUniqueId`, etc.) where a caller may legitimately need the plaintext TOTP seed, e.g. login/MFA-verification flows. Still decrypts `mfa_secret` on every call.

Both mappers share a new `buildSummaryFields()` helper for the field-by-field `ResultSet` mapping they have in common, so the two mappers can't silently drift apart on the shared fields.

## Testing

- `ant -lib lib/war -lib lib/tests clean ci-test` -- full suite green (405 suites / 2888 tests, 0 failures/errors).
- Added two `UserRepositoryTest` cases:
  - `findAllDoesNotDecryptTheMfaSecret` -- captures the mapper `findAll()` passes to `DB.selectAllFrom`, feeds it a row with an encrypted `mfa_secret`, and asserts the resulting `User#getMfaSecret()` is null and `SecretCryptoCommand.decrypt()` is never invoked.
  - `findByUserIdStillDecryptsTheMfaSecret` -- same technique against `findByUserId`'s mapper, confirming the single-record path is unchanged and still decrypts.