### PR TITLE
Add in-page guidance and pre-send check to Send Newsletter

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidget.java
@@ -17,6 +17,8 @@
 package com.simisinc.platform.presentation.widgets.admin;
 
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.mailinglists.MailChimpCommand;
 import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
@@ -27,6 +29,7 @@ import com.simisinc.platform.infrastructure.persistence.mailinglists.MailingList
 import com.simisinc.platform.presentation.controller.AuditEventCommand;
 import com.simisinc.platform.presentation.controller.WidgetContext;
 import com.simisinc.platform.presentation.widgets.GenericWidget;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +64,16 @@ public class NewsletterSendWidget extends GenericWidget {
     DataConstraints constraints = new DataConstraints(1, 50).setDefaultColumnToSortBy("published DESC");
     List<BlogPost> blogPosts = BlogPostRepository.findAll(specification, constraints);
     context.getRequest().setAttribute("blogPosts", blogPosts);
+
+    // Catch the #1 real-world failure mode before an admin wastes a send on it: neither delivery
+    // path is configured at all, so every recipient would silently fail (SMTP) or the enqueue
+    // itself would error out (MailChimp -- NewsletterSendCommand.sendViaMailChimp requires a
+    // reachable, correctly-keyed account). MailChimp being enabled makes the SMTP host irrelevant,
+    // so this only warns when BOTH are unset.
+    boolean mailChimpEnabled = MailChimpCommand.isEnabled();
+    boolean smtpConfigured = StringUtils.isNotBlank(LoadSitePropertyCommand.loadByName("mail.host_name"));
+    context.getRequest().setAttribute("sendMethodConfigured", mailChimpEnabled || smtpConfigured);
+    context.getRequest().setAttribute("mailChimpEnabled", mailChimpEnabled);
 
     context.setJsp(JSP);
     return context;

--- a/src/main/webapp/WEB-INF/jsp/admin/newsletter-send.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/newsletter-send.jsp
@@ -25,18 +25,97 @@
 <%@include file="../page_messages.jspf" %>
 
 <p>
-  Pick a mailing list and a published blog post to queue a notification email to everyone
-  currently subscribed to that list. Sending happens in the background over the next few
-  minutes, not instantly -- the page won't wait for it, and re-checking this page won't show a
-  progress bar.
+  Pick a mailing list and a published blog post below to queue a notification email to everyone
+  currently subscribed to that list. This is a one-shot broadcast tool for a single post, not a
+  general email composer -- there's no free-text subject or body, and no scheduling. It's the same
+  underlying mechanism as the <strong>"Notify subscribers"</strong> checkbox on the blog editor;
+  this page is here for a post that was already published without checking that box.
+</p>
+
+<h5>How it works</h5>
+<ul>
+  <li>Only people currently <strong>subscribed to, and not unsubscribed from,</strong> the chosen
+    list receive it -- pending (unconfirmed double opt-in) and quarantined addresses are skipped.</li>
+  <li>Every email includes an unsubscribe link specific to that person and that list, so an
+    unsubscribe from one newsletter doesn't affect their other list subscriptions.</li>
+  <li>Sending happens in the <strong>background, not instantly</strong>. Clicking "Send Newsletter"
+    only queues the job -- the page won't wait for delivery, and reloading it afterward won't show
+    a progress bar. For a large list, expect delivery to finish over several minutes, not seconds
+    (see Timing below).</li>
+  <li>Which delivery path is used depends on the site's <strong>Mailing List Settings</strong>:
+    <c:choose>
+      <c:when test="${mailChimpEnabled}">
+        this site currently sends via <strong>MailChimp</strong> -- clicking send creates and
+        immediately sends a real MailChimp Campaign to everyone MailChimp has tagged with this
+        list. MailChimp handles its own delivery and retries from that point on; this admin page
+        has no further visibility into it once the campaign is sent.
+      </c:when>
+      <c:otherwise>
+        this site currently sends via its own configured <strong>SMTP server</strong> -- clicking
+        send creates one queued row per recipient, and a background job sends a batch of 25 every
+        minute (see Timing below).
+      </c:otherwise>
+    </c:choose>
+  </li>
+</ul>
+
+<h5>Timing (SMTP path)</h5>
+<p>
+  When sending via this site's own SMTP server (not MailChimp), delivery isn't immediate: a
+  scheduled job sends <strong>25 emails per minute</strong>. A 500-person list takes roughly 20
+  minutes to fully deliver, start to finish. A failed send is retried automatically up to
+  <strong>3 times</strong> before being given up on -- no admin action is needed for a transient
+  failure to resolve itself, only for a persistent one.
+</p>
+
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>Nothing sends, and there's no error on this page.</strong> Almost always a delivery
+    path that's configured but broken (a wrong SMTP password, an expired MailChimp API key), not
+    something this page can detect at click-time -- see "What to check if delivery seems stuck"
+    below.</li>
+  <li><strong>A subscriber says they never received it, but others did.</strong> Check they weren't
+    already unsubscribed or quarantined (bounced/complained addresses stop receiving mail
+    automatically) -- see their status on
+    <a href="${ctx}/admin/mailing-lists">Mailing Lists</a>. Otherwise, ask them to check spam/junk
+    -- this is the most common cause and isn't something this admin can fix from here.</li>
+  <li><strong>Trying to send the same post again does nothing new.</strong> There's no duplicate
+    guard on this page -- if you send the same list/post combination twice, subscribers get it
+    twice. Re-sending isn't blocked, so double-check before resubmitting rather than relying on the
+    system to catch it.</li>
+</ul>
+
+<h5>What to check if delivery seems stuck</h5>
+<p>
+  There's currently <strong>no dedicated page here showing a send's delivery status</strong>
+  (sent/failed/skipped counts) -- that's a real gap, not something hidden elsewhere in the admin.
+  What IS available today:
 </p>
 <ul>
-  <li>Only people currently subscribed to (and not unsubscribed from) the chosen list receive it.</li>
-  <li>Every email includes an unsubscribe link specific to that person and that list.</li>
-  <li>Emails go out via the site's own configured SMTP settings -- if those aren't set up, sends
-    will fail quietly in the background rather than error here; check the Audit Log if subscribers
-    report not receiving anything.</li>
+  <li>The <a href="${ctx}/admin/audit-log">Audit Log</a> records that a send was
+    <strong>queued</strong> (event type <code>newsletter.enqueue</code>) and how many recipients
+    it targeted at that moment -- it does <strong>not</strong> record final per-recipient delivery
+    outcomes for the SMTP path, since those happen later, asynchronously, outside this request.</li>
+  <li>For the SMTP path, a failed send (after all 3 retries) is only visible in the
+    <strong>application server logs</strong> ("Newsletter send error" entries) -- if a send seems
+    to have stalled or subscribers report widespread non-delivery, that's the next place to look,
+    which typically means asking whoever has server access.</li>
+  <li>For the MailChimp path, check the campaign's status directly in the
+    <strong>MailChimp dashboard</strong> -- delivery and bounce reporting live there, not here.</li>
+  <li>If nothing was configured at all when you tried to send, see the warning below -- that's the
+    one failure mode this page actively catches before you click send.</li>
 </ul>
+
+<c:if test="${!sendMethodConfigured}">
+  <div class="callout radius alert" style="margin-bottom:20px">
+    <p style="margin-bottom:0">
+      <i class="fa fa-exclamation-triangle"></i> <strong>No email delivery method is configured.</strong>
+      Sending now would queue recipients that can never actually be delivered. Set up SMTP on
+      <a href="${ctx}/admin/mail-properties">Email Settings</a>, or enable MailChimp on
+      <a href="${ctx}/admin/mailing-list-properties">Mailing List Settings</a>, before sending.
+    </p>
+  </div>
+</c:if>
 
 <c:if test="${empty mailingLists}">
   <div class="callout radius warning" style="margin-bottom:20px">

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/NewsletterSendWidgetTest.java
@@ -33,6 +33,8 @@ import org.mockito.MockedStatic;
 
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.mailinglists.MailChimpCommand;
 import com.simisinc.platform.application.mailinglists.NewsletterSendCommand;
 import com.simisinc.platform.domain.model.cms.BlogPost;
 import com.simisinc.platform.domain.model.mailinglists.MailingList;
@@ -65,15 +67,72 @@ class NewsletterSendWidgetTest extends WidgetBase {
     lists.add(mailingList(2L, "Disabled List", false));
 
     try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
-        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class)) {
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
       listRepo.when(MailingListRepository::findAll).thenReturn(lists);
       blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(false);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn("smtp.example.org");
 
       WidgetContext result = new NewsletterSendWidget().execute(widgetContext);
 
       List<MailingList> shown = (List<MailingList>) result.getRequest().getAttribute("mailingLists");
       assertEquals(1, shown.size());
       assertEquals("Active List", shown.get(0).getTitle());
+    }
+  }
+
+  @Test
+  void executeReportsNoSendMethodConfiguredWhenNeitherSmtpNorMailChimpAreSetUp() {
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(false);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn(null);
+
+      WidgetContext result = new NewsletterSendWidget().execute(widgetContext);
+
+      assertEquals(false, result.getRequest().getAttribute("sendMethodConfigured"));
+    }
+  }
+
+  @Test
+  void executeReportsSendMethodConfiguredWhenSmtpAloneIsSetUp() {
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(false);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn("smtp.example.org");
+
+      WidgetContext result = new NewsletterSendWidget().execute(widgetContext);
+
+      assertEquals(true, result.getRequest().getAttribute("sendMethodConfigured"));
+      assertEquals(false, result.getRequest().getAttribute("mailChimpEnabled"));
+    }
+  }
+
+  @Test
+  void executeReportsSendMethodConfiguredWhenMailChimpAloneIsEnabled() {
+    try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
+        MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
+      listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
+      blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(true);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn(null);
+
+      WidgetContext result = new NewsletterSendWidget().execute(widgetContext);
+
+      assertEquals(true, result.getRequest().getAttribute("sendMethodConfigured"));
+      assertEquals(true, result.getRequest().getAttribute("mailChimpEnabled"));
     }
   }
 
@@ -133,9 +192,13 @@ class NewsletterSendWidgetTest extends WidgetBase {
 
     try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
         MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
-        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
       listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
       blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(false);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn("smtp.example.org");
 
       WidgetContext result = new NewsletterSendWidget().post(widgetContext);
 
@@ -152,9 +215,13 @@ class NewsletterSendWidgetTest extends WidgetBase {
 
     try (MockedStatic<MailingListRepository> listRepo = mockStatic(MailingListRepository.class);
         MockedStatic<BlogPostRepository> blogRepo = mockStatic(BlogPostRepository.class);
-        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class)) {
+        MockedStatic<NewsletterSendCommand> sendCommand = mockStatic(NewsletterSendCommand.class);
+        MockedStatic<MailChimpCommand> mailChimp = mockStatic(MailChimpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProps = mockStatic(LoadSitePropertyCommand.class)) {
       listRepo.when(MailingListRepository::findAll).thenReturn(new ArrayList<>());
       blogRepo.when(() -> BlogPostRepository.findAll(any(), any())).thenReturn(new ArrayList<>());
+      mailChimp.when(MailChimpCommand::isEnabled).thenReturn(false);
+      siteProps.when(() -> LoadSitePropertyCommand.loadByName("mail.host_name")).thenReturn("smtp.example.org");
 
       new NewsletterSendWidget().post(widgetContext);
 


### PR DESCRIPTION
## Summary
- Expands `/admin/newsletter-send` with in-page guidance: how it works (SMTP vs MailChimp delivery paths), real timing (25/minute, up to 3 retries), common failure causes and fixes, and an honest accounting of monitoring -- there's currently no dedicated send-status view; the Audit Log only records that a batch was **queued**, not per-recipient delivery outcomes for the SMTP path.
- Adds a proactive check: `NewsletterSendWidget` now detects when neither SMTP (`mail.host_name`) nor MailChimp is configured at all, and shows a warning before a send is attempted, rather than only being discoverable after subscribers report nothing arrived.

## Test plan
- [x] Full `ant ci-test` suite: 0 failures
- [x] `compile-jsp` EL/JSP gate: clean
- [x] Live verification in a rehearsal container: page renders correctly with the new guidance and empty-state warnings