### PR TITLE
Fix spurious failing update on every Navigation Menu save

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/SiteMapEditorWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/SiteMapEditorWidget.java
@@ -73,16 +73,23 @@ public class SiteMapEditorWidget extends GenericWidget {
 
     List<MenuTab> menuTabList = MenuTabRepository.findAll();
     for (MenuTab thisTab : menuTabList) {
-      // Check for a renamed menu tab
+      // Check for a renamed menu tab or icon
       String name = context.getParameter("menuTab" + thisTab.getId() + "name");
-      thisTab.setName(name);
-      // Update the menu tab icon
       String icon = context.getParameter("menuTab" + thisTab.getId() + "icon");
-      thisTab.setIcon(icon);
-      try {
-        SaveMenuTabCommand.renameTab(thisTab);
-      } catch (DataException e) {
-        LOG.error("Rename tab update error: " + e.getMessage());
+      boolean nameChanged = StringUtils.isNotBlank(name) && !name.equals(thisTab.getName());
+      boolean iconChanged = StringUtils.isNotBlank(icon) && !icon.equals(thisTab.getIcon());
+      if (nameChanged || iconChanged) {
+        if (nameChanged) {
+          thisTab.setName(name);
+        }
+        if (iconChanged) {
+          thisTab.setIcon(icon);
+        }
+        try {
+          SaveMenuTabCommand.renameTab(thisTab);
+        } catch (DataException e) {
+          LOG.error("Rename tab update error: " + e.getMessage());
+        }
       }
       // Check for a renamed link
       String link = context.getParameter("menuTab" + thisTab.getId() + "link");

--- a/src/main/java/com/simisinc/platform/presentation/widgets/cms/SiteMapWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/cms/SiteMapWidget.java
@@ -108,16 +108,23 @@ public class SiteMapWidget extends GenericWidget {
 
     List<MenuTab> menuTabList = MenuTabRepository.findAll();
     for (MenuTab thisTab : menuTabList) {
-      // Check for a renamed menu tab
+      // Check for a renamed menu tab or icon
       String name = context.getParameter("menuTab" + thisTab.getId() + "name");
-      thisTab.setName(name);
-      // Update the menu tab icon
       String icon = context.getParameter("menuTab" + thisTab.getId() + "icon");
-      thisTab.setIcon(icon);
-      try {
-        SaveMenuTabCommand.renameTab(thisTab);
-      } catch (DataException e) {
-        LOG.error("Rename tab update error: " + e.getMessage());
+      boolean nameChanged = StringUtils.isNotBlank(name) && !name.equals(thisTab.getName());
+      boolean iconChanged = StringUtils.isNotBlank(icon) && !icon.equals(thisTab.getIcon());
+      if (nameChanged || iconChanged) {
+        if (nameChanged) {
+          thisTab.setName(name);
+        }
+        if (iconChanged) {
+          thisTab.setIcon(icon);
+        }
+        try {
+          SaveMenuTabCommand.renameTab(thisTab);
+        } catch (DataException e) {
+          LOG.error("Rename tab update error: " + e.getMessage());
+        }
       }
       // Check for an added menu item
       String menuItemName = context.getParameter("menuTab" + thisTab.getId() + "menuItemName");

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/SiteMapEditorWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/SiteMapEditorWidgetTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.MenuItem;
+import com.simisinc.platform.domain.model.cms.MenuTab;
+import com.simisinc.platform.infrastructure.persistence.cms.MenuItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.MenuTabRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Guards against the same null-write bug as {@link SiteMapWidgetTest}: the locked/first ("Home")
+ * tab has no rendered Name/Link/Icon inputs on this page either, so saving must not attempt to
+ * rename it to null.
+ *
+ * @author SimIS Inc.
+ */
+class SiteMapEditorWidgetTest extends WidgetBase {
+
+  @Test
+  void savingWithNoNameOrIconParameterForATabDoesNotAttemptToRenameIt() throws InvocationTargetException, IllegalAccessException {
+    MenuTab home = new MenuTab();
+    home.setId(1L);
+    home.setName("Home");
+    home.setLink("/");
+
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class);
+        MockedStatic<MenuItemRepository> menuItemRepository = mockStatic(MenuItemRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(List.of(home));
+      menuItemRepository.when(MenuItemRepository::findAll).thenReturn(Collections.<MenuItem>emptyList());
+
+      new SiteMapEditorWidget().post(widgetContext);
+
+      menuTabRepository.verify(() -> MenuTabRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void savingARealNameChangeSavesIt() throws InvocationTargetException, IllegalAccessException {
+    MenuTab solutions = new MenuTab();
+    solutions.setId(7L);
+    solutions.setName("Solutions");
+    solutions.setLink("/solutions");
+
+    addQueryParameter(widgetContext, "menuTab7name", "Our Solutions");
+
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class);
+        MockedStatic<MenuItemRepository> menuItemRepository = mockStatic(MenuItemRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(List.of(solutions));
+      menuItemRepository.when(MenuItemRepository::findAll).thenReturn(Collections.<MenuItem>emptyList());
+      menuTabRepository.when(() -> MenuTabRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      new SiteMapEditorWidget().post(widgetContext);
+
+      Assertions.assertEquals("Our Solutions", solutions.getName());
+      menuTabRepository.verify(() -> MenuTabRepository.save(solutions));
+    }
+  }
+
+  @Test
+  void executeShowsTheEditor() {
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(Collections.<MenuTab>emptyList());
+
+      WidgetContext result = new SiteMapEditorWidget().execute(widgetContext);
+
+      Assertions.assertEquals(SiteMapEditorWidget.JSP, result.getJsp());
+    }
+  }
+}

--- a/src/test/java/com/simisinc/platform/presentation/widgets/cms/SiteMapWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/cms/SiteMapWidgetTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 SimIS Inc. (https://www.simiscms.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.simisinc.platform.presentation.widgets.cms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.simisinc.platform.WidgetBase;
+import com.simisinc.platform.domain.model.cms.MenuItem;
+import com.simisinc.platform.domain.model.cms.MenuTab;
+import com.simisinc.platform.infrastructure.persistence.cms.MenuItemRepository;
+import com.simisinc.platform.infrastructure.persistence.cms.MenuTabRepository;
+import com.simisinc.platform.presentation.controller.WidgetContext;
+
+/**
+ * Guards against a bug where "Save Site Map Changes" would attempt to null out a tab's Name and
+ * Icon on every save, for every tab, because this page never renders inputs for them (unlike the
+ * Edit Links page) -- the old code always called setName()/setIcon() with whatever
+ * getParameter() returned, which is null when no such input exists.
+ *
+ * @author SimIS Inc.
+ */
+class SiteMapWidgetTest extends WidgetBase {
+
+  @Test
+  void savingTheSiteMapWithNoNameOrIconParametersDoesNotAttemptToRenameAnyTab() throws InvocationTargetException, IllegalAccessException {
+    MenuTab home = new MenuTab();
+    home.setId(1L);
+    home.setName("Home");
+    home.setLink("/");
+
+    addQueryParameter(widgetContext, "method", "sitemap-editor");
+
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class);
+        MockedStatic<MenuItemRepository> menuItemRepository = mockStatic(MenuItemRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(List.of(home));
+      menuItemRepository.when(MenuItemRepository::findAll).thenReturn(Collections.<MenuItem>emptyList());
+
+      new SiteMapWidget().post(widgetContext);
+
+      menuTabRepository.verify(() -> MenuTabRepository.save(any()), never());
+    }
+  }
+
+  @Test
+  void savingASiteMapChangeWithARealNameSavesIt() throws InvocationTargetException, IllegalAccessException {
+    MenuTab solutions = new MenuTab();
+    solutions.setId(7L);
+    solutions.setName("Solutions");
+    solutions.setLink("/solutions");
+
+    addQueryParameter(widgetContext, "method", "sitemap-editor");
+    addQueryParameter(widgetContext, "menuTab7name", "Our Solutions");
+
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class);
+        MockedStatic<MenuItemRepository> menuItemRepository = mockStatic(MenuItemRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(List.of(solutions));
+      menuItemRepository.when(MenuItemRepository::findAll).thenReturn(Collections.<MenuItem>emptyList());
+      menuTabRepository.when(() -> MenuTabRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      new SiteMapWidget().post(widgetContext);
+
+      Assertions.assertEquals("Our Solutions", solutions.getName());
+      menuTabRepository.verify(() -> MenuTabRepository.save(solutions));
+    }
+  }
+
+  @Test
+  void executeShowsTheEditor() {
+    try (MockedStatic<MenuTabRepository> menuTabRepository = mockStatic(MenuTabRepository.class)) {
+      menuTabRepository.when(MenuTabRepository::findAll).thenReturn(Collections.<MenuTab>emptyList());
+
+      WidgetContext result = new SiteMapWidget().execute(widgetContext);
+
+      Assertions.assertEquals(SiteMapWidget.JSP, result.getJsp());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `SiteMapWidget.processSiteMapChanges()` and `SiteMapEditorWidget`'s own copy of the same loop both wrote `thisTab.setName(...)`/`setIcon(...)` unconditionally from `context.getParameter(...)`, unlike the analogous menu-item rename code a few lines below in the same methods, which correctly guards with `StringUtils.isNotBlank(name) && !name.equals(...)`.
- Neither admin page actually renders a Name/Icon input for every tab: `sitemap.jsp` (Navigation Menu Editor) never renders one at all for existing tabs, and `sitemap-editor.jsp` (Edit Links) doesn't render one for the locked/first ("Home") tab. So those request parameters come back `null` for those tabs on every save, and the code proceeded to call `MenuTabRepository.save()` with a null name -- which fails against the `NOT NULL` constraint on `menu_tabs.name`, logged as `"The update failed!"`.
- Net effect: on `sitemap.jsp`, clicking "Save Site Map Changes" attempted (and failed) one wasted `UPDATE` per existing tab, every time. On `sitemap-editor.jsp`, the same happened once per save, for the locked tab only. The `NOT NULL` constraint on `name` happens to prevent any actual data loss (a single `UPDATE` statement's columns commit atomically, so the null-name failure also kept `icon` from being wiped) -- but it's still a wasted DB round trip and an ERROR-level log line on the single most common action on this page.
- Fix: guard both fields with the same not-blank-and-changed check already used for menu-item renames and tab/item links, and only call `SaveMenuTabCommand.renameTab()` when something actually changed.

## Test plan
- [x] Added `SiteMapWidgetTest` and `SiteMapEditorWidgetTest`: saving with no name/icon parameter for a tab no longer calls `MenuTabRepository.save()` at all; saving with a real changed name still saves it correctly
- [x] `ant ci-test`: BUILD SUCCESSFUL, all tests green