### PR TITLE
Fix broken Home menu-tab delete protection

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/DeleteMenuTabCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/DeleteMenuTabCommand.java
@@ -41,7 +41,7 @@ public class DeleteMenuTabCommand {
       throw new DataException("The menu tab was not specified");
     }
 
-    if ("/".equals(menuTabBean.getLink()) && menuTabBean.getId() == -1) {
+    if ("/".equals(menuTabBean.getLink())) {
       throw new DataException("The Home menu tab cannot be deleted");
     }
 

--- a/src/test/java/com/simisinc/platform/application/cms/DeleteMenuTabCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/DeleteMenuTabCommandTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.application.cms;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.application.DataException;
+import com.simisinc.platform.domain.model.cms.MenuTab;
+import com.simisinc.platform.infrastructure.persistence.cms.MenuTabRepository;
+
+/**
+ * Verifies {@link DeleteMenuTabCommand}'s validation, in particular that the Home tab guard
+ * actually fires for a real, existing Home tab (its previous {@code menuTabBean.getId() == -1}
+ * condition could never be true alongside a tab that was actually found by id, making the guard
+ * a no-op).
+ *
+ * @author SimIS Inc.
+ */
+class DeleteMenuTabCommandTest {
+
+  @Test
+  void aNullMenuTabIsRejected() {
+    assertThrows(DataException.class, () -> DeleteMenuTabCommand.deleteMenuTab(null));
+  }
+
+  @Test
+  void aMenuTabWithNoIdIsRejected() {
+    MenuTab bean = new MenuTab();
+    assertThrows(DataException.class, () -> DeleteMenuTabCommand.deleteMenuTab(bean));
+  }
+
+  @Test
+  void anExistingHomeTabCannotBeDeleted() {
+    MenuTab bean = new MenuTab();
+    bean.setId(1L);
+    bean.setLink("/");
+    assertThrows(DataException.class, () -> DeleteMenuTabCommand.deleteMenuTab(bean));
+  }
+
+  @Test
+  void aNonHomeTabIsRemovedViaTheRepository() throws DataException {
+    MenuTab bean = new MenuTab();
+    bean.setId(7L);
+    bean.setLink("/solutions");
+
+    try (MockedStatic<MenuTabRepository> repository = mockStatic(MenuTabRepository.class)) {
+      repository.when(() -> MenuTabRepository.remove(bean)).thenReturn(true);
+
+      assertTrue(DeleteMenuTabCommand.deleteMenuTab(bean));
+
+      repository.verify(() -> MenuTabRepository.remove(bean));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `DeleteMenuTabCommand.deleteMenuTab()`'s guard against deleting the Home tab was `"/".equals(menuTabBean.getLink()) && menuTabBean.getId() == -1` -- but any tab actually looked up via `MenuTabRepository.findById()` always has a real id, so `getId() == -1` can never be true at the same time as a real, found Home tab. The guard was dead code: it could never fire for an actual existing Home tab.
- In practice the Home tab was only protected because neither `/admin/sitemap` nor `/admin/sitemap-editor` renders a delete icon for the first (positionally-locked) tab. But both pages' delete action is a direct POST to `?command=delete&menuTabId=<id>` (via the shared `postAction()` helper) -- the exact same request shape the UI's own delete links construct for every other tab. A user who knows or guesses the Home tab's numeric id (commonly the very first row, id 1) could delete it directly, which would break the top navigation menu's Home entry with no server-side objection.
- Fix: the guard now simply checks the link, `if ("/".equals(menuTabBean.getLink()))`, so it actually fires whenever the tab being deleted is the Home tab, regardless of id.

## Test plan
- [x] Added `DeleteMenuTabCommandTest`: null tab rejected, tab with no id rejected, an existing Home tab (`id=1, link="/"`) is now rejected, a non-Home tab is still removed via the repository as before
- [x] `ant ci-test`: BUILD SUCCESSFUL, all tests green