### PR TITLE
Exclude "All Guests" group from the edit-user Groups checkbox list

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidget.java
@@ -143,11 +143,20 @@ public class UserFormWidget extends GenericWidget {
       userBean.setRoleList(userRoleList);
     }
 
-    // Populate the groups
+    // Populate the groups -- "All Guests" has no checkbox on this form (see users-list.jsp's New
+    // User modal, "not a logged in user group"); if the target already belongs to it, e.g. via
+    // CSV/OAuth group provisioning, preserve that rather than letting an unrelated save drop it.
     List<Group> groupList = GroupRepository.findAll();
     if (groupList != null) {
+      boolean targetHasAllGuests = targetAlreadyHasAllGuests(userBean.getId());
       List<Group> userGroupList = new ArrayList<>();
       for (Group group : groupList) {
+        if ("All Guests".equals(group.getName())) {
+          if (targetHasAllGuests) {
+            userGroupList.add(group);
+          }
+          continue;
+        }
         String groupValue = context.getParameter("groupId" + group.getId());
         if (groupValue != null && groupValue.equals(String.valueOf(group.getId()))) {
           userGroupList.add(group);
@@ -229,5 +238,26 @@ public class UserFormWidget extends GenericWidget {
       }
     }
     return codes;
+  }
+
+  /**
+   * True when the target user already belongs to "All Guests" -- a group this form has no
+   * checkbox for (see users-list.jsp's New User modal, "not a logged in user group"). Existing
+   * membership is preserved rather than dropped by an unrelated save.
+   */
+  private static boolean targetAlreadyHasAllGuests(long userId) {
+    if (userId < 0) {
+      return false;
+    }
+    User existing = LoadUserCommand.loadUser(userId);
+    if (existing == null || existing.getGroupList() == null) {
+      return false;
+    }
+    for (Group group : existing.getGroupList()) {
+      if ("All Guests".equals(group.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/user-form.jsp
@@ -276,7 +276,14 @@
           </div>
           <div class="small-9 cell">
             <c:forEach items="${groupList}" var="group">
-              <input id="groupId${group.id}" type="checkbox" name="groupId${group.id}" value="${group.id}" <c:if test="${user.hasGroup(group.uniqueId)}">checked</c:if>/><label for="groupId${group.id}"><c:out value="${group.name}" /></label><br />
+              <c:choose>
+                <c:when test="${group.name eq 'All Guests'}">
+                  <%-- not a logged in user group --%>
+                </c:when>
+                <c:otherwise>
+                  <input id="groupId${group.id}" type="checkbox" name="groupId${group.id}" value="${group.id}" <c:if test="${user.hasGroup(group.uniqueId)}">checked</c:if>/><label for="groupId${group.id}"><c:out value="${group.name}" /></label><br />
+                </c:otherwise>
+              </c:choose>
             </c:forEach>
           </div>
         </div>

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/login/UserFormWidgetTest.java
@@ -31,6 +31,7 @@ import org.mockito.MockedStatic;
 import com.simisinc.platform.WidgetBase;
 import com.simisinc.platform.application.LoadUserCommand;
 import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Group;
 import com.simisinc.platform.domain.model.Role;
 import com.simisinc.platform.domain.model.User;
 import com.simisinc.platform.infrastructure.persistence.GroupRepository;
@@ -187,6 +188,71 @@ class UserFormWidgetTest extends WidgetBase {
       List<String> codes = captor.getValue().getRoleList().stream().map(Role::getCode).toList();
       Assertions.assertTrue(codes.contains("admin"), "a higher role the target already holds must be preserved, not stripped");
       Assertions.assertTrue(codes.contains("content-editor"));
+    }
+  }
+
+  @Test
+  void postCannotGrantAllGuestsGroupEvenIfSubmitted() throws Exception {
+    // "All Guests" has no checkbox on the edit form (see users-list.jsp's New User modal, "not a
+    // logged in user group"), but the server must refuse it even if a request forges the parameter --
+    // the fix can't rely on the checkbox being hidden client-side.
+    setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
+    addQueryParameter(widgetContext, "id", "-1");
+    Group allGuests = new Group("All Guests", "all-guests");
+    allGuests.setId(9L);
+    addQueryParameter(widgetContext, "groupId9", "9");
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(List.of(allGuests));
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(savedUser());
+
+      new UserFormWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      List<String> names = captor.getValue().getGroupList().stream().map(Group::getName).toList();
+      Assertions.assertFalse(names.contains("All Guests"), "a new membership in 'All Guests' must never be granted through this form");
+    }
+  }
+
+  @Test
+  void editingExistingUserPreservesAllGuestsMembershipItAlreadyHeld() throws Exception {
+    // A user can already be a member of "All Guests" from a path that isn't gated the same way
+    // (e.g. CSV import's Groups column, or an OAuth group claim). Since the checkbox is hidden,
+    // an unrelated save must not silently drop that pre-existing membership.
+    setRoles(widgetContext, ADMIN);
+    grantStepUp(widgetContext);
+    addQueryParameter(widgetContext, "id", "5"); // editing an existing user; groupId9 left unchecked
+
+    Group allGuests = new Group("All Guests", "all-guests");
+    allGuests.setId(9L);
+    User target = new User();
+    target.setId(5L);
+    List<Group> held = new ArrayList<>();
+    held.add(allGuests);
+    target.setGroupList(held);
+
+    ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+    try (MockedStatic<RoleRepository> roleRepo = mockStatic(RoleRepository.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<LoadUserCommand> loadCmd = mockStatic(LoadUserCommand.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<AuditEventCommand> audit = mockStatic(AuditEventCommand.class)) {
+      roleRepo.when(RoleRepository::findAll).thenReturn(allRoles());
+      groupRepo.when(GroupRepository::findAll).thenReturn(List.of(allGuests));
+      loadCmd.when(() -> LoadUserCommand.loadUser(anyLong())).thenReturn(target);
+      saveCmd.when(() -> SaveUserCommand.saveUser(any())).thenReturn(savedUser());
+
+      new UserFormWidget().post(widgetContext);
+
+      saveCmd.verify(() -> SaveUserCommand.saveUser(captor.capture()));
+      List<String> names = captor.getValue().getGroupList().stream().map(Group::getName).toList();
+      Assertions.assertTrue(names.contains("All Guests"), "existing 'All Guests' membership must survive an unrelated save, not be silently stripped");
     }
   }
 }


### PR DESCRIPTION
## Summary

`users-list.jsp`'s New User modal excludes the "All Guests" group from its Groups checkboxes with a `<!-- not a logged in user group -->` comment, but the edit-user form (`user-form.jsp`) had no matching exclusion. An admin could check "All Guests" for a real, logged-in user's account — something the product's own New User flow already treats as invalid.

## Is this a real bug?

Yes, though a narrow one, not a critical vulnerability — filing it as `bug` rather than `security`.

- Group-based folder/collection/item ACL grants (`CheckFolderPermissionCommand`, `CheckItemFolderPermissionCommand`, `CheckCollectionPermissionCommand`) are purely membership-driven: they join `user_groups` against whatever permissions were granted to a `group_id`, with no special-casing by group name. So a real user checked into a group literally named "All Guests" inherits exactly whatever access that group has been granted via `folder_groups`/`collection_groups` — same mechanism as any other group. Nothing crashes and no separate "guest" code path gets confused.
- "All Guests" is **not** a system-seeded group (only `All Users` is seeded in `NEW_10000__new_database.sql`); it only exists if an admin created a group with that exact name. So this only matters in deployments where such a group exists and has been granted meaningful folder/collection permissions.
- The asymmetry does contradict the app's own stated intent: the New User modal was clearly written to keep real accounts out of this group, and the edit form didn't honor that.

## The fix needed more than hiding the checkbox

`UserRepository.update()` does a full delete-then-reinsert of a user's `user_groups` rows on every save, driven entirely by the list `UserFormWidget.post()` builds from submitted checkboxes. If "All Guests" is just hidden from the JSP loop without a matching change on the server side, its checkbox parameter is never submitted — so *any* edit-user save (even one unrelated to groups) would silently strip an existing "All Guests" membership.

That's not a hypothetical: `ProcessUserCSVFileCommand` (CSV import's `Groups` column) and `OAuthUserInfoCommand` (OAuth group-claim mapping) both allow assigning a user to any named group, including "All Guests" — neither excludes it the way the New User modal does. So a real user could already hold that membership via either import path.

`UserFormWidget.post()` now mirrors the "preserve, never grant" pattern the form already uses for role escalation: "All Guests" can never be newly granted through this form (enforced server-side via `targetAlreadyHasAllGuests()`, not just hidden client-side — covered by a test that forges the `groupId` parameter directly), but a pre-existing membership is left untouched rather than silently dropped.

## Follow-up (not in this PR)

CSV import and OAuth group-claim provisioning have the same missing-exclusion gap through entirely separate code paths. Flagging as a follow-up rather than folding into this PR, which is scoped to the edit-user form only.

## Test plan

- [x] `ant -lib lib/war clean compile` — builds clean
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes
- [x] `python3 tools/check-unescaped-el.py --strict .` — 0 unallowlisted findings
- [x] `ant -lib lib/tests ci-test` — full suite, 405 test classes, 0 failures
- [x] `.github/scripts/check-security-coverage.sh` — passes
- [x] `ant -lib lib/war package` — WAR builds
- [x] Added `postCannotGrantAllGuestsGroupEvenIfSubmitted` and `editingExistingUserPreservesAllGuestsMembershipItAlreadyHeld` to `UserFormWidgetTest`; verified both fail with the exact expected assertion when the `UserFormWidget.java` change is reverted, confirming they test the real fix and not something vacuous