### PR TITLE
Add in-page guidance to the Users admin pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-details.jsp
@@ -118,6 +118,14 @@
   <hr>
 </div>
 <%@include file="../page_messages.jspf" %>
+<div class="callout primary radius">
+  <p style="margin-bottom:0">
+    Full detail and every single-account action for this one user. Bulk equivalents (suspend,
+    unsuspend, reset password, grant a role) live on the <a href="${ctx}/admin/users">Users list</a>;
+    a few actions here -- Delete, Unlock, and approving/denying an unsuspend request -- don't exist
+    there at all.
+  </p>
+</div>
 <div class="grid-container">
 <div class="grid-x">
   <div class="small-12 medium-6 large-4 cell">
@@ -409,6 +417,80 @@
 </div>
 <hr>
 <p><a href="${ctx}/admin/users"><i class="fa fa-angle-double-left"></i> Back to list</a></p>
+
+<h5>Actions, explained</h5>
+<ul>
+  <li><strong>Reset Password</strong> emails the account a password-reset link -- it doesn't set or
+    reveal a password directly. Sending it requires you (the admin) to re-enter your own password or
+    authenticator code first.</li>
+  <li><strong>Suspend Account</strong> immediately blocks sign-in. The modal marks a reason as
+    required, but that's enforced by the form, not the server. You can't suspend your own account, or
+    one with a higher role level than yours -- an explicit error message says so if you try, e.g. from
+    a stale page or a shared link.</li>
+  <li><strong>Restore Account / Request Unsuspend&hellip;</strong> -- which one you see depends on the
+    target's role. A non-elevated account restores in one click. A community-manager-or-above account
+    instead requires a second, <em>different</em> admin's approval -- filing the request notifies
+    other eligible admins, and you can't also approve your own request.</li>
+  <li><strong>Approve Unsuspend Request / Deny Unsuspend Request</strong> only appear when a request is
+    pending <em>and</em> it was filed by someone else. Approving requires your own step-up
+    re-authentication, restores the account, and immediately invalidates its password -- the account
+    holder gets an email to set a new one before they can sign in again. Denying just requires a
+    reason and leaves the account suspended.</li>
+  <li><strong>Unlock Account</strong> only appears once the account is actually locked (too many failed
+    sign-in attempts). It clears the failed-attempt counter and lockout timer only -- it does not
+    touch the password, MFA, or suspension status.</li>
+  <li><strong>Delete Account</strong> is permanent, with no confirmation beyond the browser's own "Are
+    you sure?" prompt. It fails safely, with an explicit error rather than a partial delete, if the
+    account is still referenced elsewhere in the database (it authored content, owns uploaded files,
+    etc. -- see "Common problems" below). You can't delete your own account --
+    <strong>but unlike Suspend and Restore above, deleting an account with a higher role level than
+    yours is not currently blocked.</strong> A community-manager can permanently delete an admin
+    account from here. Treat this as a real gap, not a safety net: double-check who you're deleting,
+    especially on this page specifically.</li>
+</ul>
+
+<h5>Reading the detail grid</h5>
+<ul>
+  <li><strong>Validated</strong> shows when the account's invitation or password-reset link was
+    actually used. "Not Validated" means that step has never happened and the account can't sign in
+    yet, regardless of what the Status badge next to the name says.</li>
+  <li><strong>Password Changed</strong> gets an <span class="label warning">Aging</span> or
+    <span class="label alert">Overdue</span> badge once it passes the site's configured password-age
+    threshold (Overdue at twice that threshold). An account whose password change was never tracked
+    is always shown as Overdue -- there's no way to distinguish "recently created" from "ancient,
+    unmonitored password" from this field alone.</li>
+  <li><strong>MFA</strong> here is a status display only -- there is currently no action on this page
+    to reset or disable a user's MFA. See the callout below if that's what you need.</li>
+</ul>
+
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>"You cannot suspend/restore an account with a higher role level than your
+    own."</strong> A community-manager can act on ordinary users but not on admins (or another account
+    holding a higher-level custom role) -- enforced here even if the action is reached via a
+    bookmarked link. This specific check covers Suspend and Restore only; see the Delete Account
+    warning above for the one action it doesn't currently cover.</li>
+  <li><strong>Restore doesn't take effect immediately.</strong> Expected for a community-manager-and-
+    above account -- it needs a second, different administrator's approval. Check who requested it in
+    the banner at the top of this page, or on <a href="${ctx}/admin/unsuspend-requests">Unsuspend
+    Requests</a>.</li>
+  <li><strong>A user is locked out of MFA</strong> (lost their device, no backup codes left). There is
+    no admin "Reset MFA" action on this page today -- see the callout below.</li>
+  <li><strong>Delete failed with "referenced in other tables."</strong> The account owns something
+    else in the system (content, files, form submissions, etc.) that deleting it outright would
+    orphan. Suspending instead of deleting is usually the safer option here.</li>
+</ul>
+
+<div class="callout radius" style="margin-bottom:20px">
+  <p style="margin-bottom:0">
+    <i class="fa fa-info-circle"></i> <strong>Coming soon, not yet available:</strong> a "Reset MFA"
+    action on this page for an account that's lost its authenticator device. Also, the
+    "Capability Grants" link above is currently shown to every community-manager who can reach this
+    page, even though that page itself is admin-only -- a community-manager who clicks it today just
+    hits an access-denied page.
+  </p>
+</div>
+
 <div class="reveal" id="resetPasswordReveal" role="dialog" aria-modal="true" aria-labelledby="resetPasswordRevealTitle"
      data-reveal data-close-on-click="true">
   <h4 id="resetPasswordRevealTitle">Reset Password</h4>

--- a/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
@@ -258,6 +258,10 @@
             <label>Roles</label>
           </div>
           <div class="small-9 cell">
+            <p class="help-text" style="margin-bottom:6px">You can only grant a role at or below your
+              own highest role level; a role you check above that level is silently not saved (no
+              error is shown) -- and a role the account already holds above your level stays in place
+              either way, whether or not you touch this list.</p>
             <c:forEach items="${roleList}" var="role">
               <c:choose>
                 <c:when test="${role.code eq 'admin' && !userSession.hasRole('admin')}"><%-- --%></c:when>
@@ -275,6 +279,8 @@
             <label>Groups</label>
           </div>
           <div class="small-9 cell">
+            <p class="help-text" style="margin-bottom:6px">Unlike roles, group membership isn't
+              level-ranked -- anyone who can reach this form can add or remove any group.</p>
             <c:forEach items="${groupList}" var="group">
               <input id="groupId${group.id}" type="checkbox" name="groupId${group.id}" value="${group.id}" <c:if test="${user.hasGroup(group.uniqueId)}">checked</c:if>/><label for="groupId${group.id}"><c:out value="${group.name}" /></label><br />
             </c:forEach>

--- a/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/users-list.jsp
@@ -31,6 +31,16 @@
   <h1><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h1>
 </c:if>
 <%@include file="../page_messages.jspf" %>
+<div class="callout primary radius">
+  <p style="margin-bottom:0">
+    Every account on the site: search and filter, add one at a time or in bulk, and act on many at
+    once (suspend, unsuspend, reset password, grant a role). Click a name to open that account's
+    <a href="${ctx}/admin/user-details">full detail page</a>, including its own actions (delete,
+    unlock, approve/deny an unsuspend request). Reachable by <strong>admin</strong> and
+    <strong>community-manager</strong> -- a community-manager has everything here except granting a
+    role above their own level, and the guardrails below apply the same way to both.
+  </p>
+</div>
 <c:if test="${pendingUnsuspendRequestCount gt 0}">
   <div class="callout warning radius">
     <a href="${ctx}/admin/unsuspend-requests">
@@ -389,6 +399,119 @@
     </div>
   </form>
 </div>
+
+<hr>
+<h5>Adding users</h5>
+<ul>
+  <li><strong>New User</strong> creates one account and emails it an invitation with instructions to
+    set a password. The account shows as <strong>Inactive</strong> until that link is used -- there's
+    no separate "activate" step, using the link is what activates it.</li>
+  <li><strong>Upload CSV File</strong> creates many accounts at once. The file needs
+    <code>Email</code>, <code>First Name</code>, and <code>Last Name</code> columns; an optional
+    <code>Groups</code> column (comma-separated group names) adds group membership beyond the default
+    "All Users", and an optional <code>Date</code> column (<code>yyyy-MM-dd hh:mm:ss</code>) backdates
+    the created timestamp. A row is skipped as a likely duplicate, silently and not reported as an
+    error, if its email already matches an existing account's <em>username</em> -- true for any
+    account still using the default (its username was never set separately from its email), but not
+    a guaranteed email-uniqueness check once an account's username has been customized away from its
+    email on the edit form.
+    <strong>Unlike New User, CSV import sends no invitation email and grants no role</strong> -- every
+    imported account can't sign in until an admin explicitly sends it a password-reset email (select
+    the imported rows on this page and use <strong>Reset Password</strong> below), and has no role
+    beyond default group membership until one is granted via <strong>Assign Roles</strong> or the
+    account's own <a href="${ctx}/admin/user-details">detail page</a>.</li>
+  <li>The roles offered on the <strong>New User</strong> form are capped at
+    <strong>your own highest role level</strong> -- you can't grant admin from this form unless you
+    are yourself an admin, and community-managers won't see it as an option at all. CSV import has no
+    role selection at all, at any level -- see above.</li>
+</ul>
+
+<h5>Bulk actions</h5>
+<p>
+  Select rows with the checkboxes to reveal the bulk action bar. Selection is scoped to <strong>the
+  current page of results</strong> only (up to <c:out value="${recordPaging.pageSize}" /> at a time,
+  and a request is rejected outright, never silently trimmed, past 100 ids) -- "select all" does not
+  reach across pages.
+</p>
+<ul>
+  <li><strong>Assign Roles</strong> adds one role to every selected account; it never removes an
+    existing role, and an account that already has the role is counted as already-done, not a
+    failure. The <em>grant itself</em> is capped at your own role level either way -- but unlike New
+    User's role checkboxes, this dropdown's visible options aren't filtered by level, only "admin" is
+    hidden from non-admins by name. A community-manager may still see a role above their own level
+    listed here; picking it and submitting is rejected, just not hidden from the list first.</li>
+  <li><strong>Reset Password</strong> emails password-reset instructions to every selected account,
+    same as the single-account action on its detail page.</li>
+  <li><strong>Suspend</strong> requires a reason (via the modal; a raw request without one is not
+    rejected server-side the way Deny/Request Unsuspend are) and skips your own account if it's in
+    the selection -- suspending yourself out of the admin console isn't possible from here or from
+    the detail page. A suspended account can't sign in until it's unsuspended.
+    <strong>Unlike the single-account Suspend action on the detail page, this bulk action does not
+    currently check whether a selected account outranks you</strong> -- a community-manager can bulk-
+    suspend an admin account here even though they'd be refused doing the same thing one at a time
+    from that account's own page. Treat that gap as a reason to double-check a selection before
+    suspending in bulk, not as protection you can rely on.</li>
+  <li><strong>Unsuspend</strong> restores a suspended account directly -- <em>unless</em> that account
+    holds an elevated role (community-manager and above), in which case it can't be reactivated by one
+    admin acting alone: it's filed as a request instead, and a <em>different</em> eligible admin has to
+    review and approve it from that account's <a href="${ctx}/admin/user-details">detail page</a>
+    (or from <a href="${ctx}/admin/unsuspend-requests">Unsuspend Requests</a>). A reason is required
+    only when at least one selected account is elevated. Approval immediately invalidates the account's
+    password, so its owner has to set a new one.</li>
+  <li><strong>Reset Password</strong> and <strong>Assign Roles</strong> both require you to re-enter
+    your own password or authenticator code first (a "step-up" prompt) -- this re-authentication is
+    good for 5 minutes per session, so acting on several batches in a row won't re-prompt every time.
+    A missing or wrong step-up code rejects the whole batch before anything happens; nothing is done
+    partially.</li>
+  <li>No bulk action can ever grant a role above your own level or apply to more than 100 accounts at
+    once -- both are enforced on every account in the batch, not just checked once up front, so a
+    mixed selection can't slip a higher-level role grant through. The equivalent protection against
+    acting on an account that outranks you exists for Assign Roles' grant and (indirectly, via the
+    maker-checker approval requirement) for Unsuspend, but currently does <strong>not</strong> exist
+    for bulk Suspend -- see above.</li>
+</ul>
+
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>A CSV-imported user says they can't sign in.</strong> Expected -- CSV import sends no
+    invitation. Select them here and use bulk <strong>Reset Password</strong> to send them a
+    password-setup link.</li>
+  <li><strong>An admin role isn't offered when adding or promoting someone.</strong> You can only
+    grant a role at or below your own highest role level. If you need to grant admin and aren't one
+    yourself, an existing admin needs to do it (or grant you the role first).</li>
+  <li><strong>"You cannot suspend/restore an account with a higher role level than your own."</strong>
+    The same role-level guard that limits what you can grant also limits who you can act on for the
+    single-account Suspend and Restore actions on a detail page -- a community-manager can't suspend
+    or restore an admin account that way. That specific check does not extend to bulk Suspend on this
+    page (see "Bulk actions" above) or to Delete Account on the detail page, which today only blocks
+    deleting your own account, not a higher-level one.</li>
+  <li><strong>Unsuspending an elevated account didn't restore it immediately.</strong> By design -- a
+    community-manager or higher account requires a second, different admin's approval. Check
+    <a href="${ctx}/admin/unsuspend-requests">Unsuspend Requests</a> for its status.</li>
+  <li><strong>"Too many accounts were selected."</strong> The cap is 100 per bulk action. Narrow the
+    filters/search first, or run the action in smaller batches.</li>
+</ul>
+
+<h5>What to monitor</h5>
+<p>
+  The <a href="${ctx}/admin/audit-log">Audit Log</a> records every action on this page individually --
+  each account in a bulk batch gets its own event (so you can see exactly which 3 of 40 selected
+  accounts failed), plus one summary event for the batch as a whole. Watch in particular for repeated
+  <code>user.disable</code> (suspensions) or <code>user.delete</code> events you didn't expect, and for
+  the <span class="label warning radius">unsuspend request awaiting review</span> banner at the top of
+  this page piling up -- a growing queue usually means there aren't enough admins available to approve
+  each other's unsuspend requests (remember: the requester can't approve their own).
+</p>
+
+<div class="callout radius" style="margin-top:10px">
+  <p style="margin-bottom:0">
+    <i class="fa fa-info-circle"></i> <strong>Coming soon, not yet available:</strong> a CSV export/
+    download button on this page, a "Reset MFA" action on the account detail page, and moving this
+    page's access check from a hardcoded role list to the newer capability-grant system (so a custom
+    role could be given user-management access without also being a full community-manager).
+  </p>
+</div>
+
 <%--<script nonce="${cspNonce}">--%>
 <%--  $(document).on('open.zf.reveal', '[data-reveal]', function () {--%>
 <%--    let modal = $(this);--%>


### PR DESCRIPTION
## What

`/admin/users`, `/admin/user-details`, and `/admin/modify-user` had no explanatory text -- what each bulk action actually does, why CSV-imported users can't sign in until someone resets their password, what the step-up re-authentication prompts are for, or what a "higher role level" error means. Same treatment already applied to Send Newsletter (#1039) and now User Groups (#1041).

## What changed

- `users-list.jsp`: intro callout + sections on adding users (New User vs. CSV import, including CSV's real duplicate-detection behavior and that it sends no invite/grants no role), bulk actions (selection scope, the 100-account cap, step-up requirements, the two-admin unsuspend-approval flow), common problems, and what to monitor via the Audit Log.
- `user-details.jsp`: intro callout + a full walkthrough of every action in the dropdown menu, how to read the detail grid (Validated, Password Changed severity badges, MFA display), and common problems.
- `user-form.jsp` (the edit form): short inline notes on the role-grant level cap and the step-up requirement.

## A note on accuracy

I wrote this against an adversarial verification pass (a separate agent re-reading the actual widget/command source against every claim in the new text, not just proofreading). It caught two real inaccuracies in my first draft, both now corrected in this PR:

- I'd claimed bulk Suspend and Delete Account are blocked against acting on a higher-role account, the same way single-account Suspend/Restore are. They're not -- `UsersListWidget.bulkSuspendAction()` and `UserDetailsWidget.deleteAccount()` have no `targetOutranksActor()` check on current `main`. Both gaps are already fixed in #1037 (open, not yet merged) -- I left a comment there confirming they're live issues, not just theoretical. This PR describes today's actual (unpatched) behavior rather than the post-#1037 state, per this repo's convention of flagging pending-not-yet-merged behavior explicitly instead of describing it as already live.
- A couple of smaller claims (the CSV duplicate check, the Bulk Assign Roles dropdown's filtering) were also corrected to match the real code rather than the intended behavior.

## Verification

- `ant -lib lib/war compile-jsp`: BUILD SUCCESSFUL, 0 errors
- `python3 tools/check-unescaped-el.py`: 0 unallowlisted findings
- `ant ci-test`: BUILD SUCCESSFUL, all tests green (JSP-only change, no Java touched)