### PR TITLE
Fix ImageUsageCommand to miss wiki page image references

### DIFF
--- a/src/main/java/com/simisinc/platform/application/cms/ImageUsageCommand.java
+++ b/src/main/java/com/simisinc/platform/application/cms/ImageUsageCommand.java
@@ -45,6 +45,10 @@ import com.simisinc.platform.infrastructure.database.DB;
  * <li>raw {@code <img src="...">} tags embedded inside rich-text HTML bodies (CMS content blocks,
  * blog post bodies) -- inserted the same way, via the TinyMCE image-browser integration
  * (see the same JSP's {@code postMessage({mceAction: 'FileSelected', ...})} handler).</li>
+ * <li>the same URL, in markdown image syntax or raw HTML, inside a wiki page body -- unlike the
+ * sources above, {@code wiki-editor.jsp} has no image-browser integration of its own, so an author
+ * gets the URL by copying it from the image-browser popup or from {@code /admin/images}' "Image Link"
+ * and pastes it into the markdown by hand.</li>
  * </ul>
  * This is unrelated to the widget-XML-tree scan the sibling content-block-usage work (#499) uses --
  * that walks page layout structure; this matches a literal URL substring.
@@ -84,6 +88,7 @@ public class ImageUsageCommand {
       { "content", "content", "content_unique_id", "Content Block" },
       { "content", "draft_content", "content_unique_id", "Content Block (draft)" },
       { "blog_posts", "body", "title", "Blog Post" },
+      { "wiki_pages", "body", "title", "Wiki Page" },
   };
 
   private ImageUsageCommand() {

--- a/src/test/java/com/simisinc/platform/application/cms/ImageUsageCommandTest.java
+++ b/src/test/java/com/simisinc/platform/application/cms/ImageUsageCommandTest.java
@@ -49,7 +49,9 @@ import com.simisinc.platform.infrastructure.persistence.cms.ImageRepository;
  * referenced through a plain varchar "image URL" column (e.g. {@code web_pages.page_image_url})
  * must be detected, an image referenced only through a raw {@code <img src="...">} inside an HTML
  * body ({@code content.content}/{@code content.draft_content}) must ALSO be detected -- not just
- * orphaned by omission -- and a genuinely unreferenced image must come back orphaned.
+ * orphaned by omission -- an image referenced only through markdown/HTML pasted into a wiki page
+ * body ({@code wiki_pages.body}) must ALSO be detected, and a genuinely unreferenced image must
+ * come back orphaned.
  *
  * @author SimIS Inc.
  */
@@ -115,6 +117,7 @@ class ImageUsageCommandTest {
       statement.execute("TRUNCATE TABLE images RESTART IDENTITY");
       statement.execute("TRUNCATE TABLE web_pages RESTART IDENTITY");
       statement.execute("TRUNCATE TABLE content RESTART IDENTITY");
+      statement.execute("TRUNCATE TABLE wiki_pages RESTART IDENTITY");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not reset tables", se);
     }
@@ -162,6 +165,22 @@ class ImageUsageCommandTest {
   }
 
   @Test
+  void imageReferencedOnlyViaMarkdownPastedIntoAWikiPageBodyIsDetectedAsUsed() {
+    Image image = insertImage("wiki-diagram.png");
+    String fullUrl = "/assets/img/" + image.getUrl();
+    String markdownBody = "See the diagram below\n\n![architecture](" + fullUrl + ")\n\nmore text";
+    insertWikiPage("Architecture Overview", markdownBody);
+
+    List<ImageUsageCommand.UsageReference> usages = ImageUsageCommand.findUsages(image);
+
+    assertFalse(usages.isEmpty(),
+        "an image referenced only via markdown pasted into a wiki page body must be detected as used, "
+            + "not orphaned by omission");
+    assertTrue(usages.stream().anyMatch(u -> "Wiki Page".equals(u.getSourceType()) && "Architecture Overview".equals(u.getLabel())));
+    assertFalse(ImageUsageCommand.isOrphaned(image));
+  }
+
+  @Test
   void aGenuinelyUnusedImageIsCorrectlyFlaggedOrphaned() {
     Image image = insertImage("never-used.png");
     // A different image and unrelated page/content rows exist, but none reference this one.
@@ -203,6 +222,7 @@ class ImageUsageCommandTest {
   private static void createSchema() {
     try (Connection connection = DB.getConnection();
         Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS wiki_pages CASCADE");
       statement.execute("DROP TABLE IF EXISTS content CASCADE");
       statement.execute("DROP TABLE IF EXISTS web_pages CASCADE");
       statement.execute("DROP TABLE IF EXISTS images CASCADE");
@@ -237,6 +257,11 @@ class ImageUsageCommandTest {
           + "content_unique_id VARCHAR(255) UNIQUE, "
           + "content TEXT, "
           + "draft_content TEXT)");
+      // A focused subset of wiki_pages -- just title + body, the only columns this scan reads.
+      statement.execute("CREATE TABLE wiki_pages ("
+          + "wiki_page_id BIGSERIAL PRIMARY KEY, "
+          + "title VARCHAR(255) NOT NULL, "
+          + "body TEXT)");
     } catch (SQLException se) {
       throw new IllegalStateException("Could not create the test schema", se);
     }
@@ -280,6 +305,18 @@ class ImageUsageCommandTest {
       pst.executeUpdate();
     } catch (SQLException se) {
       throw new IllegalStateException("Could not insert test web page", se);
+    }
+  }
+
+  private static void insertWikiPage(String title, String body) {
+    try (Connection connection = DB.getConnection();
+        PreparedStatement pst = connection.prepareStatement(
+            "INSERT INTO wiki_pages (title, body) VALUES (?, ?)")) {
+      pst.setString(1, title);
+      pst.setString(2, body);
+      pst.executeUpdate();
+    } catch (SQLException se) {
+      throw new IllegalStateException("Could not insert test wiki page", se);
     }
   }
 


### PR DESCRIPTION
## Summary
- `ImageUsageCommand` (the scan behind `/admin/images`' "Orphaned"/"Used" badge and delete-confirmation warning) checked web pages, blog posts, calendar events, products, collections, items, user profiles, and CMS content blocks for a reference to an image's URL -- but never `wiki_pages.body`.
- The wiki editor has no image-picker integration of its own (unlike the other editors), so an author gets an image's URL from the image-browser popup or `/admin/images`' "Image Link" and pastes it into the markdown body by hand -- a legitimate way to reference an image that the scan simply never looked at.
- Net effect: an image genuinely in use on a wiki page showed as "Orphaned" on `/admin/images`, and could be deleted with no warning, silently breaking that wiki page's rendered content.

## Fix
- Added `{ "wiki_pages", "body", "title", "Wiki Page" }` to `ImageUsageCommand.HTML_BODY_SOURCES` -- the same substring-match scan already used for `content.content`/`content.draft_content`/`blog_posts.body`, since a wiki body can carry either markdown image syntax or raw HTML and either way the image's URL appears as a literal substring.
- Corrected the class javadoc, which previously implied every usage source came through a TinyMCE image-picker integration -- wiki pages don't have one.

## Test plan
- [x] New `ImageUsageCommandTest` case: an image referenced only via markdown pasted into a wiki page body is detected as used (not orphaned by omission), against a real PostgreSQL Testcontainer.
- [x] Full `ant -lib lib/war ci-test` passes.