### PR TITLE
Fix duplicate form field Names silently overwriting each other's data

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/SaveFormFieldCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/SaveFormFieldCommand.java
@@ -16,6 +16,8 @@
 
 package com.simisinc.platform.application.cms;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -90,9 +92,29 @@ public class SaveFormFieldCommand {
     // The html/database field name defaults to a slug of the label, the same conversion
     // FormFieldCommand#generateHtmlName already performs for XML-defined fields, so an admin can
     // leave "Name" blank and still get a valid one
-    String name = StringUtils.isNotBlank(fieldBean.getName())
+    String requestedName = StringUtils.isNotBlank(fieldBean.getName())
         ? fieldBean.getName().trim()
         : FormFieldCommand.generateHtmlName(fieldBean.getLabel(), null);
+    // On the live form, every field's submitted value is read back by this exact string
+    // (FormWidget reads context.getParameter(widgetUniqueId + field.getName())), and a repeated
+    // HTML form-field name only ever yields its FIRST value to getParameter() -- so two fields on
+    // the same form sharing a Name isn't cosmetic, it's silent data loss: the second field's real
+    // answer is discarded and a blank second required field can pass validation by inheriting the
+    // first field's value. Neither the "Name" input's own uniqueness nor the label-based slug this
+    // falls back to when Name is left blank are deduped against sibling fields, so guarantee it here.
+    Set<String> siblingNames = new HashSet<>();
+    List<FormField> siblingFields = FormFieldRepository.findAllByFormDefinitionId(fieldBean.getFormDefinitionId());
+    for (FormField sibling : siblingFields) {
+      if (sibling.getId() != field.getId()) {
+        siblingNames.add(sibling.getName());
+      }
+    }
+    String name = requestedName;
+    int suffix = 2;
+    while (siblingNames.contains(name)) {
+      name = requestedName + "-" + suffix;
+      ++suffix;
+    }
     field.setName(name);
     field.setLabel(fieldBean.getLabel());
     field.setType(StringUtils.isNotBlank(fieldBean.getType()) ? fieldBean.getType() : "text");

--- a/src/test/java/com/simisinc/platform/application/cms/SaveFormFieldCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/SaveFormFieldCommandTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.FormDefinition;
+import com.simisinc.platform.domain.model.cms.FormField;
+import com.simisinc.platform.infrastructure.persistence.cms.FormDefinitionRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.FormFieldRepository;
+
+/**
+ * Verifies {@link SaveFormFieldCommand}, including the sibling-name dedup guard added to stop two
+ * fields on the same form from silently sharing an html/database Name -- on the live form, a
+ * repeated field name only ever yields its first submitted value, so a collision was previously
+ * silent data loss, not just a display quirk.
+ */
+class SaveFormFieldCommandTest {
+
+  private static FormField field(long id, long formDefinitionId, String label, String name) {
+    FormField field = new FormField();
+    field.setId(id);
+    field.setFormDefinitionId(formDefinitionId);
+    field.setLabel(label);
+    field.setName(name);
+    return field;
+  }
+
+  private static List<FormField> siblings(FormField... fields) {
+    return new ArrayList<>(List.of(fields));
+  }
+
+  @Test
+  void savingANewFieldWithNoSiblingsKeepsItsRequestedName() throws DataException {
+    FormField bean = field(-1L, 5L, "Email Address", "email");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings());
+      formFieldRepository.when(() -> FormFieldRepository.getNextFieldOrder(5L)).thenReturn(10);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(bean);
+
+      assertEquals("email", saved.getName());
+    }
+  }
+
+  @Test
+  void aSecondFieldWithAnExplicitNameAlreadyUsedBySiblingGetsANumberedSuffix() throws DataException {
+    FormField existingEmailField = field(1L, 5L, "Email", "email");
+    FormField bean = field(-1L, 5L, "Confirm Email", "email");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings(existingEmailField));
+      formFieldRepository.when(() -> FormFieldRepository.getNextFieldOrder(5L)).thenReturn(20);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(bean);
+
+      assertEquals("email-2", saved.getName());
+    }
+  }
+
+  @Test
+  void twoFieldsWithBlankNamesAndTheSameLabelGetDistinctAutoSlugs() throws DataException {
+    FormField existingEmailField = field(1L, 5L, "Email", "email");
+    // Second field leaves Name blank and happens to reuse the same Label -- the auto-slug fallback
+    // must go through the same dedup check as an explicitly-typed Name, not just the request bean's
+    // own value.
+    FormField bean = field(-1L, 5L, "Email", "");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings(existingEmailField));
+      formFieldRepository.when(() -> FormFieldRepository.getNextFieldOrder(5L)).thenReturn(20);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(bean);
+
+      assertEquals("email-2", saved.getName());
+    }
+  }
+
+  @Test
+  void editingAFieldAndKeepingItsOwnNameIsNotTreatedAsACollisionWithItself() throws DataException {
+    FormField existing = field(7L, 5L, "Email", "email");
+    FormField editBean = field(7L, 5L, "Email Address", "email");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findById(7L)).thenReturn(existing);
+      // The sibling list returned by the repository includes the field's own current row --
+      // the command must exclude it by id, not just by identity, since this is a fresh object.
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings(existing));
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(editBean);
+
+      assertEquals("email", saved.getName());
+    }
+  }
+
+  @Test
+  void editingAFieldToCollideWithADifferentSiblingsNameGetsANumberedSuffix() throws DataException {
+    FormField existing = field(7L, 5L, "Confirm Email", "confirm-email");
+    FormField otherSibling = field(1L, 5L, "Email", "email");
+    FormField editBean = field(7L, 5L, "Confirm Email", "email");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findById(7L)).thenReturn(existing);
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings(existing, otherSibling));
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(editBean);
+
+      assertEquals("email-2", saved.getName());
+    }
+  }
+
+  @Test
+  void threeFieldsCollidingOnTheSameNameEachGetADistinctSuffix() throws DataException {
+    FormField first = field(1L, 5L, "Phone", "phone");
+    FormField second = field(2L, 5L, "Phone", "phone-2");
+    FormField bean = field(-1L, 5L, "Phone", "phone");
+
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+      formFieldRepository.when(() -> FormFieldRepository.findAllByFormDefinitionId(5L)).thenReturn(siblings(first, second));
+      formFieldRepository.when(() -> FormFieldRepository.getNextFieldOrder(5L)).thenReturn(30);
+      formFieldRepository.when(() -> FormFieldRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+      FormField saved = SaveFormFieldCommand.saveField(bean);
+
+      assertEquals("phone-3", saved.getName());
+    }
+  }
+
+  @Test
+  void aBlankLabelIsRejected() {
+    FormField bean = field(-1L, 5L, "", "name");
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+
+      assertThrows(DataException.class, () -> SaveFormFieldCommand.saveField(bean));
+      formFieldRepository.verify(() -> FormFieldRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void anInvalidTypeIsRejected() {
+    FormField bean = field(-1L, 5L, "Label", "name");
+    bean.setType("radio");
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+      formDefinitionRepository.when(() -> FormDefinitionRepository.findById(5L)).thenReturn(new FormDefinition());
+
+      DataException e = assertThrows(DataException.class, () -> SaveFormFieldCommand.saveField(bean));
+      org.junit.jupiter.api.Assertions.assertTrue(e.getMessage().contains("valid field type"));
+      formFieldRepository.verify(() -> FormFieldRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void aMissingFormIsRejected() {
+    FormField bean = field(-1L, -1L, "Label", "name");
+    try (MockedStatic<FormDefinitionRepository> formDefinitionRepository = mockStatic(FormDefinitionRepository.class);
+        MockedStatic<FormFieldRepository> formFieldRepository = mockStatic(FormFieldRepository.class)) {
+
+      assertThrows(DataException.class, () -> SaveFormFieldCommand.saveField(bean));
+      formFieldRepository.verify(() -> FormFieldRepository.save(any()), never());
+    }
+  }
+}


### PR DESCRIPTION
## What

Found while writing in-page admin guidance for the Form Builder pages (#1045): two fields on the same form definition can silently end up with the same internal `name` -- either by an admin explicitly typing a Name another field already uses, or by both fields being left blank and their labels slugifying to the same value (e.g. two fields both labeled "Email").

## Why this matters (not just cosmetic)

Each field renders on the live form with an HTML input name of `widgetUniqueId + field.getName()`. `FormWidget.post()` reads a field's submitted value with `context.getParameter(...)`, and per the servlet spec, `getParameter()` returns only the **first** value when a request has multiple parameters sharing the same name. So two fields with the same `name`:

- Both read back the exact same submitted value in the per-field validation/storage loop -- the second field's real, distinct answer is silently discarded, never stored anywhere.
- A blank second field marked Required can pass validation by inheriting the first field's non-blank value, since both fields are reading the same parameter.

Neither `FormFieldFormWidget` nor `SaveFormFieldCommand` checked for this. The `form_fields.name` column also has no `UNIQUE` constraint, so nothing at the DB layer would have caught it either.

## Fix

`SaveFormFieldCommand.saveField()` now resolves the field's requested name (explicit input, or the existing label-based auto-slug fallback) against its sibling fields on the same form (excluding itself when editing), and appends a numbered suffix (`-2`, `-3`, ...) on collision -- the same suffixing approach `FormFieldCommand.generateHtmlName()` already uses on the legacy XML-defined-fields path, just wired up here too, where it wasn't reachable before.

## Testing

Added `SaveFormFieldCommandTest` covering: no siblings (name kept as-is), an explicit Name colliding with a sibling (gets `-2`), two blank-Name fields with the same Label (auto-slug collision also gets `-2`), editing a field and keeping its own name (not treated as a self-collision), editing a field into colliding with a *different* sibling (gets `-2`), a three-way collision (`-2`, `-3`), plus the existing required-field/type/form-existence validation paths.

- `ant ci-test`: BUILD SUCCESSFUL, all tests green