### PR TITLE
Add in-page guidance to the User Groups admin pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/group-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/group-form.jsp
@@ -29,11 +29,23 @@
     <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
   </c:if>
   <%@include file="../page_messages.jspf" %>
+  <c:if test="${group.name eq 'All Users'}">
+    <div class="callout radius warning">
+      <p style="margin-bottom:0">
+        <i class="fa fa-exclamation-triangle"></i> This is the built-in default group every new
+        account is automatically added to, looked up by this exact name. Changing the name here
+        means new accounts stop being found by that lookup and silently miss the group they're
+        supposed to get. If you're trying to reorganize access, create a new group instead.
+      </p>
+    </div>
+  </c:if>
   <%-- Form Content --%>
   <label>Name <span class="required">*</span>
     <input type="text" placeholder="Give it a name..." name="name" aria-describedby="uniqueNameHelpText" value="<c:out value="${group.name}"/>" required>
   </label>
-    <p class="help-text" id="uniqueNameHelpText">The name must be unique</p>
+    <p class="help-text" id="uniqueNameHelpText">Must be unique among groups when creating a new one;
+      editing an existing group does not re-check this, so it's possible (if unwise) to rename one
+      group to collide with another's name.</p>
   <label>Description
     <input type="text" placeholder="Describe it..." name="description" value="<c:out value="${group.description}"/>">
   </label>
@@ -41,6 +53,14 @@
     <input type="text" placeholder="Internal Reference Id..." name="uniqueId" aria-describedby="uniqueIdHelpText" value="<c:out value="${group.uniqueId}"/>">
   </label>
   <p class="help-text" id="uniqueIdHelpText">Leave blank to auto-generate; this value does not usually change! No spaces, use lowercase, a-z, 0-9, dashes</p>
+  <p class="help-text">
+    This isn't just an internal label -- some access rules elsewhere on the site (restricting a page,
+    section, or widget to this group) reference it by this exact Unique Id, not by the Name above.
+    Unlike a Collection's "Access Groups" settings (which track a group by an internal id that
+    doesn't change), those rules match this string directly, so editing it after the group is
+    already in use can silently disconnect them -- they won't error, they'll just stop matching
+    anyone. If in doubt, leave it as-is once set.
+  </p>
   <div class="button-container">
     <input type="submit" class="button radius success expanded" value="Save"/>
   </div>

--- a/src/main/webapp/WEB-INF/jsp/admin/groups-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/groups-list.jsp
@@ -25,6 +25,17 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <%@include file="../page_messages.jspf" %>
+<div class="callout primary radius">
+  <p style="margin-bottom:0">
+    Groups are access-control buckets, separate from <a href="${ctx}/admin/users">Roles</a>. A
+    role decides what an account can <em>do</em> in the admin console (manage users, edit content,
+    and so on); a group decides what content an account can <em>see</em> -- for example, a
+    Collection's "Access Groups" settings can restrict its records to members of a specific group.
+    Use the "Add a user group" form on this page to create a new group; click the pencil next to an
+    existing one to rename or describe it, or the X to delete it. Admin-only -- unlike Users, this
+    page isn't open to community-managers.
+  </p>
+</div>
 <table class="unstriped">
   <thead>
     <tr>
@@ -56,3 +67,26 @@
     </c:if>
   </tbody>
 </table>
+
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>"Error. Group could not be deleted."</strong> This generic message almost always means
+    the group still has members -- deleting it is blocked at the database level rather than silently
+    cascading, so no one's group membership disappears without you noticing. Move or remove its
+    members first (edit each account, or use bulk actions on the
+    <a href="${ctx}/admin/users">Users list</a>), then delete the now-empty group.</li>
+  <li><strong>Don't rename or delete "All Users."</strong> It's the one built-in group every new
+    account -- created here, self-registered, signed up via CSV import, or provisioned via
+    OAuth/SSO -- is automatically added to, by looking up that exact name. Renaming it means those
+    lookups quietly stop finding it, and new accounts stop getting the group they're supposed to.
+    If you need to reorganize access, add a new group instead of repurposing this one.</li>
+  <li><strong>A Collection's "Access Groups" rule for a group you deleted disappeared, or a
+    page/section restricted to a group you deleted no longer seems restricted at all.</strong>
+    Deleting a group doesn't check whether anything still references it for access control -- a
+    Collection's per-group access rule is simply gone along with it, and any other content whose
+    restriction depended solely on that group effectively stops being restricted (no one matches a
+    group that no longer exists), rather than failing loudly. Creating a new group with the same name
+    afterward gets a new internal identity -- it will not automatically reattach to a Collection's old
+    access rule, which has to be reconfigured from scratch on the
+    <a href="${ctx}/admin/collections">Collections</a> page.</li>
+</ul>


### PR DESCRIPTION
## What

The User Groups admin pages (`/admin/groups`, `/admin/group`) had no explanatory text at all -- what a group actually gates, how it differs from a Role, or what to do when a delete fails or a name/unique id needs changing. Same treatment already applied to Users/User Details/Send Newsletter in earlier PRs.

## What changed

- `groups-list.jsp`: intro callout explaining groups vs. roles (groups gate *content* access -- e.g. a Collection's "Access Groups" settings -- roles gate admin *capabilities*), plus a "Common problems" section covering the three real gotchas found while writing this:
  - A generic "Error. Group could not be deleted." almost always means the group still has members -- the `user_groups` foreign key has no cascade, so deletion is blocked at the DB level rather than silently orphaning membership rows.
  - "All Users" is looked up by its exact name (`GroupRepository.findByName("All Users")`) in five separate places (New User creation, CSV import, self-registration, OAuth signup, item-file upload default) -- renaming or deleting it breaks all of them silently.
  - Deleting a group doesn't check whether a Collection's "Access Groups" rule still references it -- that access rule just disappears, and recreating a same-named group gets a new internal id, so it does not automatically reattach.
- `group-form.jsp`: a warning callout when editing the "All Users" group specifically, a corrected note that name-uniqueness is only checked on create (not on edit -- confirmed in `SaveGroupCommand.saveGroup()`), and an explanation of why the Unique Id field matters more than its current one-line hint suggests -- some access rules elsewhere reference a group by this exact string, not by name or internal id, so editing it after the group is in use can silently disconnect those rules without erroring.

## Verification

- `ant -lib lib/war compile-jsp`: BUILD SUCCESSFUL, 0 errors
- `python3 tools/check-unescaped-el.py`: 0 unallowlisted findings
- `ant ci-test`: BUILD SUCCESSFUL, all tests green (JSP-only change, no Java touched)