### PR TITLE
Add admin guidance to Web Redirects list page

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/web-redirects-list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/web-redirects-list.jsp
@@ -23,7 +23,7 @@
   <h4><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h4>
 </c:if>
 <%@include file="../page_messages.jspf" %>
-<p class="help-text">Redirects send an incoming request path to another URL with a 301 (permanent) or 302 (temporary) status. They are checked before the legacy CMS_PATH/config/cms/redirects.csv file, so a redirect added here can shadow a not-yet-migrated CSV entry for the same path.</p>
+<p class="help-text">Redirects send an incoming request path to another URL with a 301 (permanent) or 302 (temporary) status. They are checked before the legacy CMS_PATH/config/cms/redirects.csv file, so a redirect added here can shadow a not-yet-migrated CSV entry for the same path. They're also checked before anything else on the site, including an actual live page -- there's nothing stopping a From Path here from matching a page that already works, and if it does, this redirect wins: every visitor hits the redirect instead, silently, with no warning at save time.</p>
 <a class="button small radius primary float-left" href="${ctx}/admin/web-redirect">Add a Redirect <i class="fa fa-arrow-circle-right"></i></a>
 <table class="unstriped">
   <thead>
@@ -78,3 +78,20 @@
     </c:if>
   </tbody>
 </table>
+<h5>Common problems and how to fix them</h5>
+<ul>
+  <li><strong>"The from path conflicts with a reserved system path."</strong> A short list of prefixes --
+    <code>/admin</code>, <code>/login</code>, <code>/logout</code>, <code>/api</code>, and the site's static
+    asset paths, among a few others -- can never be used as a From Path, for any role, so a redirect can't take
+    down the admin console or turn the login page into a phishing link.</li>
+  <li><strong>"This redirect would create a redirect loop."</strong> Saving is blocked if the chain starting
+    from To URL eventually leads back to From Path, whether that's a direct A&harr;B pair or a longer chain that
+    only closes the loop once this redirect is added.</li>
+  <li><strong>"A redirect for that from path already exists."</strong> From Path must be unique -- including
+    against a <em>disabled</em> redirect for the same path, not just enabled ones. Edit or delete the existing
+    row instead of trying to add a second one.</li>
+  <li><strong>Disabling a redirect doesn't bring back a legacy CSV entry for the same path.</strong> Once a From
+    Path exists as a row here at all, it's fully governed by that row for the life of this server -- a disabled
+    row falls through to normal page handling, never to the legacy redirects.csv fallback, even if the CSV still
+    has an entry for that same path.</li>
+</ul>


### PR DESCRIPTION
## Summary
- Strengthens the intro help text on `/admin/web-redirects` to call out that a redirect is checked before an actual live page and silently wins if the From Path collides, with no warning at save time.
- Adds a "Common problems and how to fix them" section explaining the four validation error messages a user can hit when saving a redirect (reserved system path, redirect loop, duplicate from-path, and the fact that a disabled redirect never falls back to a legacy CSV entry for the same path).

All claims were grounded by reading `SaveWebRedirectCommand`, `WebRequestFilter`, `WebRedirectRepository`, and `LoadWebRedirectCommand`, and independently fact-checked via an adversarial verification pass (all 7 checked claims came back accurate, no corrections needed).

The per-field help text on the add/edit form (`web-redirect-form.jsp`) already covered this well from issue #408, so this PR only adds what was missing at the list-page level.

## Test plan
- [x] `ant -lib lib/war ci-test` passes
- [x] Unescaped-EL gate clean
- [x] Adversarial fact-check pass: 7/7 claims accurate