### PR TITLE
Exclude "All Guests" group from CSV import and OAuth group-claim mapping

### DIFF
--- a/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
+++ b/src/main/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommand.java
@@ -124,7 +124,10 @@ public class ProcessUserCSVFileCommand {
           String[] groups = record.getString("Groups").split(",");
           for (String group : groups) {
             String groupValue = group.trim();
-            if ("All Users".equals(groupValue)) {
+            // "All Guests" has no checkbox on the manual New User/edit-user forms (see
+            // users-list.jsp's New User modal, "not a logged in user group") -- keep this import
+            // path from being able to grant it to a real, logged-in user either.
+            if ("All Users".equals(groupValue) || "All Guests".equals(groupValue)) {
               continue;
             }
             Group thisGroup = GroupRepository.findByName(groupValue);

--- a/src/main/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommand.java
+++ b/src/main/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommand.java
@@ -115,7 +115,12 @@ public class OAuthUserInfoCommand {
       for (JsonNode jsonNode : json.get(groupAttribute)) {
         String groupValue = jsonNode.asText();
         Group thisGroup = GroupRepository.findByOAuthPath(groupValue);
-        if (thisGroup != null) {
+        // "All Guests" has no checkbox on the manual New User/edit-user forms (see
+        // users-list.jsp's New User modal, "not a logged in user group") -- keep an IdP group
+        // claim from being able to grant it to a real, logged-in user either. Checked against the
+        // resolved group's name, not the raw claim value, since oauth_path is an admin-configured
+        // mapping and need not literally read "All Guests".
+        if (thisGroup != null && !"All Guests".equals(thisGroup.getName())) {
           userGroupList.add(thisGroup);
         }
       }

--- a/src/test/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/admin/ProcessUserCSVFileCommandTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.application.audit.SaveAuditEventCommand;
+import com.simisinc.platform.application.cms.SaveFilePartCommand;
+import com.simisinc.platform.application.filesystem.FileSystemCommand;
+import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.cms.FileItem;
+import com.simisinc.platform.infrastructure.persistence.GroupRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * The New User modal (users-list.jsp) has no checkbox for "All Guests" ("not a logged in user
+ * group"), and the edit-user form mirrors that exclusion server-side (see
+ * UserFormWidgetTest#postCannotGrantAllGuestsGroupEvenIfSubmitted). The CSV "Groups" column import
+ * path is a separate route to the same group-membership table and must refuse "All Guests" too,
+ * the same way it already refuses "All Users" (a group every user gets automatically, not one an
+ * import file should be able to name).
+ *
+ * @author SimIS Inc.
+ */
+class ProcessUserCSVFileCommandTest extends WidgetBase {
+
+  private static Group group(long id, String name) {
+    Group g = new Group();
+    g.setId(id);
+    g.setName(name);
+    return g;
+  }
+
+  private static Path writeCsv(Path dir, String content) throws Exception {
+    Path csv = dir.resolve("import.csv");
+    Files.writeString(csv, content, StandardCharsets.UTF_8);
+    return csv;
+  }
+
+  @Test
+  void csvGroupsColumnCannotGrantAllGuests(@TempDir Path tempDir) throws Exception {
+    Path csvFile = writeCsv(tempDir,
+        "Email,First Name,Last Name,Groups\ncsv-user@example.com,CSV,User,All Guests\n");
+
+    FileItem fileItemBean = new FileItem();
+    fileItemBean.setFileServerPath("uploads/import.csv");
+
+    Group allUsers = group(1L, "All Users");
+
+    try (MockedStatic<SaveFilePartCommand> saveFilePart = mockStatic(SaveFilePartCommand.class);
+        MockedStatic<FileSystemCommand> fileSystem = mockStatic(FileSystemCommand.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class);
+        MockedStatic<SaveAuditEventCommand> audit = mockStatic(SaveAuditEventCommand.class)) {
+
+      saveFilePart.when(() -> SaveFilePartCommand.saveFile(any())).thenReturn(fileItemBean);
+      fileSystem.when(FileSystemCommand::getFileServerRootPath).thenReturn(tempDir.toString());
+      fileSystem.when(() -> FileSystemCommand.resolveWithinRoot(any(), any())).thenReturn(csvFile.toFile());
+      groupRepo.when(() -> GroupRepository.findByName("All Users")).thenReturn(allUsers);
+      userRepo.when(() -> UserRepository.findByUsername(anyString())).thenReturn(null);
+
+      ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+      saveCmd.when(() -> SaveUserCommand.saveUser(captor.capture())).thenAnswer(inv -> null);
+
+      ProcessUserCSVFileCommand.processCSV(widgetContext);
+
+      // The row named "All Guests" in its Groups column is skipped by raw value, the same way
+      // "All Users" already is -- it should never even reach a GroupRepository lookup
+      groupRepo.verify(() -> GroupRepository.findByName("All Guests"), never());
+      List<Group> savedGroups = captor.getValue().getGroupList();
+      assertFalse(savedGroups.stream().anyMatch(g -> "All Guests".equals(g.getName())),
+          "a CSV import must never be able to grant 'All Guests' membership");
+      assertEquals(1, savedGroups.size(), "only the default 'All Users' group should be assigned");
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommandGroupMappingTest.java
+++ b/src/test/java/com/simisinc/platform/application/oauth/OAuthUserInfoCommandGroupMappingTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.simisinc.platform.application.admin.LoadSitePropertyCommand;
+import com.simisinc.platform.application.register.SaveUserCommand;
+import com.simisinc.platform.domain.model.Group;
+import com.simisinc.platform.domain.model.User;
+import com.simisinc.platform.domain.model.login.OAuthToken;
+import com.simisinc.platform.infrastructure.persistence.GroupRepository;
+import com.simisinc.platform.infrastructure.persistence.UserRepository;
+
+/**
+ * The New User modal (users-list.jsp) has no checkbox for "All Guests" ("not a logged in user
+ * group"), and the edit-user form mirrors that exclusion server-side (see
+ * UserFormWidgetTest#postCannotGrantAllGuestsGroupEvenIfSubmitted). An OAuth login maps an IdP
+ * group claim to a local Group via {@code oauth_path} and must refuse "All Guests" too -- checked
+ * against the resolved group's name, since the admin-configured oauth_path value need not
+ * literally read "All Guests".
+ *
+ * @author SimIS Inc.
+ */
+class OAuthUserInfoCommandGroupMappingTest {
+
+  private static Group group(long id, String name) {
+    Group g = new Group();
+    g.setId(id);
+    g.setName(name);
+    return g;
+  }
+
+  private static OAuthToken token() {
+    OAuthToken token = new OAuthToken();
+    token.setAccessToken("access-token");
+    return token;
+  }
+
+  @Test
+  void oauthGroupClaimCannotGrantAllGuests() {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode json = mapper.createObjectNode();
+    json.put("preferred_username", "oauthuser");
+    json.put("email", "oauthuser@example.com");
+    json.put("email_verified", true);
+    ArrayNode groups = json.putArray("groups");
+    groups.add("guest-idp-group");
+
+    Group allUsers = group(1L, "All Users");
+    Group allGuests = group(2L, "All Guests");
+
+    try (MockedStatic<OAuthHttpCommand> http = mockStatic(OAuthHttpCommand.class);
+        MockedStatic<LoadSitePropertyCommand> siteProperty = mockStatic(LoadSitePropertyCommand.class);
+        MockedStatic<GroupRepository> groupRepo = mockStatic(GroupRepository.class);
+        MockedStatic<UserRepository> userRepo = mockStatic(UserRepository.class);
+        MockedStatic<SaveUserCommand> saveCmd = mockStatic(SaveUserCommand.class)) {
+
+      http.when(() -> OAuthHttpCommand.sendHttpGet(anyString(), any())).thenReturn(json);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("oauth.role.attribute")).thenReturn(null);
+      siteProperty.when(() -> LoadSitePropertyCommand.loadByName("oauth.group.attribute")).thenReturn("groups");
+      groupRepo.when(() -> GroupRepository.findByName("All Users")).thenReturn(allUsers);
+      groupRepo.when(() -> GroupRepository.findByOAuthPath("guest-idp-group")).thenReturn(allGuests);
+      userRepo.when(() -> UserRepository.findByEmailAddress(anyString())).thenReturn(null);
+      userRepo.when(() -> UserRepository.findByUsername(anyString())).thenReturn(null);
+
+      ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+      User saved = new User();
+      saved.setId(42L);
+      saveCmd.when(() -> SaveUserCommand.saveUser(captor.capture(), eq(true))).thenReturn(saved);
+
+      OAuthUserInfoCommand.createUser(token());
+
+      List<Group> savedGroups = captor.getValue().getGroupList();
+      assertFalse(savedGroups.stream().anyMatch(g -> "All Guests".equals(g.getName())),
+          "an OAuth group claim must never be able to grant 'All Guests' membership");
+      assertTrue(savedGroups.stream().anyMatch(g -> "All Users".equals(g.getName())),
+          "the default 'All Users' group should still be assigned");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR #1043 fixed `user-form.jsp`'s edit-user form so it can't put a real, logged-in user into the "All Guests" group, mirroring the exclusion `users-list.jsp`'s New User modal already had (`<!-- not a logged in user group -->`). That PR's description flagged a follow-up: two other code paths assign group membership by name and have the identical gap.

- `ProcessUserCSVFileCommand` (CSV `Groups` column import) skips `"All Users"` by name but not `"All Guests"`.
- `OAuthUserInfoCommand` (OAuth group-claim mapping via `oauth.group.attribute`) resolves an IdP group claim through `GroupRepository.findByOAuthPath()` with no exclusion at all.

This PR closes both gaps.

## Is this a real bug?

Yes, same narrow classification as #1043 — filing as `bug`, not `security`. Group-based folder/collection/item ACL grants (`CheckFolderPermissionCommand` and friends) are purely membership-driven and name-agnostic, so a real user placed into a group literally named "All Guests" inherits whatever access that group has been granted via `folder_groups`/`collection_groups` — same mechanism as any other group, but contrary to the reserved semantics implied by the New User modal and now the edit-user form. "All Guests" is not system-seeded, so this only matters in deployments where an admin created such a group and granted it meaningful permissions.

## The fix

- **CSV import**: `"All Guests"` is now skipped alongside `"All Users"`, checked against the raw CSV column value before the `GroupRepository.findByName()` lookup — the same shape the existing `"All Users"` exclusion already uses.
- **OAuth group-claim mapping**: the exclusion is checked against the *resolved* group's name after `GroupRepository.findByOAuthPath()` returns, not the raw claim value — `oauth_path` is an admin-configured mapping on the `Group` record and need not literally read "All Guests".

Neither path needs the "preserve, never grant" treatment #1043 added to `UserFormWidget`:
- CSV import only ever creates new users — an existing username is skipped outright (`if (UserRepository.findByUsername(email) != null) continue;`), so there's no existing membership a save could silently strip.
- OAuth login already fully rebuilds a user's group list from the current IdP claims on every login, and `UserRepository.update()` does a delete-then-reinsert of `user_groups` driven by that list regardless of this change — so an OAuth login that doesn't claim "All Guests" already doesn't preserve it today. This fix doesn't change that existing behavior, it just stops OAuth from being able to *grant* it in the first place.

## Test plan

- [x] `ant clean compile` — builds clean
- [x] `ant -lib lib/war compile-jsp` — JSP syntax gate passes (no JSPs touched)
- [x] `python3 tools/check-unescaped-el.py --strict .` — 0 unallowlisted findings
- [x] `ant -lib lib/tests ci-test` — full suite, 0 failures
- [x] `.github/scripts/check-security-coverage.sh` — passes
- [x] `ant -lib lib/war package` — WAR builds
- [x] Added `ProcessUserCSVFileCommandTest#csvGroupsColumnCannotGrantAllGuests` and `OAuthUserInfoCommandGroupMappingTest#oauthGroupClaimCannotGrantAllGuests`; verified both fail with the expected assertion/verification message when their respective fix is reverted, confirming they test the real change and not something vacuous