### PR TITLE
Add in-page guidance to the Navigation Menu admin pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap-editor.jsp
@@ -28,10 +28,21 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
 <p class="help-text">
-  This page renames existing navigation tabs/items and changes the page they link to. Link must start with /
-  (e.g. /solutions). Reorder tabs and items with the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i>
-  drag handles or the arrow buttons. To add a new tab/item or to delete one, use
+  This page renames existing entries in the drop-down navigation menu across the top of your site, and changes
+  the page they link to -- a <strong>tab</strong> sits in the top bar itself (e.g. "Solutions"), an
+  <strong>item</strong> only appears in the drop-down underneath a tab once a visitor opens it (see the example
+  on the <a href="${ctx}/admin/sitemap">Navigation Menu Editor</a> page if that distinction isn't clear). Link
+  must start with / (e.g. /solutions); if you leave off the leading slash it's added for you rather than
+  rejected. Reorder tabs and items with the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i> drag
+  handles or the arrow buttons. To add a new tab/item or to delete one, use
   <a href="${ctx}/admin/sitemap">Navigation Menu Editor</a> instead.
+</p>
+<p class="help-text">
+  <strong>Save Site Map Changes saves every visible tab and item at once</strong> -- there's no per-row save, so
+  a typo in one field doesn't stop the rest of the page's edits from being saved. As on the Navigation Menu
+  Editor page, the first tab (usually "Home") has no editable Name/Link/Icon fields here, for the same reason:
+  whichever tab links to exactly <code>/</code> is always forced back to the first position on save, so it's
+  never actually reachable through this UI's rename/relink controls.
 </p>
 <%@include file="../page_messages.jspf" %>
 <c:if test="${empty menuTabList}">
@@ -117,6 +128,16 @@
     <a href="${ctx}/admin" class="button radius secondary">Cancel</a>
   </div>
 </form>
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>I changed a tab's Link and now the old page it used to point to has no way to be reached from the
+    menu.</strong> Changing a Link here only repoints the menu entry -- it doesn't touch the underlying page,
+    move it, or add a redirect. If anything still linked to the old path (bookmarks, search results, other
+    pages), set up a redirect separately rather than relying on the menu to keep working.</li>
+  <li><strong>I renamed a tab and the change didn't stick.</strong> Every field on this page is saved together
+    by the single "Save Site Map Changes" button at the bottom -- editing a field and navigating away without
+    clicking it discards that edit along with everything else unsaved on the page.</li>
+</ul>
 <script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
 <script nonce="${cspNonce}">
   var menuTabs = dragula([document.getElementById('site-map-container')], {

--- a/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/sitemap.jsp
@@ -28,12 +28,42 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}"/></h4>
 </c:if>
 <p class="help-text">
-  This page controls the top navigation menu shown on your website -- not an XML sitemap or a visual page map.
-  A <strong>tab</strong> is a top-level menu entry (e.g. "Solutions"); an <strong>item</strong> is a submenu entry
-  shown when a visitor opens a tab. Add tabs and items below, drag the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i>
+  This page designs the drop-down navigation menu shown across the very top of every page on your website --
+  not an XML sitemap and not a visual map of your pages. Everything you add or reorder here shows up immediately,
+  site-wide, for every visitor.
+</p>
+<div class="callout radius" style="max-width:460px;">
+  <p style="margin-bottom:8px;"><strong>Example: what a tab and its items look like to a visitor</strong></p>
+  <div style="border:1px solid #ccc;border-radius:4px;overflow:hidden;font-size:0.9rem;">
+    <div style="background:#2c2c2c;color:#fff;padding:8px 14px;display:flex;gap:20px;">
+      <span>Home</span>
+      <span style="border-bottom:2px solid #fff;padding-bottom:2px;">Solutions &#9662;</span>
+      <span>Contact Us</span>
+    </div>
+    <div style="background:#fff;padding:8px 14px;">
+      <div style="padding:2px 0;">Government Services</div>
+      <div style="padding:2px 0;">Commercial Services</div>
+    </div>
+  </div>
+  <p class="help-text" style="margin-top:8px;margin-bottom:0;">
+    "Solutions" is a <strong>tab</strong> (Name: Solutions, Link: /solutions) sitting in the bar across the top
+    of the site. "Government Services" and "Commercial Services" are <strong>items</strong> -- they only appear
+    in the drop-down underneath "Solutions" when a visitor opens it. A tab with no items just links straight to
+    its own page instead of opening a drop-down at all (that's what "Home" and "Contact Us" are above).
+  </p>
+</div>
+<p class="help-text">
+  Add tabs and items below, drag the <i class="fa fa-arrows-h"></i>/<i class="fa fa-arrows"></i>
   handles to reorder them, or click <i class="fa fa-circle-xmark"></i> to delete one. Changes take effect as soon as you save.
   This page can add and delete tabs/items but not change an existing one's link -- to rename an existing tab/item or change
   where it links, use <a href="${ctx}/admin/sitemap-editor">Navigation Menu Editor - Edit Links</a> instead.
+</p>
+<p class="help-text">
+  The first tab shown below (usually "Home") has no delete icon, no drag handle, and no "Add Item" box --
+  that's not a display bug. Whichever tab's link is exactly <code>/</code> is automatically pinned back to the
+  very first position every time you save a reorder here or on the Edit Links page, so it can never actually be
+  moved, and this page always renders it as locked to match. If your site has no tab linking to exactly
+  <code>/</code>, whichever tab happens to sort first gets this same locked treatment instead.
 </p>
 <%@include file="../page_messages.jspf" %>
 <form method="post">
@@ -134,6 +164,27 @@
     <a href="${ctx}/admin" class="button radius secondary">Cancel</a>
   </div>
 </form>
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>Deleting a tab also deletes every submenu item under it.</strong> The confirmation prompt tells you
+    how many items will go with it, but there's no way to keep the items and only remove the tab -- move anything
+    you want to keep to a different tab first.</li>
+  <li><strong>A visitor sees a tab that opens to nothing, or a submenu item that 404s.</strong> Neither this page
+    nor Edit Links checks that a Link actually points to a real page, and nothing here checks for duplicate
+    links either -- two tabs (or two items) can point at the same page, or at a page that doesn't exist, with no
+    warning.</li>
+  <li><strong>There's no way to temporarily hide a tab or item without deleting it.</strong> Everything added here
+    is immediately live to every visitor; there's no draft or disabled state exposed on this page.</li>
+  <li><strong>Known issue, fixed in progress:</strong> the server-side check that's supposed to block deleting
+    the Home tab even if someone bypasses this page's UI (e.g. by directly hitting the delete action with the
+    Home tab's id) doesn't currently fire. This page's own UI never exposes a way to do that -- the delete icon
+    is never shown for the locked first tab -- so this only matters if something else constructs that request
+    directly.</li>
+  <li><strong>Known issue, fixed in progress:</strong> clicking "Save Site Map Changes" currently attempts (and
+    fails) a wasted update for every existing tab's Name, since this page never actually lets you edit an
+    existing tab's name here -- that has no visible effect (the failed attempt is silently rejected before your
+    real name is touched), but it does mean an error gets logged on the server for every tab on every save.</li>
+</ul>
 <script src="${ctx}/javascript/dragula-3.7.3/dragula.min.js"></script>
 <script nonce="${cspNonce}">
   var menuTabs = dragula([document.getElementById('site-map-container')], {


### PR DESCRIPTION
## What

`/admin/sitemap` (Navigation Menu Editor) and `/admin/sitemap-editor` (Edit Links) had no explanatory text at all -- this is one of the original admin pages. Feedback: people never understood that this page designs the drop-down navigation menu across the top of the site, or the tab/item distinction, so it's stayed confusing since it shipped.

## What changed

- **Navigation Menu Editor** (`sitemap.jsp`): leads with a small visual example -- a mockup of the actual top nav bar (Home / Solutions ▾ / Contact Us) with the "Solutions" drop-down open showing its two items -- to make the tab-vs-item distinction concrete instead of just described. Explains what this page can do (add/delete tabs and items, reorder) and can't (rename, relink -- that's Edit Links), the Home-tab position-locking behavior (whichever tab links to exactly `/` is always pinned back to first on every save), and a Common Problems section (cascade-delete of a tab's items, no duplicate/dead-link checking, no draft/disabled state).
- **Edit Links** (`sitemap-editor.jsp`): explains what it does (rename, relink, reorder -- not add/delete), cross-references the visual example on the Editor page for the tab/item distinction, notes link auto-prefixing, that Save Site Map Changes saves everything on the page at once (no per-row save), and a Common Problems section (changing a Link doesn't move the underlying page or add a redirect; unsaved edits are lost together).

## Two real bugs found while writing this, not just documentation gaps

Verified with an adversarial pass (a separate agent re-reading the actual widget/command source against every claim) before shipping -- all 8 claims checked came back accurate, and the pass also independently surfaced two live bugs:

1. **The Home tab's delete protection was dead code.** `DeleteMenuTabCommand.deleteMenuTab()`'s guard was `"/".equals(link) && id == -1` -- but any tab found by id always has a real id, so that condition could never be true for an actual existing Home tab. The UI never exposes a delete icon for it, but a direct request to the delete action with the Home tab's id would have succeeded. Fixed in #1049 (open, not yet merged).
2. **Every "Save Site Map Changes" click attempted a wasted, failing update.** Both `SiteMapWidget` and `SiteMapEditorWidget` wrote a tab's Name/Icon unconditionally from request parameters, unlike the correctly-guarded menu-item rename code a few lines below. Neither page renders those inputs for every tab (sitemap.jsp never renders them for existing tabs at all; sitemap-editor.jsp doesn't for the locked Home tab), so the parameter comes back null and the save fails against `menu_tabs.name`'s `NOT NULL` constraint, logging an error every time. No actual data loss (the constraint keeps the whole row's update from committing), but real wasted work and log noise on the most common action on this page. Fixed in #1050 (open, not yet merged).

This PR describes today's actual (unpatched) behavior for both, per this repo's convention of flagging pending-not-yet-merged behavior explicitly rather than describing it as already live.

## Verification

- `ant -lib lib/war compile-jsp`: BUILD SUCCESSFUL, 0 errors
- `python3 tools/check-unescaped-el.py`: 0 unallowlisted findings
- `ant ci-test`: BUILD SUCCESSFUL, all tests green (JSP-only change, no Java touched)
- Adversarial fact-check workflow: all 8 verified claims accurate; independently corroborated both bugs above
- Live Docker rehearsal: verified both pages render correctly, including the new visual example