### PR TITLE
Fix: duplicate-email validation missing on user edit path

### DIFF
--- a/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
+++ b/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
@@ -80,7 +80,7 @@ public class SaveUserCommand {
       }
       user.setModifiedBy(userBean.getModifiedBy());
       // See if a different user already has this email
-      User userWithEmail = UserRepository.findByUsername(userBean.getEmail());
+      User userWithEmail = UserRepository.findByEmailAddress(userBean.getEmail());
       if (userWithEmail != null && userWithEmail.getId().longValue() != userBean.getId().longValue()) {
         throw new AccountException("Information could not be saved. There is an account with this email address already.");
       }

--- a/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
+++ b/src/main/java/com/simisinc/platform/application/register/SaveUserCommand.java
@@ -79,6 +79,11 @@ public class SaveUserCommand {
         throw new DataException("The existing record could not be found");
       }
       user.setModifiedBy(userBean.getModifiedBy());
+      // See if a different user already has this email
+      User userWithEmail = UserRepository.findByUsername(userBean.getEmail());
+      if (userWithEmail != null && userWithEmail.getId().longValue() != userBean.getId().longValue()) {
+        throw new AccountException("Information could not be saved. There is an account with this email address already.");
+      }
       // Validate (skip if managed by provider)
       if (!isSystemUser) {
         if (user.getId() == userBean.getModifiedBy()) {

--- a/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
@@ -154,15 +154,18 @@ class SaveUserCommandTest {
   void editingUserEmailToOneUsedByADifferentAccountIsRejected() {
     // Editing user (TARGET_ID) attempts to change their email to one already
     // registered to a different account (id 99).
+    // Note: the editing user's username is deliberately different from the
+    // email being claimed, so a check that queries the username column
+    // instead of the email column would miss this collision entirely.
     User editor = userWithRoles(EDITOR_ID, "admin");
     User existing = userWithRoles(TARGET_ID, "users");
     User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users");
+    bean.setUsername("editing-user");
     bean.setEmail("taken@example.com");
-    bean.setUsername("taken@example.com");
 
     User otherAccountWithEmail = userWithRoles(99L, "users");
+    otherAccountWithEmail.setUsername("other-user");
     otherAccountWithEmail.setEmail("taken@example.com");
-    otherAccountWithEmail.setUsername("taken@example.com");
 
     try (MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
          MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
@@ -170,7 +173,7 @@ class SaveUserCommandTest {
       loadUser.when(() -> LoadUserCommand.loadUser(bean.getModifiedBy())).thenReturn(editor);
       loadUser.when(() -> LoadUserCommand.loadUser(bean.getId())).thenReturn(existing);
       genId.when(() -> GenerateUserUniqueIdCommand.generateUniqueId(any(), any())).thenReturn("uniqueid");
-      userRepo.when(() -> UserRepository.findByUsername("taken@example.com")).thenReturn(otherAccountWithEmail);
+      userRepo.when(() -> UserRepository.findByEmailAddress("taken@example.com")).thenReturn(otherAccountWithEmail);
       userRepo.when(() -> UserRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
       AccountException ex = Assertions.assertThrows(AccountException.class,

--- a/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/register/SaveUserCommandTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.mockStatic;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.security.auth.login.AccountException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -146,5 +148,35 @@ class SaveUserCommandTest {
     DataException ex = Assertions.assertThrows(DataException.class,
         () -> runSaveUser(self, self, bean));
     Assertions.assertTrue(ex.getMessage().toLowerCase().contains("admin role from your own account"));
+  }
+
+  @Test
+  void editingUserEmailToOneUsedByADifferentAccountIsRejected() {
+    // Editing user (TARGET_ID) attempts to change their email to one already
+    // registered to a different account (id 99).
+    User editor = userWithRoles(EDITOR_ID, "admin");
+    User existing = userWithRoles(TARGET_ID, "users");
+    User bean = editBeanRequesting(TARGET_ID, EDITOR_ID, "users");
+    bean.setEmail("taken@example.com");
+    bean.setUsername("taken@example.com");
+
+    User otherAccountWithEmail = userWithRoles(99L, "users");
+    otherAccountWithEmail.setEmail("taken@example.com");
+    otherAccountWithEmail.setUsername("taken@example.com");
+
+    try (MockedStatic<LoadUserCommand> loadUser = mockStatic(LoadUserCommand.class);
+         MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+         MockedStatic<GenerateUserUniqueIdCommand> genId = mockStatic(GenerateUserUniqueIdCommand.class)) {
+      loadUser.when(() -> LoadUserCommand.loadUser(bean.getModifiedBy())).thenReturn(editor);
+      loadUser.when(() -> LoadUserCommand.loadUser(bean.getId())).thenReturn(existing);
+      genId.when(() -> GenerateUserUniqueIdCommand.generateUniqueId(any(), any())).thenReturn("uniqueid");
+      userRepo.when(() -> UserRepository.findByUsername("taken@example.com")).thenReturn(otherAccountWithEmail);
+      userRepo.when(() -> UserRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      AccountException ex = Assertions.assertThrows(AccountException.class,
+          () -> SaveUserCommand.saveUser(bean));
+      Assertions.assertTrue(ex.getMessage().toLowerCase().contains("account with this email address already"),
+          "expected a clear duplicate-email message, got: " + ex.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## Summary
- The admin "New User" flow validates duplicate emails with a clear, friendly error. The "Edit User" flow had no equivalent check, so a duplicate collision was only caught by the DB's `UNIQUE` constraint, whose failure gets swallowed inside `UserRepository.update()` (returns null) and surfaces as a generic "could not be saved due to a system error" message instead.
- Added the same explicit duplicate check to the edit branch of `SaveUserCommand.saveUser()`, querying `UserRepository.findByEmailAddress(...)` (the correct email-lookup method already used elsewhere in this codebase) rather than `findByUsername`.
- No data corruption or account-takeover risk existed either way -- the DB constraint always caught real duplicates -- this is purely a validation/error-message quality fix.

## Test plan
- [x] Full `ant ci-test` suite: 0 failures
- [x] `compile-jsp` EL/JSP gate: clean
- [x] New test: editing a user's email to one already used by a different account is rejected with the duplicate-email message