### PR TITLE
Fix form Enabled/Check for spam checkboxes never actually saving as off

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidget.java
@@ -68,6 +68,13 @@ public class FormDefinitionFormWidget extends GenericWidget {
     // Populate the fields
     FormDefinition formDefinitionBean = new FormDefinition();
     BeanUtils.populate(formDefinitionBean, context.getParameterMap());
+    // An unchecked checkbox sends no request parameter at all, so BeanUtils.populate() never
+    // overwrites these -- fine for a field that defaults to false (like useCaptcha), but
+    // enabled/checkForSpam default to true on a fresh bean, so leaving them to populate() alone
+    // means unchecking either box in the UI has no effect and always saves as true. Set both
+    // explicitly from parameter presence instead.
+    formDefinitionBean.setEnabled(context.getParameter("enabled") != null);
+    formDefinitionBean.setCheckForSpam(context.getParameter("checkForSpam") != null);
     // createdBy is only honored by the command on insert (it preserves the original value on an
     // edit); modifiedBy always reflects whoever is saving right now
     formDefinitionBean.setCreatedBy(context.getUserId());

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/FormDefinitionFormWidgetTest.java
@@ -104,6 +104,62 @@ class FormDefinitionFormWidgetTest extends WidgetBase {
   }
 
   /**
+   * Guards against reintroducing the bug where unchecking "Enabled?" or "Check for spam?" had no
+   * effect: both fields default to true on a fresh FormDefinition bean, and BeanUtils.populate()
+   * never overwrites a property whose checkbox parameter is simply absent from the request (as an
+   * unchecked checkbox always is), so a form could never actually be disabled through this widget.
+   */
+  @Test
+  void postWithBothCheckboxesUncheckedSavesThemAsFalse() throws InvocationTargetException, IllegalAccessException {
+    FormDefinition existing = new FormDefinition();
+    existing.setId(5L);
+    existing.setUniqueId("contact-us");
+    existing.setName("Contact Us");
+    existing.setEnabled(true);
+    existing.setCheckForSpam(true);
+
+    // Neither "enabled" nor "checkForSpam" is present -- an unchecked HTML checkbox sends no
+    // parameter at all, this is not a value of "false" being submitted
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "name", "Contact Us");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(existing);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      new FormDefinitionFormWidget().post(widgetContext);
+
+      Assertions.assertFalse(existing.getEnabled());
+      Assertions.assertFalse(existing.getCheckForSpam());
+    }
+  }
+
+  @Test
+  void postWithBothCheckboxesCheckedSavesThemAsTrue() throws InvocationTargetException, IllegalAccessException {
+    FormDefinition existing = new FormDefinition();
+    existing.setId(5L);
+    existing.setUniqueId("contact-us");
+    existing.setName("Contact Us");
+    existing.setEnabled(false);
+    existing.setCheckForSpam(false);
+
+    addQueryParameter(widgetContext, "id", "5");
+    addQueryParameter(widgetContext, "name", "Contact Us");
+    addQueryParameter(widgetContext, "enabled", "true");
+    addQueryParameter(widgetContext, "checkForSpam", "true");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(existing);
+      formDefinitionRepository.when(() -> FormDefinitionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      new FormDefinitionFormWidget().post(widgetContext);
+
+      Assertions.assertTrue(existing.getEnabled());
+      Assertions.assertTrue(existing.getCheckForSpam());
+    }
+  }
+
+  /**
    * Guards against reintroducing the createdBy-on-edit bug this codebase has already hit once in a
    * sibling command (mailing lists) -- editing an existing form must not overwrite createdBy with
    * whoever happens to be saving right now.


### PR DESCRIPTION
## What

Found while writing in-page admin guidance for the Form Builder pages: unchecking either "Enabled?" or "Check for spam?" on a form's settings (`/admin/forms` sidebar, or the Form Settings section of `/admin/forms-editor`) has no effect. Both are silently saved as still-on regardless of what's checked, so a form can never actually be taken offline or have spam-checking disabled through this UI once created.

## Why

`FormDefinitionFormWidget.post()` builds a fresh `FormDefinition` bean and populates it with `BeanUtils.populate(formDefinitionBean, context.getParameterMap())`. An unchecked HTML checkbox sends no request parameter at all, so `BeanUtils.populate()` never touches that property -- the bean is simply left at whatever its constructor default was.

`FormDefinition`'s constructor defaults `enabled = true` and `checkForSpam = true`. Since `post()` always starts from `new FormDefinition()` (both on create and edit), unchecking either box just leaves the bean at its already-true default -- there's no request signal that ever reaches `false`. `useCaptcha` happens to work correctly only because it's the one boolean here that defaults to `false`, which is the pattern this codebase's other checkbox-backed widgets (e.g. `BlogFormWidget`, `MailingListFormWidget`) rely on for their own booleans.

## Fix

Set both fields explicitly from parameter presence right after `BeanUtils.populate()`:
```java
formDefinitionBean.setEnabled(context.getParameter("enabled") != null);
formDefinitionBean.setCheckForSpam(context.getParameter("checkForSpam") != null);
```
`SaveFormDefinitionCommand.saveFormDefinition()` already copies both fields straight from the bean (`formDefinition.setEnabled(formDefinitionBean.getEnabled())`, same for `checkForSpam`), so this is the only place the fix needs to live.

## Testing

Added two regression tests to `FormDefinitionFormWidgetTest`: one posts with neither checkbox parameter present and asserts both save as `false`, the other posts with both present and asserts both save as `true`. Ran the existing 4 tests unchanged to confirm no regression.

- `ant ci-test`: BUILD SUCCESSFUL, all tests green