### PR TITLE
Add sort and orphaned/used filtering to the Images page

### DIFF
--- a/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidget.java
+++ b/src/main/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidget.java
@@ -99,11 +99,42 @@ public class AdminImageBrowserWidget extends GenericWidget {
     DataConstraints constraints = new DataConstraints(page, itemsPerPage);
     context.getRequest().setAttribute(RequestConstants.RECORD_PAGING, constraints);
 
-    // Carry the current search term through pagination links (paging_control.jspf appends this
-    // to each page link's query string) so paging forward/back doesn't lose the search. URL-encoded
+    // Sort by date/name/size -- an invalid or missing value falls back to "date", which maps to
+    // the same "created DESC" order this list used before sorting existed, so a plain page load
+    // (no sortBy param) keeps its prior ordering. Mirrors FolderFilesListWidget's sortBy switch
+    // (issue #502) -- the column name is chosen from this fixed allowlist, never taken from the
+    // request parameter directly, so it cannot be used to inject arbitrary SQL.
+    String sortBy = context.getParameter(RequestConstants.RECORD_SORT_BY, "date");
+    switch (sortBy) {
+      case "name":
+        constraints.setColumnToSortBy("filename");
+        break;
+      case "size":
+        constraints.setColumnToSortBy("file_length", "desc");
+        break;
+      case "date":
+      default:
+        sortBy = "date";
+        constraints.setColumnToSortBy("created", "desc");
+        break;
+    }
+    context.getRequest().setAttribute(RequestConstants.RECORD_SORT_BY, sortBy);
+
+    // Carry the current search term and sort through pagination links (paging_control.jspf appends
+    // this to each page link's query string) so paging forward/back doesn't lose either. URL-encoded
     // so the free-text search term cannot break the query string or the href.
+    StringBuilder pagingParams = new StringBuilder();
     if (query != null) {
-      context.getRequest().setAttribute("recordPagingParams", "query=" + URLEncoder.encode(query, StandardCharsets.UTF_8));
+      pagingParams.append("query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+    }
+    if (!"date".equals(sortBy)) {
+      if (pagingParams.length() > 0) {
+        pagingParams.append("&");
+      }
+      pagingParams.append("sortBy=").append(sortBy);
+    }
+    if (pagingParams.length() > 0) {
+      context.getRequest().setAttribute("recordPagingParams", pagingParams.toString());
     }
 
     List<Image> imageList;
@@ -361,18 +392,23 @@ public class AdminImageBrowserWidget extends GenericWidget {
   }
 
   /**
-   * Builds the post-delete redirect back to the image grid, preserving both the search term and
+   * Builds the post-delete redirect back to the image grid, preserving the search term, sort, and
    * the page the admin was on (issue #498 slice 2) -- otherwise every delete bounces back to page 1
-   * of the (optionally search-filtered) grid instead of the page the admin was triaging.
+   * of the (optionally search-filtered/sorted) grid instead of the page the admin was triaging.
    */
   private String redirectWithQuery(WidgetContext context) {
     String query = StringUtils.trimToNull(context.getParameter("query"));
+    String sortBy = context.getParameter(RequestConstants.RECORD_SORT_BY, "date");
     int page = context.getParameterAsInt("page", 1);
 
     StringBuilder redirect = new StringBuilder("/admin/images");
     String separator = "?";
     if (query != null) {
       redirect.append(separator).append("query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+      separator = "&";
+    }
+    if (!"date".equals(sortBy)) {
+      redirect.append(separator).append("sortBy=").append(sortBy);
       separator = "&";
     }
     if (page > 1) {

--- a/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/image-browser.jsp
@@ -25,6 +25,7 @@
 <jsp:useBean id="widgetContext" class="com.simisinc.platform.presentation.controller.WidgetContext" scope="request"/>
 <jsp:useBean id="imageList" class="java.util.ArrayList" scope="request"/>
 <jsp:useBean id="query" class="java.lang.String" scope="request"/>
+<jsp:useBean id="sortBy" class="java.lang.String" scope="request"/>
 <jsp:useBean id="recordPaging" class="com.simisinc.platform.infrastructure.database.DataConstraints" scope="request"/>
 <c:if test="${!empty title}">
   <h1><c:if test="${!empty icon}"><i class="fa ${fn:escapeXml(icon)}"></i> </c:if><c:out value="${title}" /></h1>
@@ -34,12 +35,30 @@
   <div class="input-group no-gap width-auto">
     <input class="input-group-field" type="search" name="query" aria-label="Search images by filename"
            placeholder="<c:if test="${empty query}">Search filenames...</c:if>"<c:if test="${!empty query}"> value="<c:out value="${query}"/>"</c:if> autocomplete="off">
+    <label for="imageSortBy" class="show-for-sr">Sort by</label>
+    <select id="imageSortBy" name="sortBy" class="input-group-field" style="max-width:220px;" onchange="this.form.submit();">
+      <option value="date" <c:if test="${sortBy eq 'date'}">selected</c:if>>Date (Newest First)</option>
+      <option value="name" <c:if test="${sortBy eq 'name'}">selected</c:if>>Name (A-Z)</option>
+      <option value="size" <c:if test="${sortBy eq 'size'}">selected</c:if>>Size (Largest First)</option>
+    </select>
     <div class="input-group-button">
       <button type="submit" class="button search" aria-label="Search"><i class="fa fa-search" aria-hidden="true"></i></button>
     </div>
   </div>
 </form>
 <div style="clear: both;"></div>
+<%-- Client-side only -- filters the usage badges already being computed lazily below, on whichever
+     images are on the current page. This deliberately does NOT run a server-side query across the
+     whole (possibly 200+ image) list: ImageUsageCommand's usage scan is meant to run for one image
+     at a time on demand, not eagerly for a full list (see its class docs), so "Orphaned only" here
+     only ever narrows what's already been fetched for this page, not the whole library. --%>
+<c:if test="${!empty imageList}">
+  <div id="usageFilterBar" class="button-group margin-bottom-10" style="clear:both;">
+    <button type="button" class="button tiny primary radius usage-filter-btn" data-usage-filter="all">All (this page)</button>
+    <button type="button" class="button tiny secondary radius usage-filter-btn" data-usage-filter="orphaned">Orphaned only</button>
+    <button type="button" class="button tiny secondary radius usage-filter-btn" data-usage-filter="used">Used only</button>
+  </div>
+</c:if>
 <div id="bulkActionsBar" class="callout radius" style="display:none;padding:10px 15px;margin-bottom:10px;">
   <span id="bulkSelectedCount"></span>
   <button type="button" class="button tiny alert radius" id="bulkDeleteBtn">Delete Selected</button>
@@ -55,7 +74,7 @@
   </c:if>
   <div class="grid-x grid-margin-x small-up-2 medium-up-3 large-up-5">
     <c:forEach items="${imageList}" var="image" varStatus="status">
-      <div class="cell card">
+      <div class="cell card" data-image-card-id="${image.id}">
         <div class="image-browser" style="position: relative;">
           <input type="checkbox" class="imageRowCheckbox" value="${image.id}"
                  data-filename="${fn:escapeXml(image.filename)}"
@@ -182,6 +201,7 @@
       if (!el) {
         return;
       }
+      var status = 'unknown';
       if (data.orphaned === null) {
         el.textContent = 'Usage unknown';
         el.className = 'usage-badge label secondary';
@@ -189,12 +209,42 @@
         el.textContent = 'Orphaned';
         el.className = 'usage-badge label warning';
         el.removeAttribute('title');
+        status = 'orphaned';
       } else {
         el.textContent = 'Used (' + data.usages.length + ')';
         el.className = 'usage-badge label success';
         el.title = describeUsage(data);
+        status = 'used';
+      }
+      var card = document.querySelector('.cell.card[data-image-card-id="' + imageId + '"]');
+      if (card) {
+        card.setAttribute('data-usage-status', status);
+        applyUsageFilter(card);
       }
     }
+
+    // Orphaned/Used filter (client-side only, this page only -- see the comment above
+    // #usageFilterBar). A card not yet resolved (still "Checking usage...") is always shown, since
+    // hiding it before its badge resolves would look like it silently vanished.
+    var activeUsageFilter = 'all';
+
+    function applyUsageFilter(card) {
+      var status = card.getAttribute('data-usage-status');
+      var hide = (activeUsageFilter === 'orphaned' && status !== 'orphaned' && status)
+          || (activeUsageFilter === 'used' && status !== 'used' && status);
+      card.style.display = hide ? 'none' : '';
+    }
+
+    document.querySelectorAll('.usage-filter-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        activeUsageFilter = btn.getAttribute('data-usage-filter');
+        document.querySelectorAll('.usage-filter-btn').forEach(function (b) {
+          b.classList.toggle('primary', b === btn);
+          b.classList.toggle('secondary', b !== btn);
+        });
+        document.querySelectorAll('.cell.card[data-image-card-id]').forEach(applyUsageFilter);
+      });
+    });
 
     // Populate each row's badge lazily, one request at a time, after the page has already
     // rendered -- not blocking the initial page load and not run as part of the server-side

--- a/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidgetTest.java
+++ b/src/test/java/com/simisinc/platform/presentation/widgets/admin/cms/AdminImageBrowserWidgetTest.java
@@ -191,6 +191,132 @@ class AdminImageBrowserWidgetTest extends WidgetBase {
   }
 
   @Test
+  void executeWithNoSortByParamDefaultsToDateNewestFirst() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findAll(isNull(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.execute(widgetContext);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.findAll(isNull(), constraintsCaptor.capture()));
+      Assertions.assertArrayEquals(new String[] { "created" }, constraintsCaptor.getValue().getColumnsToSortBy());
+      Assertions.assertArrayEquals(new String[] { "desc" }, constraintsCaptor.getValue().getSortOrder());
+    }
+
+    Assertions.assertEquals("date", request.getAttribute("sortBy"));
+    // The default sort must not appear in the paging-links param -- a plain page load stays bare
+    Assertions.assertNull(request.getAttribute("recordPagingParams"));
+  }
+
+  @Test
+  void executeWithSortByNameSortsByFilenameAscending() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    addQueryParameter(widgetContext, "sortBy", "name");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findAll(isNull(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.execute(widgetContext);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.findAll(isNull(), constraintsCaptor.capture()));
+      Assertions.assertArrayEquals(new String[] { "filename" }, constraintsCaptor.getValue().getColumnsToSortBy());
+      Assertions.assertNull(constraintsCaptor.getValue().getSortOrder());
+    }
+
+    Assertions.assertEquals("name", request.getAttribute("sortBy"));
+    Assertions.assertEquals("sortBy=name", request.getAttribute("recordPagingParams"));
+  }
+
+  @Test
+  void executeWithSortBySizeSortsByFileLengthDescending() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    addQueryParameter(widgetContext, "sortBy", "size");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findAll(isNull(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.execute(widgetContext);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.findAll(isNull(), constraintsCaptor.capture()));
+      Assertions.assertArrayEquals(new String[] { "file_length" }, constraintsCaptor.getValue().getColumnsToSortBy());
+      Assertions.assertArrayEquals(new String[] { "desc" }, constraintsCaptor.getValue().getSortOrder());
+    }
+
+    Assertions.assertEquals("size", request.getAttribute("sortBy"));
+  }
+
+  @Test
+  void executeWithAnUnrecognizedSortByFallsBackToDate() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    addQueryParameter(widgetContext, "sortBy", "not-a-real-sort");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findAll(isNull(), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.execute(widgetContext);
+
+      ArgumentCaptor<DataConstraints> constraintsCaptor = ArgumentCaptor.forClass(DataConstraints.class);
+      imageRepositoryMockedStatic.verify(() -> ImageRepository.findAll(isNull(), constraintsCaptor.capture()));
+      Assertions.assertArrayEquals(new String[] { "created" }, constraintsCaptor.getValue().getColumnsToSortBy());
+    }
+
+    Assertions.assertEquals("date", request.getAttribute("sortBy"));
+  }
+
+  @Test
+  void executeWithASearchQueryAndASortByCarriesBothInThePagingParams() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    addQueryParameter(widgetContext, "query", "3d");
+    addQueryParameter(widgetContext, "sortBy", "size");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findAll(any(ImageSpecification.class), any(DataConstraints.class)))
+          .thenReturn(Collections.emptyList());
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.execute(widgetContext);
+    }
+
+    Assertions.assertEquals("query=3d&sortBy=size", request.getAttribute("recordPagingParams"));
+  }
+
+  @Test
+  void deleteWithAdminRolePreservesANonDefaultSortByOnRedirect() {
+    addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
+    setRoles(widgetContext, ADMIN);
+    addQueryParameter(widgetContext, "imageId", "42");
+    addQueryParameter(widgetContext, "sortBy", "size");
+
+    Image image = new Image();
+    image.setId(42L);
+    image.setFilename("old-banner.png");
+
+    try (MockedStatic<ImageRepository> imageRepositoryMockedStatic = mockStatic(ImageRepository.class);
+        MockedStatic<DeleteImageCommand> deleteMockedStatic = mockStatic(DeleteImageCommand.class);
+        MockedStatic<AuditEventCommand> auditMockedStatic = mockStatic(AuditEventCommand.class)) {
+      imageRepositoryMockedStatic.when(() -> ImageRepository.findById(42L)).thenReturn(image);
+      deleteMockedStatic.when(() -> DeleteImageCommand.deleteImage(image)).thenReturn(true);
+
+      AdminImageBrowserWidget widget = new AdminImageBrowserWidget();
+      widget.delete(widgetContext);
+    }
+
+    Assertions.assertEquals("/admin/images?sortBy=size", widgetContext.getRedirect());
+  }
+
+  @Test
   void executeWithCheckUsageParamReturnsJsonInsteadOfRenderingTheJsp() {
     addPreferencesFromWidgetXml(widgetContext, "<widget name=\"adminImageBrowser\"/>");
     addQueryParameter(widgetContext, "checkUsage", "true");


### PR DESCRIPTION
## Summary
Part of a 3-piece response to feedback that `/admin/images` "lacks everything -- no organization or filters":

- **Sort**: a Date/Name/Size dropdown next to the existing search box, server-side, mirroring `FolderFilesListWidget`'s existing `sortBy` switch pattern (`/admin/folders`). Preserved across pagination and post-delete redirects the same way the search query already was.
- **Orphaned/Used filter**: a button group that filters the currently-loaded page of thumbnails using the usage badges the page already computes lazily, one image at a time. This is deliberately client-side and scoped to the current page only -- `ImageUsageCommand`'s usage scan is designed to run for one image at a time on demand, not eagerly for a full (possibly 200+ image) list (see its class docs), so adding a real site-wide "show me every orphaned image" search isn't a safe fit for that design without a much bigger change to how usage is tracked. This gets the common case (triaging what's visible right now) without that cost.

This is PR 2 of 3 for the Images page. PR 1 (wiki-page usage-detection bug fix) is #1054. PR 3 (tags for images) is in progress, stacked on this branch.

## Test plan
- [x] New widget tests for the sort switch (default/name/size/unrecognized fallback), paging-params carry-through, and delete-redirect preservation
- [x] Full `ant -lib lib/war ci-test` passes
- [x] Unescaped-EL gate clean (0 unallowlisted findings)