### PR TITLE
Add in-page guidance to the Form Builder admin pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/form-definition-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-definition-form.jsp
@@ -29,6 +29,13 @@
     <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
   </c:if>
   <%@include file="../page_messages.jspf" %>
+  <p class="help-text">
+    <strong>Name is admin-only</strong> -- it labels this form throughout the admin list and editor,
+    and it's the text this form's internal id is generated from, but a visitor never sees it. Title
+    and Subtitle are what actually appear on the public form itself. "Email submissions to" and
+    Success Title/Message control what happens after a visitor submits -- there's no
+    redirect-to-a-URL option; success is a message shown on its own success page.
+  </p>
   <%-- Form Content --%>
   <div class="grid-x grid-margin-x">
     <div class="small-12 medium-6 cell">
@@ -58,6 +65,9 @@
       <label>Email submissions to
         <input type="text" placeholder="name@example.com" name="emailTo" value="<c:out value="${formDefinition.emailTo}"/>">
       </label>
+      <p class="help-text" style="margin-top:-8px">Free text, not validated as an email address -- a
+        typo here means notifications silently go nowhere, with no error shown to you or the
+        submitter.</p>
     </div>
   </div>
   <label>Success Message
@@ -66,6 +76,16 @@
   <input id="useCaptcha" type="checkbox" name="useCaptcha" value="true" <c:if test="${formDefinition.useCaptcha}">checked</c:if>/><label for="useCaptcha">Use Captcha?</label>
   <input id="checkForSpam" type="checkbox" name="checkForSpam" value="true" <c:if test="${formDefinition.checkForSpam}">checked</c:if>/><label for="checkForSpam">Check for spam?</label>
   <input id="enabled" type="checkbox" name="enabled" value="true" <c:if test="${formDefinition.enabled}">checked</c:if>/><label for="enabled">Enabled?</label>
+  <div class="callout radius warning" style="margin-top:10px">
+    <p style="margin-bottom:0">
+      <i class="fa fa-exclamation-triangle"></i> <strong>Known issue:</strong> unchecking "Enabled?"
+      or "Check for spam?" currently has no effect -- both are silently saved as still-on no matter
+      what's checked here, on both a new form and an edit. A fix is in progress. Until it ships, the
+      only way to actually take a form offline is to remove its "Form" widget from the page it's
+      placed on -- disabled-looking submissions here will still go through if the widget stays in
+      place.
+    </p>
+  </div>
   <div class="button-container">
     <c:choose>
       <c:when test="${formDefinition.id eq -1}">

--- a/src/main/webapp/WEB-INF/jsp/admin/form-field-form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-field-form.jsp
@@ -30,6 +30,13 @@
     <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
   </c:if>
   <%@include file="../page_messages.jspf" %>
+  <p class="help-text">
+    Only these six field types exist -- there's no radio-button type (use <strong>Select</strong>
+    for a single-choice dropdown; <strong>Checkbox</strong> with Options is a multi-select group,
+    not a single-choice substitute -- see the note below), no file-upload type, and no CAPTCHA field
+    (CAPTCHA is a whole-form setting on the previous "Form Settings" screen, not something you add
+    per field).
+  </p>
   <%-- Form Content --%>
   <label>Label <span class="required">*</span>
     <input type="text" placeholder="What the visitor sees, e.g. Full Name" name="label" value="<c:out value="${field.label}"/>" required>
@@ -37,6 +44,16 @@
   <label>Name
     <input type="text" placeholder="Auto-generated from the label if left blank" name="name" value="<c:out value="${field.name}"/>">
   </label>
+  <p class="help-text" style="margin-top:-8px">
+    An internal identifier, not shown to visitors. Left blank, it's slugified from the Label.
+    <strong>Known issue, fix in progress:</strong> this doesn't currently check for a collision
+    against this form's other fields, so two fields can end up sharing a Name (including two
+    blank-Name fields that slugify the same way, e.g. both labeled "Email"). That's not just a
+    display quirk -- the live form reads each field's submitted answer back by this exact string, so
+    a shared Name silently makes one field's answer overwrite the other's, and can let a blank
+    second required field pass validation by inheriting the first field's value. Until this is fixed,
+    give every field on a form a distinct Name yourself.
+  </p>
   <label>Type
     <select name="type">
       <option value="text" <c:if test="${empty field.type || field.type eq 'text'}">selected</c:if>>Text</option>
@@ -56,6 +73,19 @@
   <label>Options
     <input type="text" placeholder="Select/Checkbox only, e.g. red=Red,blue=Blue,green=Green" name="options" value="<c:out value="${optionsText}"/>">
   </label>
+  <p class="help-text" style="margin-top:-8px">
+    <strong>Filling this in overrides how the field renders, for every Type, not just Select and
+    Checkbox.</strong> The live form checks "does this field have Options" before it checks Type --
+    so a Text, Email, Textarea, or Date field with Options stops rendering as its normal input and
+    becomes a dropdown instead. This is especially easy to get wrong on an <strong>Email</strong>
+    field: Options turns it into a dropdown of your option keys, but the field's email-format check
+    still runs against whatever was submitted -- so unless your option keys happen to look like email
+    addresses, every submission through that field will fail validation. Leave Options blank unless
+    you specifically want a dropdown. A <strong>Checkbox</strong> field with Options becomes a
+    multi-select group (the visitor can check several) -- not a single-choice substitute for a radio
+    button; use <strong>Select</strong> for that. A Checkbox field left without Options is a single
+    plain checkbox instead.
+  </p>
   <input id="fieldRequired" type="checkbox" name="required" value="true" <c:if test="${field.required}">checked</c:if>/><label for="fieldRequired">Required?</label>
   <div class="button-container">
     <c:choose>
@@ -69,3 +99,18 @@
     </c:choose>
   </div>
 </form>
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>A visitor says they can never successfully submit the form, always getting "&lt;label&gt;
+    is required" for a field that's clearly filled in.</strong> If the page the form actually lives on
+    was built from a template that never renders this field's input at all, the submission looks
+    identical to that field being left blank -- there's no way to tell the two apart from here, and
+    no way for that visitor to ever satisfy a field their form can't physically show. Check that every
+    field marked Required here is actually present on the live page.</li>
+  <li><strong>Where do I see actual submissions, or find out why some are being rejected?</strong>
+    Real, successful submissions are reviewed on <a href="${ctx}/admin/form-data">Form Data</a>
+    (filterable by form, status, and date, with CSV export). For rejections -- missing required
+    fields, invalid email format, failed CAPTCHA, rate limiting -- there's currently no page listing
+    individual failed attempts, only an aggregate count by reason on the Site Analytics dashboard.
+    That's enough to notice a spike, but not to see which specific submission failed or why.</li>
+</ul>

--- a/src/main/webapp/WEB-INF/jsp/admin/form-fields-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/form-fields-list.jsp
@@ -27,8 +27,17 @@
 </c:if>
 <p class="help-text">
   Drag the <i class="fa fa-arrows"></i> handle to reorder fields, click <i class="${font:fas()} fa-edit"></i> to edit
-  a field, or <i class="fa fa-circle-xmark"></i> to remove it. Reordering is saved when you click
-  <strong>Save Field Order</strong> below.
+  a field, or <i class="fa fa-circle-xmark"></i> to remove it. Reordering is staged in the browser
+  only, as you drag -- nothing is saved until you click <strong>Save Field Order</strong> below;
+  navigating away first discards it. There's no limit on how many fields a form can have.
+</p>
+<p class="help-text">
+  Deleting a field is permanent and immediate (no separate save step) -- but it only affects the
+  field definition itself, not anything already submitted through it. Every past submission stores
+  its own independent snapshot of each field's label, name, type, and answer at the moment it was
+  submitted, so removing (or renaming) a field afterward doesn't touch or reformat data already
+  sitting in <a href="${ctx}/admin/form-data">Form Data</a> -- old submissions keep showing the old
+  field as it was, new ones reflect whatever the form looks like now.
 </p>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${empty fieldList}">

--- a/src/main/webapp/WEB-INF/jsp/admin/forms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/forms.jsp
@@ -26,6 +26,13 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <%@include file="../page_messages.jspf" %>
+<div class="callout primary radius">
+  <p style="margin-bottom:0">
+    Each row is a form definition -- its settings, success/notification text, and fields, built here
+    and placed on a live page separately as a "Form" widget. Click a name (or the pencil) to open its
+    full editor for Fields and Form Settings; use the "Add a form" panel to create a new one.
+  </p>
+</div>
 <table class="unstriped">
   <thead>
     <tr>
@@ -64,3 +71,38 @@
     </c:if>
   </tbody>
 </table>
+
+<h5>Putting a form on a live page</h5>
+<p>
+  Building or editing a form here doesn't publish it anywhere by itself. A "Form" widget still needs
+  to be placed on a page (through page/content editing) and pointed at this form via its numeric
+  database id, not the name or the unique id shown under it. That numeric id isn't displayed directly
+  in this list -- the easiest way to find it is to click a form's edit pencil and read the
+  <code>formDefinitionId</code> value out of the resulting URL. The unique id shown here (under the
+  name) is a different, internal value -- it's what submitted data is matched against, and it's what
+  regenerates if you rename the form -- but it isn't what a page uses to display the form.
+</p>
+
+<h5>Deleting a form</h5>
+<p>
+  Deleting a form is permanent and also deletes all of its fields -- the confirmation prompt says so.
+  It does <strong>not</strong> touch any data already submitted through it: submissions are matched to
+  a form by that internal unique id, not a database link back to this row, so prior submissions stay
+  exactly as they were in <a href="${ctx}/admin/form-data">Form Data</a>. One consequence worth
+  knowing: deleting a form frees its unique id for reuse, so a brand-new form later given the same
+  name could end up sharing that internal id with the deleted form's old, now-orphaned submissions.
+</p>
+
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>Unchecking "Enabled" on a form's settings doesn't actually take it offline, and neither
+    does unchecking "Check for spam."</strong> This is a known bug in the current build, not expected
+    behavior -- both checkboxes are silently saved as still-on regardless of what's checked, so a form
+    can't currently be disabled through this UI at all once created. A fix is in progress; until it
+    ships, the only way to stop a form from accepting submissions is to remove the "Form" widget from
+    the page it's placed on.</li>
+  <li><strong>"Form could not be deleted."</strong> Unlike some other admin pages, nothing here is
+    designed to block a delete (no existing-submissions check, no "still referenced elsewhere"
+    guard) -- if you see this, it's most likely a transient database-level failure. Try again, and
+    check the application server logs if it keeps happening.</li>
+</ul>


### PR DESCRIPTION
## What

`/admin/forms`, `/admin/forms-editor` (Form Settings + Fields), and the individual field editor had no explanatory text -- what a form definition actually consists of, how a built form gets placed on a live page (which isn't obvious -- it's by numeric database id, not any of the three name-like fields on the page), what the six field types can and can't do, and what deleting something does or doesn't affect.

## What changed

- `forms.jsp`: intro callout, an explanation of how to actually embed a form on a page (the `formDefinitionId` from the edit URL, since there's no copy-embed-code UI), what deleting a form does (cascades to its fields, never touches submitted data since `form_data` matches by unique-id string, not a foreign key), and a known-issue note that the Enabled/Check for Spam checkboxes on the settings screen don't currently persist when unchecked.
- `form-definition-form.jsp`: field-by-field explanation, corrected to say only Title/Subtitle are visitor-facing (Name is admin-only), and no redirect-URL option exists -- success is a message on its own page.
- `form-fields-list.jsp`: explains the drag-and-drop reorder is staged client-side until "Save Field Order" is clicked, and that deleting/renaming a field never touches prior submissions (each submission stores its own independent label/name/type/value snapshot).
- `form-field-form.jsp`: explains the six field types (no radio, no file upload, no per-field CAPTCHA), the Options field's real behavior, and points to Form Data / the Site Analytics failure-reason tile for reviewing submissions vs. rejections.

## Two real bugs found while writing this, not just documentation gaps

Verified with an adversarial pass (a separate agent re-reading the actual widget/command source against every claim, not just proofreading) before shipping:

1. **Enabled/Check for Spam checkboxes never actually save as off** -- `FormDefinitionFormWidget.post()` populates its bean with `BeanUtils.populate()`, which never overwrites a property whose checkbox parameter is absent (an unchecked box sends none). Both fields default to `true` on a fresh bean, so unchecking either has no effect, create or edit. Fixed in #1044 (open, not yet merged) -- this PR describes today's actual (unpatched) behavior rather than the post-#1044 state, per this repo's convention of flagging pending-not-yet-merged behavior explicitly instead of describing it as already live.
2. **Two fields on the same form can silently share a Name, and the live form doesn't handle it gracefully.** `SaveFormFieldCommand` never checked for a collision, on either the explicit Name input or the label-based auto-slug fallback. On the live form, `WidgetContext.getParameter()` only returns the first value for a repeated HTML field name, so a collision means one field's real answer is silently discarded, and a blank second required field can pass validation by inheriting the first field's value. Fixed in #1046 (open, not yet merged) -- documented here as a known issue describing current (unpatched) behavior, same convention as above.

My first draft of the Options-field guidance also had this backwards -- I'd described it as a harmless no-op outside Select/Checkbox, but it actually forces every field type into a dropdown (the live form checks "has Options" before it checks Type), and breaks Email format validation when combined with that type. Corrected in this PR; no code fix needed there, just accurate documentation of a genuinely confusing-but-consistent behavior.

## Verification

- `ant -lib lib/war compile-jsp`: BUILD SUCCESSFUL, 0 errors
- `python3 tools/check-unescaped-el.py`: 0 unallowlisted findings
- `ant ci-test`: BUILD SUCCESSFUL, all tests green (JSP-only change, no Java touched)
